### PR TITLE
Add project session imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ This is an early MVP scaffold. It includes:
   - `/hindsight:setup`
   - `/hindsight:init`
   - `/hindsight:import`
+  - `/hindsight:import-current`
+  - `/hindsight:import-file`
+  - `/hindsight:import-project-sessions`
   - `/hindsight:flush`
   - `/hindsight:last-recall`
   - `/hindsight:session`
@@ -40,7 +43,7 @@ This is an early MVP scaffold. It includes:
   - `/hindsight:tag`
 - tests for config, bank derivation, stable document IDs, sanitization, recall formatting, retain payloads, diagnostics, client request shapes, extension hook placement, historical import, import manifests, and queue replay
 
-Historical import supports importing the current Pi session or an explicit JSONL path via tool. Imports write deterministic document IDs and update an import manifest so `/hindsight:debug` can show imported document count and latest import provenance. Use `/hindsight:import --dry-run` or `hindsight_import` with `dryRun: true` to preview documents, message counts, content sizes, tags, update mode, and target bank without writing Hindsight memory or mutating the manifest. Add `--all-leaves` or `allLeaves: true` to preview/import every branch leaf instead of only the current branch. Imports maintain `.pi/hindsight/import-checkpoint.json` by default and resume completed documents without re-retaining them when `import.resume` is enabled.
+Historical import supports importing the current Pi session, an explicit JSONL path, or all Pi session JSONL files in the current session directory that belong to the current repo/cwd. Imports write deterministic document IDs and update an import manifest so `/hindsight:debug` can show imported document count and latest import provenance. Use `/hindsight:import --dry-run`, `/hindsight:import-project-sessions --dry-run`, or `hindsight_import` with `dryRun: true` to preview documents, message counts, content sizes, tags, update mode, and target bank without writing Hindsight memory or mutating the manifest. Add `--all-leaves` or `allLeaves: true` to preview/import every branch leaf instead of only the current branch. Project session discovery intentionally avoids broad history imports: it scans only the current session file's directory and keeps only `.jsonl` session files whose parsed `cwd` exactly matches the current repo/cwd. Imports maintain `.pi/hindsight/import-checkpoint.json` by default and resume completed documents without re-retaining them when `import.resume` is enabled.
 
 ## Install for local development
 

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -10,6 +10,10 @@ function firstArg(args: unknown): string | undefined {
   return undefined;
 }
 
+function firstNonFlagArg(args: unknown): string | undefined {
+  return argList(args).find((arg) => !arg.startsWith("--"));
+}
+
 function secondArg(args: unknown): string | undefined {
   if (Array.isArray(args)) return typeof args[1] === "string" ? args[1] : undefined;
   if (typeof args === "string") return args.split(/\s+/).filter(Boolean)[1];
@@ -30,6 +34,17 @@ function sessionFile(ctx: {
 
 function isSessionMode(value: string | undefined): value is SessionMemoryMode {
   return value === "normal" || value === "read-only" || value === "ignored";
+}
+
+function importOptions(args: unknown): {
+  dryRun: boolean;
+  includeBranches?: "all-leaves";
+} {
+  const flags = new Set(argList(args));
+  return {
+    dryRun: flags.has("--dry-run") || flags.has("--preview"),
+    ...(flags.has("--all-leaves") ? { includeBranches: "all-leaves" as const } : {}),
+  };
 }
 
 export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
@@ -114,16 +129,71 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         );
         return;
       }
-      const flags = new Set(argList(args));
       const result = await operations.importSession({
         sessionFile,
-        dryRun: flags.has("--dry-run") || flags.has("--preview"),
-        ...(flags.has("--all-leaves") ? { includeBranches: "all-leaves" } : {}),
+        ...importOptions(args),
       });
       ctx.ui.notify(
         result.dryRun
           ? `Import preview: ${result.messageCount} messages across ${result.documents.length} document${result.documents.length === 1 ? "" : "s"}; first ${result.documentId}; manifest unchanged ${result.manifestPath}`
           : `Imported ${result.messageCount} messages as ${result.documentId}; manifest ${result.manifestPath}`,
+        "info",
+      );
+    },
+  });
+
+  pi.registerCommand("hindsight:import-current", {
+    description: "Import the current Pi session JSONL into Hindsight.",
+    handler: async (args, ctx) => {
+      const current = sessionFile(ctx);
+      if (!current) {
+        ctx.ui.notify("No current session file available.", "warning");
+        return;
+      }
+      const result = await operations.importSession({
+        sessionFile: current,
+        ...importOptions(args),
+      });
+      ctx.ui.notify(
+        result.dryRun
+          ? `Import preview: current session ${result.messageCount} messages across ${result.documents.length} document${result.documents.length === 1 ? "" : "s"}`
+          : `Imported current session ${result.messageCount} messages as ${result.documentId}`,
+        "info",
+      );
+    },
+  });
+
+  pi.registerCommand("hindsight:import-file", {
+    description: "Import an explicit Pi session JSONL file into Hindsight.",
+    handler: async (args, ctx) => {
+      const file = firstNonFlagArg(args);
+      if (!file) {
+        ctx.ui.notify("Usage: /hindsight:import-file <path> [--dry-run] [--all-leaves]", "warning");
+        return;
+      }
+      const result = await operations.importSession({ sessionFile: file, ...importOptions(args) });
+      ctx.ui.notify(
+        result.dryRun
+          ? `Import preview: ${result.messageCount} messages from ${file} across ${result.documents.length} document${result.documents.length === 1 ? "" : "s"}`
+          : `Imported ${result.messageCount} messages from ${file} as ${result.documentId}`,
+        "info",
+      );
+    },
+  });
+
+  pi.registerCommand("hindsight:import-project-sessions", {
+    description: "Import Pi session JSONL files scoped to the current repo/cwd.",
+    handler: async (args, ctx) => {
+      const current = sessionFile(ctx);
+      const result = await operations.importProjectSessions({
+        cwd: ctx.cwd,
+        ...(current ? { currentSessionFile: current } : {}),
+        ...importOptions(args),
+      });
+      ctx.ui.notify(
+        result.dryRun
+          ? `Project import preview: ${result.documentCount} documents from ${result.sessionFiles.length}/${result.scanned} scoped sessions; ${result.messageCount} messages`
+          : `Imported ${result.documentCount} documents from ${result.sessionFiles.length}/${result.scanned} scoped sessions; ${result.messageCount} messages`,
         "info",
       );
     },

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -12,7 +12,11 @@ import {
   writeImportCheckpoint,
   type ImportCheckpoint,
 } from "./import-checkpoint.js";
-import { resolveImportManifestPath, upsertImportManifestEntries } from "./import-manifest.js";
+import {
+  hashImportContent,
+  resolveImportManifestPath,
+  upsertImportManifestEntries,
+} from "./import-manifest.js";
 import { previewImportBranch, retainImportBranch } from "./import-retain.js";
 
 export { parseImportSessionJsonl, parsePiSessionJsonl } from "./import-parser.js";
@@ -31,6 +35,10 @@ async function isFile(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function projectSessionCheckpointPath(basePath: string, sessionFile: string): string {
+  return `${basePath}.${hashImportContent(sessionFile).slice(0, 12)}.json`;
 }
 
 export async function discoverProjectSessionFiles(args: {
@@ -284,7 +292,16 @@ export async function importProjectSessions(args: {
         sessionFile,
         bankId: args.bankId,
         client: args.client,
-        config: args.config,
+        config: {
+          ...args.config,
+          import: {
+            ...args.config.import,
+            checkpointPath: projectSessionCheckpointPath(
+              args.config.import.checkpointPath,
+              sessionFile,
+            ),
+          },
+        },
         ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
         ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
       }),

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -1,5 +1,5 @@
-import { readFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { dirname, extname, join } from "node:path";
 import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
 import { importDocumentId, stableSessionId } from "./session.js";
 import { parseImportSessionJsonl, parsePiSessionJsonl } from "./import-parser.js";
@@ -19,6 +19,60 @@ export { parseImportSessionJsonl, parsePiSessionJsonl } from "./import-parser.js
 export { selectImportBranches } from "./import-branches.js";
 export type { ImportBranch } from "./import-branches.js";
 export type { ParsedMessage, ParsedSession } from "./import-parser.js";
+
+function sameProjectCwd(sessionCwd: string | undefined, cwd: string): boolean {
+  if (!sessionCwd) return false;
+  return sessionCwd === cwd;
+}
+
+async function isFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export async function discoverProjectSessionFiles(args: {
+  cwd: string;
+  currentSessionFile?: string;
+  searchDir?: string;
+}): Promise<ProjectSessionDiscoveryResult> {
+  const searchDir =
+    args.searchDir ?? (args.currentSessionFile ? dirname(args.currentSessionFile) : undefined);
+  if (!searchDir) return { sessionFiles: [], scanned: 0 };
+  const entries = await readdir(searchDir);
+  const candidates = entries
+    .filter((entry) => extname(entry) === ".jsonl")
+    .map((entry) => join(searchDir, entry));
+  const sessionFiles: string[] = [];
+  let scanned = 0;
+  for (const candidate of candidates) {
+    if (!(await isFile(candidate))) continue;
+    scanned += 1;
+    try {
+      const parsed = parseImportSessionJsonl(await readFile(candidate, "utf8"));
+      if (sameProjectCwd(parsed.cwd, args.cwd)) sessionFiles.push(candidate);
+    } catch {
+      // Ignore unrelated or malformed JSONL files during project-scoped discovery.
+    }
+  }
+  return { sessionFiles: sessionFiles.sort(), scanned };
+}
+
+export interface ProjectSessionDiscoveryResult {
+  sessionFiles: string[];
+  scanned: number;
+}
+
+export interface ImportProjectSessionsResult {
+  sessionFiles: string[];
+  scanned: number;
+  imported: ImportSessionResult[];
+  messageCount: number;
+  documentCount: number;
+  dryRun: boolean;
+}
 
 export interface ImportSessionDocumentResult {
   documentId: string;
@@ -205,5 +259,43 @@ export async function importPiSession(args: {
     checkpointPath,
     runId,
     documents,
+  };
+}
+
+export async function importProjectSessions(args: {
+  cwd: string;
+  currentSessionFile?: string;
+  searchDir?: string;
+  bankId: string;
+  client: HindsightLikeClient;
+  config: ResolvedConfig;
+  dryRun?: boolean;
+  includeBranches?: ResolvedConfig["import"]["includeBranches"];
+}): Promise<ImportProjectSessionsResult> {
+  const discovery = await discoverProjectSessionFiles({
+    cwd: args.cwd,
+    ...(args.currentSessionFile ? { currentSessionFile: args.currentSessionFile } : {}),
+    ...(args.searchDir ? { searchDir: args.searchDir } : {}),
+  });
+  const imported: ImportSessionResult[] = [];
+  for (const sessionFile of discovery.sessionFiles) {
+    imported.push(
+      await importPiSession({
+        sessionFile,
+        bankId: args.bankId,
+        client: args.client,
+        config: args.config,
+        ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+        ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
+      }),
+    );
+  }
+  return {
+    sessionFiles: discovery.sessionFiles,
+    scanned: discovery.scanned,
+    imported,
+    messageCount: imported.reduce((count, result) => count + result.messageCount, 0),
+    documentCount: imported.reduce((count, result) => count + result.documents.length, 0),
+    dryRun: Boolean(args.dryRun),
   };
 }

--- a/extensions/memory-operations.ts
+++ b/extensions/memory-operations.ts
@@ -8,7 +8,7 @@ import {
   writeProjectConfig,
   type ProjectConfigPatchInput,
 } from "./config-writer.js";
-import { importPiSession } from "./import-sessions.js";
+import { importPiSession, importProjectSessions } from "./import-sessions.js";
 import {
   importManifestSummary,
   readImportManifest,
@@ -131,6 +131,28 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
       const bankId = args.bank || deps.getProjectBankId();
       const result = await importPiSession({
         sessionFile: args.sessionFile,
+        bankId,
+        client: deps.getClient(),
+        config: deps.getConfig(),
+        ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+        ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
+      });
+      return { bankId, ...result };
+    },
+
+    async importProjectSessions(args: {
+      cwd: string;
+      currentSessionFile?: string;
+      searchDir?: string;
+      bank?: string;
+      dryRun?: boolean;
+      includeBranches?: ResolvedConfig["import"]["includeBranches"];
+    }) {
+      const bankId = args.bank || deps.getProjectBankId();
+      const result = await importProjectSessions({
+        cwd: args.cwd,
+        ...(args.currentSessionFile ? { currentSessionFile: args.currentSessionFile } : {}),
+        ...(args.searchDir ? { searchDir: args.searchDir } : {}),
         bankId,
         client: deps.getClient(),
         config: deps.getConfig(),

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -450,6 +450,74 @@ describe("Pi session import", () => {
     expect(result.sessionFiles).toEqual([current, related].sort());
   });
 
+  it("resumes project session imports with per-file checkpoints", async () => {
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    const sessionsDir = mkdtempSync(join(tmpdir(), "pi-hindsight-sessions-"));
+    const first = join(sessionsDir, "first.jsonl");
+    const second = join(sessionsDir, "second.jsonl");
+    writeFileSync(
+      first,
+      [
+        JSON.stringify({ type: "session", id: "first", cwd: project }),
+        JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "first" } }),
+      ].join("\n"),
+    );
+    writeFileSync(
+      second,
+      [
+        JSON.stringify({ type: "session", id: "second", cwd: project }),
+        JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "second" } }),
+      ].join("\n"),
+    );
+    const firstCalls: unknown[][] = [];
+    await expect(
+      importProjectSessions({
+        cwd: project,
+        currentSessionFile: first,
+        bankId: "bank",
+        config: {
+          ...DEFAULT_CONFIG,
+          import: { ...DEFAULT_CONFIG.import, replaceExistingImportedDocs: false },
+        },
+        client: {
+          retain: async (...args: unknown[]) => {
+            firstCalls.push(args);
+            if (firstCalls.length === 2) throw new Error("interrupted");
+          },
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+      }),
+    ).rejects.toThrow(/interrupted/);
+
+    const secondCalls: unknown[][] = [];
+    const result = await importProjectSessions({
+      cwd: project,
+      currentSessionFile: first,
+      bankId: "bank",
+      config: {
+        ...DEFAULT_CONFIG,
+        import: { ...DEFAULT_CONFIG.import, replaceExistingImportedDocs: false },
+      },
+      client: {
+        retain: async (...args: unknown[]) => {
+          secondCalls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(secondCalls).toHaveLength(1);
+    const retainedOptions = secondCalls[0]?.[2] as { documentId: string };
+    expect(retainedOptions.documentId).toBe("pi-import:second:leaf:1");
+    expect(result.imported.map((item) => [item.sessionFile, item.documents[0]?.status])).toEqual([
+      [first, "skipped"],
+      [second, "completed"],
+    ]);
+    expect(result.imported[0]?.checkpointPath).not.toBe(result.imported[1]?.checkpointPath);
+  });
+
   it("dry-runs project session import without writing unrelated sessions", async () => {
     const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
     const sessionsDir = mkdtempSync(join(tmpdir(), "pi-hindsight-sessions-"));

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import {
+  discoverProjectSessionFiles,
   importPiSession,
+  importProjectSessions,
   parseImportSessionJsonl,
   parsePiSessionJsonl,
   selectImportBranches,
@@ -410,6 +412,86 @@ describe("Pi session import", () => {
     expect(calls).toHaveLength(1);
     expect(result.documents[0]).toMatchObject({ status: "completed", updateMode: "replace" });
     expect(result.runId).toContain(":replace:");
+  });
+
+  it("discovers only sessions scoped to the current project cwd", async () => {
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    const other = mkdtempSync(join(tmpdir(), "pi-hindsight-other-"));
+    const sessionsDir = mkdtempSync(join(tmpdir(), "pi-hindsight-sessions-"));
+    const current = join(sessionsDir, "current.jsonl");
+    const related = join(sessionsDir, "related.jsonl");
+    const unrelated = join(sessionsDir, "unrelated.jsonl");
+    writeFileSync(
+      current,
+      [
+        JSON.stringify({ type: "session", id: "current", cwd: project }),
+        JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "c" } }),
+      ].join("\n"),
+    );
+    writeFileSync(
+      related,
+      [
+        JSON.stringify({ type: "session", id: "related", cwd: project }),
+        JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "r" } }),
+      ].join("\n"),
+    );
+    writeFileSync(
+      unrelated,
+      [
+        JSON.stringify({ type: "session", id: "other", cwd: other }),
+        JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "o" } }),
+      ].join("\n"),
+    );
+    writeFileSync(join(sessionsDir, "note.txt"), "ignore");
+
+    const result = await discoverProjectSessionFiles({ cwd: project, currentSessionFile: current });
+
+    expect(result.scanned).toBe(3);
+    expect(result.sessionFiles).toEqual([current, related].sort());
+  });
+
+  it("dry-runs project session import without writing unrelated sessions", async () => {
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    const sessionsDir = mkdtempSync(join(tmpdir(), "pi-hindsight-sessions-"));
+    const current = join(sessionsDir, "current.jsonl");
+    const unrelated = join(sessionsDir, "unrelated.jsonl");
+    writeFileSync(
+      current,
+      [
+        JSON.stringify({ type: "session", id: "current", cwd: project }),
+        JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "c" } }),
+      ].join("\n"),
+    );
+    writeFileSync(
+      unrelated,
+      [
+        JSON.stringify({ type: "session", id: "other", cwd: "/other" }),
+        JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "o" } }),
+      ].join("\n"),
+    );
+    const calls: unknown[][] = [];
+
+    const result = await importProjectSessions({
+      cwd: project,
+      currentSessionFile: current,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      dryRun: true,
+      client: {
+        retain: async (...args: unknown[]) => {
+          calls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.scanned).toBe(2);
+    expect(result.sessionFiles).toEqual([current]);
+    expect(result.documentCount).toBe(1);
+    expect(result.messageCount).toBe(1);
+    expect(calls).toHaveLength(0);
   });
 
   it("selects import branches without retaining or writing manifests", () => {


### PR DESCRIPTION
## Summary
- add `/hindsight:import-current` for the active Pi session
- add `/hindsight:import-file <path>` for explicit session files
- add `/hindsight:import-project-sessions` to import or preview project-scoped session JSONL files
- discover project sessions only from the current session directory and only when parsed `cwd` exactly matches the current repo/cwd
- preserve dry-run behavior for project-session imports
- document the scoped discovery safety rule

## Reviewer
- reviewer found no blockers
- fixed non-blocking command parsing/docs issue before PR: `/hindsight:import-file --dry-run <path>` now uses first non-flag arg

## Verification
- `npm run check`
- `npm run typecheck:tsc`
