### PR TITLE
Harden recall failure handling

### DIFF
--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -220,9 +220,14 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       if (!sessionMemory.recall) return undefined;
       const scopes = selectMemoryScopes(runtime.cwd, config);
       if (scopes.length === 0) return undefined;
+      if (config.recall.injectionPosition === "append") {
+        const last = event.messages[event.messages.length - 1];
+        const lastRole = (last as unknown as { role?: string } | undefined)?.role;
+        if (!last || lastRole !== "user") return undefined;
+      }
       try {
         setMemoryStatus(runtime, "recalling");
-        const { rendered, blocks } = await recallForContext({
+        const { rendered, blocks, failed } = await recallForContext({
           client,
           config,
           scopes,
@@ -230,17 +235,23 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           cwd: runtime.cwd,
         });
         const memoryCount = blocks.reduce((count, block) => count + block.memoryCount, 0);
-        setMemoryStatus(runtime, memoryCount > 0 ? "recalled" : "recall-empty", memoryCount);
+        setMemoryStatus(
+          runtime,
+          memoryCount > 0 ? "recalled" : failed > 0 ? "recall-failed" : "recall-empty",
+          memoryCount,
+        );
         if (config.notifications.recall) {
           notify(
             runtime,
             memoryCount > 0
-              ? `Hindsight recalled ${memoryCount} memory item${memoryCount === 1 ? "" : "s"} from ${blocks.map((block) => block.bankId).join(", ")}`
-              : "Hindsight recalled no matching memory",
-            "info",
+              ? `Hindsight recalled ${memoryCount} memory item${memoryCount === 1 ? "" : "s"} from ${blocks.map((block) => block.bankId).join(", ")}${failed > 0 ? `; ${failed} bank${failed === 1 ? "" : "s"} failed` : ""}`
+              : failed > 0
+                ? `Hindsight recall failed for ${failed} bank${failed === 1 ? "" : "s"}`
+                : "Hindsight recalled no matching memory",
+            failed > 0 && memoryCount === 0 ? "warning" : "info",
           );
         }
-        if (config.recall.storeLastRecall) {
+        if (config.recall.storeLastRecall && (rendered || failed === 0)) {
           try {
             await writeLastRecallSnapshot(runtime.cwd, config.recall.lastRecallPath, {
               query: blocks[0]?.query ?? "",

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -25,6 +25,10 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function removeDirectory(path: string): Promise<void> {
+  await rm(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 });
+}
+
 function isAppendUnsupportedError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   const mentionsAppendMode = /append|update[_ ]?mode/i.test(message);
@@ -104,7 +108,7 @@ async function isQueueLockStale(lockPath: string, owner: QueueLockOwner): Promis
 
 async function removeLockIfOwned(lockPath: string, token: string): Promise<void> {
   const owner = await readQueueLockOwner(lockPath);
-  if (owner?.token === token) await rm(lockPath, { recursive: true, force: true });
+  if (owner?.token === token) await removeDirectory(lockPath);
 }
 
 function staleClaimPath(lockPath: string): string {
@@ -116,7 +120,7 @@ async function isStaleCleanupClaimActive(lockPath: string): Promise<boolean> {
   try {
     const info = await stat(claimPath);
     if (Date.now() - info.mtimeMs <= RETAIN_QUEUE_LOCK.staleMs) return true;
-    await rm(claimPath, { recursive: true, force: true });
+    await removeDirectory(claimPath);
     return false;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
@@ -138,7 +142,7 @@ async function withStaleCleanupClaim<T>(
   try {
     return await fn();
   } finally {
-    await rm(claimPath, { recursive: true, force: true });
+    await removeDirectory(claimPath);
   }
 }
 
@@ -150,7 +154,7 @@ async function removeLockIfStillStale(lockPath: string): Promise<boolean> {
         ? await isQueueLockStale(lockPath, owner)
         : await isOwnerlessLockDirectoryStale(lockPath);
       if (!stale) return false;
-      await rm(lockPath, { recursive: true, force: true });
+      await removeDirectory(lockPath);
       return true;
     })) ?? false
   );
@@ -173,7 +177,7 @@ async function acquireFileLock(path: string): Promise<() => Promise<void>> {
       try {
         await writeQueueLockOwner(lockPath, token);
       } catch (error) {
-        await rm(lockPath, { recursive: true, force: true });
+        await removeDirectory(lockPath);
         if (["ENOENT", "EINVAL"].includes((error as NodeJS.ErrnoException).code ?? "")) continue;
         throw error;
       }

--- a/extensions/recall.ts
+++ b/extensions/recall.ts
@@ -167,8 +167,9 @@ export async function recallForContext(args: {
   scopes: RecallScope[];
   messages: AgentMessage[];
   cwd?: string;
-}): Promise<{ rendered: string; blocks: RecallBlock[] }> {
+}): Promise<{ rendered: string; blocks: RecallBlock[]; failed: number }> {
   const blocks: RecallBlock[] = [];
+  let failed = 0;
   for (const scope of args.scopes) {
     const query = composeRecallQuery(args.messages, {
       roles: args.config.recall.roles,
@@ -178,25 +179,29 @@ export async function recallForContext(args: {
       includeDate: args.config.recall.includeDateInQuery,
       hints: args.cwd ? queryHints(args.cwd, args.config, scope) : [],
     });
-    const response = await withTimeout(
-      args.client.recall(scope.bankId, query, {
-        budget: args.config.recall.budget,
-        maxTokens: args.config.recall.maxTokens,
-        types: args.config.recall.types,
-        ...(scope.tags ? { tags: scope.tags } : {}),
-        ...(scope.tagsMatch ? { tagsMatch: scope.tagsMatch } : {}),
-      }),
-      args.config.recall.timeoutMs,
-    );
-    const results = textFromRecallResponse(response);
-    blocks.push({
-      bankId: scope.bankId,
-      query,
-      results,
-      memoryCount: results.length,
-      rendered: "",
-    });
+    try {
+      const response = await withTimeout(
+        args.client.recall(scope.bankId, query, {
+          budget: args.config.recall.budget,
+          maxTokens: args.config.recall.maxTokens,
+          types: args.config.recall.types,
+          ...(scope.tags ? { tags: scope.tags } : {}),
+          ...(scope.tagsMatch ? { tagsMatch: scope.tagsMatch } : {}),
+        }),
+        args.config.recall.timeoutMs,
+      );
+      const results = textFromRecallResponse(response);
+      blocks.push({
+        bankId: scope.bankId,
+        query,
+        results,
+        memoryCount: results.length,
+        rendered: "",
+      });
+    } catch {
+      failed += 1;
+    }
   }
   const rendered = renderRecallBlocks(blocks, args.config.recall.topK);
-  return { rendered, blocks: blocks.map((block) => ({ ...block, rendered })) };
+  return { rendered, blocks: blocks.map((block) => ({ ...block, rendered })), failed };
 }

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -362,6 +362,7 @@ describe("extension hooks", () => {
     const { default: hindsightExtension } = await import("../extensions/index.js");
     hindsightExtension(pi as any);
     await handlers.session_start?.[0]?.({}, ctx);
+    const beforeCalls = mocked.client.recall.mock.calls.length;
     const contextResult = await handlers.context?.[0]?.(
       {
         messages: [
@@ -374,6 +375,7 @@ describe("extension hooks", () => {
     );
 
     expect(contextResult).toBeUndefined();
+    expect(mocked.client.recall).toHaveBeenCalledTimes(beforeCalls);
   });
 
   it("ensures global bank even when project bank is disabled", async () => {

--- a/tests/recall-format.test.ts
+++ b/tests/recall-format.test.ts
@@ -166,6 +166,30 @@ describe("recall formatting", () => {
     expect(queries[1]).toContain("scope:global");
   });
 
+  it("keeps successful bank recall when another bank fails", async () => {
+    const result = await recallForContext({
+      client: {
+        retain: async () => undefined,
+        recall: async (bankId) => {
+          if (bankId === "project-bank") throw new Error("timeout");
+          return { results: [{ text: "global memory" }] };
+        },
+        reflect: async () => ({}),
+      },
+      config: DEFAULT_CONFIG,
+      scopes: [
+        { kind: "project", bankId: "project-bank" },
+        { kind: "global", bankId: "global-bank" },
+      ],
+      cwd: "/repo/project",
+      messages: [{ role: "user", content: "q", timestamp: 1 }] as unknown as AgentMessage[],
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.rendered).toContain("global memory");
+    expect(result.blocks.map((block) => block.bankId)).toEqual(["global-bank"]);
+  });
+
   it("uses bank-aware preambles and query hints", async () => {
     const queries: string[] = [];
     await recallForContext({
@@ -232,21 +256,21 @@ describe("recall formatting", () => {
     expect(rendered).not.toContain("two");
   });
 
-  it("times out slow recall", async () => {
-    await expect(
-      recallForContext({
-        client: {
-          retain: async () => undefined,
-          recall: async () => new Promise(() => undefined),
-          reflect: async () => ({}),
-        },
-        config: {
-          ...DEFAULT_CONFIG,
-          recall: { ...DEFAULT_CONFIG.recall, timeoutMs: 5 },
-        },
-        scopes: [{ bankId: "b" }],
-        messages: [{ role: "user", content: "q", timestamp: 1 }] as unknown as AgentMessage[],
-      }),
-    ).rejects.toThrow(/timed out/);
+  it("records slow recall as failed without throwing", async () => {
+    const result = await recallForContext({
+      client: {
+        retain: async () => undefined,
+        recall: async () => new Promise(() => undefined),
+        reflect: async () => ({}),
+      },
+      config: {
+        ...DEFAULT_CONFIG,
+        recall: { ...DEFAULT_CONFIG.recall, timeoutMs: 5 },
+      },
+      scopes: [{ bankId: "b" }],
+      messages: [{ role: "user", content: "q", timestamp: 1 }] as unknown as AgentMessage[],
+    });
+
+    expect(result).toMatchObject({ rendered: "", blocks: [], failed: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- skip append-position automatic recall before calling Hindsight when context does not end with a user message
- tolerate per-bank recall failures/timeouts so successful bank recall still renders
- mark all-failed recall as failed, emit warning notifications, and avoid overwriting last-recall snapshots with empty failed recall data
- add retry options to queue directory cleanup to reduce transient `ENOTEMPTY` failures

## Review context
Follow-up review of early PR #4 found two blockers:
- append recall could call Hindsight after non-user turns and then discard results
- multi-bank recall dropped successful bank memory when any bank failed

## Reviewer
- reviewer found one notification/snapshot regression; fixed
- final reviewer found no blockers

## Verification
- `npm run check`
- `npm run typecheck:tsc`
