### PR TITLE
Harden append fallback replay

### DIFF
--- a/extensions/capabilities.ts
+++ b/extensions/capabilities.ts
@@ -11,6 +11,18 @@ export function perDeltaDocumentId(baseDocumentId: string, parts: unknown[]): st
   return `${baseDocumentId}:delta:${hash}`;
 }
 
+export function appendFallbackTarget(args: {
+  config: ResolvedConfig;
+  documentId: string;
+  fallbackParts: unknown[];
+}): { documentId: string; updateMode: "replace" } | undefined {
+  if (args.config.retain.appendFallback !== "per-turn-documents") return undefined;
+  return {
+    documentId: perDeltaDocumentId(args.documentId, args.fallbackParts),
+    updateMode: "replace",
+  };
+}
+
 export function resolveRetainDocumentTarget(args: {
   config: ResolvedConfig;
   capabilities?: HindsightCapabilities;
@@ -23,15 +35,23 @@ export function resolveRetainDocumentTarget(args: {
   if (!args.capabilities || args.capabilities.appendUpdateMode) {
     return { documentId: args.documentId, updateMode: args.updateMode };
   }
-  if (args.config.retain.appendFallback === "per-turn-documents") {
-    return {
-      documentId: perDeltaDocumentId(args.documentId, args.fallbackParts),
-      updateMode: "replace",
-    };
-  }
+  const fallback = appendFallbackTarget(args);
+  if (fallback) return fallback;
   throw new Error(
     "Hindsight append update mode is unsupported. Upgrade Hindsight or set retain.appendFallback to per-turn-documents.",
   );
+}
+
+export function isAppendUnsupportedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const mentionsAppendMode = /append|update[_ ]?mode/i.test(message);
+  const explicitUnsupported =
+    /unsupported|invalid|unknown|unrecognized|not allowed|not permitted/i.test(message);
+  const validationUnsupported =
+    /update[_ ]?mode/i.test(message) &&
+    /append/i.test(message) &&
+    /input should be|expected|literal_error|permitted|allowed/i.test(message);
+  return mentionsAppendMode && (explicitUnsupported || validationUnsupported);
 }
 
 export async function detectAppendCapability(
@@ -55,9 +75,7 @@ export async function detectAppendCapability(
     return { appendUpdateMode: true, checkedAt, probeDocumentId: documentId };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const appendUnsupported =
-      /append|update[_ ]?mode/i.test(message) &&
-      /unsupported|invalid|unknown|unrecognized|not allowed|not permitted/i.test(message);
+    const appendUnsupported = isAppendUnsupportedError(error);
     return {
       appendUpdateMode: !appendUnsupported,
       checkedAt,

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -25,6 +25,18 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function isAppendUnsupportedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const mentionsAppendMode = /append|update[_ ]?mode/i.test(message);
+  const explicitUnsupported =
+    /unsupported|invalid|unknown|unrecognized|not allowed|not permitted/i.test(message);
+  const validationUnsupported =
+    /update[_ ]?mode/i.test(message) &&
+    /append/i.test(message) &&
+    /input should be|expected|literal_error|permitted|allowed/i.test(message);
+  return mentionsAppendMode && (explicitUnsupported || validationUnsupported);
+}
+
 async function writeQueueHeartbeat(lockPath: string, token: string): Promise<void> {
   const heartbeatPath = `${lockPath}/heartbeat-${token}`;
   const tmpPath = `${heartbeatPath}.${process.pid}.tmp`;
@@ -314,7 +326,7 @@ export async function flushRetainQueue(
         break;
       }
       try {
-        await client.retain(job.bankId, job.item.content, {
+        const options = {
           context: job.item.context,
           ...(job.item.timestamp ? { timestamp: job.item.timestamp } : {}),
           ...(job.item.metadata ? { metadata: job.item.metadata } : {}),
@@ -323,7 +335,17 @@ export async function flushRetainQueue(
           ...(job.item.observationScopes ? { observationScopes: job.item.observationScopes } : {}),
           documentId: job.documentId,
           updateMode: job.updateMode,
-        });
+        };
+        try {
+          await client.retain(job.bankId, job.item.content, options);
+        } catch (error) {
+          if (!job.appendFallback || !isAppendUnsupportedError(error)) throw error;
+          await client.retain(job.bankId, job.item.content, {
+            ...options,
+            documentId: job.appendFallback.documentId,
+            updateMode: job.appendFallback.updateMode,
+          });
+        }
         sent += 1;
       } catch (error) {
         const retries = job.retries + 1;

--- a/extensions/retain-durable.ts
+++ b/extensions/retain-durable.ts
@@ -13,7 +13,7 @@ import {
   resolveQueuePath,
 } from "./queue.js";
 import { redactSecrets } from "./sanitize.js";
-import { resolveRetainDocumentTarget } from "./capabilities.js";
+import { appendFallbackTarget, resolveRetainDocumentTarget } from "./capabilities.js";
 
 export type DurableRetainSource = "auto" | "tool" | "command" | "import";
 
@@ -42,12 +42,18 @@ export interface RetainDurablyResult {
 
 export function buildDurableRetainJob(args: Omit<RetainDurablyArgs, "client">): RetainJob {
   const content = args.config.retain.redactSecrets ? redactSecrets(args.content) : args.content;
+  const fallbackParts = [content, args.context, args.tags, args.metadata];
   const target = resolveRetainDocumentTarget({
     config: args.config,
     ...(args.capabilities ? { capabilities: args.capabilities } : {}),
     documentId: args.documentId,
     updateMode: args.updateMode,
-    fallbackParts: [content, args.context, args.tags, args.metadata],
+    fallbackParts,
+  });
+  const fallback = appendFallbackTarget({
+    config: args.config,
+    documentId: args.documentId,
+    fallbackParts,
   });
   return {
     id: randomUUID(),
@@ -55,6 +61,7 @@ export function buildDurableRetainJob(args: Omit<RetainDurablyArgs, "client">): 
     createdAt: new Date().toISOString(),
     documentId: target.documentId,
     updateMode: target.updateMode,
+    ...(fallback && target.updateMode === "append" ? { appendFallback: fallback } : {}),
     item: {
       content,
       context: args.context,

--- a/extensions/retain.ts
+++ b/extensions/retain.ts
@@ -11,7 +11,7 @@ import { projectMessages } from "./messages.js";
 import { redactSecrets } from "./sanitize.js";
 import { contextLabel, liveDocumentId, stableSessionId } from "./session.js";
 import { enqueueRetainJob, flushRetainQueue, resolveQueuePath } from "./queue.js";
-import { resolveRetainDocumentTarget } from "./capabilities.js";
+import { appendFallbackTarget, resolveRetainDocumentTarget } from "./capabilities.js";
 import { createMemoryIdentity } from "./memory-identity.js";
 import { expandObservationScopes } from "./observation-scopes.js";
 
@@ -38,12 +38,18 @@ export function buildRetainJob(args: {
       })
     : [];
   const baseDocumentId = liveDocumentId(args.sessionFile, args.cwd);
+  const fallbackParts = [content, args.cwd, args.sessionFile, sessionId];
   const target = resolveRetainDocumentTarget({
     config: args.config,
     ...(args.capabilities ? { capabilities: args.capabilities } : {}),
     documentId: baseDocumentId,
     updateMode: args.config.retain.updateMode,
-    fallbackParts: [content, args.cwd, args.sessionFile, sessionId],
+    fallbackParts,
+  });
+  const fallback = appendFallbackTarget({
+    config: args.config,
+    documentId: baseDocumentId,
+    fallbackParts,
   });
   return {
     id: randomUUID(),
@@ -51,6 +57,7 @@ export function buildRetainJob(args: {
     createdAt: new Date().toISOString(),
     documentId: target.documentId,
     updateMode: target.updateMode,
+    ...(fallback && target.updateMode === "append" ? { appendFallback: fallback } : {}),
     item: {
       content,
       context: contextLabel(args.cwd, args.sessionFile),

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -119,6 +119,10 @@ export interface RetainJob {
   createdAt: string;
   documentId: string;
   updateMode: UpdateMode;
+  appendFallback?: {
+    documentId: string;
+    updateMode: "replace";
+  };
   item: {
     content: string;
     context: string;

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import {
   detectAppendCapability,
+  isAppendUnsupportedError,
   perDeltaDocumentId,
   resolveRetainDocumentTarget,
 } from "../extensions/capabilities.js";
@@ -59,6 +60,21 @@ describe("append capabilities", () => {
 
     expect(capabilities.appendUpdateMode).toBe(false);
     expect(capabilities.error).toContain("append unsupported");
+  });
+
+  it("detects append validation errors from old servers", async () => {
+    const error = new Error(
+      `retain failed: [{"loc":["body","items",0,"update_mode"],"msg":"Input should be 'replace'","input":"append"}]`,
+    );
+    expect(isAppendUnsupportedError(error)).toBe(true);
+
+    const capabilities = await detectAppendCapability(
+      client(async () => {
+        throw error;
+      }),
+      "bank",
+    );
+    expect(capabilities.appendUpdateMode).toBe(false);
   });
 
   it("does not mark generic probe failures as unsupported", async () => {

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -112,6 +112,37 @@ describe("retain queue", () => {
     expect(calls[0]).toMatchObject(["b", "raw", { observationScopes: [["repo:abc"], ["bank:b"]] }]);
   });
 
+  it("replays queued append jobs through fallback target when append is unsupported", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    await enqueueRetainJob(path, {
+      ...job,
+      appendFallback: { documentId: "doc:delta:abc", updateMode: "replace" },
+    });
+    const calls: unknown[] = [];
+
+    const result = await flushRetainQueue(path, {
+      retain: async (...args: unknown[]) => {
+        calls.push(args);
+        if (calls.length === 1)
+          throw new Error(
+            `retain failed: [{"loc":["body","items",0,"update_mode"],"msg":"Input should be 'replace'","input":"append"}]`,
+          );
+      },
+      recall: async () => [],
+      reflect: async () => ({}),
+    });
+
+    expect(result).toMatchObject({ sent: 1, remaining: 0, deadLettered: 0 });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toMatchObject(["b", "raw", { documentId: "doc", updateMode: "append" }]);
+    expect(calls[1]).toMatchObject([
+      "b",
+      "raw",
+      { documentId: "doc:delta:abc", updateMode: "replace" },
+    ]);
+    expect(await readRetainQueue(path)).toHaveLength(0);
+  });
+
   it("moves exhausted failed jobs to the dead-letter queue", async () => {
     const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
     await enqueueRetainJob(path, job);

--- a/tests/retain-durable.test.ts
+++ b/tests/retain-durable.test.ts
@@ -204,6 +204,34 @@ describe("durable explicit retain", () => {
     expect(await readRetainQueue(resolveQueuePath(cwd, config.retain.queuePath))).toHaveLength(0);
   });
 
+  it("stores fallback targets when append support is unknown and fallback is configured", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
+    const config: ResolvedConfig = {
+      ...testConfig(),
+      retain: { ...testConfig().retain, appendFallback: "per-turn-documents" },
+    };
+    const operations = createMemoryOperations({
+      getClient: () =>
+        client(async () => {
+          throw new Error("down");
+        }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+      getCapabilities: () => ({ appendUpdateMode: true, checkedAt: "now", error: "unknown" }),
+    });
+
+    await operations.retainExplicit({
+      cwd,
+      content: "Decision: keep fallback target.",
+      context: "unit test explicit retain",
+    });
+
+    const queued = await readRetainQueue(resolveQueuePath(cwd, config.retain.queuePath));
+    expect(queued[0]?.updateMode).toBe("append");
+    expect(queued[0]?.appendFallback?.documentId).toMatch(/^pi-explicit:.*:delta:/);
+    expect(queued[0]?.appendFallback?.updateMode).toBe("replace");
+  });
+
   it("uses per-delta explicit documents when append is unsupported and fallback is configured", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
     const config: ResolvedConfig = {


### PR DESCRIPTION
## Summary
- classify old-server `update_mode` validation errors as append unsupported
- persist deterministic per-delta fallback targets on queued append jobs when fallback is configured
- replay queued append jobs through fallback `replace` documents after append-specific failures
- add regression tests for validation classification and queued fallback replay

## Review context
Follow-up review of early PR #3 found append capability false positives and queued append jobs that could later dead-letter instead of using configured fallback.

## Reviewer
- reviewer found no blockers
- queue replay test now uses a realistic old-server validation message

## Verification
- `npm run check`
- `npm run typecheck:tsc`
