### PR TITLE
Add import dry-run previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This is an early MVP scaffold. It includes:
   - `/hindsight:tag`
 - tests for config, bank derivation, stable document IDs, sanitization, recall formatting, retain payloads, diagnostics, client request shapes, extension hook placement, historical import, import manifests, and queue replay
 
-Historical import MVP supports importing the current Pi session or an explicit JSONL path via tool. Imports write deterministic document IDs and update an import manifest so `/hindsight:debug` can show imported document count and latest import provenance.
+Historical import supports importing the current Pi session or an explicit JSONL path via tool. Imports write deterministic document IDs and update an import manifest so `/hindsight:debug` can show imported document count and latest import provenance. Use `/hindsight:import --dry-run` or `hindsight_import` with `dryRun: true` to preview documents, message counts, content sizes, tags, update mode, and target bank without writing Hindsight memory or mutating the manifest. Add `--all-leaves` or `allLeaves: true` to preview/import every branch leaf instead of only the current branch.
 
 ## Install for local development
 

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -16,6 +16,12 @@ function secondArg(args: unknown): string | undefined {
   return undefined;
 }
 
+function argList(args: unknown): string[] {
+  if (Array.isArray(args)) return args.filter((arg): arg is string => typeof arg === "string");
+  if (typeof args === "string") return args.split(/\s+/).filter(Boolean);
+  return [];
+}
+
 function sessionFile(ctx: {
   sessionManager?: { getSessionFile?: () => string | undefined };
 }): string | undefined {
@@ -31,7 +37,7 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
 
   pi.registerCommand("hindsight:status", {
     description: "Show Hindsight extension status.",
-    handler: async (_args, ctx) => {
+    handler: async (args, ctx) => {
       const status = await operations.status(ctx.cwd);
       const bank = status.config.banks.project.enabled
         ? status.bankId
@@ -50,7 +56,7 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
 
   pi.registerCommand("hindsight:doctor", {
     description: "Check Hindsight connectivity and queue.",
-    handler: async (_args, ctx) => {
+    handler: async (args, ctx) => {
       const doctor = await operations.doctor(ctx.cwd);
       const append = doctor.capabilities
         ? doctor.capabilities.appendUpdateMode
@@ -99,7 +105,7 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
 
   pi.registerCommand("hindsight:import", {
     description: "Import the current Pi session JSONL into Hindsight.",
-    handler: async (_args, ctx) => {
+    handler: async (args, ctx) => {
       const sessionFile = ctx.sessionManager.getSessionFile?.();
       if (!sessionFile) {
         ctx.ui.notify(
@@ -108,9 +114,16 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         );
         return;
       }
-      const result = await operations.importSession({ sessionFile });
+      const flags = new Set(argList(args));
+      const result = await operations.importSession({
+        sessionFile,
+        dryRun: flags.has("--dry-run") || flags.has("--preview"),
+        ...(flags.has("--all-leaves") ? { includeBranches: "all-leaves" } : {}),
+      });
       ctx.ui.notify(
-        `Imported ${result.messageCount} messages as ${result.documentId}; manifest ${result.manifestPath}`,
+        result.dryRun
+          ? `Import preview: ${result.messageCount} messages across ${result.documents.length} document${result.documents.length === 1 ? "" : "s"}; first ${result.documentId}; manifest unchanged ${result.manifestPath}`
+          : `Imported ${result.messageCount} messages as ${result.documentId}; manifest ${result.manifestPath}`,
         "info",
       );
     },

--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -20,17 +20,30 @@ export interface ImportRetainArgs {
   branch: ImportBranch;
 }
 
+export interface ImportDocumentPreview {
+  documentId: string;
+  leafId: string;
+  messageCount: number;
+  contentHash: string;
+  contentBytes: number;
+  tags: string[];
+  updateMode: "append" | "replace";
+  bankId: string;
+  wouldWrite: boolean;
+}
+
 export interface ImportRetainResult {
-  document: {
-    documentId: string;
-    leafId: string;
-    messageCount: number;
-    contentHash: string;
-  };
+  document: ImportDocumentPreview;
   manifestEntry: ImportManifestEntry;
 }
 
-export async function retainImportBranch(args: ImportRetainArgs): Promise<ImportRetainResult> {
+interface ImportBranchBuildResult extends ImportRetainResult {
+  content: string;
+  context: string;
+  observationScopes: string[][];
+}
+
+function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranchBuildResult {
   const leafId = args.branch.leafId;
   const branchMessages = args.branch.messages;
   const documentId = importDocumentId(args.sessionId, leafId);
@@ -64,37 +77,62 @@ export async function retainImportBranch(args: ImportRetainArgs): Promise<Import
         projectBankId: args.bankId,
       })
     : [];
-  await args.client.retain(args.bankId, content, {
-    context: `Historical Pi session import from ${args.sessionFile}, branch ${leafId}`,
+  const document: ImportDocumentPreview = {
     documentId,
-    updateMode,
-    async: args.config.retain.async,
+    leafId,
+    messageCount: branchMessages.length,
+    contentHash,
+    contentBytes: Buffer.byteLength(content, "utf8"),
     tags,
+    updateMode,
+    bankId: args.bankId,
+    wouldWrite: true,
+  };
+  const manifestEntry: ImportManifestEntry = {
+    documentId,
+    bankId: args.bankId,
+    sourceFile: args.sessionFile,
+    importedAt: new Date().toISOString(),
+    contentHash,
+    messageCount: branchMessages.length,
+    leafId,
+    sessionId: args.sessionId,
+    cwd: args.cwd,
+    includeBranches: args.config.import.includeBranches,
+    updateMode,
+  };
+  return {
+    document,
+    manifestEntry,
+    content,
+    context: `Historical Pi session import from ${args.sessionFile}, branch ${leafId}`,
+    observationScopes,
+  };
+}
+
+export function previewImportBranch(args: Omit<ImportRetainArgs, "client">): ImportRetainResult {
+  const built = buildImportBranch(args);
+  return { document: { ...built.document, wouldWrite: false }, manifestEntry: built.manifestEntry };
+}
+
+export async function retainImportBranch(args: ImportRetainArgs): Promise<ImportRetainResult> {
+  const built = buildImportBranch(args);
+  await args.client.retain(args.bankId, built.content, {
+    context: built.context,
+    documentId: built.document.documentId,
+    updateMode: built.document.updateMode,
+    async: args.config.retain.async,
+    tags: built.document.tags,
     metadata: {
       pi_session_file: args.sessionFile,
       imported: "true",
       cwd: args.cwd,
       session_id: args.sessionId,
-      branch_leaf_id: leafId,
+      branch_leaf_id: built.document.leafId,
       include_branches: args.config.import.includeBranches,
       ...(args.parsed.sessionTimestamp ? { session_timestamp: args.parsed.sessionTimestamp } : {}),
     },
-    ...(observationScopes.length ? { observationScopes } : {}),
+    ...(built.observationScopes.length ? { observationScopes: built.observationScopes } : {}),
   });
-  return {
-    document: { documentId, leafId, messageCount: branchMessages.length, contentHash },
-    manifestEntry: {
-      documentId,
-      bankId: args.bankId,
-      sourceFile: args.sessionFile,
-      importedAt: new Date().toISOString(),
-      contentHash,
-      messageCount: branchMessages.length,
-      leafId,
-      sessionId: args.sessionId,
-      cwd: args.cwd,
-      includeBranches: args.config.import.includeBranches,
-      updateMode,
-    },
-  };
+  return { document: built.document, manifestEntry: built.manifestEntry };
 }

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -5,7 +5,7 @@ import { importDocumentId, stableSessionId } from "./session.js";
 import { parseImportSessionJsonl, parsePiSessionJsonl } from "./import-parser.js";
 import { leafIds, selectImportBranches } from "./import-branches.js";
 import { resolveImportManifestPath, upsertImportManifestEntries } from "./import-manifest.js";
-import { retainImportBranch } from "./import-retain.js";
+import { previewImportBranch, retainImportBranch } from "./import-retain.js";
 
 export { parseImportSessionJsonl, parsePiSessionJsonl } from "./import-parser.js";
 export { selectImportBranches } from "./import-branches.js";
@@ -17,6 +17,11 @@ export interface ImportSessionDocumentResult {
   leafId: string;
   messageCount: number;
   contentHash: string;
+  contentBytes: number;
+  tags: string[];
+  updateMode: "append" | "replace";
+  bankId: string;
+  wouldWrite: boolean;
 }
 
 export interface ImportSessionResult {
@@ -24,6 +29,7 @@ export interface ImportSessionResult {
   documentId: string;
   messageCount: number;
   retained: boolean;
+  dryRun: boolean;
   manifestPath: string;
   documents: ImportSessionDocumentResult[];
 }
@@ -33,48 +39,62 @@ export async function importPiSession(args: {
   bankId: string;
   client: HindsightLikeClient;
   config: ResolvedConfig;
+  dryRun?: boolean;
+  includeBranches?: ResolvedConfig["import"]["includeBranches"];
 }): Promise<ImportSessionResult> {
   const text = await readFile(args.sessionFile, "utf8");
   const parsed = parseImportSessionJsonl(text);
   const cwd = parsed.cwd ?? dirname(args.sessionFile);
   const sessionId = parsed.sessionId ?? stableSessionId(args.sessionFile, cwd);
   const leaves = leafIds(parsed.messages);
-  const branches = selectImportBranches(parsed, args.config.import.includeBranches);
+  const includeBranches = args.includeBranches ?? args.config.import.includeBranches;
+  const branches = selectImportBranches(parsed, includeBranches);
   const manifestPath = resolveImportManifestPath(cwd, args.config.import.manifestPath);
 
-  const retained = await Promise.all(
-    branches.map((branch) =>
-      retainImportBranch({
+  const importConfig = { ...args.config, import: { ...args.config.import, includeBranches } };
+  const results = await Promise.all(
+    branches.map((branch) => {
+      const common = {
         sessionFile: args.sessionFile,
         bankId: args.bankId,
-        client: args.client,
-        config: args.config,
+        config: importConfig,
         parsed,
         cwd,
         sessionId,
         leaves,
         branch,
-      }),
-    ),
+      };
+      return args.dryRun
+        ? Promise.resolve(previewImportBranch(common))
+        : retainImportBranch({ ...common, client: args.client });
+    }),
   );
 
-  const documents = retained.map((result) => result.document);
-  await upsertImportManifestEntries(
-    manifestPath,
-    retained.map((result) => result.manifestEntry),
-  );
+  const documents = results.map((result) => result.document);
+  if (!args.dryRun) {
+    await upsertImportManifestEntries(
+      manifestPath,
+      results.map((result) => result.manifestEntry),
+    );
+  }
 
   const first = documents[0] ?? {
     documentId: importDocumentId(sessionId, "root"),
     leafId: "root",
     messageCount: 0,
     contentHash: "",
+    contentBytes: 0,
+    tags: [],
+    updateMode: args.config.import.replaceExistingImportedDocs ? "replace" : "append",
+    bankId: args.bankId,
+    wouldWrite: !args.dryRun,
   };
   return {
     sessionFile: args.sessionFile,
     documentId: first.documentId,
     messageCount: documents.reduce((count, document) => count + document.messageCount, 0),
-    retained: true,
+    retained: !args.dryRun,
+    dryRun: Boolean(args.dryRun),
     manifestPath,
     documents,
   };

--- a/extensions/memory-operations.ts
+++ b/extensions/memory-operations.ts
@@ -122,13 +122,20 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
       return { ...result, projectBankId };
     },
 
-    async importSession(args: { sessionFile: string; bank?: string }) {
+    async importSession(args: {
+      sessionFile: string;
+      bank?: string;
+      dryRun?: boolean;
+      includeBranches?: ResolvedConfig["import"]["includeBranches"];
+    }) {
       const bankId = args.bank || deps.getProjectBankId();
       const result = await importPiSession({
         sessionFile: args.sessionFile,
         bankId,
         client: deps.getClient(),
         config: deps.getConfig(),
+        ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+        ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
       });
       return { bankId, ...result };
     },

--- a/extensions/tools.ts
+++ b/extensions/tools.ts
@@ -122,6 +122,10 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       bank: Type.Optional(
         Type.String({ description: "Optional bank id. Defaults to project bank." }),
       ),
+      dryRun: Type.Optional(Type.Boolean({ description: "Preview import without writing." })),
+      allLeaves: Type.Optional(
+        Type.Boolean({ description: "Import or preview all branch leaves." }),
+      ),
     }),
     async execute(_id, params, _signal, _onUpdate, ctx) {
       const sessionFile = params.sessionFile || ctx.sessionManager.getSessionFile?.();
@@ -129,12 +133,18 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       const result = await operations.importSession({
         sessionFile,
         ...(params.bank ? { bank: params.bank } : {}),
+        ...(params.dryRun !== undefined ? { dryRun: params.dryRun } : {}),
+        ...(params.allLeaves !== undefined
+          ? { includeBranches: params.allLeaves ? "all-leaves" : "current-only" }
+          : {}),
       });
       return {
         content: [
           {
             type: "text",
-            text: `Imported ${result.messageCount} messages into ${result.bankId} as ${result.documentId}. Manifest: ${result.manifestPath}.`,
+            text: result.dryRun
+              ? `Import preview: ${result.messageCount} messages would write ${result.documents.length} document${result.documents.length === 1 ? "" : "s"} to ${result.bankId}. First document: ${result.documentId}. Manifest unchanged: ${result.manifestPath}.`
+              : `Imported ${result.messageCount} messages into ${result.bankId} as ${result.documentId}. Manifest: ${result.manifestPath}.`,
           },
         ],
         details: result,

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -78,12 +78,17 @@ describe("Pi session import", () => {
     expect(result.messageCount).toBe(2);
     expect(result.documentId).toBe("pi-import:session-1:leaf:current");
     expect(result.documents).toEqual([
-      {
+      expect.objectContaining({
         documentId: "pi-import:session-1:leaf:current",
         leafId: "current",
         messageCount: 2,
         contentHash: expect.any(String),
-      },
+        contentBytes: expect.any(Number),
+        tags: expect.arrayContaining(["import:historical"]),
+        updateMode: "replace",
+        bankId: "bank",
+        wouldWrite: true,
+      }),
     ]);
     const manifest = await readImportManifest(result.manifestPath);
     expect(manifest.imports[result.documentId]).toMatchObject({
@@ -171,24 +176,97 @@ describe("Pi session import", () => {
       },
     });
     expect(result.documents).toEqual([
-      {
+      expect.objectContaining({
         documentId: "pi-import:session-2:leaf:a",
         leafId: "a",
         messageCount: 2,
         contentHash: expect.any(String),
-      },
-      {
+      }),
+      expect.objectContaining({
         documentId: "pi-import:session-2:leaf:b",
         leafId: "b",
         messageCount: 2,
         contentHash: expect.any(String),
-      },
+      }),
     ]);
     expect(calls).toHaveLength(2);
     expect(calls.map((call) => (call[2] as { documentId: string }).documentId)).toEqual([
       "pi-import:session-2:leaf:a",
       "pi-import:session-2:leaf:b",
     ]);
+  });
+
+  it("previews import without retaining or writing manifests", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-preview", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "root" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "a",
+          parentId: "root",
+          message: { role: "assistant", content: "a" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "b",
+          parentId: "root",
+          message: { role: "assistant", content: "b" },
+        }),
+      ].join("\n"),
+    );
+    const calls: unknown[][] = [];
+
+    const result = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      includeBranches: "all-leaves",
+      dryRun: true,
+      client: {
+        retain: async (...args: unknown[]) => {
+          calls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(result.retained).toBe(false);
+    expect(result.dryRun).toBe(true);
+    expect(result.messageCount).toBe(4);
+    expect(result.documents).toEqual([
+      expect.objectContaining({
+        documentId: "pi-import:session-preview:leaf:a",
+        leafId: "a",
+        messageCount: 2,
+        contentBytes: expect.any(Number),
+        tags: expect.arrayContaining(["import:historical", "forked:true"]),
+        updateMode: "replace",
+        bankId: "bank",
+        wouldWrite: false,
+      }),
+      expect.objectContaining({
+        documentId: "pi-import:session-preview:leaf:b",
+        leafId: "b",
+        messageCount: 2,
+        wouldWrite: false,
+      }),
+    ]);
+    expect(calls).toHaveLength(0);
+    await expect(readImportManifest(result.manifestPath)).resolves.toEqual({
+      version: 1,
+      imports: {},
+    });
   });
 
   it("selects import branches without retaining or writing manifests", () => {


### PR DESCRIPTION
## Summary
- add dry-run/preview mode for historical Pi session imports
- add per-call branch selection override for all leaf branches
- return deterministic import previews with document ID, leaf ID, message count, content hash/size, tags, update mode, target bank, and write intent
- expose `/hindsight:import --dry-run`, `/hindsight:import --preview`, `/hindsight:import --all-leaves`
- expose `hindsight_import` `dryRun` and `allLeaves` tool options
- keep dry-run side-effect free: no Hindsight retain call and no manifest mutation

## Reviewer
- reviewer found `allLeaves: false` should force current-only when config defaults to all-leaves
- fixed before PR

## Verification
- `npm run check`
- `npm run typecheck:tsc`
