### PR TITLE
Harden retain queue locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ Example project config:
   },
   "retain": {
     "queuePath": ".pi/hindsight/retain-queue.jsonl",
-    "updateMode": "append"
+    "updateMode": "append",
+    "shutdownFlushMaxJobs": 10,
+    "shutdownFlushTimeoutMs": 2000
   },
   "import": {
     "manifestPath": ".pi/hindsight/import-manifest.json"
@@ -132,7 +134,9 @@ Automatic recall runs in the `context` hook and injects an ephemeral `<hindsight
 
 Automatic retain runs in the `agent_end` hook. It stores a structured JSON projection of new messages, not a summary. Live sessions use stable `documentId` values and `updateMode: "append"`. A persisted retain cursor under `.pi/hindsight/retain-cursors.json` prevents duplicate appends when Pi provides overlapping transcripts, including after extension restart. Explicit retain tool tags are merged with the base `source:pi`, repo, and session tags so manually retained memories remain visible to default project recall.
 
-Retain jobs are written to a JSONL queue before sending. If Hindsight is down, jobs remain on disk for later flushing. This queue-first behavior applies to both automatic retain and the explicit `hindsight_retain` tool, so manual memories are not lost during Hindsight outages. Queue operations use an in-process mutex plus a lock directory next to the queue file so multiple Pi processes do not rewrite the active queue concurrently. Jobs that exceed the retry limit are moved to a sibling dead-letter file (`<queue>.dead.jsonl`) instead of retrying forever.
+Retain jobs are written to a JSONL queue before sending. If Hindsight is down, jobs remain on disk for later flushing. This queue-first behavior applies to both automatic retain and the explicit `hindsight_retain` tool, so manual memories are not lost during Hindsight outages. Queue operations use an in-process mutex plus a lock directory next to the queue file so multiple Pi processes do not rewrite the active queue concurrently. Stale queue locks are judged from the lock owner's `acquiredAt` timestamp, not from the waiting process age. Jobs that exceed the retry limit are moved to a sibling dead-letter file (`<queue>.dead.jsonl`) instead of retrying forever.
+
+Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs` and `retain.shutdownFlushTimeoutMs`. If jobs remain after shutdown, they stay on disk and are visible through `/hindsight:debug` queue length for later flushing.
 
 At session start, the extension shows the selected bank ID. If no bank ID is configured, it reports the automatically derived bank ID and how to override it.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Automatic retain runs in the `agent_end` hook. It stores a structured JSON proje
 
 Retain jobs are written to a JSONL queue before sending. If Hindsight is down, jobs remain on disk for later flushing. This queue-first behavior applies to both automatic retain and the explicit `hindsight_retain` tool, so manual memories are not lost during Hindsight outages. Queue operations use an in-process mutex plus a lock directory next to the queue file so multiple Pi processes do not rewrite the active queue concurrently. Stale queue locks are judged from the lock owner's `acquiredAt` timestamp, not from the waiting process age. Jobs that exceed the retry limit are moved to a sibling dead-letter file (`<queue>.dead.jsonl`) instead of retrying forever.
 
-Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs` and `retain.shutdownFlushTimeoutMs`. If jobs remain after shutdown, they stay on disk and are visible through `/hindsight:debug` queue length for later flushing.
+Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs` and `retain.shutdownFlushTimeoutMs`. The timeout is a soft bound checked between queued jobs so shutdown does not leave a background flush holding the queue lock. If jobs remain after shutdown, they stay on disk and are visible through `/hindsight:debug` queue length for later flushing.
 
 At session start, the extension shows the selected bank ID. If no bank ID is configured, it reports the automatically derived bank ID and how to override it.
 

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -25,6 +25,8 @@ const DEFAULT_CONFIG: ResolvedConfig = {
     includeToolResults: "meaningful-only",
     redactSecrets: true,
     queuePath: ".pi/hindsight/retain-queue.jsonl",
+    shutdownFlushMaxJobs: 10,
+    shutdownFlushTimeoutMs: 2_000,
   },
   import: {
     includeBranches: "current-only",
@@ -160,6 +162,14 @@ export function normalizeConfig(config: ResolvedConfig): ResolvedConfig {
       ),
       redactSecrets: bool(config.retain?.redactSecrets, DEFAULT_CONFIG.retain.redactSecrets),
       queuePath: stringValue(config.retain?.queuePath, DEFAULT_CONFIG.retain.queuePath),
+      shutdownFlushMaxJobs: positiveInt(
+        config.retain?.shutdownFlushMaxJobs,
+        DEFAULT_CONFIG.retain.shutdownFlushMaxJobs,
+      ),
+      shutdownFlushTimeoutMs: positiveInt(
+        config.retain?.shutdownFlushTimeoutMs,
+        DEFAULT_CONFIG.retain.shutdownFlushTimeoutMs,
+      ),
     },
     import: {
       includeBranches: enumValue(

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -66,20 +66,6 @@ function snapshotRuntime(ctx: RuntimeCtx): RuntimeSnapshot | undefined {
   }
 }
 
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  let timeout: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>((_resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error("Timed out flushing retain queue")), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeout) clearTimeout(timeout);
-  }
-}
-
 export function createMemoryLifecycle(initialCwd: string = process.cwd()): MemoryLifecycle {
   let config: ResolvedConfig = resolveConfig(initialCwd);
   let client: HindsightLikeClient = createHindsightClient(config);
@@ -269,13 +255,11 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       const runtime = snapshotRuntime(ctx);
       if (!runtime) return;
       try {
-        await withTimeout(
-          flushRetainQueue(resolveQueuePath(runtime.cwd, config.retain.queuePath), client, {
-            maxJobs: config.retain.shutdownFlushMaxJobs,
-            stopOnFirstFailure: true,
-          }),
-          config.retain.shutdownFlushTimeoutMs,
-        );
+        await flushRetainQueue(resolveQueuePath(runtime.cwd, config.retain.queuePath), client, {
+          maxJobs: config.retain.shutdownFlushMaxJobs,
+          maxElapsedMs: config.retain.shutdownFlushTimeoutMs,
+          stopOnFirstFailure: true,
+        });
       } catch {
         // Keep queue on disk for next run.
       }

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -66,6 +66,20 @@ function snapshotRuntime(ctx: RuntimeCtx): RuntimeSnapshot | undefined {
   }
 }
 
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error("Timed out flushing retain queue")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 export function createMemoryLifecycle(initialCwd: string = process.cwd()): MemoryLifecycle {
   let config: ResolvedConfig = resolveConfig(initialCwd);
   let client: HindsightLikeClient = createHindsightClient(config);
@@ -255,10 +269,13 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       const runtime = snapshotRuntime(ctx);
       if (!runtime) return;
       try {
-        await flushRetainQueue(resolveQueuePath(runtime.cwd, config.retain.queuePath), client, {
-          maxJobs: 1,
-          stopOnFirstFailure: true,
-        });
+        await withTimeout(
+          flushRetainQueue(resolveQueuePath(runtime.cwd, config.retain.queuePath), client, {
+            maxJobs: config.retain.shutdownFlushMaxJobs,
+            stopOnFirstFailure: true,
+          }),
+          config.retain.shutdownFlushTimeoutMs,
+        );
       } catch {
         // Keep queue on disk for next run.
       }

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 import type { HindsightLikeClient, RetainJob } from "./types.js";
 
@@ -14,8 +14,40 @@ export const RETAIN_QUEUE_LOCK = {
   staleMs: LOCK_STALE_MS,
 };
 
+export interface QueueLockOwner {
+  pid?: number;
+  acquiredAt?: string;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function isQueueLockOwnerStale(
+  owner: QueueLockOwner | undefined,
+  now = Date.now(),
+  staleMs = RETAIN_QUEUE_LOCK.staleMs,
+): boolean {
+  if (!owner) return true;
+  const acquiredAt = owner.acquiredAt ? Date.parse(owner.acquiredAt) : Number.NaN;
+  return !Number.isFinite(acquiredAt) || now - acquiredAt > staleMs;
+}
+
+async function readQueueLockOwner(lockPath: string): Promise<QueueLockOwner | undefined> {
+  try {
+    return JSON.parse(await readFile(`${lockPath}/owner`, "utf8")) as QueueLockOwner;
+  } catch {
+    return undefined;
+  }
+}
+
+async function isOwnerlessLockDirectoryStale(lockPath: string): Promise<boolean> {
+  try {
+    const info = await stat(lockPath);
+    return Date.now() - info.mtimeMs > RETAIN_QUEUE_LOCK.staleMs;
+  } catch {
+    return true;
+  }
 }
 
 async function acquireFileLock(path: string): Promise<() => Promise<void>> {
@@ -35,9 +67,15 @@ async function acquireFileLock(path: string): Promise<() => Promise<void>> {
       };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      const age = Date.now() - started;
-      if (age > RETAIN_QUEUE_LOCK.staleMs) await rm(lockPath, { recursive: true, force: true });
-      if (age > RETAIN_QUEUE_LOCK.timeoutMs)
+      const owner = await readQueueLockOwner(lockPath);
+      const stale = owner
+        ? isQueueLockOwnerStale(owner)
+        : await isOwnerlessLockDirectoryStale(lockPath);
+      if (stale) {
+        await rm(lockPath, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() - started > RETAIN_QUEUE_LOCK.timeoutMs)
         throw new Error(`Timed out waiting for retain queue lock ${lockPath}`);
       await sleep(RETAIN_QUEUE_LOCK.retryMs);
     }

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -23,6 +23,23 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function writeQueueLockOwner(lockPath: string): Promise<void> {
+  await writeFile(
+    `${lockPath}/owner`,
+    JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }),
+    "utf8",
+  );
+}
+
+function startQueueLockHeartbeat(lockPath: string): NodeJS.Timeout {
+  const heartbeatMs = Math.max(1, Math.min(5_000, Math.floor(RETAIN_QUEUE_LOCK.staleMs / 2)));
+  const heartbeat = setInterval(() => {
+    void writeQueueLockOwner(lockPath).catch(() => undefined);
+  }, heartbeatMs);
+  heartbeat.unref?.();
+  return heartbeat;
+}
+
 export function isQueueLockOwnerStale(
   owner: QueueLockOwner | undefined,
   now = Date.now(),
@@ -57,12 +74,10 @@ async function acquireFileLock(path: string): Promise<() => Promise<void>> {
   while (true) {
     try {
       await mkdir(lockPath, { recursive: false });
-      await writeFile(
-        `${lockPath}/owner`,
-        JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }),
-        "utf8",
-      );
+      await writeQueueLockOwner(lockPath);
+      const heartbeat = startQueueLockHeartbeat(lockPath);
       return async () => {
+        clearInterval(heartbeat);
         await rm(lockPath, { recursive: true, force: true });
       };
     } catch (error) {
@@ -151,6 +166,7 @@ export type FlushRetainQueueOptions = {
   maxRetries?: number;
   maxJobs?: number;
   stopOnFirstFailure?: boolean;
+  maxElapsedMs?: number;
 };
 
 export interface FlushRetainQueueResult {
@@ -169,13 +185,15 @@ export async function flushRetainQueue(
       typeof options === "number" ? { maxRetries: options } : options;
     const maxRetries = resolvedOptions.maxRetries ?? 5;
     const maxJobs = resolvedOptions.maxJobs ?? Number.POSITIVE_INFINITY;
+    const maxElapsedMs = resolvedOptions.maxElapsedMs ?? Number.POSITIVE_INFINITY;
+    const started = Date.now();
     const jobs = await readRetainQueue(path);
     const remaining: RetainJob[] = [];
     const deadLetteredJobs: RetainJob[] = [];
     let sent = 0;
     for (const [index, job] of jobs.entries()) {
-      if (index >= maxJobs) {
-        remaining.push(job, ...jobs.slice(index + 1));
+      if (index >= maxJobs || Date.now() - started >= maxElapsedMs) {
+        remaining.push(...jobs.slice(index));
         break;
       }
       try {

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -27,6 +27,8 @@ export interface ResolvedConfig {
     includeToolResults: "meaningful-only" | "all" | "none";
     redactSecrets: boolean;
     queuePath: string;
+    shutdownFlushMaxJobs: number;
+    shutdownFlushTimeoutMs: number;
   };
   import: {
     includeBranches: "current-only" | "all-leaves";

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -39,7 +39,12 @@ describe("resolveConfig", () => {
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
         recall: { budget: "huge", maxTokens: -1, types: ["world", 42] },
-        retain: { includeToolResults: "sometimes", queuePath: "" },
+        retain: {
+          includeToolResults: "sometimes",
+          queuePath: "",
+          shutdownFlushMaxJobs: -1,
+          shutdownFlushTimeoutMs: 0,
+        },
         import: {
           includeBranches: "all-the-branches",
           includeCompactionSummaries: false,
@@ -56,6 +61,8 @@ describe("resolveConfig", () => {
     expect(config.recall.types).toEqual(["world", "experience", "observation"]);
     expect(config.retain.includeToolResults).toBe("meaningful-only");
     expect(config.retain.queuePath).toBe(".pi/hindsight/retain-queue.jsonl");
+    expect(config.retain.shutdownFlushMaxJobs).toBe(10);
+    expect(config.retain.shutdownFlushTimeoutMs).toBe(2_000);
     expect(config.import.includeBranches).toBe("current-only");
     expect(config).not.toHaveProperty("import.includeCompactionSummaries");
     expect(config).not.toHaveProperty("import.includeBranchSummaries");

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { enqueueRetainJob, readRetainQueue, resolveQueuePath } from "../extensions/queue.js";
+import type { RetainJob } from "../extensions/types.js";
 
 const mocked = vi.hoisted(() => ({
   client: {
@@ -291,6 +293,47 @@ describe("extension hooks", () => {
     expect(secondContent).toContain("a2");
     expect(secondContent).not.toContain("u1");
     expect(secondContent).not.toContain("a1");
+  });
+
+  it("uses configured shutdown flush bounds", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({
+        retain: { shutdownFlushMaxJobs: 2, shutdownFlushTimeoutMs: 1_000 },
+        notifications: { startup: false },
+      }),
+    );
+    const queuePath = resolveQueuePath(cwd, ".pi/hindsight/retain-queue.jsonl");
+    const baseJob: RetainJob = {
+      id: "1",
+      bankId: "project-bank",
+      createdAt: "now",
+      documentId: "doc",
+      updateMode: "append",
+      item: { content: "raw", context: "ctx", async: true, tags: ["source:pi"] },
+      retries: 0,
+    };
+    await enqueueRetainJob(queuePath, { ...baseJob, id: "1" });
+    await enqueueRetainJob(queuePath, { ...baseJob, id: "2" });
+    await enqueueRetainJob(queuePath, { ...baseJob, id: "3" });
+
+    const { createMemoryLifecycle } = await import("../extensions/memory-lifecycle.js");
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => join(cwd, "session.jsonl") },
+    };
+
+    const lifecycle = createMemoryLifecycle(cwd);
+    await lifecycle.initialize(ctx);
+    mocked.client.retain.mockClear();
+    await lifecycle.shutdown(ctx);
+
+    expect(mocked.client.retain).toHaveBeenCalledTimes(2);
+    expect((await readRetainQueue(queuePath)).map((job) => job.id)).toEqual(["3"]);
   });
 
   it("emits optional recall and retain notifications", async () => {

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
 import {
   enqueueRetainJob,
   flushRetainQueue,
+  isQueueLockOwnerStale,
   readDeadLetterQueue,
   readRetainQueue,
   RETAIN_QUEUE_LOCK,
@@ -43,6 +44,18 @@ function runWorker(mode: string, path: string, id: string): Promise<void> {
 }
 
 describe("retain queue", () => {
+  it("checks stale locks from owner acquiredAt instead of waiter age", () => {
+    const now = Date.parse("2026-04-27T12:00:00.000Z");
+    expect(
+      isQueueLockOwnerStale({ pid: 123, acquiredAt: "2026-04-27T11:59:59.000Z" }, now, 2_000),
+    ).toBe(false);
+    expect(
+      isQueueLockOwnerStale({ pid: 123, acquiredAt: "2026-04-27T11:59:57.000Z" }, now, 2_000),
+    ).toBe(true);
+    expect(isQueueLockOwnerStale(undefined, now, 2_000)).toBe(true);
+    expect(isQueueLockOwnerStale({ pid: 123, acquiredAt: "not-a-date" }, now, 2_000)).toBe(true);
+  });
+
   it("persists and flushes jobs", async () => {
     const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
     await enqueueRetainJob(path, job);
@@ -162,6 +175,31 @@ describe("retain queue", () => {
     );
     expect(resolveQueuePath("/repo", "/tmp/q.jsonl")).toBe("/tmp/q.jsonl");
     expect(resolveDeadLetterQueuePath("/tmp/q.jsonl")).toBe("/tmp/q.jsonl.dead.jsonl");
+  });
+
+  it("does not remove fresh owner locks while waiting", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    const lockPath = `${path}.lock`;
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(
+      join(lockPath, "owner"),
+      JSON.stringify({ pid: 123, acquiredAt: new Date().toISOString() }),
+    );
+    const originalStaleMs = RETAIN_QUEUE_LOCK.staleMs;
+    const originalTimeoutMs = RETAIN_QUEUE_LOCK.timeoutMs;
+    const originalRetryMs = RETAIN_QUEUE_LOCK.retryMs;
+    RETAIN_QUEUE_LOCK.staleMs = 30_000;
+    RETAIN_QUEUE_LOCK.timeoutMs = 50;
+    RETAIN_QUEUE_LOCK.retryMs = 1;
+    try {
+      await expect(enqueueRetainJob(path, job)).rejects.toThrow(/Timed out waiting/);
+      expect(existsSync(lockPath)).toBe(true);
+      expect(await readRetainQueue(path)).toHaveLength(0);
+    } finally {
+      RETAIN_QUEUE_LOCK.staleMs = originalStaleMs;
+      RETAIN_QUEUE_LOCK.timeoutMs = originalTimeoutMs;
+      RETAIN_QUEUE_LOCK.retryMs = originalRetryMs;
+    }
   });
 
   it("cleans stale lock directories instead of waiting forever", async () => {

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -119,6 +119,27 @@ describe("retain queue", () => {
     expect((await readRetainQueue(path)).map((item) => item.id)).toEqual(["2", "3"]);
   });
 
+  it("stops bounded flushing between jobs instead of leaving background work", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    await enqueueRetainJob(path, { ...job, id: "1" });
+    await enqueueRetainJob(path, { ...job, id: "2" });
+    const calls: unknown[] = [];
+    const result = await flushRetainQueue(
+      path,
+      {
+        retain: async (...args: unknown[]) => {
+          calls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+      { maxElapsedMs: 0 },
+    );
+    expect(result.sent).toBe(0);
+    expect(calls).toHaveLength(0);
+    expect((await readRetainQueue(path)).map((item) => item.id)).toEqual(["1", "2"]);
+  });
+
   it("stops shutdown flushing after first failure", async () => {
     const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
     await enqueueRetainJob(path, { ...job, id: "1" });


### PR DESCRIPTION
## Summary
- fix stale retain queue lock detection to use owner timestamps instead of waiter age
- avoid deleting fresh ownerless lock directories during concurrent lock creation
- add configurable shutdown flush bounds for max jobs and timeout
- document bounded shutdown behavior and add tests

## Verification
- npm run check
- npm run typecheck:tsc
