### PR TITLE
Default recall for prompt caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ Example project config:
     }
   },
   "recall": {
-    "budget": "low",
+    "budget": "mid",
     "maxTokens": 800,
     "roles": ["user", "assistant"],
     "contextTurns": 2,
     "maxQueryChars": 800,
     "topK": 8,
     "timeoutMs": 10000,
-    "injectionPosition": "prepend"
+    "injectionPosition": "append"
   },
   "observations": {
     "enabled": true,
@@ -176,7 +176,7 @@ Example project config:
 
 ## Memory behavior
 
-Automatic recall runs in the `context` hook and injects an ephemeral `<hindsight-memory>` message into the provider context. Project bank recall is scoped by the current repo tag. If a global bank is enabled, global recall uses an explicit non-repo `source:pi` scope so cross-project memories can be found without requiring the current repo tag. Recall query composition is bounded by `recall.roles`, `recall.contextTurns`, and `recall.maxQueryChars`; slow recalls are bounded by `recall.timeoutMs`. `recall.topK` limits injected results per bank. The injected memory block is not written to the Pi transcript by this extension.
+Automatic recall runs in the `context` hook and injects an ephemeral `<hindsight-memory>` message into the provider context. Project bank recall is scoped by the current repo tag. If a global bank is enabled, global recall uses an explicit non-repo `source:pi` scope so cross-project memories can be found without requiring the current repo tag. Recall query composition is bounded by `recall.roles`, `recall.contextTurns`, and `recall.maxQueryChars`; slow recalls are bounded by `recall.timeoutMs`. `recall.topK` limits injected results per bank. The default recall budget is `mid`, and the default injection position is `append`: recall is inserted near the end of provider context, before the current user message when present, so fresh memory does not change the beginning of the provider prompt and break prompt caching. `prepend` remains configurable for users who explicitly prefer memory before the transcript, but it can reduce prompt-cache hits because every recalled block changes the prompt prefix. The injected memory block is not written to the Pi transcript by this extension.
 
 Automatic retain runs in the `agent_end` hook. It stores a structured JSON projection of new messages, not a summary. The retain projection is controlled by `retain.content`, `retain.toolFilter`, and `retain.strip`; defaults keep user/assistant text, assistant tool calls, and tool result errors while excluding recursive Hindsight tool output and noisy read/search results. The legacy `includeToolResults` option remains as a compatibility shorthand for tool result content. Live sessions use stable `documentId` values and `updateMode: "append"`. On startup, the extension probes append support with a deterministic `pi-hindsight-capability:append:<bank>` document tagged `test:capability` and `feature:append-probe`. If append is known unsupported, `retain.appendFallback: "error"` refuses retain clearly; `"per-turn-documents"` uses deterministic per-delta document IDs with `updateMode: "replace"` to avoid overwriting earlier turns. A persisted retain cursor under `.pi/hindsight/retain-cursors.json` prevents duplicate appends when Pi provides overlapping transcripts, including after extension restart. Explicit retain tool tags are merged with the base `source:pi`, repo, and session tags so manually retained memories remain visible to default project recall. Per-session governance is stored outside provider-visible messages under `.pi/hindsight/session-meta/`. `/hindsight:mode normal|read-only|ignored` controls whether a session recalls and/or retains memory, `/hindsight:retain on|off` toggles retain for the session, and `/hindsight:tag add|remove <tag>` merges manual tags into automatic retain jobs.
 

--- a/docs/next-changes-plan.md
+++ b/docs/next-changes-plan.md
@@ -554,7 +554,7 @@ Add config:
     "maxQueryChars": 800,
     "topK": 8,
     "timeoutMs": 10000,
-    "injectionPosition": "prepend"
+    "injectionPosition": "append"
   }
 }
 ```
@@ -1914,7 +1914,7 @@ Roadmap impact:
 
 ### 3. Stop prepending by default; protect prompt caching
 
-This is the strongest actionable criticism. Prepending fresh recall before existing context changes the early prompt prefix every turn and can damage provider prompt caching. Current default `recall.injectionPosition = "prepend"` should change.
+This is the strongest actionable criticism. Prepending fresh recall before existing context changes the early prompt prefix every turn and can damage provider prompt caching. The previous default `recall.injectionPosition = "prepend"` should change to `append`.
 
 Decision:
 

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -11,7 +11,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
   },
   recall: {
     enabled: true,
-    budget: "low",
+    budget: "mid",
     maxTokens: 800,
     types: ["world", "experience", "observation"],
     recentTurnsForQuery: 2,
@@ -21,7 +21,7 @@ const DEFAULT_CONFIG: ResolvedConfig = {
     topK: 8,
     timeoutMs: 10_000,
     injectionMode: "context",
-    injectionPosition: "prepend",
+    injectionPosition: "append",
     includeFactsInDebug: false,
   },
   observations: {

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -245,7 +245,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           if (last && lastRole === "user") {
             return { messages: [...event.messages.slice(0, -1), recallMessage, last] };
           }
-          return { messages: [...event.messages, recallMessage] };
+          return undefined;
         }
         return { messages: [recallMessage, ...event.messages] };
       } catch {

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -235,16 +235,19 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
         }
         if (!rendered) return undefined;
         const recallMessage = {
-          role: config.recall.injectionPosition === "append" ? "system" : "user",
+          role: "user",
           content: rendered,
           timestamp: Date.now(),
         } as AgentMessage;
-        return {
-          messages:
-            config.recall.injectionPosition === "append"
-              ? [...event.messages, recallMessage]
-              : [recallMessage, ...event.messages],
-        };
+        if (config.recall.injectionPosition === "append") {
+          const last = event.messages[event.messages.length - 1];
+          const lastRole = (last as unknown as { role?: string } | undefined)?.role;
+          if (last && lastRole === "user") {
+            return { messages: [...event.messages.slice(0, -1), recallMessage, last] };
+          }
+          return { messages: [...event.messages, recallMessage] };
+        }
+        return { messages: [recallMessage, ...event.messages] };
       } catch {
         setMemoryStatus(runtime, "recall-failed");
         return undefined;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -73,7 +73,7 @@ describe("resolveConfig", () => {
     );
 
     const config = resolveConfig(cwd);
-    expect(config.recall.budget).toBe("low");
+    expect(config.recall.budget).toBe("mid");
     expect(config.recall.maxTokens).toBe(800);
     expect(config.recall.types).toEqual(["world", "experience", "observation"]);
     expect(config.observations.enabled).toBe(true);
@@ -83,7 +83,7 @@ describe("resolveConfig", () => {
     expect(config.recall.maxQueryChars).toBe(800);
     expect(config.recall.topK).toBe(8);
     expect(config.recall.timeoutMs).toBe(10_000);
-    expect(config.recall.injectionPosition).toBe("prepend");
+    expect(config.recall.injectionPosition).toBe("append");
     expect(config.retain.appendFallback).toBe("error");
     expect(config.retain.includeToolResults).toBe("meaningful-only");
     expect(config.retain.content.toolResult).toEqual(["error"]);

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -228,6 +228,41 @@ describe("extension hooks", () => {
     expect(contextResult.messages.at(-1)).toEqual(original[0]);
   });
 
+  it("does not append synthetic recall when transcript does not end with user", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi"));
+    const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
+    const pi = {
+      on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
+        handlers[name] = [...(handlers[name] ?? []), handler];
+      }),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+    };
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => join(cwd, "session.jsonl") },
+    };
+
+    const { default: hindsightExtension } = await import("../extensions/index.js");
+    hindsightExtension(pi as any);
+    await handlers.session_start?.[0]?.({}, ctx);
+    const contextResult = await handlers.context?.[0]?.(
+      {
+        messages: [
+          { role: "user", content: "Use tools", timestamp: 1 },
+          { role: "assistant", content: "Calling tool", timestamp: 2 },
+          { role: "toolResult", content: "tool output", timestamp: 3 },
+        ],
+      },
+      ctx,
+    );
+
+    expect(contextResult).toBeUndefined();
+  });
+
   it("ensures global bank even when project bank is disabled", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -40,7 +40,7 @@ describe("extension hooks", () => {
     mocked.client.retain.mockImplementation(async (..._args: unknown[]) => undefined);
   });
 
-  it("prepends recalled memory in context and keeps that block out of retained transcript content", async () => {
+  it("appends recalled memory before current user by default and keeps that block out of retained transcript content", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
@@ -70,19 +70,22 @@ describe("extension hooks", () => {
     await handlers.session_start?.[0]?.({}, ctx);
     mocked.client.retain.mockClear();
     const originalMessages = [
+      { role: "assistant", content: "Earlier context", timestamp: Date.now() - 1 },
       { role: "user", content: "What did we decide?", timestamp: Date.now() },
     ];
     const contextResult = await handlers.context?.[0]?.({ messages: originalMessages }, ctx);
 
-    expect(contextResult.messages[0].content).toContain("<hindsight-memory>");
-    expect(contextResult.messages[0].content).toContain("repo-specific remembered fact");
-    expect(contextResult.messages.slice(1)).toEqual(originalMessages);
+    expect(contextResult.messages[0]).toEqual(originalMessages[0]);
+    expect(contextResult.messages[1].role).toBe("user");
+    expect(contextResult.messages[1].content).toContain("<hindsight-memory>");
+    expect(contextResult.messages[1].content).toContain("repo-specific remembered fact");
+    expect(contextResult.messages.at(-1)).toEqual(originalMessages[1]);
 
     await handlers.agent_end?.[0]?.(
       {
         messages: [
-          contextResult.messages[0],
           ...originalMessages,
+          contextResult.messages[1],
           { role: "assistant", content: "Decision still stands.", timestamp: Date.now() },
         ],
       },
@@ -135,7 +138,9 @@ describe("extension hooks", () => {
       ctx,
     );
 
+    expect(contextResult.messages[0].role).toBe("user");
     expect(contextResult.messages[0].content).toContain("global-bank memory");
+    expect(contextResult.messages.at(-1).content).toBe("What do I know?");
     expect(mocked.client.recall).toHaveBeenCalledTimes(2);
     expect(mocked.client.recall.mock.calls[0]?.[0]).toMatch(/^pi-project-/);
     expect(mocked.client.recall.mock.calls[0]?.[1]).toBe("What do I know?");
@@ -157,7 +162,40 @@ describe("extension hooks", () => {
     );
   });
 
-  it("honors append recall injection position", async () => {
+  it("honors explicit prepend recall injection position with user role", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({ recall: { injectionPosition: "prepend" } }),
+    );
+    const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
+    const pi = {
+      on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
+        handlers[name] = [...(handlers[name] ?? []), handler];
+      }),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+    };
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => join(cwd, "session.jsonl") },
+    };
+
+    const { default: hindsightExtension } = await import("../extensions/index.js");
+    hindsightExtension(pi as any);
+    await handlers.session_start?.[0]?.({}, ctx);
+    const original = [{ role: "user", content: "q", timestamp: 1 }];
+    const contextResult = await handlers.context?.[0]?.({ messages: original }, ctx);
+
+    expect(contextResult.messages[0].role).toBe("user");
+    expect(contextResult.messages[0].content).toContain("<hindsight-memory>");
+    expect(contextResult.messages[1]).toEqual(original[0]);
+  });
+
+  it("honors explicit append recall injection position", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
@@ -185,9 +223,9 @@ describe("extension hooks", () => {
     const original = [{ role: "user", content: "q", timestamp: 1 }];
     const contextResult = await handlers.context?.[0]?.({ messages: original }, ctx);
 
-    expect(contextResult.messages[0]).toEqual(original[0]);
-    expect(contextResult.messages[1].role).toBe("system");
-    expect(contextResult.messages[1].content).toContain("<hindsight-memory>");
+    expect(contextResult.messages[0].role).toBe("user");
+    expect(contextResult.messages[0].content).toContain("<hindsight-memory>");
+    expect(contextResult.messages.at(-1)).toEqual(original[0]);
   });
 
   it("ensures global bank even when project bank is disabled", async () => {
@@ -333,7 +371,9 @@ describe("extension hooks", () => {
       { messages: [{ role: "user", content: "q", timestamp: 1 }] },
       ctx,
     );
+    expect(recall.messages[0].role).toBe("user");
     expect(recall.messages[0].content).toContain("<hindsight-memory>");
+    expect(recall.messages.at(-1).content).toBe("q");
     await handlers.agent_end?.[0]?.(
       { messages: [{ role: "user", content: "remember", timestamp: 1 }] },
       ctx,


### PR DESCRIPTION
## Summary
- change default recall budget from low to mid
- change default recall injection from prepend to append
- append recall before the current user message when possible so provider-visible current user remains final
- keep explicit prepend and append options configurable
- document prompt-cache rationale and warn about prepend

## Reviewer
- pre-PR reviewer found appended system-role recall would be dropped by Pi provider serialization
- fixed by using provider-visible user-role recall and inserting before the final user message
- second reviewer pass found no blockers

## Verification
- npm run check
- npm run typecheck:tsc
