### PR TITLE
Detect append retain capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Example project config:
   "retain": {
     "queuePath": ".pi/hindsight/retain-queue.jsonl",
     "updateMode": "append",
+    "appendFallback": "error",
     "shutdownFlushMaxJobs": 10,
     "shutdownFlushTimeoutMs": 2000
   },
@@ -132,7 +133,7 @@ Example project config:
 
 Automatic recall runs in the `context` hook and injects an ephemeral `<hindsight-memory>` message into the provider context. Project bank recall is scoped by the current repo tag. If a global bank is enabled, global recall uses an explicit non-repo `source:pi` scope so cross-project memories can be found without requiring the current repo tag. The injected memory block is not written to the Pi transcript by this extension.
 
-Automatic retain runs in the `agent_end` hook. It stores a structured JSON projection of new messages, not a summary. Live sessions use stable `documentId` values and `updateMode: "append"`. A persisted retain cursor under `.pi/hindsight/retain-cursors.json` prevents duplicate appends when Pi provides overlapping transcripts, including after extension restart. Explicit retain tool tags are merged with the base `source:pi`, repo, and session tags so manually retained memories remain visible to default project recall.
+Automatic retain runs in the `agent_end` hook. It stores a structured JSON projection of new messages, not a summary. Live sessions use stable `documentId` values and `updateMode: "append"`. On startup, the extension probes append support with a deterministic `pi-hindsight-capability:append:<bank>` document tagged `test:capability` and `feature:append-probe`. If append is known unsupported, `retain.appendFallback: "error"` refuses retain clearly; `"per-turn-documents"` uses deterministic per-delta document IDs with `updateMode: "replace"` to avoid overwriting earlier turns. A persisted retain cursor under `.pi/hindsight/retain-cursors.json` prevents duplicate appends when Pi provides overlapping transcripts, including after extension restart. Explicit retain tool tags are merged with the base `source:pi`, repo, and session tags so manually retained memories remain visible to default project recall.
 
 Retain jobs are written to a JSONL queue before sending. If Hindsight is down, jobs remain on disk for later flushing. This queue-first behavior applies to both automatic retain and the explicit `hindsight_retain` tool, so manual memories are not lost during Hindsight outages. Queue operations use an in-process mutex plus a lock directory next to the queue file so multiple Pi processes do not rewrite the active queue concurrently. Stale queue locks are judged from the lock owner's `acquiredAt` timestamp, not from the waiting process age. Jobs that exceed the retry limit are moved to a sibling dead-letter file (`<queue>.dead.jsonl`) instead of retrying forever.
 

--- a/extensions/capabilities.ts
+++ b/extensions/capabilities.ts
@@ -1,0 +1,70 @@
+import { createHash } from "node:crypto";
+import type {
+  HindsightCapabilities,
+  HindsightLikeClient,
+  ResolvedConfig,
+  UpdateMode,
+} from "./types.js";
+
+export function perDeltaDocumentId(baseDocumentId: string, parts: unknown[]): string {
+  const hash = createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 16);
+  return `${baseDocumentId}:delta:${hash}`;
+}
+
+export function resolveRetainDocumentTarget(args: {
+  config: ResolvedConfig;
+  capabilities?: HindsightCapabilities;
+  documentId: string;
+  updateMode: UpdateMode;
+  fallbackParts: unknown[];
+}): { documentId: string; updateMode: UpdateMode } {
+  if (args.updateMode !== "append")
+    return { documentId: args.documentId, updateMode: args.updateMode };
+  if (!args.capabilities || args.capabilities.appendUpdateMode) {
+    return { documentId: args.documentId, updateMode: args.updateMode };
+  }
+  if (args.config.retain.appendFallback === "per-turn-documents") {
+    return {
+      documentId: perDeltaDocumentId(args.documentId, args.fallbackParts),
+      updateMode: "replace",
+    };
+  }
+  throw new Error(
+    "Hindsight append update mode is unsupported. Upgrade Hindsight or set retain.appendFallback to per-turn-documents.",
+  );
+}
+
+export async function detectAppendCapability(
+  client: HindsightLikeClient,
+  bankId: string,
+): Promise<HindsightCapabilities> {
+  const checkedAt = new Date().toISOString();
+  const documentId = `pi-hindsight-capability:append:${bankId}`;
+  try {
+    await client.retain(bankId, "Pi Hindsight append capability probe. Safe to ignore.", {
+      async: true,
+      documentId,
+      updateMode: "append",
+      context: "Pi Hindsight append capability detection",
+      tags: ["source:pi", "test:capability", "feature:append-probe"],
+      metadata: {
+        source: "pi-hindsight",
+        capability: "append-update-mode",
+      },
+    });
+    return { appendUpdateMode: true, checkedAt, probeDocumentId: documentId };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const appendUnsupported =
+      /append|update[_ ]?mode/i.test(message) &&
+      /unsupported|invalid|unknown|unrecognized|not allowed|not permitted/i.test(message);
+    return {
+      appendUpdateMode: !appendUnsupported,
+      checkedAt,
+      error: appendUnsupported
+        ? message
+        : `Probe inconclusive; assuming append support: ${message}`,
+      probeDocumentId: documentId,
+    };
+  }
+}

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -21,9 +21,14 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
     description: "Check Hindsight connectivity and queue.",
     handler: async (_args, ctx) => {
       const doctor = await operations.doctor(ctx.cwd);
+      const append = doctor.capabilities
+        ? doctor.capabilities.appendUpdateMode
+          ? "append supported"
+          : "append unsupported"
+        : "append not checked";
       ctx.ui.notify(
-        `Hindsight ${doctor.health.ok ? "reachable" : `unreachable: ${doctor.health.error}`}; queue ${doctor.queueLength}; imports ${doctor.imports.count}`,
-        doctor.health.ok ? "info" : "warning",
+        `Hindsight ${doctor.health.ok ? "reachable" : `unreachable: ${doctor.health.error}`}; ${append}; queue ${doctor.queueLength}; imports ${doctor.imports.count}`,
+        doctor.health.ok && doctor.capabilities?.appendUpdateMode !== false ? "info" : "warning",
       );
     },
   });

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -22,6 +22,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
     enabled: true,
     async: true,
     updateMode: "append",
+    appendFallback: "error",
     includeToolResults: "meaningful-only",
     redactSecrets: true,
     queuePath: ".pi/hindsight/retain-queue.jsonl",
@@ -154,6 +155,11 @@ export function normalizeConfig(config: ResolvedConfig): ResolvedConfig {
         config.retain?.updateMode,
         ["append", "replace"],
         DEFAULT_CONFIG.retain.updateMode,
+      ),
+      appendFallback: enumValue(
+        config.retain?.appendFallback,
+        ["error", "per-turn-documents"],
+        DEFAULT_CONFIG.retain.appendFallback,
       ),
       includeToolResults: enumValue(
         config.retain?.includeToolResults,

--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -1,4 +1,4 @@
-import type { ResolvedConfig } from "./types.js";
+import type { HindsightCapabilities, ResolvedConfig } from "./types.js";
 import { baseTags, findRepoRoot } from "./banking.js";
 import { stableSessionId } from "./session.js";
 import type { ImportManifestEntry } from "./import-manifest.js";
@@ -18,6 +18,7 @@ export interface DebugReportArgs {
   importCount?: number;
   latestImport?: ImportManifestEntry;
   health?: { ok: boolean; error?: string };
+  capabilities?: HindsightCapabilities;
   activity?: HindsightActivity;
   memoryCount?: number;
   queueRemaining?: number;
@@ -69,6 +70,18 @@ export function formatDebugReport(args: DebugReportArgs): string {
       tags,
       queuePath: args.config.retain.queuePath,
       queueLength: args.queueLength,
+      capabilities: args.capabilities
+        ? {
+            appendUpdateMode: args.capabilities.appendUpdateMode ? "supported" : "unsupported",
+            checkedAt: args.capabilities.checkedAt,
+            error: args.capabilities.error ?? null,
+            probeDocumentId: args.capabilities.probeDocumentId ?? null,
+            appendFallback: args.config.retain.appendFallback,
+            action: args.capabilities.appendUpdateMode
+              ? null
+              : "Upgrade Hindsight or set retain.appendFallback to per-turn-documents.",
+          }
+        : { appendUpdateMode: "not checked", appendFallback: args.config.retain.appendFallback },
       imports: {
         manifestPath: args.importManifestPath ?? args.config.import.manifestPath,
         count: args.importCount ?? 0,
@@ -105,6 +118,7 @@ export function formatDebugReport(args: DebugReportArgs): string {
         enabled: args.config.retain.enabled,
         async: args.config.retain.async,
         updateMode: args.config.retain.updateMode,
+        appendFallback: args.config.retain.appendFallback,
         redactSecrets: args.config.retain.redactSecrets,
         includeToolResults: args.config.retain.includeToolResults,
       },

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -6,6 +6,7 @@ import { createHindsightClient } from "./client.js";
 import { ensureProjectBank } from "./bank-operations.js";
 import { recallForContext } from "./recall.js";
 import { enqueueRetainFromAgentEnd } from "./retain.js";
+import { detectAppendCapability } from "./capabilities.js";
 import { flushRetainQueue, resolveQueuePath } from "./queue.js";
 import { getSessionFile, stableSessionId } from "./session.js";
 import { bankSelectionMessage } from "./diagnostics.js";
@@ -17,7 +18,7 @@ import {
   messageFingerprint,
   readRetainFingerprints,
 } from "./retain-cursor.js";
-import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
+import type { HindsightCapabilities, HindsightLikeClient, ResolvedConfig } from "./types.js";
 
 export type RuntimeCtx = {
   cwd: string;
@@ -41,6 +42,7 @@ export interface MemoryLifecycleDeps {
   getClient(): HindsightLikeClient;
   getConfig(): ResolvedConfig;
   getProjectBankId(): string;
+  getCapabilities(): HindsightCapabilities | undefined;
   reloadConfig(cwd: string): void;
 }
 
@@ -70,12 +72,14 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
   let config: ResolvedConfig = resolveConfig(initialCwd);
   let client: HindsightLikeClient = createHindsightClient(config);
   let projectBankId = deriveProjectBankId(initialCwd, config);
+  let capabilities: HindsightCapabilities | undefined;
   const retainedBySession = new Map<string, Set<string>>();
 
   const reloadConfig = (cwd: string) => {
     config = resolveConfig(cwd);
     client = createHindsightClient(config);
     projectBankId = deriveProjectBankId(cwd, config);
+    capabilities = undefined;
   };
 
   const setMemoryStatus = (
@@ -140,6 +144,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
     getClient: () => client,
     getConfig: () => config,
     getProjectBankId: () => projectBankId,
+    getCapabilities: () => capabilities,
     reloadConfig,
   };
 
@@ -152,14 +157,20 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       reloadConfig(runtime.cwd);
       if (!config.enabled) return;
       if (config.banks.project.enabled)
-        void ensureProjectBank(client, projectBankId).catch((error) => {
-          setMemoryStatus(runtime, "recall-failed");
-          notify(
-            runtime,
-            `Hindsight bank ensure failed: ${error instanceof Error ? error.message : String(error)}`,
-            "warning",
-          );
-        });
+        void (async () => {
+          try {
+            await ensureProjectBank(client, projectBankId);
+            if (config.retain.enabled)
+              capabilities = await detectAppendCapability(client, projectBankId);
+          } catch (error) {
+            setMemoryStatus(runtime, "recall-failed");
+            notify(
+              runtime,
+              `Hindsight bank ensure/capability check failed: ${error instanceof Error ? error.message : String(error)}`,
+              "warning",
+            );
+          }
+        })();
       setMemoryStatus(runtime, "idle");
       if (config.notifications.startup)
         notify(runtime, bankSelectionMessage(projectBankId, config), "info");
@@ -223,6 +234,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           config,
           client,
           bankId: projectBankId,
+          ...(capabilities ? { capabilities } : {}),
         });
         if (result.queued) await markRetainedMessages(runtime, messages);
         setMemoryStatus(

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -156,21 +156,20 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       if (!runtime) return;
       reloadConfig(runtime.cwd);
       if (!config.enabled) return;
-      if (config.banks.project.enabled)
-        void (async () => {
-          try {
-            await ensureProjectBank(client, projectBankId);
-            if (config.retain.enabled)
-              capabilities = await detectAppendCapability(client, projectBankId);
-          } catch (error) {
-            setMemoryStatus(runtime, "recall-failed");
-            notify(
-              runtime,
-              `Hindsight bank ensure/capability check failed: ${error instanceof Error ? error.message : String(error)}`,
-              "warning",
-            );
-          }
-        })();
+      if (config.banks.project.enabled) {
+        try {
+          await ensureProjectBank(client, projectBankId);
+          if (config.retain.enabled)
+            capabilities = await detectAppendCapability(client, projectBankId);
+        } catch (error) {
+          setMemoryStatus(runtime, "recall-failed");
+          notify(
+            runtime,
+            `Hindsight bank ensure/capability check failed: ${error instanceof Error ? error.message : String(error)}`,
+            "warning",
+          );
+        }
+      }
       setMemoryStatus(runtime, "idle");
       if (config.notifications.startup)
         notify(runtime, bankSelectionMessage(projectBankId, config), "info");

--- a/extensions/memory-operations.ts
+++ b/extensions/memory-operations.ts
@@ -1,5 +1,5 @@
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
-import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
+import type { HindsightCapabilities, HindsightLikeClient, ResolvedConfig } from "./types.js";
 import { checkHindsight } from "./client.js";
 import { readRetainQueue, flushRetainQueue, resolveQueuePath } from "./queue.js";
 import { formatDebugReport, safeConfig } from "./diagnostics.js";
@@ -23,6 +23,7 @@ export interface MemoryOperationsDeps {
   getClient(): HindsightLikeClient;
   getConfig(): ResolvedConfig;
   getProjectBankId(): string;
+  getCapabilities?(): HindsightCapabilities | undefined;
   reloadConfig?(cwd: string): void;
 }
 
@@ -64,6 +65,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
       const config = deps.getConfig();
       const bankId = args.bank || deps.getProjectBankId();
       const tags = explicitRetainTags(args.cwd, args.sessionFile, args.tags);
+      const capabilities = deps.getCapabilities?.();
       const result = await retainDurably({
         cwd: args.cwd,
         config,
@@ -79,6 +81,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
           ...(args.sessionFile ? { pi_session_file: args.sessionFile } : {}),
         },
         source: "tool",
+        ...(capabilities ? { capabilities } : {}),
       });
       return { bankId, tags, ...result, queued: result.enqueued };
     },
@@ -135,7 +138,12 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
         readRetainQueue(resolveQueuePath(cwd, config.retain.queuePath)),
         readImportManifest(resolveImportManifestPath(cwd, config.import.manifestPath)),
       ]);
-      return { health, queueLength: queue.length, imports: importManifestSummary(manifest) };
+      return {
+        health,
+        ...(deps.getCapabilities?.() ? { capabilities: deps.getCapabilities() } : {}),
+        queueLength: queue.length,
+        imports: importManifestSummary(manifest),
+      };
     },
 
     config() {
@@ -152,6 +160,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
       const manifest = await readImportManifest(manifestPath);
       const imports = importManifestSummary(manifest);
       const sessionFile = ctx.sessionManager.getSessionFile?.();
+      const capabilities = deps.getCapabilities?.();
       return {
         health,
         report: formatDebugReport({
@@ -164,6 +173,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
           importCount: imports.count,
           ...(imports.latest ? { latestImport: imports.latest } : {}),
           health,
+          ...(capabilities ? { capabilities } : {}),
         }),
       };
     },

--- a/extensions/retain-durable.ts
+++ b/extensions/retain-durable.ts
@@ -1,7 +1,14 @@
 import { randomUUID } from "node:crypto";
-import type { HindsightLikeClient, ResolvedConfig, RetainJob, UpdateMode } from "./types.js";
+import type {
+  HindsightCapabilities,
+  HindsightLikeClient,
+  ResolvedConfig,
+  RetainJob,
+  UpdateMode,
+} from "./types.js";
 import { enqueueRetainJob, flushRetainQueue, resolveQueuePath } from "./queue.js";
 import { redactSecrets } from "./sanitize.js";
+import { resolveRetainDocumentTarget } from "./capabilities.js";
 
 export type DurableRetainSource = "auto" | "tool" | "command" | "import";
 
@@ -18,6 +25,7 @@ export interface RetainDurablyArgs {
   metadata?: Record<string, string>;
   source: DurableRetainSource;
   timestamp?: string;
+  capabilities?: HindsightCapabilities;
 }
 
 export interface RetainDurablyResult {
@@ -29,12 +37,19 @@ export interface RetainDurablyResult {
 
 export function buildDurableRetainJob(args: Omit<RetainDurablyArgs, "client">): RetainJob {
   const content = args.config.retain.redactSecrets ? redactSecrets(args.content) : args.content;
+  const target = resolveRetainDocumentTarget({
+    config: args.config,
+    ...(args.capabilities ? { capabilities: args.capabilities } : {}),
+    documentId: args.documentId,
+    updateMode: args.updateMode,
+    fallbackParts: [content, args.context, args.tags, args.metadata],
+  });
   return {
     id: randomUUID(),
     bankId: args.bankId,
     createdAt: new Date().toISOString(),
-    documentId: args.documentId,
-    updateMode: args.updateMode,
+    documentId: target.documentId,
+    updateMode: target.updateMode,
     item: {
       content,
       context: args.context,

--- a/extensions/retain.ts
+++ b/extensions/retain.ts
@@ -1,11 +1,17 @@
 import { randomUUID } from "node:crypto";
 import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
-import type { HindsightLikeClient, ResolvedConfig, RetainJob } from "./types.js";
+import type {
+  HindsightCapabilities,
+  HindsightLikeClient,
+  ResolvedConfig,
+  RetainJob,
+} from "./types.js";
 import { baseTags } from "./banking.js";
 import { projectMessages } from "./messages.js";
 import { redactSecrets } from "./sanitize.js";
 import { contextLabel, liveDocumentId, stableSessionId } from "./session.js";
 import { enqueueRetainJob, flushRetainQueue, resolveQueuePath } from "./queue.js";
+import { resolveRetainDocumentTarget } from "./capabilities.js";
 
 export function buildRetainJob(args: {
   config: ResolvedConfig;
@@ -13,6 +19,7 @@ export function buildRetainJob(args: {
   sessionFile?: string;
   bankId: string;
   messages: AgentEndEvent["messages"];
+  capabilities?: HindsightCapabilities;
 }): RetainJob | undefined {
   const projected = projectMessages(args.messages, args.config.retain.includeToolResults);
   if (projected.length === 0) return undefined;
@@ -20,12 +27,20 @@ export function buildRetainJob(args: {
     ? redactSecrets(JSON.stringify(projected, null, 2))
     : JSON.stringify(projected, null, 2);
   const sessionId = stableSessionId(args.sessionFile, args.cwd);
+  const baseDocumentId = liveDocumentId(args.sessionFile, args.cwd);
+  const target = resolveRetainDocumentTarget({
+    config: args.config,
+    ...(args.capabilities ? { capabilities: args.capabilities } : {}),
+    documentId: baseDocumentId,
+    updateMode: args.config.retain.updateMode,
+    fallbackParts: [content, args.cwd, args.sessionFile, sessionId],
+  });
   return {
     id: randomUUID(),
     bankId: args.bankId,
     createdAt: new Date().toISOString(),
-    documentId: liveDocumentId(args.sessionFile, args.cwd),
-    updateMode: args.config.retain.updateMode,
+    documentId: target.documentId,
+    updateMode: target.updateMode,
     item: {
       content,
       context: contextLabel(args.cwd, args.sessionFile),
@@ -49,6 +64,7 @@ export async function enqueueRetainFromAgentEnd(args: {
   config: ResolvedConfig;
   client: HindsightLikeClient;
   bankId: string;
+  capabilities?: HindsightCapabilities;
 }): Promise<{ queued: boolean; sent: number; remaining: number }> {
   if (!args.config.enabled || !args.config.retain.enabled)
     return { queued: false, sent: 0, remaining: 0 };
@@ -58,6 +74,7 @@ export async function enqueueRetainFromAgentEnd(args: {
     ...(args.sessionFile ? { sessionFile: args.sessionFile } : {}),
     bankId: args.bankId,
     messages: args.event.messages,
+    ...(args.capabilities ? { capabilities: args.capabilities } : {}),
   });
   if (!job) return { queued: false, sent: 0, remaining: 0 };
   const queuePath = resolveQueuePath(args.cwd, args.config.retain.queuePath);

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -1,5 +1,6 @@
 export type Budget = "low" | "mid" | "high";
 export type UpdateMode = "append" | "replace";
+export type AppendFallback = "error" | "per-turn-documents";
 export type TagsMatch = "any" | "all" | "any_strict" | "all_strict";
 export type StatusStyle = "off" | "text" | "emoji" | "nerdfont";
 export type StatusDetail = "minimal" | "project" | "activity" | "verbose";
@@ -24,6 +25,7 @@ export interface ResolvedConfig {
     enabled: boolean;
     async: boolean;
     updateMode: UpdateMode;
+    appendFallback: AppendFallback;
     includeToolResults: "meaningful-only" | "all" | "none";
     redactSecrets: boolean;
     queuePath: string;
@@ -88,6 +90,14 @@ export interface RetainJob {
   retries: number;
   lastError?: string;
   deadLetteredAt?: string;
+}
+
+export interface HindsightCapabilities {
+  version?: string;
+  appendUpdateMode: boolean;
+  checkedAt: string;
+  error?: string;
+  probeDocumentId?: string;
 }
 
 export interface HindsightLikeClient {

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+import {
+  detectAppendCapability,
+  perDeltaDocumentId,
+  resolveRetainDocumentTarget,
+} from "../extensions/capabilities.js";
+import type { HindsightLikeClient, ResolvedConfig } from "../extensions/types.js";
+
+function config(
+  appendFallback: ResolvedConfig["retain"]["appendFallback"] = "error",
+): ResolvedConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    retain: { ...DEFAULT_CONFIG.retain, appendFallback },
+  };
+}
+
+function client(retain: HindsightLikeClient["retain"]): HindsightLikeClient {
+  return {
+    retain,
+    recall: async () => [],
+    reflect: async () => ({}),
+  };
+}
+
+describe("append capabilities", () => {
+  it("detects append support with an isolated probe document", async () => {
+    const calls: unknown[] = [];
+    const capabilities = await detectAppendCapability(
+      client(async (...args: unknown[]) => {
+        calls.push(args);
+      }),
+      "bank",
+    );
+
+    expect(capabilities.appendUpdateMode).toBe(true);
+    expect(capabilities.probeDocumentId).toBe("pi-hindsight-capability:append:bank");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject([
+      "bank",
+      "Pi Hindsight append capability probe. Safe to ignore.",
+      {
+        async: true,
+        documentId: "pi-hindsight-capability:append:bank",
+        updateMode: "append",
+        tags: ["source:pi", "test:capability", "feature:append-probe"],
+      },
+    ]);
+  });
+
+  it("reports unsupported append when the probe fails with an append-specific error", async () => {
+    const capabilities = await detectAppendCapability(
+      client(async () => {
+        throw new Error("update_mode append unsupported");
+      }),
+      "bank",
+    );
+
+    expect(capabilities.appendUpdateMode).toBe(false);
+    expect(capabilities.error).toContain("append unsupported");
+  });
+
+  it("does not mark generic probe failures as unsupported", async () => {
+    const capabilities = await detectAppendCapability(
+      client(async () => {
+        throw new Error("ECONNREFUSED");
+      }),
+      "bank",
+    );
+
+    expect(capabilities.appendUpdateMode).toBe(true);
+    expect(capabilities.error).toContain("Probe inconclusive");
+  });
+
+  it("keeps stable append document IDs when append is supported or unknown", () => {
+    expect(
+      resolveRetainDocumentTarget({
+        config: config(),
+        documentId: "doc",
+        updateMode: "append",
+        fallbackParts: ["content"],
+      }),
+    ).toEqual({ documentId: "doc", updateMode: "append" });
+
+    expect(
+      resolveRetainDocumentTarget({
+        config: config(),
+        capabilities: { appendUpdateMode: true, checkedAt: "now" },
+        documentId: "doc",
+        updateMode: "append",
+        fallbackParts: ["content"],
+      }),
+    ).toEqual({ documentId: "doc", updateMode: "append" });
+  });
+
+  it("refuses append when unsupported and fallback is error", () => {
+    expect(() =>
+      resolveRetainDocumentTarget({
+        config: config("error"),
+        capabilities: { appendUpdateMode: false, checkedAt: "now" },
+        documentId: "doc",
+        updateMode: "append",
+        fallbackParts: ["content"],
+      }),
+    ).toThrow(/append update mode is unsupported/);
+  });
+
+  it("falls back to deterministic per-delta documents when configured", () => {
+    const target = resolveRetainDocumentTarget({
+      config: config("per-turn-documents"),
+      capabilities: { appendUpdateMode: false, checkedAt: "now" },
+      documentId: "doc",
+      updateMode: "append",
+      fallbackParts: ["content"],
+    });
+
+    expect(target).toEqual({
+      documentId: perDeltaDocumentId("doc", ["content"]),
+      updateMode: "replace",
+    });
+    expect(target.documentId).toMatch(/^doc:delta:/);
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -42,6 +42,7 @@ describe("resolveConfig", () => {
         retain: {
           includeToolResults: "sometimes",
           queuePath: "",
+          appendFallback: "overwrite",
           shutdownFlushMaxJobs: -1,
           shutdownFlushTimeoutMs: 0,
         },
@@ -59,6 +60,7 @@ describe("resolveConfig", () => {
     expect(config.recall.budget).toBe("low");
     expect(config.recall.maxTokens).toBe(800);
     expect(config.recall.types).toEqual(["world", "experience", "observation"]);
+    expect(config.retain.appendFallback).toBe("error");
     expect(config.retain.includeToolResults).toBe("meaningful-only");
     expect(config.retain.queuePath).toBe(".pi/hindsight/retain-queue.jsonl");
     expect(config.retain.shutdownFlushMaxJobs).toBe(10);

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -44,7 +44,36 @@ describe("diagnostics", () => {
     expect(report.projectBankId).toBe("bank");
     expect(report.health).toBe("reachable");
     expect(report.queueLength).toBe(2);
+    expect(report.capabilities).toMatchObject({
+      appendUpdateMode: "not checked",
+      appendFallback: "error",
+    });
     expect(report.overrideProjectBankId).toContain("PI_HINDSIGHT_PROJECT_BANK_ID");
     expect(report.tags).toEqual(expect.arrayContaining(["source:pi"]));
+  });
+
+  it("formats append capability diagnostics", () => {
+    const report = JSON.parse(
+      formatDebugReport({
+        cwd: process.cwd(),
+        projectBankId: "bank",
+        config: DEFAULT_CONFIG,
+        queueLength: 0,
+        capabilities: {
+          appendUpdateMode: false,
+          checkedAt: "2026-04-27T12:00:00.000Z",
+          error: "unsupported",
+          probeDocumentId: "pi-hindsight-capability:append:bank",
+        },
+      }),
+    ) as Record<string, unknown>;
+
+    expect(report.capabilities).toMatchObject({
+      appendUpdateMode: "unsupported",
+      appendFallback: "error",
+      error: "unsupported",
+      probeDocumentId: "pi-hindsight-capability:append:bank",
+      action: "Upgrade Hindsight or set retain.appendFallback to per-turn-documents.",
+    });
   });
 });

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -65,6 +65,7 @@ describe("extension hooks", () => {
     hindsightExtension(pi as any);
 
     await handlers.session_start?.[0]?.({}, ctx);
+    mocked.client.retain.mockClear();
     const originalMessages = [
       { role: "user", content: "What did we decide?", timestamp: Date.now() },
     ];
@@ -85,8 +86,10 @@ describe("extension hooks", () => {
       ctx,
     );
 
-    expect(mocked.client.retain).toHaveBeenCalledTimes(1);
-    const retainCalls = mocked.client.retain.mock.calls as unknown[][];
+    const retainCalls = (mocked.client.retain.mock.calls as unknown[][]).filter(
+      (call) => call[1] !== "Pi Hindsight append capability probe. Safe to ignore.",
+    );
+    expect(retainCalls).toHaveLength(1);
     const retainedContent = retainCalls[0]?.[1] as string;
     expect(retainedContent).toContain("What did we decide?");
     expect(retainedContent).toContain("Decision still stands.");
@@ -247,11 +250,15 @@ describe("extension hooks", () => {
     const { default: hindsightExtension } = await import("../extensions/index.js");
     hindsightExtension(pi as any);
     await handlers.session_start?.[0]?.({}, ctx);
+    mocked.client.retain.mockClear();
     await handlers.agent_end?.[0]?.({ messages: [u1, a1] }, ctx);
     await handlers.agent_end?.[0]?.({ messages: [u1, a1, u2, a2] }, ctx);
 
-    expect(mocked.client.retain).toHaveBeenCalledTimes(2);
-    const secondContent = mocked.client.retain.mock.calls[1]?.[1] as string;
+    const retainCalls = (mocked.client.retain.mock.calls as unknown[][]).filter(
+      (call) => call[1] !== "Pi Hindsight append capability probe. Safe to ignore.",
+    );
+    expect(retainCalls).toHaveLength(2);
+    const secondContent = retainCalls[1]?.[1] as string;
     expect(secondContent).toContain("u2");
     expect(secondContent).toContain("a2");
     expect(secondContent).not.toContain("u1");
@@ -281,14 +288,18 @@ describe("extension hooks", () => {
 
     const first = createMemoryLifecycle(cwd);
     await first.initialize(ctx);
+    mocked.client.retain.mockClear();
     await first.retain({ messages: [u1, a1] } as any, ctx);
 
     const second = createMemoryLifecycle(cwd);
     await second.initialize(ctx);
     await second.retain({ messages: [u1, a1, u2, a2] } as any, ctx);
 
-    expect(mocked.client.retain).toHaveBeenCalledTimes(2);
-    const secondContent = mocked.client.retain.mock.calls[1]?.[1] as string;
+    const retainCalls = (mocked.client.retain.mock.calls as unknown[][]).filter(
+      (call) => call[1] !== "Pi Hindsight append capability probe. Safe to ignore.",
+    );
+    expect(retainCalls).toHaveLength(2);
+    const secondContent = retainCalls[1]?.[1] as string;
     expect(secondContent).toContain("u2");
     expect(secondContent).toContain("a2");
     expect(secondContent).not.toContain("u1");

--- a/tests/retain-durable.test.ts
+++ b/tests/retain-durable.test.ts
@@ -117,6 +117,54 @@ describe("durable explicit retain", () => {
     ]);
   });
 
+  it("refuses explicit append retain when known unsupported and fallback is error", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
+    const config = testConfig();
+    const operations = createMemoryOperations({
+      getClient: () => client(async () => undefined),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+      getCapabilities: () => ({ appendUpdateMode: false, checkedAt: "now" }),
+    });
+
+    await expect(
+      operations.retainExplicit({
+        cwd,
+        content: "Decision: no overwrite.",
+        context: "unit test explicit retain",
+      }),
+    ).rejects.toThrow(/append update mode is unsupported/);
+    expect(await readRetainQueue(resolveQueuePath(cwd, config.retain.queuePath))).toHaveLength(0);
+  });
+
+  it("uses per-delta explicit documents when append is unsupported and fallback is configured", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
+    const config: ResolvedConfig = {
+      ...testConfig(),
+      retain: { ...testConfig().retain, appendFallback: "per-turn-documents" },
+    };
+    const operations = createMemoryOperations({
+      getClient: () =>
+        client(async () => {
+          throw new Error("down");
+        }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+      getCapabilities: () => ({ appendUpdateMode: false, checkedAt: "now" }),
+    });
+
+    await operations.retainExplicit({
+      cwd,
+      content: "Decision: use per-delta docs.",
+      context: "unit test explicit retain",
+    });
+
+    const queued = await readRetainQueue(resolveQueuePath(cwd, config.retain.queuePath));
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.documentId).toMatch(/^pi-explicit:.*:delta:/);
+    expect(queued[0]?.updateMode).toBe("replace");
+  });
+
   it("sends explicit retain immediately after enqueue when Hindsight is up", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
     const config = testConfig();


### PR DESCRIPTION
## Summary
- add append update-mode capability probing with isolated probe tags/document IDs
- add retain.appendFallback with error and per-turn-documents behavior
- apply fallback policy to automatic and explicit retain writes
- expose append capability state in doctor/debug output and docs

## Verification
- npm run check
- npm run typecheck:tsc
