### PR TITLE
Add import checkpoint resume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ skills-lock.json
 .pi/hindsight/retain-queue.jsonl
 .pi/hindsight/retain-queue.jsonl.*
 .pi/hindsight/import-manifest.json
+.pi/hindsight/import-checkpoint.json
 .pi/hindsight/retain-cursors.json
 .pi/hindsight/session-meta/
 .pi/hindsight/last-recall.json

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This is an early MVP scaffold. It includes:
   - `/hindsight:tag`
 - tests for config, bank derivation, stable document IDs, sanitization, recall formatting, retain payloads, diagnostics, client request shapes, extension hook placement, historical import, import manifests, and queue replay
 
-Historical import supports importing the current Pi session or an explicit JSONL path via tool. Imports write deterministic document IDs and update an import manifest so `/hindsight:debug` can show imported document count and latest import provenance. Use `/hindsight:import --dry-run` or `hindsight_import` with `dryRun: true` to preview documents, message counts, content sizes, tags, update mode, and target bank without writing Hindsight memory or mutating the manifest. Add `--all-leaves` or `allLeaves: true` to preview/import every branch leaf instead of only the current branch.
+Historical import supports importing the current Pi session or an explicit JSONL path via tool. Imports write deterministic document IDs and update an import manifest so `/hindsight:debug` can show imported document count and latest import provenance. Use `/hindsight:import --dry-run` or `hindsight_import` with `dryRun: true` to preview documents, message counts, content sizes, tags, update mode, and target bank without writing Hindsight memory or mutating the manifest. Add `--all-leaves` or `allLeaves: true` to preview/import every branch leaf instead of only the current branch. Imports maintain `.pi/hindsight/import-checkpoint.json` by default and resume completed documents without re-retaining them when `import.resume` is enabled.
 
 ## Install for local development
 
@@ -78,7 +78,7 @@ Inside Pi, open the interactive configuration TUI:
 /hindsight:setup
 ```
 
-The setup TUI lets you edit the memory profile, project bank ID, Hindsight base URL, timeout, global bank, recall budget, token budget, retain settings, queue path, import branch mode, statusline display, and Pi window notifications. It writes `.pi/hindsight.json` and reloads the extension config after each change. Active MVP import config is limited to branch mode, replace-vs-append behavior, and manifest path.
+The setup TUI lets you edit the memory profile, project bank ID, Hindsight base URL, timeout, global bank, recall budget, token budget, retain settings, queue path, import branch mode, statusline display, and Pi window notifications. It writes `.pi/hindsight.json` and reloads the extension config after each change. Active import config covers branch mode, replace-vs-append behavior, manifest path, checkpoint path, and resume behavior.
 
 Memory profiles make global memory explicit. Choose the narrowest route that fits the repo:
 

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -71,6 +71,8 @@ const DEFAULT_CONFIG: ResolvedConfig = {
     includeBranches: "current-only",
     replaceExistingImportedDocs: true,
     manifestPath: ".pi/hindsight/import-manifest.json",
+    checkpointPath: ".pi/hindsight/import-checkpoint.json",
+    resume: true,
   },
   status: {
     style: "text",
@@ -345,6 +347,11 @@ export function normalizeConfig(config: ResolvedConfig, rawConfig?: unknown): Re
         DEFAULT_CONFIG.import.replaceExistingImportedDocs,
       ),
       manifestPath: stringValue(config.import?.manifestPath, DEFAULT_CONFIG.import.manifestPath),
+      checkpointPath: stringValue(
+        config.import?.checkpointPath,
+        DEFAULT_CONFIG.import.checkpointPath,
+      ),
+      resume: bool(config.import?.resume, DEFAULT_CONFIG.import.resume),
     },
     status: {
       style: enumValue(

--- a/extensions/import-checkpoint.ts
+++ b/extensions/import-checkpoint.ts
@@ -37,8 +37,16 @@ export function importRunId(args: {
   bankId: string;
   sessionId: string;
   includeBranches: "current-only" | "all-leaves";
+  updateMode: UpdateMode;
 }): string {
-  return ["pi-import", args.bankId, args.sessionId, args.includeBranches, args.sourceFile]
+  return [
+    "pi-import",
+    args.bankId,
+    args.sessionId,
+    args.includeBranches,
+    args.updateMode,
+    args.sourceFile,
+  ]
     .join(":")
     .replace(/\s+/g, "_");
 }

--- a/extensions/import-checkpoint.ts
+++ b/extensions/import-checkpoint.ts
@@ -1,0 +1,92 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join } from "node:path";
+import type { UpdateMode } from "./types.js";
+
+export type ImportDocumentStatus = "pending" | "completed" | "failed" | "skipped";
+
+export interface ImportCheckpointDocument {
+  documentId: string;
+  leafId: string;
+  contentHash: string;
+  messageCount: number;
+  status: ImportDocumentStatus;
+  updatedAt: string;
+  error?: string;
+}
+
+export interface ImportCheckpoint {
+  version: 1;
+  runId: string;
+  sourceFile: string;
+  bankId: string;
+  sessionId: string;
+  cwd: string;
+  includeBranches: "current-only" | "all-leaves";
+  updateMode: UpdateMode;
+  startedAt: string;
+  updatedAt: string;
+  documents: Record<string, ImportCheckpointDocument>;
+}
+
+export function resolveImportCheckpointPath(cwd: string, checkpointPath: string): string {
+  return isAbsolute(checkpointPath) ? checkpointPath : join(cwd, checkpointPath);
+}
+
+export function importRunId(args: {
+  sourceFile: string;
+  bankId: string;
+  sessionId: string;
+  includeBranches: "current-only" | "all-leaves";
+}): string {
+  return ["pi-import", args.bankId, args.sessionId, args.includeBranches, args.sourceFile]
+    .join(":")
+    .replace(/\s+/g, "_");
+}
+
+export async function readImportCheckpoint(path: string): Promise<ImportCheckpoint | undefined> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+      throw new Error("import checkpoint must be a JSON object");
+    const record = parsed as ImportCheckpoint;
+    return { ...record, version: 1, documents: record.documents ?? {} };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+export async function writeImportCheckpoint(
+  path: string,
+  checkpoint: ImportCheckpoint,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(checkpoint, null, 2)}\n`, "utf8");
+  await rename(tmp, path);
+}
+
+export function createImportCheckpoint(args: {
+  runId: string;
+  sourceFile: string;
+  bankId: string;
+  sessionId: string;
+  cwd: string;
+  includeBranches: "current-only" | "all-leaves";
+  updateMode: UpdateMode;
+  now: string;
+}): ImportCheckpoint {
+  return {
+    version: 1,
+    runId: args.runId,
+    sourceFile: args.sourceFile,
+    bankId: args.bankId,
+    sessionId: args.sessionId,
+    cwd: args.cwd,
+    includeBranches: args.includeBranches,
+    updateMode: args.updateMode,
+    startedAt: args.now,
+    updatedAt: args.now,
+    documents: {},
+  };
+}

--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -30,6 +30,8 @@ export interface ImportDocumentPreview {
   updateMode: "append" | "replace";
   bankId: string;
   wouldWrite: boolean;
+  status: "pending" | "completed" | "failed" | "skipped";
+  error?: string;
 }
 
 export interface ImportRetainResult {
@@ -87,6 +89,7 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
     updateMode,
     bankId: args.bankId,
     wouldWrite: true,
+    status: "pending" as const,
   };
   const manifestEntry: ImportManifestEntry = {
     documentId,

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -4,6 +4,14 @@ import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
 import { importDocumentId, stableSessionId } from "./session.js";
 import { parseImportSessionJsonl, parsePiSessionJsonl } from "./import-parser.js";
 import { leafIds, selectImportBranches } from "./import-branches.js";
+import {
+  createImportCheckpoint,
+  importRunId,
+  readImportCheckpoint,
+  resolveImportCheckpointPath,
+  writeImportCheckpoint,
+  type ImportCheckpoint,
+} from "./import-checkpoint.js";
 import { resolveImportManifestPath, upsertImportManifestEntries } from "./import-manifest.js";
 import { previewImportBranch, retainImportBranch } from "./import-retain.js";
 
@@ -22,6 +30,8 @@ export interface ImportSessionDocumentResult {
   updateMode: "append" | "replace";
   bankId: string;
   wouldWrite: boolean;
+  status: "pending" | "completed" | "failed" | "skipped";
+  error?: string;
 }
 
 export interface ImportSessionResult {
@@ -31,6 +41,8 @@ export interface ImportSessionResult {
   retained: boolean;
   dryRun: boolean;
   manifestPath: string;
+  checkpointPath: string;
+  runId: string;
   documents: ImportSessionDocumentResult[];
 }
 
@@ -50,31 +62,123 @@ export async function importPiSession(args: {
   const includeBranches = args.includeBranches ?? args.config.import.includeBranches;
   const branches = selectImportBranches(parsed, includeBranches);
   const manifestPath = resolveImportManifestPath(cwd, args.config.import.manifestPath);
+  const checkpointPath = resolveImportCheckpointPath(cwd, args.config.import.checkpointPath);
+  const updateMode = args.config.import.replaceExistingImportedDocs ? "replace" : "append";
+  const runId = importRunId({
+    sourceFile: args.sessionFile,
+    bankId: args.bankId,
+    sessionId,
+    includeBranches,
+  });
 
   const importConfig = { ...args.config, import: { ...args.config.import, includeBranches } };
-  const results = await Promise.all(
-    branches.map((branch) => {
-      const common = {
-        sessionFile: args.sessionFile,
-        bankId: args.bankId,
-        config: importConfig,
-        parsed,
-        cwd,
-        sessionId,
-        leaves,
-        branch,
+  const now = new Date().toISOString();
+  const existingCheckpoint = args.config.import.resume
+    ? await readImportCheckpoint(checkpointPath)
+    : undefined;
+  let checkpoint: ImportCheckpoint =
+    existingCheckpoint?.runId === runId
+      ? existingCheckpoint
+      : createImportCheckpoint({
+          runId,
+          sourceFile: args.sessionFile,
+          bankId: args.bankId,
+          sessionId,
+          cwd,
+          includeBranches,
+          updateMode,
+          now,
+        });
+  checkpoint = { ...checkpoint, updatedAt: now };
+
+  const results = [];
+  for (const branch of branches) {
+    const common = {
+      sessionFile: args.sessionFile,
+      bankId: args.bankId,
+      config: importConfig,
+      parsed,
+      cwd,
+      sessionId,
+      leaves,
+      branch,
+    };
+    const preview = previewImportBranch(common);
+    const previous = checkpoint.documents[preview.document.documentId];
+    const canSkip =
+      !args.dryRun &&
+      args.config.import.resume &&
+      previous?.status === "completed" &&
+      previous.contentHash === preview.document.contentHash;
+    if (args.dryRun || canSkip) {
+      results.push({
+        ...preview,
+        document: {
+          ...preview.document,
+          wouldWrite: false,
+          status: canSkip ? ("skipped" as const) : preview.document.status,
+        },
+      });
+      continue;
+    }
+
+    checkpoint.documents[preview.document.documentId] = {
+      documentId: preview.document.documentId,
+      leafId: preview.document.leafId,
+      contentHash: preview.document.contentHash,
+      messageCount: preview.document.messageCount,
+      status: "pending",
+      updatedAt: new Date().toISOString(),
+    };
+    await writeImportCheckpoint(checkpointPath, checkpoint);
+
+    try {
+      const retained = await retainImportBranch({ ...common, client: args.client });
+      const completedAt = new Date().toISOString();
+      checkpoint.documents[retained.document.documentId] = {
+        documentId: retained.document.documentId,
+        leafId: retained.document.leafId,
+        contentHash: retained.document.contentHash,
+        messageCount: retained.document.messageCount,
+        status: "completed",
+        updatedAt: completedAt,
       };
-      return args.dryRun
-        ? Promise.resolve(previewImportBranch(common))
-        : retainImportBranch({ ...common, client: args.client });
-    }),
-  );
+      checkpoint.updatedAt = completedAt;
+      await writeImportCheckpoint(checkpointPath, checkpoint);
+      results.push({
+        ...retained,
+        document: { ...retained.document, status: "completed" as const },
+      });
+    } catch (error) {
+      const failedAt = new Date().toISOString();
+      const message = error instanceof Error ? error.message : String(error);
+      checkpoint.documents[preview.document.documentId] = {
+        documentId: preview.document.documentId,
+        leafId: preview.document.leafId,
+        contentHash: preview.document.contentHash,
+        messageCount: preview.document.messageCount,
+        status: "failed",
+        updatedAt: failedAt,
+        error: message,
+      };
+      checkpoint.updatedAt = failedAt;
+      await writeImportCheckpoint(checkpointPath, checkpoint);
+      results.push({
+        ...preview,
+        document: { ...preview.document, status: "failed" as const, error: message },
+      });
+      throw error;
+    }
+  }
 
   const documents = results.map((result) => result.document);
-  if (!args.dryRun) {
+  const completedResults = results.filter(
+    (result) => result.document.status === "completed" || result.document.status === "skipped",
+  );
+  if (!args.dryRun && completedResults.length > 0) {
     await upsertImportManifestEntries(
       manifestPath,
-      results.map((result) => result.manifestEntry),
+      completedResults.map((result) => result.manifestEntry),
     );
   }
 
@@ -88,6 +192,7 @@ export async function importPiSession(args: {
     updateMode: args.config.import.replaceExistingImportedDocs ? "replace" : "append",
     bankId: args.bankId,
     wouldWrite: !args.dryRun,
+    status: "pending" as const,
   };
   return {
     sessionFile: args.sessionFile,
@@ -96,6 +201,8 @@ export async function importPiSession(args: {
     retained: !args.dryRun,
     dryRun: Boolean(args.dryRun),
     manifestPath,
+    checkpointPath,
+    runId,
     documents,
   };
 }

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -69,6 +69,7 @@ export async function importPiSession(args: {
     bankId: args.bankId,
     sessionId,
     includeBranches,
+    updateMode,
   });
 
   const importConfig = { ...args.config, import: { ...args.config.import, includeBranches } };

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -74,6 +74,8 @@ export interface ResolvedConfig {
     includeBranches: "current-only" | "all-leaves";
     replaceExistingImportedDocs: boolean;
     manifestPath: string;
+    checkpointPath: string;
+    resume: boolean;
   };
   status: {
     style: StatusStyle;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -148,6 +148,8 @@ describe("resolveConfig", () => {
     expect(config.retain.shutdownFlushMaxJobs).toBe(10);
     expect(config.retain.shutdownFlushTimeoutMs).toBe(2_000);
     expect(config.import.includeBranches).toBe("current-only");
+    expect(config.import.checkpointPath).toBe(".pi/hindsight/import-checkpoint.json");
+    expect(config.import.resume).toBe(true);
     expect(config).not.toHaveProperty("import.includeCompactionSummaries");
     expect(config).not.toHaveProperty("import.includeBranchSummaries");
     expect(config.status.style).toBe("text");

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -9,6 +9,7 @@ import {
   parsePiSessionJsonl,
   selectImportBranches,
 } from "../extensions/import-sessions.js";
+import { readImportCheckpoint } from "../extensions/import-checkpoint.js";
 import { readImportManifest } from "../extensions/import-manifest.js";
 
 describe("Pi session import", () => {
@@ -244,6 +245,8 @@ describe("Pi session import", () => {
     expect(result.retained).toBe(false);
     expect(result.dryRun).toBe(true);
     expect(result.messageCount).toBe(4);
+    expect(result.checkpointPath).toBe(join(dir, ".pi/hindsight/import-checkpoint.json"));
+    await expect(readImportCheckpoint(result.checkpointPath)).resolves.toBeUndefined();
     expect(result.documents).toEqual([
       expect.objectContaining({
         documentId: "pi-import:session-preview:leaf:a",
@@ -267,6 +270,94 @@ describe("Pi session import", () => {
       version: 1,
       imports: {},
     });
+  });
+
+  it("resumes completed checkpoint documents without duplicate retain", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-resume", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "root" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "a",
+          parentId: "root",
+          message: { role: "assistant", content: "a" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "b",
+          parentId: "root",
+          message: { role: "assistant", content: "b" },
+        }),
+      ].join("\n"),
+    );
+    const firstCalls: unknown[][] = [];
+    await expect(
+      importPiSession({
+        sessionFile,
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        includeBranches: "all-leaves",
+        client: {
+          retain: async (...args: unknown[]) => {
+            firstCalls.push(args);
+            if (firstCalls.length === 2) throw new Error("interrupted");
+          },
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+      }),
+    ).rejects.toThrow(/interrupted/);
+
+    const checkpoint = await readImportCheckpoint(
+      join(dir, ".pi/hindsight/import-checkpoint.json"),
+    );
+    expect(checkpoint?.documents["pi-import:session-resume:leaf:a"]?.status).toBe("completed");
+    expect(checkpoint?.documents["pi-import:session-resume:leaf:b"]?.status).toBe("failed");
+
+    const secondCalls: unknown[][] = [];
+    const result = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      includeBranches: "all-leaves",
+      client: {
+        retain: async (...args: unknown[]) => {
+          secondCalls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(secondCalls).toHaveLength(1);
+    const retainedOptions = secondCalls[0]?.[2] as { documentId: string };
+    expect(retainedOptions.documentId).toBe("pi-import:session-resume:leaf:b");
+    expect(result.documents.map((document) => [document.leafId, document.status])).toEqual([
+      ["a", "skipped"],
+      ["b", "completed"],
+    ]);
+    const resumedCheckpoint = await readImportCheckpoint(result.checkpointPath);
+    expect(resumedCheckpoint?.documents["pi-import:session-resume:leaf:a"]?.status).toBe(
+      "completed",
+    );
+    expect(resumedCheckpoint?.documents["pi-import:session-resume:leaf:b"]?.status).toBe(
+      "completed",
+    );
+    const manifest = await readImportManifest(result.manifestPath);
+    expect(Object.keys(manifest.imports).sort()).toEqual([
+      "pi-import:session-resume:leaf:a",
+      "pi-import:session-resume:leaf:b",
+    ]);
   });
 
   it("selects import branches without retaining or writing manifests", () => {

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -360,6 +360,58 @@ describe("Pi session import", () => {
     ]);
   });
 
+  it("starts a fresh checkpoint run when update mode changes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-mode", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "root" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "leaf",
+          parentId: "root",
+          message: { role: "assistant", content: "leaf" },
+        }),
+      ].join("\n"),
+    );
+
+    await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config: {
+        ...DEFAULT_CONFIG,
+        import: { ...DEFAULT_CONFIG.import, replaceExistingImportedDocs: false },
+      },
+      client: { retain: async () => undefined, recall: async () => [], reflect: async () => ({}) },
+    });
+
+    const calls: unknown[][] = [];
+    const result = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      client: {
+        retain: async (...args: unknown[]) => {
+          calls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(result.documents[0]).toMatchObject({ status: "completed", updateMode: "replace" });
+    expect(result.runId).toContain(":replace:");
+  });
+
   it("selects import branches without retaining or writing manifests", () => {
     const parsed = parseImportSessionJsonl(
       [


### PR DESCRIPTION
## Summary
- add import checkpoint state with per-document pending/completed/failed/skipped statuses
- add `import.checkpointPath` and `import.resume` config defaults
- resume imports by skipping checkpoint-completed documents without duplicate retain
- retry failed documents on the next run
- keep dry-run side-effect free: no retain, manifest, or checkpoint writes
- write completed/skipped documents to manifest so resumed imports preserve provenance
- ignore default checkpoint path and document resume behavior

## Reviewer
- reviewer found two blockers: completed docs were overwritten as skipped in checkpoint, and manifest could miss completed docs after partial failure/resume
- both fixed before PR
- final reviewer found no blockers

## Verification
- `npm run check`
- `npm run typecheck:tsc`
