### PR TITLE
Harden retain queue durability

### DIFF
--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { appendFile, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 import type { HindsightLikeClient, RetainJob } from "./types.js";
@@ -17,24 +18,36 @@ export const RETAIN_QUEUE_LOCK = {
 export interface QueueLockOwner {
   pid?: number;
   acquiredAt?: string;
+  token?: string;
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function writeQueueLockOwner(lockPath: string): Promise<void> {
-  await writeFile(
-    `${lockPath}/owner`,
-    JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() }),
-    "utf8",
-  );
+async function writeQueueHeartbeat(lockPath: string, token: string): Promise<void> {
+  const heartbeatPath = `${lockPath}/heartbeat-${token}`;
+  const tmpPath = `${heartbeatPath}.${process.pid}.tmp`;
+  await writeFile(tmpPath, new Date().toISOString(), "utf8");
+  await rename(tmpPath, heartbeatPath);
 }
 
-function startQueueLockHeartbeat(lockPath: string): NodeJS.Timeout {
+async function writeQueueLockOwner(lockPath: string, token: string): Promise<void> {
+  const ownerPath = `${lockPath}/owner`;
+  const tmpPath = `${ownerPath}.${process.pid}.${token}.tmp`;
+  await writeFile(
+    tmpPath,
+    JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), token }),
+    "utf8",
+  );
+  await rename(tmpPath, ownerPath);
+  await writeQueueHeartbeat(lockPath, token);
+}
+
+function startQueueLockHeartbeat(lockPath: string, token: string): NodeJS.Timeout {
   const heartbeatMs = Math.max(1, Math.min(5_000, Math.floor(RETAIN_QUEUE_LOCK.staleMs / 2)));
   const heartbeat = setInterval(() => {
-    void writeQueueLockOwner(lockPath).catch(() => undefined);
+    void writeQueueHeartbeat(lockPath, token).catch(() => undefined);
   }, heartbeatMs);
   heartbeat.unref?.();
   return heartbeat;
@@ -67,35 +80,99 @@ async function isOwnerlessLockDirectoryStale(lockPath: string): Promise<boolean>
   }
 }
 
+async function isQueueLockStale(lockPath: string, owner: QueueLockOwner): Promise<boolean> {
+  if (!owner.token) return isQueueLockOwnerStale(owner);
+  try {
+    const heartbeat = await stat(`${lockPath}/heartbeat-${owner.token}`);
+    return Date.now() - heartbeat.mtimeMs > RETAIN_QUEUE_LOCK.staleMs;
+  } catch {
+    return isQueueLockOwnerStale(owner);
+  }
+}
+
+async function removeLockIfOwned(lockPath: string, token: string): Promise<void> {
+  const owner = await readQueueLockOwner(lockPath);
+  if (owner?.token === token) await rm(lockPath, { recursive: true, force: true });
+}
+
+function staleClaimPath(lockPath: string): string {
+  return `${lockPath}.stale-claim`;
+}
+
+async function isStaleCleanupClaimActive(lockPath: string): Promise<boolean> {
+  const claimPath = staleClaimPath(lockPath);
+  try {
+    const info = await stat(claimPath);
+    if (Date.now() - info.mtimeMs <= RETAIN_QUEUE_LOCK.staleMs) return true;
+    await rm(claimPath, { recursive: true, force: true });
+    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function withStaleCleanupClaim<T>(
+  lockPath: string,
+  fn: () => Promise<T>,
+): Promise<T | undefined> {
+  const claimPath = staleClaimPath(lockPath);
+  try {
+    await mkdir(claimPath, { recursive: false });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") return undefined;
+    throw error;
+  }
+  try {
+    return await fn();
+  } finally {
+    await rm(claimPath, { recursive: true, force: true });
+  }
+}
+
+async function removeLockIfStillStale(lockPath: string): Promise<boolean> {
+  return (
+    (await withStaleCleanupClaim(lockPath, async () => {
+      const owner = await readQueueLockOwner(lockPath);
+      const stale = owner
+        ? await isQueueLockStale(lockPath, owner)
+        : await isOwnerlessLockDirectoryStale(lockPath);
+      if (!stale) return false;
+      await rm(lockPath, { recursive: true, force: true });
+      return true;
+    })) ?? false
+  );
+}
+
 async function acquireFileLock(path: string): Promise<() => Promise<void>> {
   const lockPath = `${path}.lock`;
   const started = Date.now();
   await mkdir(dirname(path), { recursive: true });
   while (true) {
+    if (await isStaleCleanupClaimActive(lockPath)) {
+      if (Date.now() - started > RETAIN_QUEUE_LOCK.timeoutMs)
+        throw new Error(`Timed out waiting for retain queue lock ${lockPath}`);
+      await sleep(RETAIN_QUEUE_LOCK.retryMs);
+      continue;
+    }
+    const token = randomUUID();
     try {
       await mkdir(lockPath, { recursive: false });
       try {
-        await writeQueueLockOwner(lockPath);
+        await writeQueueLockOwner(lockPath, token);
       } catch (error) {
         await rm(lockPath, { recursive: true, force: true });
         if (["ENOENT", "EINVAL"].includes((error as NodeJS.ErrnoException).code ?? "")) continue;
         throw error;
       }
-      const heartbeat = startQueueLockHeartbeat(lockPath);
+      const heartbeat = startQueueLockHeartbeat(lockPath, token);
       return async () => {
         clearInterval(heartbeat);
-        await rm(lockPath, { recursive: true, force: true });
+        await removeLockIfOwned(lockPath, token);
       };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      const owner = await readQueueLockOwner(lockPath);
-      const stale = owner
-        ? isQueueLockOwnerStale(owner)
-        : await isOwnerlessLockDirectoryStale(lockPath);
-      if (stale) {
-        await rm(lockPath, { recursive: true, force: true });
-        continue;
-      }
+      if (await removeLockIfStillStale(lockPath)) continue;
       if (Date.now() - started > RETAIN_QUEUE_LOCK.timeoutMs)
         throw new Error(`Timed out waiting for retain queue lock ${lockPath}`);
       await sleep(RETAIN_QUEUE_LOCK.retryMs);
@@ -133,11 +210,25 @@ export function resolveDeadLetterQueuePath(path: string): string {
   return `${path}.dead.jsonl`;
 }
 
-export async function enqueueRetainJob(path: string, job: RetainJob): Promise<void> {
-  await withQueueLock(path, async () => {
+export interface EnqueueRetainJobResult {
+  previousLength: number;
+  currentLength: number;
+}
+
+export async function enqueueRetainJobWithStats(
+  path: string,
+  job: RetainJob,
+): Promise<EnqueueRetainJobResult> {
+  return withQueueLock(path, async () => {
+    const previousLength = (await readRetainQueue(path)).length;
     await mkdir(dirname(path), { recursive: true });
     await appendFile(path, `${JSON.stringify(job)}\n`, "utf8");
+    return { previousLength, currentLength: previousLength + 1 };
   });
+}
+
+export async function enqueueRetainJob(path: string, job: RetainJob): Promise<void> {
+  await enqueueRetainJobWithStats(path, job);
 }
 
 export async function readRetainQueue(path: string): Promise<RetainJob[]> {
@@ -166,6 +257,17 @@ export async function writeRetainQueue(path: string, jobs: RetainJob[]): Promise
     "utf8",
   );
   await rename(tmp, path);
+}
+
+async function appendDeadLetterJobs(path: string, jobs: RetainJob[]): Promise<void> {
+  if (jobs.length === 0) return;
+  const deadLetterPath = resolveDeadLetterQueuePath(path);
+  await mkdir(dirname(deadLetterPath), { recursive: true });
+  await appendFile(
+    deadLetterPath,
+    jobs.map((job) => JSON.stringify(job)).join("\n") + "\n",
+    "utf8",
+  );
 }
 
 export type FlushRetainQueueOptions = {
@@ -236,10 +338,8 @@ export async function flushRetainQueue(
         }
       }
     }
+    await appendDeadLetterJobs(path, deadLetteredJobs);
     await writeRetainQueue(path, remaining);
-    for (const deadLetteredJob of deadLetteredJobs) {
-      await enqueueRetainJob(resolveDeadLetterQueuePath(path), deadLetteredJob);
-    }
     return { sent, remaining: remaining.length, deadLettered: deadLetteredJobs.length };
   });
 }

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -215,12 +215,21 @@ export interface EnqueueRetainJobResult {
   currentLength: number;
 }
 
+async function countQueuedLines(path: string): Promise<number> {
+  try {
+    return (await readFile(path, "utf8")).split("\n").filter(Boolean).length;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw error;
+  }
+}
+
 export async function enqueueRetainJobWithStats(
   path: string,
   job: RetainJob,
 ): Promise<EnqueueRetainJobResult> {
   return withQueueLock(path, async () => {
-    const previousLength = (await readRetainQueue(path)).length;
+    const previousLength = await countQueuedLines(path);
     await mkdir(dirname(path), { recursive: true });
     await appendFile(path, `${JSON.stringify(job)}\n`, "utf8");
     return { previousLength, currentLength: previousLength + 1 };

--- a/extensions/retain-durable.ts
+++ b/extensions/retain-durable.ts
@@ -6,7 +6,12 @@ import type {
   RetainJob,
   UpdateMode,
 } from "./types.js";
-import { enqueueRetainJob, flushRetainQueue, resolveQueuePath } from "./queue.js";
+import {
+  enqueueRetainJobWithStats,
+  flushRetainQueue,
+  readRetainQueue,
+  resolveQueuePath,
+} from "./queue.js";
 import { redactSecrets } from "./sanitize.js";
 import { resolveRetainDocumentTarget } from "./capabilities.js";
 
@@ -68,7 +73,11 @@ export function buildDurableRetainJob(args: Omit<RetainDurablyArgs, "client">): 
 
 export async function retainDurably(args: RetainDurablyArgs): Promise<RetainDurablyResult> {
   const queuePath = resolveQueuePath(args.cwd, args.config.retain.queuePath);
-  await enqueueRetainJob(queuePath, buildDurableRetainJob(args));
-  const result = await flushRetainQueue(queuePath, args.client);
+  const enqueueResult = await enqueueRetainJobWithStats(queuePath, buildDurableRetainJob(args));
+  if (enqueueResult.previousLength > 0) {
+    const remaining = (await readRetainQueue(queuePath)).length;
+    return { enqueued: true, sent: 0, remaining, deadLettered: 0 };
+  }
+  const result = await flushRetainQueue(queuePath, args.client, { maxJobs: 1 });
   return { enqueued: true, ...result };
 }

--- a/extensions/tools.ts
+++ b/extensions/tools.ts
@@ -55,10 +55,13 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         ...(params.bank ? { bank: params.bank } : {}),
         ...(params.tags ? { tags: params.tags } : {}),
       });
+      const deadLetterStatus = result.deadLettered
+        ? ` ${result.deadLettered} job${result.deadLettered === 1 ? "" : "s"} moved to dead-letter queue; run /hindsight:debug to inspect.`
+        : "";
       const status =
         result.remaining > 0
-          ? `Queued for ${result.bankId}; ${result.remaining} job${result.remaining === 1 ? "" : "s"} pending.`
-          : `Retained in ${result.bankId}.`;
+          ? `Queued for ${result.bankId}; ${result.remaining} job${result.remaining === 1 ? "" : "s"} pending.${deadLetterStatus}`
+          : `Retained in ${result.bankId}.${deadLetterStatus}`;
       return {
         content: [{ type: "text", text: status }],
         details: result,

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -114,6 +114,30 @@ describe("retain queue", () => {
     expect(dead[0]?.retries).toBe(1);
     expect(dead[0]?.lastError).toContain("moved to dead-letter queue");
     expect(dead[0]?.deadLetteredAt).toBeDefined();
+  });
+
+  it("keeps exhausted jobs active when dead-letter append fails", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    await enqueueRetainJob(path, job);
+    mkdirSync(resolveDeadLetterQueuePath(path));
+
+    await expect(
+      flushRetainQueue(
+        path,
+        {
+          retain: async () => {
+            throw new Error("down");
+          },
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+        { maxRetries: 1 },
+      ),
+    ).rejects.toThrow();
+
+    const remaining = await readRetainQueue(path);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.id).toBe("1");
   });
 
   it("can bound shutdown flushing to avoid blocking session switches", async () => {
@@ -244,11 +268,14 @@ describe("retain queue", () => {
 
   it("cleans stale lock directories instead of waiting forever", async () => {
     const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
-    mkdirSync(`${path}.lock`, { recursive: true });
+    const lockPath = `${path}.lock`;
+    mkdirSync(lockPath, { recursive: true });
+    const oldTime = new Date(Date.now() - 10_000);
+    utimesSync(lockPath, oldTime, oldTime);
     const originalStaleMs = RETAIN_QUEUE_LOCK.staleMs;
     const originalTimeoutMs = RETAIN_QUEUE_LOCK.timeoutMs;
     const originalRetryMs = RETAIN_QUEUE_LOCK.retryMs;
-    RETAIN_QUEUE_LOCK.staleMs = 0;
+    RETAIN_QUEUE_LOCK.staleMs = 1;
     RETAIN_QUEUE_LOCK.timeoutMs = 200;
     RETAIN_QUEUE_LOCK.retryMs = 1;
     try {

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { existsSync, mkdirSync, mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -72,6 +79,18 @@ describe("retain queue", () => {
     expect(await readRetainQueue(path)).toHaveLength(0);
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject(["b", "raw", { async: true }]);
+  });
+
+  it("appends jobs even when earlier queue lines are malformed", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    writeFileSync(path, "{not json}\n", "utf8");
+
+    await enqueueRetainJob(path, job);
+
+    const lines = readFileSync(path, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('"id":"1"');
+    await expect(readRetainQueue(path)).rejects.toThrow();
   });
 
   it("forwards queued observation scopes to retain", async () => {

--- a/tests/retain-durable.test.ts
+++ b/tests/retain-durable.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { createMemoryOperations } from "../extensions/memory-operations.js";
-import { flushRetainQueue, readRetainQueue, resolveQueuePath } from "../extensions/queue.js";
+import {
+  flushRetainQueue,
+  readDeadLetterQueue,
+  readRetainQueue,
+  resolveQueuePath,
+} from "../extensions/queue.js";
 import type { HindsightLikeClient, ResolvedConfig } from "../extensions/types.js";
 import {
   setSessionMemoryMode,
@@ -78,6 +83,64 @@ describe("durable explicit retain", () => {
     expect(queued[0]?.item.content).toContain("Durable fact");
     expect(queued[0]?.item.content).not.toContain("super-secret");
     expect(queued[0]?.item.tags).toEqual(expect.arrayContaining(["source:pi", "decision:test"]));
+  });
+
+  it("does not burn retries on existing backlog during a continuous outage", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
+    const config = testConfig();
+    const operations = createMemoryOperations({
+      getClient: () =>
+        client(async () => {
+          throw new Error("down");
+        }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    });
+
+    for (let index = 0; index < 7; index += 1) {
+      await operations.retainExplicit({
+        cwd,
+        content: `Decision ${index}`,
+        context: "unit test explicit retain",
+      });
+    }
+
+    const queuePath = resolveQueuePath(cwd, config.retain.queuePath);
+    const queued = await readRetainQueue(queuePath);
+    expect(queued).toHaveLength(7);
+    expect(queued[0]?.retries).toBe(1);
+    expect(queued.slice(1).every((queuedJob) => queuedJob.retries === 0)).toBe(true);
+    expect(await readDeadLetterQueue(queuePath)).toHaveLength(0);
+  });
+
+  it("does not burn retries when explicit retains race during an outage", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
+    const config = testConfig();
+    const operations = createMemoryOperations({
+      getClient: () =>
+        client(async () => {
+          throw new Error("down");
+        }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    });
+
+    await Promise.all(
+      Array.from({ length: 7 }, (_, index) =>
+        operations.retainExplicit({
+          cwd,
+          content: `Decision ${index}`,
+          context: "unit test explicit retain",
+        }),
+      ),
+    );
+
+    const queuePath = resolveQueuePath(cwd, config.retain.queuePath);
+    const queued = await readRetainQueue(queuePath);
+    expect(queued).toHaveLength(7);
+    expect(queued.filter((queuedJob) => queuedJob.retries === 1)).toHaveLength(1);
+    expect(queued.filter((queuedJob) => queuedJob.retries === 0)).toHaveLength(6);
+    expect(await readDeadLetterQueue(queuePath)).toHaveLength(0);
   });
 
   it("flushes queued explicit retain later", async () => {


### PR DESCRIPTION
## Summary
- add queue lock ownership tokens and token-specific heartbeat files
- serialize stale lock cleanup with a claim directory so competing waiters do not delete fresh locks
- release locks only when the owner token still matches
- append dead-letter jobs before rewriting the active queue so dead-letter append failures preserve active jobs
- avoid burning explicit-retain retry budgets during continuous outages by skipping opportunistic backlog flushes and flushing at most one newly queued job
- surface dead-letter counts in `hindsight_retain` tool text

## Review context
Follow-up review of early PRs found queue/explicit-retain durability blockers that were not caught before reviewer workflow existed.

## Reviewer
- reviewer initially found stale cleanup/heartbeat/concurrent explicit retain issues
- fixed and re-reviewed
- final reviewer found no blockers

## Verification
- `npm run check`
- `npm run typecheck:tsc`
