### PR TITLE
Harden session governance recovery

### DIFF
--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -266,7 +266,16 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
         await readSessionMemoryMeta(runtime.cwd, runtime.sessionFile),
       );
       if (!sessionMemory.retain) {
-        await markRetainedMessages(runtime, event.messages);
+        try {
+          await markRetainedMessages(runtime, event.messages);
+        } catch (error) {
+          setMemoryStatus(runtime, "retain-failed");
+          notify(
+            runtime,
+            `Hindsight retain cursor update failed: ${(error as Error).message}`,
+            "warning",
+          );
+        }
         return { queued: false, sent: 0, remaining: 0 };
       }
       const messages = await newRetainMessages(runtime, event.messages);

--- a/extensions/session-memory-meta.ts
+++ b/extensions/session-memory-meta.ts
@@ -168,7 +168,13 @@ export async function setSessionMemoryMode(
   mode: SessionMemoryMode,
 ): Promise<HindsightSessionMeta> {
   const meta = await readSessionMemoryMeta(cwd, sessionFile);
-  return writeSessionMemoryMeta(cwd, sessionFile, { ...meta, mode });
+  const updates: Partial<HindsightSessionMeta> = { mode };
+  if (mode === "normal" || mode === "read-only") updates.recallMode = "normal";
+  if (mode === "normal") {
+    updates.retained = true;
+    updates.retainMode = "normal";
+  }
+  return writeSessionMemoryMeta(cwd, sessionFile, { ...meta, ...updates });
 }
 
 export async function setSessionRetainEnabled(

--- a/extensions/session-memory-meta.ts
+++ b/extensions/session-memory-meta.ts
@@ -170,7 +170,12 @@ export async function setSessionMemoryMode(
   const meta = await readSessionMemoryMeta(cwd, sessionFile);
   const updates: Partial<HindsightSessionMeta> = { mode };
   if (mode === "normal" || mode === "read-only") updates.recallMode = "normal";
-  if (mode === "normal") {
+  const looksFailClosed =
+    meta.mode === "ignored" &&
+    meta.recallMode === "off" &&
+    meta.retainMode === "off" &&
+    !meta.retained;
+  if (mode === "normal" && looksFailClosed) {
     updates.retained = true;
     updates.retainMode = "normal";
   }

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -426,6 +426,42 @@ describe("extension hooks", () => {
     expect(retainCalls[0]?.[2]).toMatchObject({ tags: expect.arrayContaining(["domain:test"]) });
   });
 
+  it("does not reject when skipped-message cursor update fails", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi", "hindsight"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "hindsight", "retain-cursors.json"), "not json");
+    const sessionFile = join(cwd, "session.jsonl");
+    await setSessionMemoryMode(cwd, sessionFile, "read-only");
+    const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
+    const pi = {
+      on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
+        handlers[name] = [...(handlers[name] ?? []), handler];
+      }),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+    };
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => sessionFile },
+    };
+    const { default: hindsightExtension } = await import("../extensions/index.js");
+    hindsightExtension(pi as any);
+    await handlers.session_start?.[0]?.({}, ctx);
+
+    await expect(
+      handlers.agent_end?.[0]?.(
+        { messages: [{ role: "user", content: "private", timestamp: 1 }] },
+        ctx,
+      ),
+    ).resolves.toBeUndefined();
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("Hindsight retain cursor update failed"),
+      "warning",
+    );
+  });
+
   it("does not later retain overlapping messages skipped while read-only", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));

--- a/tests/session-memory-meta.test.ts
+++ b/tests/session-memory-meta.test.ts
@@ -106,6 +106,22 @@ describe("session memory metadata", () => {
     });
   });
 
+  it("preserves explicit retain off when switching modes back to normal", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-meta-"));
+
+    await setSessionRetainEnabled(cwd, "/tmp/session.jsonl", false);
+    await setSessionMemoryMode(cwd, "/tmp/session.jsonl", "read-only");
+    await setSessionMemoryMode(cwd, "/tmp/session.jsonl", "normal");
+
+    expect(
+      getEffectiveSessionMemoryMode(await readSessionMemoryMeta(cwd, "/tmp/session.jsonl")),
+    ).toMatchObject({
+      mode: "normal",
+      recall: true,
+      retain: false,
+    });
+  });
+
   it("adds and removes sanitized tags", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-meta-"));
     await addSessionMemoryTag(cwd, undefined, " domain:test ");

--- a/tests/session-memory-meta.test.ts
+++ b/tests/session-memory-meta.test.ts
@@ -74,6 +74,38 @@ describe("session memory metadata", () => {
     });
   });
 
+  it("restores recall and retain defaults when switching fail-closed metadata to normal", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-meta-"));
+    const path = sessionMetaPath(cwd, "/tmp/session.jsonl");
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, "not json");
+
+    await setSessionMemoryMode(cwd, "/tmp/session.jsonl", "normal");
+
+    expect(
+      getEffectiveSessionMemoryMode(await readSessionMemoryMeta(cwd, "/tmp/session.jsonl")),
+    ).toMatchObject({
+      mode: "normal",
+      recall: true,
+      retain: true,
+    });
+  });
+
+  it("restores retain defaults when switching ignored mode to normal", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-meta-"));
+
+    await setSessionMemoryMode(cwd, "/tmp/session.jsonl", "ignored");
+    await setSessionMemoryMode(cwd, "/tmp/session.jsonl", "normal");
+
+    expect(
+      getEffectiveSessionMemoryMode(await readSessionMemoryMeta(cwd, "/tmp/session.jsonl")),
+    ).toMatchObject({
+      mode: "normal",
+      recall: true,
+      retain: true,
+    });
+  });
+
   it("adds and removes sanitized tags", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-meta-"));
     await addSessionMemoryTag(cwd, undefined, " domain:test ");


### PR DESCRIPTION
## Summary
- catch skipped-message cursor update failures when retain is disabled by session governance
- restore recall defaults when switching session mode back to normal/read-only
- make /hindsight:mode normal restore retain defaults so fail-closed sidecars can recover without manual edits
- add regression tests for both late Codex PR #8 findings

## Context
Late Codex comments landed on merged PR #8 seconds after merge. This follow-up fixes both reported issues before the next roadmap PR.

## Verification
- npm run check
- npm run typecheck:tsc
