### PR TITLE
Add API key secret refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Inside Pi, open the interactive configuration TUI:
 /hindsight:setup
 ```
 
-The setup TUI lets you choose a deployment profile, edit the memory profile, project bank ID, Hindsight base URL, timeout, global bank, recall budget, token budget, retain settings, queue path, import branch mode, statusline display, and Pi window notifications. Deployment profile choices cover Hindsight Cloud, an existing local/external API, and local `hindsight-embed` guidance. The local `hindsight-embed` profile gives commands to run yourself and can set the base URL to `http://localhost:8888`; it does not manage daemons. It writes `.pi/hindsight.json` and reloads the extension config after each change. Active import config covers branch mode, replace-vs-append behavior, manifest path, checkpoint path, and resume behavior.
+The setup TUI lets you choose a deployment profile, edit the memory profile, project bank ID, Hindsight base URL, API key env reference, timeout, global bank, recall budget, token budget, retain settings, queue path, import branch mode, statusline display, and Pi window notifications. Deployment profile choices cover Hindsight Cloud, an existing local/external API, and local `hindsight-embed` guidance. The local `hindsight-embed` profile gives commands to run yourself and can set the base URL to `http://localhost:8888`; it does not manage daemons. It writes `.pi/hindsight.json` and reloads the extension config after each change. Active import config covers branch mode, replace-vs-append behavior, manifest path, checkpoint path, and resume behavior.
 
 Memory profiles make global memory explicit. Choose the narrowest route that fits the repo:
 
@@ -109,6 +109,10 @@ Supported environment overrides:
 ```bash
 export HINDSIGHT_BASE_URL=http://localhost:8888
 export HINDSIGHT_API_KEY=...
+# or point config/env at another env var without storing the raw key:
+export HINDSIGHT_API_KEY_REF=HINDSIGHT_API_KEY
+# project config SecretRef shape:
+# { "hindsight": { "apiKey": { "source": "env", "name": "HINDSIGHT_API_KEY" } } }
 export PI_HINDSIGHT_ENABLED=true
 export PI_HINDSIGHT_PROJECT_BANK_ID=pi-project-my-repo
 export PI_HINDSIGHT_GLOBAL_BANK_ID=pi-global

--- a/extensions/config-writer.ts
+++ b/extensions/config-writer.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
+import { validEnvVarName } from "./config.js";
+
 export type MemoryProfile = "project-only" | "project+global" | "global-only";
 
 export const DEFAULT_GLOBAL_BANK_ID = "pi-global";
@@ -37,6 +39,7 @@ export interface ProjectConfigPatchInput {
   enabled?: boolean;
   baseUrl?: string;
   timeoutMs?: number;
+  apiKeyEnvVar?: string;
   projectBankId?: string;
   globalBankId?: string;
   enableGlobalBank?: boolean;
@@ -62,10 +65,14 @@ export interface ProjectConfigPatchInput {
 export function buildProjectConfigPatch(input: ProjectConfigPatchInput): Record<string, unknown> {
   const patch: Record<string, unknown> = {};
   if (input.enabled !== undefined) patch.enabled = input.enabled;
-  if (input.baseUrl || input.timeoutMs !== undefined) {
+  if (input.apiKeyEnvVar && !validEnvVarName(input.apiKeyEnvVar)) {
+    throw new Error("apiKeyEnvVar must be an environment variable name");
+  }
+  if (input.baseUrl || input.timeoutMs !== undefined || input.apiKeyEnvVar) {
     patch.hindsight = {
       ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
       ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+      ...(input.apiKeyEnvVar ? { apiKey: { source: "env", name: input.apiKeyEnvVar } } : {}),
     };
   }
   if (input.memoryProfile) {

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -131,6 +131,12 @@ export function validEnvVarName(value: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
+function normalizeApiKeyRefString(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.startsWith("env:")) return undefined;
+  const name = value.slice("env:".length);
+  return validEnvVarName(name) ? value : undefined;
+}
+
 function normalizeApiKeyRef(value: unknown): string | undefined {
   if (!isRecord(value)) return undefined;
   if (value.source !== "env" || typeof value.name !== "string" || !validEnvVarName(value.name))
@@ -209,8 +215,9 @@ export function normalizeConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedConfig {
   const apiKeyRef =
-    optionalString(config.hindsight?.apiKeyRef, DEFAULT_CONFIG.hindsight.apiKeyRef) ??
-    normalizeApiKeyRef(config.hindsight?.apiKey);
+    normalizeApiKeyRef(config.hindsight?.apiKey) ??
+    normalizeApiKeyRefString(config.hindsight?.apiKeyRef) ??
+    normalizeApiKeyRefString(DEFAULT_CONFIG.hindsight.apiKeyRef);
   const apiKey =
     directApiKey(config.hindsight?.apiKey, DEFAULT_CONFIG.hindsight.apiKey) ??
     resolveApiKeyRef(apiKeyRef, env);

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -127,6 +127,28 @@ function optionalString(value: unknown, fallback?: string): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : fallback;
 }
 
+export function validEnvVarName(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}
+
+function normalizeApiKeyRef(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.source !== "env" || typeof value.name !== "string" || !validEnvVarName(value.name))
+    return undefined;
+  return `env:${value.name}`;
+}
+
+function resolveApiKeyRef(ref: string | undefined, env: NodeJS.ProcessEnv): string | undefined {
+  if (!ref) return undefined;
+  if (!ref.startsWith("env:")) return undefined;
+  const name = ref.slice("env:".length);
+  return name ? optionalString(env[name]) : undefined;
+}
+
+function directApiKey(value: unknown, fallback?: string): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
 function enumValue<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
   return typeof value === "string" && (allowed as readonly string[]).includes(value)
     ? (value as T)
@@ -181,8 +203,17 @@ function hasConfiguredRecallField(rawConfig: unknown, field: string): boolean {
   return isRecord(rawConfig) && isRecord(rawConfig.recall) && field in rawConfig.recall;
 }
 
-export function normalizeConfig(config: ResolvedConfig, rawConfig?: unknown): ResolvedConfig {
-  const apiKey = optionalString(config.hindsight?.apiKey, DEFAULT_CONFIG.hindsight.apiKey);
+export function normalizeConfig(
+  config: ResolvedConfig,
+  rawConfig?: unknown,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedConfig {
+  const apiKeyRef =
+    optionalString(config.hindsight?.apiKeyRef, DEFAULT_CONFIG.hindsight.apiKeyRef) ??
+    normalizeApiKeyRef(config.hindsight?.apiKey);
+  const apiKey =
+    directApiKey(config.hindsight?.apiKey, DEFAULT_CONFIG.hindsight.apiKey) ??
+    resolveApiKeyRef(apiKeyRef, env);
   const projectBankId = optionalString(
     config.banks?.project?.bankId,
     DEFAULT_CONFIG.banks.project.bankId,
@@ -196,6 +227,7 @@ export function normalizeConfig(config: ResolvedConfig, rawConfig?: unknown): Re
     hindsight: {
       baseUrl: stringValue(config.hindsight?.baseUrl, DEFAULT_CONFIG.hindsight.baseUrl),
       ...(apiKey ? { apiKey } : {}),
+      ...(apiKeyRef ? { apiKeyRef } : {}),
       timeoutMs: positiveInt(config.hindsight?.timeoutMs, DEFAULT_CONFIG.hindsight.timeoutMs),
     },
     banks: {
@@ -395,6 +427,11 @@ export function resolveConfig(cwd: string, env: NodeJS.ProcessEnv = process.env)
     rawConfig = merge(rawConfig, { hindsight: { baseUrl: env.HINDSIGHT_BASE_URL } });
     config = merge(config, { hindsight: { baseUrl: env.HINDSIGHT_BASE_URL } });
   }
+  if (env.HINDSIGHT_API_KEY_REF && validEnvVarName(env.HINDSIGHT_API_KEY_REF)) {
+    const ref = { source: "env", name: env.HINDSIGHT_API_KEY_REF };
+    rawConfig = merge(rawConfig, { hindsight: { apiKey: ref } });
+    config = merge(config, { hindsight: { apiKey: ref } });
+  }
   if (env.HINDSIGHT_API_KEY) {
     rawConfig = merge(rawConfig, { hindsight: { apiKey: env.HINDSIGHT_API_KEY } });
     config = merge(config, { hindsight: { apiKey: env.HINDSIGHT_API_KEY } });
@@ -413,7 +450,7 @@ export function resolveConfig(cwd: string, env: NodeJS.ProcessEnv = process.env)
     rawConfig = merge(rawConfig, patch);
     config = merge(config, patch);
   }
-  return normalizeConfig(config, rawConfig);
+  return normalizeConfig(config, rawConfig, env);
 }
 
 export { DEFAULT_CONFIG };

--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -50,6 +50,7 @@ export function safeConfig(config: ResolvedConfig): ResolvedConfig {
     hindsight: {
       ...config.hindsight,
       ...(config.hindsight.apiKey ? { apiKey: "[set]" } : {}),
+      ...(config.hindsight.apiKeyRef ? { apiKeyRef: config.hindsight.apiKeyRef } : {}),
     },
   };
 }

--- a/extensions/setup-tui.ts
+++ b/extensions/setup-tui.ts
@@ -75,6 +75,7 @@ export async function runHindsightSetupTui(
       "Choose deployment profile",
       "Set project bank ID",
       "Set Hindsight base URL",
+      "Set API key env reference",
       "Set timeout (ms)",
       config.enabled ? "Disable extension" : "Enable extension",
       "Set memory profile",
@@ -113,10 +114,9 @@ export async function runHindsightSetupTui(
         if (value === "Hindsight Cloud") {
           const baseUrl = await ctx.ui.input("Hindsight Cloud base URL", config.hindsight.baseUrl);
           if (baseUrl) await writeAndReload(ctx, deps, { baseUrl: baseUrl.trim() });
-          ctx.ui.notify(
-            "Cloud profile selected. Store API keys outside project config; SecretRef setup is a separate roadmap item.",
-            "info",
-          );
+          const envName = await ctx.ui.input("API key env var name", "HINDSIGHT_API_KEY");
+          if (envName) await writeAndReload(ctx, deps, { apiKeyEnvVar: envName.trim() });
+          ctx.ui.notify("Cloud profile selected. API key stored as env SecretRef.", "info");
         } else if (value === "Existing local/external API") {
           const baseUrl = await ctx.ui.input("Hindsight API base URL", config.hindsight.baseUrl);
           if (baseUrl) await writeAndReload(ctx, deps, { baseUrl: baseUrl.trim() });
@@ -136,6 +136,9 @@ export async function runHindsightSetupTui(
       } else if (choice === "Set Hindsight base URL") {
         const value = await ctx.ui.input("Hindsight base URL", config.hindsight.baseUrl);
         if (value) await writeAndReload(ctx, deps, { baseUrl: value.trim() });
+      } else if (choice === "Set API key env reference") {
+        const value = await ctx.ui.input("API key env var name", "HINDSIGHT_API_KEY");
+        if (value) await writeAndReload(ctx, deps, { apiKeyEnvVar: value.trim() });
       } else if (choice === "Set timeout (ms)") {
         const value = await ctx.ui.input(
           "Timeout in milliseconds",

--- a/extensions/tools.ts
+++ b/extensions/tools.ts
@@ -105,7 +105,7 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
             text: `Wrote ${result.path}\nProject bank: ${result.projectBankId}\nRun /hindsight:debug to verify.`,
           },
         ],
-        details: { path: result.path, projectBankId: result.projectBankId, config: result.config },
+        details: { path: result.path, projectBankId: result.projectBankId },
       };
     },
   });

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -12,7 +12,7 @@ export type RecallInjectionPosition = "prepend" | "append";
 
 export interface ResolvedConfig {
   enabled: boolean;
-  hindsight: { baseUrl: string; apiKey?: string; timeoutMs: number };
+  hindsight: { baseUrl: string; apiKey?: string; apiKeyRef?: string; timeoutMs: number };
   banks: {
     project: {
       enabled: boolean;

--- a/tests/config-writer.test.ts
+++ b/tests/config-writer.test.ts
@@ -39,6 +39,7 @@ describe("config writer", () => {
     expect(
       buildProjectConfigPatch({
         timeoutMs: 1234,
+        apiKeyEnvVar: "HINDSIGHT_API_KEY",
         recallBudget: "mid",
         recallMaxTokens: 900,
         retainAsync: false,
@@ -51,13 +52,19 @@ describe("config writer", () => {
         notifyRetain: true,
       }),
     ).toEqual({
-      hindsight: { timeoutMs: 1234 },
+      hindsight: { timeoutMs: 1234, apiKey: { source: "env", name: "HINDSIGHT_API_KEY" } },
       recall: { budget: "mid", maxTokens: 900 },
       retain: { async: false },
       import: { includeBranches: "all-leaves" },
       status: { style: "emoji", detail: "activity", maxLength: 30, showActivity: false },
       notifications: { recall: true, retain: true },
     });
+  });
+
+  it("rejects invalid api key env var names", () => {
+    expect(() => buildProjectConfigPatch({ apiKeyEnvVar: "sk-secret" })).toThrow(
+      /environment variable name/,
+    );
   });
 
   it("deep merges without deleting existing config", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -68,6 +68,23 @@ describe("resolveConfig", () => {
     expect(config.hindsight.apiKeyRef).toBeUndefined();
   });
 
+  it("ignores invalid apiKeyRef strings and prefers valid SecretRef objects", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({
+        hindsight: {
+          apiKeyRef: "env:sk-secret",
+          apiKey: { source: "env", name: "PROJECT_KEY" },
+        },
+      }),
+    );
+    const config = resolveConfig(cwd, { PROJECT_KEY: "project-secret" });
+    expect(config.hindsight.apiKey).toBe("project-secret");
+    expect(config.hindsight.apiKeyRef).toBe("env:PROJECT_KEY");
+  });
+
   it("keeps direct apiKey strings even if they start with env prefix", () => {
     const cwd = tmp();
     mkdirSync(join(cwd, ".pi"));

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -30,6 +30,54 @@ describe("resolveConfig", () => {
     expect(config.banks.project.mission).toBe("Project mission");
   });
 
+  it("resolves env SecretRef API keys and lets direct env override win", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({ hindsight: { apiKey: { source: "env", name: "PROJECT_KEY" } } }),
+    );
+
+    const fromRef = resolveConfig(cwd, { PROJECT_KEY: "project-secret" });
+    expect(fromRef.hindsight.apiKey).toBe("project-secret");
+    expect(fromRef.hindsight.apiKeyRef).toBe("env:PROJECT_KEY");
+
+    const override = resolveConfig(cwd, {
+      PROJECT_KEY: "project-secret",
+      HINDSIGHT_API_KEY: "override-secret",
+    });
+    expect(override.hindsight.apiKey).toBe("override-secret");
+
+    const refFromEnv = resolveConfig(cwd, {
+      HINDSIGHT_API_KEY_REF: "OTHER_KEY",
+      OTHER_KEY: "other-secret",
+    });
+    expect(refFromEnv.hindsight.apiKey).toBe("other-secret");
+    expect(refFromEnv.hindsight.apiKeyRef).toBe("env:OTHER_KEY");
+  });
+
+  it("ignores invalid project SecretRef env var names", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({ hindsight: { apiKey: { source: "env", name: "sk-secret" } } }),
+    );
+    const config = resolveConfig(cwd, { "sk-secret": "secret" });
+    expect(config.hindsight.apiKey).toBeUndefined();
+    expect(config.hindsight.apiKeyRef).toBeUndefined();
+  });
+
+  it("keeps direct apiKey strings even if they start with env prefix", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({ hindsight: { apiKey: "env:literal-secret" } }),
+    );
+    expect(resolveConfig(cwd).hindsight.apiKey).toBe("env:literal-secret");
+  });
+
   it("reads boolean overrides from injected env", () => {
     const cwd = tmp();
     expect(resolveConfig(cwd, { PI_HINDSIGHT_ENABLED: "false" }).enabled).toBe(false);

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -24,9 +24,10 @@ describe("diagnostics", () => {
   it("redacts api key in debug config", () => {
     const config = {
       ...DEFAULT_CONFIG,
-      hindsight: { ...DEFAULT_CONFIG.hindsight, apiKey: "secret" },
+      hindsight: { ...DEFAULT_CONFIG.hindsight, apiKey: "secret", apiKeyRef: "env:KEY" },
     };
     expect(safeConfig(config).hindsight.apiKey).toBe("[set]");
+    expect(safeConfig(config).hindsight.apiKeyRef).toBe("env:KEY");
   });
 
   it("formats stable debug report", () => {


### PR DESCRIPTION
## Summary
- support `hindsight.apiKey` SecretRef objects like `{ "source": "env", "name": "HINDSIGHT_API_KEY" }`
- resolve `HINDSIGHT_API_KEY_REF` as an env-var indirection while keeping `HINDSIGHT_API_KEY` as the direct override
- preserve direct string `hindsight.apiKey` compatibility
- validate env var names before writing or accepting SecretRefs
- redact resolved API keys in diagnostics while showing safe ref names
- make setup write env SecretRefs instead of raw secrets
- omit raw config from `hindsight_configure` tool details to avoid leaking existing direct string keys

## Reviewer
- reviewer found three leak/validation blockers; fixed before PR
- final reviewer found no blockers

## Verification
- `npm run check`
- `npm run typecheck:tsc`
