### PR TITLE
Pass retain observation scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs
 
 At session start, the extension shows the selected bank ID. If no bank ID is configured, it reports the automatically derived bank ID and how to override it. Project and global banks can define `mission` text; configured missions are sent to Hindsight as both `reflectMission` and `retainMission` during bank ensure so extraction and reflection stay aligned with the bank purpose. If no mission is configured, Pi-specific default missions are used.
 
-Observation scope configuration is explicit under `observations`. The current implementation validates and expands scope placeholders for diagnostics and passes `observations.enabled` to bank ensure as Hindsight `enableObservations`; it does not invent unsupported retain request fields. Supported placeholders are `{repoKey}`, `{sessionId}`, `{cwdHash}`, and `{projectBankId}`.
+Observation scope configuration is explicit under `observations`. The extension validates and expands scope placeholders for diagnostics, passes `observations.enabled` to bank ensure as Hindsight `enableObservations`, and stores expanded scopes on queued retain jobs so retries preserve the scope policy active when the job was created. The official Hindsight client exposes retain observation scopes through batch retain; the adapter uses that path only when scopes are present. Supported placeholders are `{repoKey}`, `{sessionId}`, `{cwdHash}`, and `{projectBankId}`.
 
 The footer status is configurable with two independent knobs:
 

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -30,7 +30,33 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
   });
   const timeoutMs = config.hindsight.timeoutMs;
   return {
-    retain: (...args) => withTimeout(raw.retain(...args), timeoutMs, "hindsight retain"),
+    retain: (bankId, content, options) => {
+      if (options?.observationScopes?.length) {
+        return withTimeout(
+          raw.retainBatch(
+            bankId,
+            [
+              {
+                content,
+                ...(options.timestamp ? { timestamp: options.timestamp } : {}),
+                ...(options.context ? { context: options.context } : {}),
+                ...(options.metadata ? { metadata: options.metadata } : {}),
+                ...(options.documentId ? { document_id: options.documentId } : {}),
+                ...(options.tags ? { tags: options.tags } : {}),
+                observation_scopes: options.observationScopes,
+                ...(options.updateMode ? { update_mode: options.updateMode } : {}),
+              },
+            ],
+            options.async !== undefined ? { async: options.async } : {},
+          ),
+          timeoutMs,
+          "hindsight retain",
+        );
+      }
+      return withTimeout(raw.retain(bankId, content, options), timeoutMs, "hindsight retain");
+    },
+    retainBatch: (...args) =>
+      withTimeout(raw.retainBatch(...args), timeoutMs, "hindsight retainBatch"),
     recall: (...args) => withTimeout(raw.recall(...args), timeoutMs, "hindsight recall"),
     reflect: (...args) => withTimeout(raw.reflect(...args), timeoutMs, "hindsight reflect"),
     createBank: (...args) =>

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -209,6 +209,7 @@ export async function flushRetainQueue(
           ...(job.item.metadata ? { metadata: job.item.metadata } : {}),
           ...(job.item.async !== undefined ? { async: job.item.async } : {}),
           ...(job.item.tags ? { tags: job.item.tags } : {}),
+          ...(job.item.observationScopes ? { observationScopes: job.item.observationScopes } : {}),
           documentId: job.documentId,
           updateMode: job.updateMode,
         });

--- a/extensions/retain.ts
+++ b/extensions/retain.ts
@@ -12,6 +12,8 @@ import { redactSecrets } from "./sanitize.js";
 import { contextLabel, liveDocumentId, stableSessionId } from "./session.js";
 import { enqueueRetainJob, flushRetainQueue, resolveQueuePath } from "./queue.js";
 import { resolveRetainDocumentTarget } from "./capabilities.js";
+import { createMemoryIdentity } from "./memory-identity.js";
+import { expandObservationScopes } from "./observation-scopes.js";
 
 export function buildRetainJob(args: {
   config: ResolvedConfig;
@@ -28,6 +30,13 @@ export function buildRetainJob(args: {
     ? redactSecrets(JSON.stringify(projected, null, 2))
     : JSON.stringify(projected, null, 2);
   const sessionId = stableSessionId(args.sessionFile, args.cwd);
+  const identity = createMemoryIdentity(args.cwd, args.config, args.sessionFile);
+  const observationScopes = args.config.observations.enabled
+    ? expandObservationScopes(args.config.observations.scopes, {
+        ...identity,
+        projectBankId: args.bankId,
+      })
+    : [];
   const baseDocumentId = liveDocumentId(args.sessionFile, args.cwd);
   const target = resolveRetainDocumentTarget({
     config: args.config,
@@ -53,6 +62,7 @@ export function buildRetainJob(args: {
         imported: "false",
         ...(args.sessionFile ? { pi_session_file: args.sessionFile } : {}),
       },
+      ...(observationScopes.length ? { observationScopes } : {}),
     },
     retries: 0,
   };

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -119,6 +119,7 @@ export interface RetainJob {
     async?: boolean;
     tags?: string[];
     metadata?: Record<string, string>;
+    observationScopes?: string[][];
   };
   retries: number;
   lastError?: string;
@@ -145,7 +146,23 @@ export interface HindsightLikeClient {
       async?: boolean;
       tags?: string[];
       updateMode?: UpdateMode;
+      observationScopes?: string[][];
     },
+  ): Promise<unknown>;
+  retainBatch?(
+    bankId: string,
+    items: Array<{
+      content: string;
+      timestamp?: Date | string;
+      context?: string;
+      metadata?: Record<string, string>;
+      document_id?: string;
+      entities?: Array<{ text: string; type?: string }>;
+      tags?: string[];
+      observation_scopes?: string[][];
+      update_mode?: UpdateMode;
+    }>,
+    options?: { documentId?: string; documentTags?: string[]; async?: boolean },
   ): Promise<unknown>;
   recall(
     bankId: string,

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -85,6 +85,13 @@ describe("Hindsight client adapter integration", () => {
       async: true,
       metadata: { source: "test" },
     });
+    await client.retain("test-bank", "scoped content", {
+      context: "scoped ctx",
+      tags: ["source:pi"],
+      documentId: "pi-session:scoped",
+      updateMode: "append",
+      observationScopes: [["repo:abc"], ["bank:test-bank"]],
+    });
     const recall = await client.recall("test-bank", "query", {
       tags: ["source:pi"],
       tagsMatch: "any_strict",
@@ -98,6 +105,7 @@ describe("Hindsight client adapter integration", () => {
 
     expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
       "PUT /v1/default/banks/test-bank",
+      "POST /v1/default/banks/test-bank/memories",
       "POST /v1/default/banks/test-bank/memories",
       "POST /v1/default/banks/test-bank/memories/recall",
       "POST /v1/default/banks/test-bank/reflect",
@@ -117,6 +125,19 @@ describe("Hindsight client adapter integration", () => {
       async: true,
     });
     expect(requests[2]?.body).toMatchObject({
+      items: [
+        {
+          content: "scoped content",
+          context: "scoped ctx",
+          document_id: "pi-session:scoped",
+          update_mode: "append",
+          tags: ["source:pi"],
+          observation_scopes: [["repo:abc"], ["bank:test-bank"]],
+        },
+      ],
+    });
+    expect(JSON.stringify(requests[2]?.body)).not.toContain("observationScopes");
+    expect(requests[3]?.body).toMatchObject({
       query: "query",
       max_tokens: 123,
       budget: "low",

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -74,6 +74,25 @@ describe("retain queue", () => {
     expect(calls[0]).toMatchObject(["b", "raw", { async: true }]);
   });
 
+  it("forwards queued observation scopes to retain", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    await enqueueRetainJob(path, {
+      ...job,
+      item: { ...job.item, observationScopes: [["repo:abc"], ["bank:b"]] },
+    });
+    const calls: unknown[] = [];
+
+    await flushRetainQueue(path, {
+      retain: async (...args: unknown[]) => {
+        calls.push(args);
+      },
+      recall: async () => [],
+      reflect: async () => ({}),
+    });
+
+    expect(calls[0]).toMatchObject(["b", "raw", { observationScopes: [["repo:abc"], ["bank:b"]] }]);
+  });
+
   it("moves exhausted failed jobs to the dead-letter queue", async () => {
     const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
     await enqueueRetainJob(path, job);

--- a/tests/retain.test.ts
+++ b/tests/retain.test.ts
@@ -26,6 +26,24 @@ describe("buildRetainJob", () => {
     expect(JSON.parse(job?.item.content ?? "[]")[0].role).toBe("user");
   });
 
+  it("expands observation scopes into retain jobs", () => {
+    const messages = [
+      { role: "user", content: "remember", timestamp: Date.now() },
+    ] as unknown as AgentEndEvent["messages"];
+    const job = buildRetainJob({
+      config: {
+        ...DEFAULT_CONFIG,
+        observations: { enabled: true, scopes: [["repo:{repoKey}"], ["bank:{projectBankId}"]] },
+      },
+      cwd: "/repo",
+      sessionFile: "/tmp/s.jsonl",
+      bankId: "bank",
+      messages,
+    });
+
+    expect(job?.item.observationScopes).toEqual([[expect.stringMatching(/^repo:/)], ["bank:bank"]]);
+  });
+
   it("excludes noisy and recursive tool results by default but keeps errors", () => {
     const messages = [
       { role: "assistant", content: "Running tools", timestamp: Date.now() },


### PR DESCRIPTION
## Summary
- expand configured observation scopes at retain-job build time
- persist expanded scopes in queued retain jobs so retries preserve the original policy
- forward scopes during queue flush
- map internal observationScopes to official Hindsight retainBatch observation_scopes when scopes are present
- document supported placeholders and queue-time behavior

## Reviewer
- pre-PR reviewer confirmed official client support via retainBatch and found no blockers
- quick wins applied: integration assertion for snake_case request fields and empty-scope guard

## Verification
- npm run check
- npm run typecheck:tsc
