### PR TITLE
Add observation scope config

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Example project config:
     "timeoutMs": 10000,
     "injectionPosition": "prepend"
   },
+  "observations": {
+    "enabled": false,
+    "scopes": [["harness:pi"], ["repo:{repoKey}"]]
+  },
   "retain": {
     "queuePath": ".pi/hindsight/retain-queue.jsonl",
     "updateMode": "append",
@@ -153,6 +157,8 @@ Retain jobs are written to a JSONL queue before sending. If Hindsight is down, j
 Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs` and `retain.shutdownFlushTimeoutMs`. The timeout is a soft bound checked between queued jobs so shutdown does not leave a background flush holding the queue lock. If jobs remain after shutdown, they stay on disk and are visible through `/hindsight:debug` queue length for later flushing.
 
 At session start, the extension shows the selected bank ID. If no bank ID is configured, it reports the automatically derived bank ID and how to override it. Project and global banks can define `mission` text; configured missions are sent to Hindsight as both `reflectMission` and `retainMission` during bank ensure so extraction and reflection stay aligned with the bank purpose. If no mission is configured, Pi-specific default missions are used.
+
+Observation scope configuration is explicit under `observations`. The current implementation validates and expands scope placeholders for diagnostics and passes `observations.enabled` to bank ensure as Hindsight `enableObservations`; it does not invent unsupported retain request fields. Supported placeholders are `{repoKey}`, `{sessionId}`, `{cwdHash}`, and `{projectBankId}`.
 
 The footer status is configurable with two independent knobs:
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Example project config:
     "injectionPosition": "prepend"
   },
   "observations": {
-    "enabled": false,
+    "enabled": true,
     "scopes": [["harness:pi"], ["repo:{repoKey}"]]
   },
   "retain": {

--- a/extensions/bank-operations.ts
+++ b/extensions/bank-operations.ts
@@ -14,6 +14,7 @@ const DEFAULT_GLOBAL_RETAIN_MISSION =
 
 export interface BankMissionConfig {
   mission?: string;
+  enableObservations?: boolean;
 }
 
 export async function ensureProjectBank(
@@ -27,7 +28,7 @@ export async function ensureProjectBank(
     reflectMission: config.mission ?? DEFAULT_PROJECT_REFLECT_MISSION,
     retainMission: config.mission ?? DEFAULT_PROJECT_RETAIN_MISSION,
     retainExtractionMode: "concise",
-    enableObservations: true,
+    enableObservations: config.enableObservations ?? true,
   });
 }
 
@@ -42,6 +43,6 @@ export async function ensureGlobalBank(
     reflectMission: config.mission ?? DEFAULT_GLOBAL_REFLECT_MISSION,
     retainMission: config.mission ?? DEFAULT_GLOBAL_RETAIN_MISSION,
     retainExtractionMode: "concise",
-    enableObservations: true,
+    enableObservations: config.enableObservations ?? true,
   });
 }

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -25,7 +25,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
     includeFactsInDebug: false,
   },
   observations: {
-    enabled: false,
+    enabled: true,
     scopes: [["harness:pi"], ["repo:{repoKey}"]],
   },
   retain: {

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -24,6 +24,10 @@ const DEFAULT_CONFIG: ResolvedConfig = {
     injectionPosition: "prepend",
     includeFactsInDebug: false,
   },
+  observations: {
+    enabled: false,
+    scopes: [["harness:pi"], ["repo:{repoKey}"]],
+  },
   retain: {
     enabled: true,
     async: true,
@@ -103,6 +107,16 @@ function stringArray(value: unknown, fallback: string[]): string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string") ? value : fallback;
 }
 
+function stringMatrix(value: unknown, fallback: string[][]): string[][] {
+  return Array.isArray(value) &&
+    value.every(
+      (scope) =>
+        Array.isArray(scope) && scope.length > 0 && scope.every((item) => typeof item === "string"),
+    )
+    ? value
+    : fallback;
+}
+
 function enumArray<T extends string>(value: unknown, allowed: readonly T[], fallback: T[]): T[] {
   return Array.isArray(value) && value.every((item) => allowed.includes(item as T))
     ? (value as T[])
@@ -146,6 +160,10 @@ export function normalizeConfig(config: ResolvedConfig): ResolvedConfig {
           ? { mission: config.banks.global.mission }
           : {}),
       },
+    },
+    observations: {
+      enabled: bool(config.observations?.enabled, DEFAULT_CONFIG.observations.enabled),
+      scopes: stringMatrix(config.observations?.scopes, DEFAULT_CONFIG.observations.scopes),
     },
     recall: {
       enabled: bool(config.recall?.enabled, DEFAULT_CONFIG.recall.enabled),

--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -1,6 +1,8 @@
 import type { HindsightCapabilities, ResolvedConfig } from "./types.js";
 import { baseTags, findRepoRoot } from "./banking.js";
 import { stableSessionId } from "./session.js";
+import { createMemoryIdentity } from "./memory-identity.js";
+import { expandObservationScopes } from "./observation-scopes.js";
 import type { ImportManifestEntry } from "./import-manifest.js";
 import {
   formatHindsightActivity,
@@ -44,6 +46,18 @@ export function safeConfig(config: ResolvedConfig): ResolvedConfig {
 export function formatDebugReport(args: DebugReportArgs): string {
   const sessionId = stableSessionId(args.sessionFile, args.cwd);
   const tags = baseTags(args.cwd, sessionId);
+  const identity = {
+    ...createMemoryIdentity(args.cwd, args.config, args.sessionFile),
+    projectBankId: args.projectBankId,
+  };
+  let observationScopes: string[][] | { error: string } = [];
+  try {
+    observationScopes = args.config.observations.enabled
+      ? expandObservationScopes(args.config.observations.scopes, identity)
+      : [];
+  } catch (error) {
+    observationScopes = { error: error instanceof Error ? error.message : String(error) };
+  }
   const health = args.health
     ? args.health.ok
       ? "reachable"
@@ -65,6 +79,10 @@ export function formatDebugReport(args: DebugReportArgs): string {
       bankMissions: {
         projectConfigured: Boolean(args.config.banks.project.mission),
         globalConfigured: Boolean(args.config.banks.global.mission),
+      },
+      observations: {
+        enabled: args.config.observations.enabled,
+        scopes: observationScopes,
       },
       overrideProjectBankId:
         "Set PI_HINDSIGHT_PROJECT_BANK_ID or .pi/hindsight.json banks.project.bankId",

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -158,7 +158,10 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       if (!config.enabled) return;
       if (config.banks.project.enabled) {
         try {
-          await ensureProjectBank(client, projectBankId, config.banks.project);
+          await ensureProjectBank(client, projectBankId, {
+            ...config.banks.project,
+            enableObservations: config.observations.enabled,
+          });
         } catch (error) {
           setMemoryStatus(runtime, "recall-failed");
           notify(
@@ -170,7 +173,10 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       }
       if (config.banks.global.enabled && config.banks.global.bankId) {
         try {
-          await ensureGlobalBank(client, config.banks.global.bankId, config.banks.global);
+          await ensureGlobalBank(client, config.banks.global.bankId, {
+            ...config.banks.global,
+            enableObservations: config.observations.enabled,
+          });
         } catch (error) {
           setMemoryStatus(runtime, "recall-failed");
           notify(

--- a/extensions/observation-scopes.ts
+++ b/extensions/observation-scopes.ts
@@ -1,0 +1,57 @@
+import { createHash } from "node:crypto";
+import type { MemoryIdentity } from "./memory-identity.js";
+
+const PLACEHOLDER_PATTERN = /\{([a-zA-Z0-9_]+)\}/g;
+
+export type ObservationScopeIdentity = Pick<
+  MemoryIdentity,
+  "cwd" | "repoKey" | "sessionId" | "projectBankId"
+>;
+
+function cwdHash(cwd: string): string {
+  return createHash("sha256").update(cwd).digest("hex").slice(0, 12);
+}
+
+export function observationScopePlaceholders(
+  identity: ObservationScopeIdentity,
+): Record<string, string> {
+  return {
+    cwdHash: cwdHash(identity.cwd),
+    projectBankId: identity.projectBankId,
+    repoKey: identity.repoKey,
+    sessionId: identity.sessionId,
+  };
+}
+
+export function expandObservationScopeValue(
+  value: string,
+  identity: ObservationScopeIdentity,
+): string {
+  const placeholders = observationScopePlaceholders(identity);
+  return value.replace(PLACEHOLDER_PATTERN, (_match, key: string) => {
+    const replacement = placeholders[key];
+    if (!replacement) throw new Error(`Unknown observation scope placeholder: {${key}}`);
+    return replacement;
+  });
+}
+
+export function expandObservationScopes(
+  scopes: string[][],
+  identity: ObservationScopeIdentity,
+): string[][] {
+  const expanded = scopes.map((scope) => {
+    if (scope.length === 0) throw new Error("Observation scope entries must not be empty");
+    return scope.map((value) => {
+      const expandedValue = expandObservationScopeValue(value, identity).trim();
+      if (!expandedValue) throw new Error("Observation scope values must not be empty");
+      return expandedValue;
+    });
+  });
+  const seen = new Set<string>();
+  return expanded.filter((scope) => {
+    const key = JSON.stringify(scope);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/extensions/setup-tui.ts
+++ b/extensions/setup-tui.ts
@@ -34,6 +34,7 @@ function statusLines(config: ResolvedConfig, projectBankId: string): string[] {
     `project mission: ${config.banks.project.mission ? "configured" : "default"}`,
     `global: ${config.banks.global.enabled ? (config.banks.global.bankId ?? "enabled, no id") : "disabled"}`,
     `global mission: ${config.banks.global.mission ? "configured" : "default"}`,
+    `observations: ${config.observations.enabled ? "enabled" : "disabled"}, scopes=${config.observations.scopes.length}`,
     `recall: ${config.recall.enabled}, ${config.recall.budget}, ${config.recall.maxTokens} tokens`,
     `retain: ${config.retain.enabled}, async=${config.retain.async}, update=${config.retain.updateMode}`,
     `queuePath: ${config.retain.queuePath}`,

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -34,6 +34,10 @@ export interface ResolvedConfig {
     injectionPosition: RecallInjectionPosition;
     includeFactsInDebug: boolean;
   };
+  observations: {
+    enabled: boolean;
+    scopes: string[][];
+  };
   retain: {
     enabled: boolean;
     async: boolean;

--- a/tests/bank-operations.test.ts
+++ b/tests/bank-operations.test.ts
@@ -28,6 +28,16 @@ describe("bank operations", () => {
     );
   });
 
+  it("passes configured observation enablement", async () => {
+    const createBank = vi.fn(async () => undefined);
+    await ensureProjectBank(client(createBank), "project-bank", { enableObservations: false });
+
+    expect(createBank).toHaveBeenCalledWith(
+      "project-bank",
+      expect.objectContaining({ enableObservations: false }),
+    );
+  });
+
   it("uses configured global mission when global bank is ensured", async () => {
     const createBank = vi.fn(async () => undefined);
     await ensureGlobalBank(client(createBank), "global-bank", { mission: "Global mission" });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -53,6 +53,7 @@ describe("resolveConfig", () => {
           timeoutMs: 0,
           injectionPosition: "middle",
         },
+        observations: { enabled: true, scopes: [["repo:{repoKey}"], []] },
         retain: {
           includeToolResults: "sometimes",
           queuePath: "",
@@ -74,6 +75,8 @@ describe("resolveConfig", () => {
     expect(config.recall.budget).toBe("low");
     expect(config.recall.maxTokens).toBe(800);
     expect(config.recall.types).toEqual(["world", "experience", "observation"]);
+    expect(config.observations.enabled).toBe(true);
+    expect(config.observations.scopes).toEqual([["harness:pi"], ["repo:{repoKey}"]]);
     expect(config.recall.contextTurns).toBe(2);
     expect(config.recall.roles).toEqual(["user", "assistant"]);
     expect(config.recall.maxQueryChars).toBe(800);

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -49,8 +49,26 @@ describe("diagnostics", () => {
       appendFallback: "error",
     });
     expect(report.bankMissions).toEqual({ projectConfigured: false, globalConfigured: false });
+    expect(report.observations).toEqual({ enabled: false, scopes: [] });
     expect(report.overrideProjectBankId).toContain("PI_HINDSIGHT_PROJECT_BANK_ID");
     expect(report.tags).toEqual(expect.arrayContaining(["source:pi"]));
+  });
+
+  it("formats observation scope diagnostics", () => {
+    const report = JSON.parse(
+      formatDebugReport({
+        cwd: process.cwd(),
+        projectBankId: "bank",
+        config: {
+          ...DEFAULT_CONFIG,
+          observations: { enabled: true, scopes: [["repo:{repoKey}"], ["bank:{projectBankId}"]] },
+        },
+        queueLength: 0,
+      }),
+    ) as Record<string, any>;
+
+    expect(report.observations.enabled).toBe(true);
+    expect(report.observations.scopes).toEqual([[expect.stringMatching(/^repo:/)], ["bank:bank"]]);
   });
 
   it("formats append capability diagnostics", () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -49,7 +49,10 @@ describe("diagnostics", () => {
       appendFallback: "error",
     });
     expect(report.bankMissions).toEqual({ projectConfigured: false, globalConfigured: false });
-    expect(report.observations).toEqual({ enabled: false, scopes: [] });
+    expect(report.observations).toEqual({
+      enabled: true,
+      scopes: [["harness:pi"], [expect.stringMatching(/^repo:/)]],
+    });
     expect(report.overrideProjectBankId).toContain("PI_HINDSIGHT_PROJECT_BANK_ID");
     expect(report.tags).toEqual(expect.arrayContaining(["source:pi"]));
   });

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -152,7 +152,7 @@ describe("extension hooks", () => {
     expect(mocked.ensureGlobalBank).toHaveBeenCalledWith(
       mocked.client,
       "global-bank",
-      expect.objectContaining({ enabled: true, bankId: "global-bank", enableObservations: false }),
+      expect.objectContaining({ enabled: true, bankId: "global-bank", enableObservations: true }),
     );
   });
 

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -152,7 +152,7 @@ describe("extension hooks", () => {
     expect(mocked.ensureGlobalBank).toHaveBeenCalledWith(
       mocked.client,
       "global-bank",
-      expect.objectContaining({ enabled: true, bankId: "global-bank" }),
+      expect.objectContaining({ enabled: true, bankId: "global-bank", enableObservations: false }),
     );
   });
 

--- a/tests/observation-scopes.test.ts
+++ b/tests/observation-scopes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  expandObservationScopes,
+  observationScopePlaceholders,
+} from "../extensions/observation-scopes.js";
+
+const identity = {
+  cwd: "/repo/project",
+  repoKey: "abc123",
+  sessionId: "session-1",
+  projectBankId: "pi-project-abc123",
+};
+
+describe("observation scopes", () => {
+  it("expands supported placeholders deterministically", () => {
+    expect(
+      expandObservationScopes(
+        [
+          ["harness:pi"],
+          ["repo:{repoKey}"],
+          ["bank:{projectBankId}", "session:{sessionId}", "cwd:{cwdHash}"],
+        ],
+        identity,
+      ),
+    ).toEqual([
+      ["harness:pi"],
+      ["repo:abc123"],
+      [
+        "bank:pi-project-abc123",
+        "session:session-1",
+        `cwd:${observationScopePlaceholders(identity).cwdHash}`,
+      ],
+    ]);
+  });
+
+  it("deduplicates identical expanded scopes", () => {
+    expect(expandObservationScopes([["repo:{repoKey}"], ["repo:abc123"]], identity)).toEqual([
+      ["repo:abc123"],
+    ]);
+  });
+
+  it("rejects unknown placeholders", () => {
+    expect(() => expandObservationScopes([["user:{userId}"]], identity)).toThrow(
+      /Unknown observation scope placeholder/,
+    );
+  });
+
+  it("rejects empty scopes and values", () => {
+    expect(() => expandObservationScopes([], identity)).not.toThrow();
+    expect(() => expandObservationScopes([[]], identity)).toThrow(/must not be empty/);
+    expect(() => expandObservationScopes([["   "]], identity)).toThrow(/must not be empty/);
+  });
+});


### PR DESCRIPTION
## Summary
- add observations.enabled and observations.scopes config
- add deterministic observation scope placeholder expansion for repo/session/cwd/project bank identity
- show expanded observation scopes in debug output
- pass observations.enabled to Hindsight bank ensure as enableObservations without inventing retain request fields
- document supported placeholders and add tests

## Verification
- npm run check
- npm run typecheck:tsc
