### PR TITLE
Add recall query controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,13 @@ Example project config:
   },
   "recall": {
     "budget": "low",
-    "maxTokens": 800
+    "maxTokens": 800,
+    "roles": ["user", "assistant"],
+    "contextTurns": 2,
+    "maxQueryChars": 800,
+    "topK": 8,
+    "timeoutMs": 10000,
+    "injectionPosition": "prepend"
   },
   "retain": {
     "queuePath": ".pi/hindsight/retain-queue.jsonl",
@@ -131,7 +137,7 @@ Example project config:
 
 ## Memory behavior
 
-Automatic recall runs in the `context` hook and injects an ephemeral `<hindsight-memory>` message into the provider context. Project bank recall is scoped by the current repo tag. If a global bank is enabled, global recall uses an explicit non-repo `source:pi` scope so cross-project memories can be found without requiring the current repo tag. The injected memory block is not written to the Pi transcript by this extension.
+Automatic recall runs in the `context` hook and injects an ephemeral `<hindsight-memory>` message into the provider context. Project bank recall is scoped by the current repo tag. If a global bank is enabled, global recall uses an explicit non-repo `source:pi` scope so cross-project memories can be found without requiring the current repo tag. Recall query composition is bounded by `recall.roles`, `recall.contextTurns`, and `recall.maxQueryChars`; slow recalls are bounded by `recall.timeoutMs`. `recall.topK` limits injected results per bank. The injected memory block is not written to the Pi transcript by this extension.
 
 Automatic retain runs in the `agent_end` hook. It stores a structured JSON projection of new messages, not a summary. Live sessions use stable `documentId` values and `updateMode: "append"`. On startup, the extension probes append support with a deterministic `pi-hindsight-capability:append:<bank>` document tagged `test:capability` and `feature:append-probe`. If append is known unsupported, `retain.appendFallback: "error"` refuses retain clearly; `"per-turn-documents"` uses deterministic per-delta document IDs with `updateMode: "replace"` to avoid overwriting earlier turns. A persisted retain cursor under `.pi/hindsight/retain-cursors.json` prevents duplicate appends when Pi provides overlapping transcripts, including after extension restart. Explicit retain tool tags are merged with the base `source:pi`, repo, and session tags so manually retained memories remain visible to default project recall.
 

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -15,7 +15,13 @@ const DEFAULT_CONFIG: ResolvedConfig = {
     maxTokens: 800,
     types: ["world", "experience", "observation"],
     recentTurnsForQuery: 2,
+    contextTurns: 2,
+    roles: ["user", "assistant"],
+    maxQueryChars: 800,
+    topK: 8,
+    timeoutMs: 10_000,
     injectionMode: "context",
+    injectionPosition: "prepend",
     includeFactsInDebug: false,
   },
   retain: {
@@ -97,6 +103,12 @@ function stringArray(value: unknown, fallback: string[]): string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : fallback;
 }
 
+function enumArray<T extends string>(value: unknown, allowed: readonly T[], fallback: T[]): T[] {
+  return Array.isArray(value) && value.every((item) => allowed.includes(item as T))
+    ? (value as T[])
+    : fallback;
+}
+
 export function normalizeConfig(config: ResolvedConfig): ResolvedConfig {
   const apiKey = optionalString(config.hindsight?.apiKey, DEFAULT_CONFIG.hindsight.apiKey);
   const projectBankId = optionalString(
@@ -142,7 +154,24 @@ export function normalizeConfig(config: ResolvedConfig): ResolvedConfig {
         config.recall?.recentTurnsForQuery,
         DEFAULT_CONFIG.recall.recentTurnsForQuery,
       ),
+      contextTurns: positiveInt(
+        config.recall?.contextTurns ?? config.recall?.recentTurnsForQuery,
+        DEFAULT_CONFIG.recall.contextTurns,
+      ),
+      roles: enumArray(
+        config.recall?.roles,
+        ["user", "assistant", "tool", "system"],
+        DEFAULT_CONFIG.recall.roles,
+      ),
+      maxQueryChars: positiveInt(config.recall?.maxQueryChars, DEFAULT_CONFIG.recall.maxQueryChars),
+      topK: positiveInt(config.recall?.topK, DEFAULT_CONFIG.recall.topK),
+      timeoutMs: positiveInt(config.recall?.timeoutMs, DEFAULT_CONFIG.recall.timeoutMs),
       injectionMode: "context",
+      injectionPosition: enumValue(
+        config.recall?.injectionPosition,
+        ["prepend", "append"],
+        DEFAULT_CONFIG.recall.injectionPosition,
+      ),
       includeFactsInDebug: bool(
         config.recall?.includeFactsInDebug,
         DEFAULT_CONFIG.recall.includeFactsInDebug,

--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -113,6 +113,12 @@ export function formatDebugReport(args: DebugReportArgs): string {
         maxTokens: args.config.recall.maxTokens,
         types: args.config.recall.types,
         recentTurnsForQuery: args.config.recall.recentTurnsForQuery,
+        contextTurns: args.config.recall.contextTurns,
+        roles: args.config.recall.roles,
+        maxQueryChars: args.config.recall.maxQueryChars,
+        topK: args.config.recall.topK,
+        timeoutMs: args.config.recall.timeoutMs,
+        injectionPosition: args.config.recall.injectionPosition,
       },
       retain: {
         enabled: args.config.retain.enabled,

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -202,7 +202,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
         }
         if (!rendered) return undefined;
         const recallMessage = {
-          role: "user",
+          role: config.recall.injectionPosition === "append" ? "system" : "user",
           content: rendered,
           timestamp: Date.now(),
         } as AgentMessage;

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -201,11 +201,16 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           );
         }
         if (!rendered) return undefined;
+        const recallMessage = {
+          role: "user",
+          content: rendered,
+          timestamp: Date.now(),
+        } as AgentMessage;
         return {
-          messages: [
-            { role: "user", content: rendered, timestamp: Date.now() } as AgentMessage,
-            ...event.messages,
-          ],
+          messages:
+            config.recall.injectionPosition === "append"
+              ? [...event.messages, recallMessage]
+              : [recallMessage, ...event.messages],
         };
       } catch {
         setMemoryStatus(runtime, "recall-failed");

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -74,7 +74,13 @@ async function acquireFileLock(path: string): Promise<() => Promise<void>> {
   while (true) {
     try {
       await mkdir(lockPath, { recursive: false });
-      await writeQueueLockOwner(lockPath);
+      try {
+        await writeQueueLockOwner(lockPath);
+      } catch (error) {
+        await rm(lockPath, { recursive: true, force: true });
+        if (["ENOENT", "EINVAL"].includes((error as NodeJS.ErrnoException).code ?? "")) continue;
+        throw error;
+      }
       const heartbeat = startQueueLockHeartbeat(lockPath);
       return async () => {
         clearInterval(heartbeat);

--- a/extensions/recall.ts
+++ b/extensions/recall.ts
@@ -43,7 +43,7 @@ function messageContent(message: AgentMessage): string {
 }
 
 function isInjectedHindsightMemory(message: AgentMessage): boolean {
-  return messageContent(message).includes("<hindsight-memory>");
+  return messageContent(message).trim().startsWith("<hindsight-memory>");
 }
 
 export function truncateRecallQuery(query: string, maxChars: number): string {

--- a/extensions/recall.ts
+++ b/extensions/recall.ts
@@ -3,6 +3,7 @@ import type {
   HindsightLikeClient,
   RecallBlock,
   RecallResultItem,
+  RecallRole,
   ResolvedConfig,
   TagsMatch,
 } from "./types.js";
@@ -30,22 +31,64 @@ function itemText(item: RecallResultItem): string {
   return item.text ?? item.content ?? JSON.stringify(item);
 }
 
-export function composeRecallQuery(messages: AgentMessage[], recentTurns: number): string {
-  const userMessages = messages
-    .filter((message) => (message as unknown as { role?: string }).role === "user")
-    .slice(-Math.max(1, recentTurns));
-  return (
-    userMessages
-      .map((message) => {
-        const content = projectMessage(message).content;
-        return typeof content === "string" ? content : JSON.stringify(content ?? "");
-      })
-      .join("\n\n")
-      .trim() || "current Pi coding task"
-  );
+export interface RecallQueryPolicy {
+  roles: RecallRole[];
+  contextTurns: number;
+  maxQueryChars: number;
 }
 
-export function renderRecallBlocks(blocks: RecallBlock[]): string {
+function messageContent(message: AgentMessage): string {
+  const content = projectMessage(message).content;
+  return typeof content === "string" ? content : JSON.stringify(content ?? "");
+}
+
+function isInjectedHindsightMemory(message: AgentMessage): boolean {
+  return messageContent(message).includes("<hindsight-memory>");
+}
+
+export function truncateRecallQuery(query: string, maxChars: number): string {
+  if (query.length <= maxChars) return query;
+  return query.slice(query.length - maxChars).trimStart();
+}
+
+export function composeRecallQuery(
+  messages: AgentMessage[],
+  policyOrRecentTurns: RecallQueryPolicy | number,
+): string {
+  const policy =
+    typeof policyOrRecentTurns === "number"
+      ? { roles: ["user"] as RecallRole[], contextTurns: policyOrRecentTurns, maxQueryChars: 800 }
+      : policyOrRecentTurns;
+  const allowedRoles = new Set<string>(policy.roles);
+  const selected = messages
+    .filter((message) => allowedRoles.has((message as unknown as { role?: string }).role ?? ""))
+    .filter((message) => !isInjectedHindsightMemory(message))
+    .slice(-Math.max(1, policy.contextTurns));
+  const query = selected
+    .map((message) => messageContent(message))
+    .join("\n\n")
+    .trim();
+  return query ? truncateRecallQuery(query, policy.maxQueryChars) : "current Pi coding task";
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`hindsight recall timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export function renderRecallBlocks(blocks: RecallBlock[], topK = 12): string {
   const nonEmpty = blocks.filter((block) => block.memoryCount > 0);
   if (nonEmpty.length === 0) return "";
   const lines = [
@@ -54,7 +97,7 @@ export function renderRecallBlocks(blocks: RecallBlock[]): string {
   ];
   for (const block of nonEmpty) {
     lines.push(`\nBank: ${block.bankId}`);
-    block.results.slice(0, 12).forEach((item, index) => {
+    block.results.slice(0, topK).forEach((item, index) => {
       const tags = item.tags?.length ? ` [${item.tags.join(", ")}]` : "";
       lines.push(`${index + 1}. ${itemText(item)}${tags}`);
     });
@@ -69,16 +112,23 @@ export async function recallForContext(args: {
   scopes: RecallScope[];
   messages: AgentMessage[];
 }): Promise<{ rendered: string; blocks: RecallBlock[] }> {
-  const query = composeRecallQuery(args.messages, args.config.recall.recentTurnsForQuery);
+  const query = composeRecallQuery(args.messages, {
+    roles: args.config.recall.roles,
+    contextTurns: args.config.recall.contextTurns,
+    maxQueryChars: args.config.recall.maxQueryChars,
+  });
   const blocks: RecallBlock[] = [];
   for (const scope of args.scopes) {
-    const response = await args.client.recall(scope.bankId, query, {
-      budget: args.config.recall.budget,
-      maxTokens: args.config.recall.maxTokens,
-      types: args.config.recall.types,
-      ...(scope.tags ? { tags: scope.tags } : {}),
-      ...(scope.tagsMatch ? { tagsMatch: scope.tagsMatch } : {}),
-    });
+    const response = await withTimeout(
+      args.client.recall(scope.bankId, query, {
+        budget: args.config.recall.budget,
+        maxTokens: args.config.recall.maxTokens,
+        types: args.config.recall.types,
+        ...(scope.tags ? { tags: scope.tags } : {}),
+        ...(scope.tagsMatch ? { tagsMatch: scope.tagsMatch } : {}),
+      }),
+      args.config.recall.timeoutMs,
+    );
     const results = textFromRecallResponse(response);
     blocks.push({
       bankId: scope.bankId,
@@ -88,6 +138,6 @@ export async function recallForContext(args: {
       rendered: "",
     });
   }
-  const rendered = renderRecallBlocks(blocks);
+  const rendered = renderRecallBlocks(blocks, args.config.recall.topK);
   return { rendered, blocks: blocks.map((block) => ({ ...block, rendered })) };
 }

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -4,6 +4,8 @@ export type AppendFallback = "error" | "per-turn-documents";
 export type TagsMatch = "any" | "all" | "any_strict" | "all_strict";
 export type StatusStyle = "off" | "text" | "emoji" | "nerdfont";
 export type StatusDetail = "minimal" | "project" | "activity" | "verbose";
+export type RecallRole = "user" | "assistant" | "tool" | "system";
+export type RecallInjectionPosition = "prepend" | "append";
 
 export interface ResolvedConfig {
   enabled: boolean;
@@ -18,7 +20,13 @@ export interface ResolvedConfig {
     maxTokens: number;
     types: string[];
     recentTurnsForQuery: number;
+    contextTurns: number;
+    roles: RecallRole[];
+    maxQueryChars: number;
+    topK: number;
+    timeoutMs: number;
     injectionMode: "context";
+    injectionPosition: RecallInjectionPosition;
     includeFactsInDebug: boolean;
   };
   retain: {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -38,7 +38,17 @@ describe("resolveConfig", () => {
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
-        recall: { budget: "huge", maxTokens: -1, types: ["world", 42] },
+        recall: {
+          budget: "huge",
+          maxTokens: -1,
+          types: ["world", 42],
+          contextTurns: 0,
+          roles: ["user", "alien"],
+          maxQueryChars: 0,
+          topK: -1,
+          timeoutMs: 0,
+          injectionPosition: "middle",
+        },
         retain: {
           includeToolResults: "sometimes",
           queuePath: "",
@@ -60,6 +70,12 @@ describe("resolveConfig", () => {
     expect(config.recall.budget).toBe("low");
     expect(config.recall.maxTokens).toBe(800);
     expect(config.recall.types).toEqual(["world", "experience", "observation"]);
+    expect(config.recall.contextTurns).toBe(2);
+    expect(config.recall.roles).toEqual(["user", "assistant"]);
+    expect(config.recall.maxQueryChars).toBe(800);
+    expect(config.recall.topK).toBe(8);
+    expect(config.recall.timeoutMs).toBe(10_000);
+    expect(config.recall.injectionPosition).toBe("prepend");
     expect(config.retain.appendFallback).toBe("error");
     expect(config.retain.includeToolResults).toBe("meaningful-only");
     expect(config.retain.queuePath).toBe(".pi/hindsight/retain-queue.jsonl");

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -178,6 +178,7 @@ describe("extension hooks", () => {
     const contextResult = await handlers.context?.[0]?.({ messages: original }, ctx);
 
     expect(contextResult.messages[0]).toEqual(original[0]);
+    expect(contextResult.messages[1].role).toBe("system");
     expect(contextResult.messages[1].content).toContain("<hindsight-memory>");
   });
 

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -135,7 +135,10 @@ describe("extension hooks", () => {
     expect(contextResult.messages[0].content).toContain("global-bank memory");
     expect(mocked.client.recall).toHaveBeenCalledTimes(2);
     expect(mocked.client.recall.mock.calls[0]?.[0]).toMatch(/^pi-project-/);
+    expect(mocked.client.recall.mock.calls[0]?.[1]).toBe("What do I know?");
     expect(mocked.client.recall.mock.calls[0]?.[2]).toMatchObject({
+      maxTokens: 800,
+      types: ["world", "experience", "observation"],
       tags: [expect.stringMatching(/^repo:/)],
       tagsMatch: "any_strict",
     });
@@ -144,6 +147,38 @@ describe("extension hooks", () => {
       tags: ["source:pi"],
       tagsMatch: "any_strict",
     });
+  });
+
+  it("honors append recall injection position", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({ recall: { injectionPosition: "append" } }),
+    );
+    const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
+    const pi = {
+      on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
+        handlers[name] = [...(handlers[name] ?? []), handler];
+      }),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+    };
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => join(cwd, "session.jsonl") },
+    };
+
+    const { default: hindsightExtension } = await import("../extensions/index.js");
+    hindsightExtension(pi as any);
+    await handlers.session_start?.[0]?.({}, ctx);
+    const original = [{ role: "user", content: "q", timestamp: 1 }];
+    const contextResult = await handlers.context?.[0]?.({ messages: original }, ctx);
+
+    expect(contextResult.messages[0]).toEqual(original[0]);
+    expect(contextResult.messages[1].content).toContain("<hindsight-memory>");
   });
 
   it("explicit retain keeps base tags when extra tags are provided", async () => {

--- a/tests/recall-format.test.ts
+++ b/tests/recall-format.test.ts
@@ -39,6 +39,20 @@ describe("recall formatting", () => {
     ).toBe("long suffix");
   });
 
+  it("keeps legitimate user mentions of the hindsight-memory token", () => {
+    const messages = [
+      { role: "user", content: "Please explain literal <hindsight-memory> tags", timestamp: 1 },
+    ] as unknown as AgentMessage[];
+
+    expect(
+      composeRecallQuery(messages, {
+        roles: ["user"],
+        contextTurns: 1,
+        maxQueryChars: 200,
+      }),
+    ).toBe("Please explain literal <hindsight-memory> tags");
+  });
+
   it("renders memory block", () => {
     const rendered = renderRecallBlocks([
       {

--- a/tests/recall-format.test.ts
+++ b/tests/recall-format.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { composeRecallQuery, renderRecallBlocks } from "../extensions/recall.js";
+import { composeRecallQuery, recallForContext, renderRecallBlocks } from "../extensions/recall.js";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 
 describe("recall formatting", () => {
@@ -21,6 +22,23 @@ describe("recall formatting", () => {
     expect(composeRecallQuery(messages, 1)).toBe("second");
   });
 
+  it("respects roles, context turns, max query chars, and ignores injected memory", () => {
+    const messages = [
+      { role: "user", content: "first user", timestamp: 1 },
+      { role: "assistant", content: "first assistant", timestamp: 2 },
+      { role: "user", content: "<hindsight-memory>old</hindsight-memory>", timestamp: 3 },
+      { role: "assistant", content: "second assistant with long suffix", timestamp: 4 },
+    ] as unknown as AgentMessage[];
+
+    expect(
+      composeRecallQuery(messages, {
+        roles: ["assistant"],
+        contextTurns: 1,
+        maxQueryChars: 12,
+      }),
+    ).toBe("long suffix");
+  });
+
   it("renders memory block", () => {
     const rendered = renderRecallBlocks([
       {
@@ -33,5 +51,40 @@ describe("recall formatting", () => {
     ]);
     expect(rendered).toContain("<hindsight-memory>");
     expect(rendered).toContain("Remember X");
+  });
+
+  it("limits rendered memories with topK", () => {
+    const rendered = renderRecallBlocks(
+      [
+        {
+          bankId: "b",
+          query: "q",
+          memoryCount: 2,
+          rendered: "",
+          results: [{ text: "one" }, { text: "two" }],
+        },
+      ],
+      1,
+    );
+    expect(rendered).toContain("one");
+    expect(rendered).not.toContain("two");
+  });
+
+  it("times out slow recall", async () => {
+    await expect(
+      recallForContext({
+        client: {
+          retain: async () => undefined,
+          recall: async () => new Promise(() => undefined),
+          reflect: async () => ({}),
+        },
+        config: {
+          ...DEFAULT_CONFIG,
+          recall: { ...DEFAULT_CONFIG.recall, timeoutMs: 5 },
+        },
+        scopes: [{ bankId: "b" }],
+        messages: [{ role: "user", content: "q", timestamp: 1 }] as unknown as AgentMessage[],
+      }),
+    ).rejects.toThrow(/timed out/);
   });
 });


### PR DESCRIPTION
## Summary
- add recall.roles, contextTurns, maxQueryChars, topK, timeoutMs, and injectionPosition config
- bound recall query composition and skip injected Hindsight memory in recall queries
- soft-timeout recall calls and degrade through existing lifecycle failure path
- expose recall controls in debug output and README
- harden a lock-owner write race seen during concurrent queue tests

## Verification
- npm run check
- npm run typecheck:tsc
