### PR TITLE
Use retainBatch transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs
 
 At session start, the extension shows the selected bank ID. If no bank ID is configured, it reports the automatically derived bank ID and how to override it. Project and global banks can define `mission` text; configured missions are sent to Hindsight as both `reflectMission` and `retainMission` during bank ensure so extraction and reflection stay aligned with the bank purpose. If no mission is configured, Pi-specific default missions are used.
 
-Observation scope configuration is explicit under `observations`. The extension validates and expands scope placeholders for diagnostics, passes `observations.enabled` to bank ensure as Hindsight `enableObservations`, and stores expanded scopes on queued retain jobs so retries preserve the scope policy active when the job was created. The official Hindsight client exposes retain observation scopes through batch retain; the adapter uses that path only when scopes are present. Supported placeholders are `{repoKey}`, `{sessionId}`, `{cwdHash}`, and `{projectBankId}`.
+Observation scope configuration is explicit under `observations`. The extension validates and expands scope placeholders for diagnostics, passes `observations.enabled` to bank ensure as Hindsight `enableObservations`, and stores expanded scopes on queued retain jobs so retries preserve the scope policy active when the job was created. The official Hindsight client exposes retain observation scopes through batch retain, so the adapter standardizes all retain writes on `retainBatch()`. Supported placeholders are `{repoKey}`, `{sessionId}`, `{cwdHash}`, and `{projectBankId}`.
 
 The footer status is configurable with two independent knobs:
 

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -30,31 +30,29 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
   });
   const timeoutMs = config.hindsight.timeoutMs;
   return {
-    retain: (bankId, content, options) => {
-      if (options?.observationScopes?.length) {
-        return withTimeout(
-          raw.retainBatch(
-            bankId,
-            [
-              {
-                content,
-                ...(options.timestamp ? { timestamp: options.timestamp } : {}),
-                ...(options.context ? { context: options.context } : {}),
-                ...(options.metadata ? { metadata: options.metadata } : {}),
-                ...(options.documentId ? { document_id: options.documentId } : {}),
-                ...(options.tags ? { tags: options.tags } : {}),
-                observation_scopes: options.observationScopes,
-                ...(options.updateMode ? { update_mode: options.updateMode } : {}),
-              },
-            ],
-            options.async !== undefined ? { async: options.async } : {},
-          ),
-          timeoutMs,
-          "hindsight retain",
-        );
-      }
-      return withTimeout(raw.retain(bankId, content, options), timeoutMs, "hindsight retain");
-    },
+    retain: (bankId, content, options) =>
+      withTimeout(
+        raw.retainBatch(
+          bankId,
+          [
+            {
+              content,
+              ...(options?.timestamp ? { timestamp: options.timestamp } : {}),
+              ...(options?.context ? { context: options.context } : {}),
+              ...(options?.metadata ? { metadata: options.metadata } : {}),
+              ...(options?.documentId ? { document_id: options.documentId } : {}),
+              ...(options?.tags ? { tags: options.tags } : {}),
+              ...(options?.observationScopes?.length
+                ? { observation_scopes: options.observationScopes }
+                : {}),
+              ...(options?.updateMode ? { update_mode: options.updateMode } : {}),
+            },
+          ],
+          options?.async !== undefined ? { async: options.async } : {},
+        ),
+        timeoutMs,
+        "hindsight retain",
+      ),
     retainBatch: (...args) =>
       withTimeout(raw.retainBatch(...args), timeoutMs, "hindsight retainBatch"),
     recall: (...args) => withTimeout(raw.recall(...args), timeoutMs, "hindsight recall"),

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -124,6 +124,7 @@ describe("Hindsight client adapter integration", () => {
       ],
       async: true,
     });
+    expect(JSON.stringify(requests[1]?.body)).not.toContain("observation_scopes");
     expect(requests[2]?.body).toMatchObject({
       items: [
         {


### PR DESCRIPTION
## Summary
- route all client retain writes through official Hindsight retainBatch
- keep single-item retain API at extension boundary
- omit observation_scopes when no scopes are configured
- preserve document_id, update_mode, async, metadata, tags, and timeout behavior
- update docs to describe retainBatch transport standardization

## Reviewer
- reviewer found no blockers
- noted timeout label remains public operation label: hindsight retain

## Verification
- npm run check
- npm run typecheck:tsc
