### PR TITLE
Improve doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Use the debug command inside Pi to inspect what the extension believes:
 /hindsight:debug
 ```
 
-The report includes the project bank ID, whether it was configured or derived, current tags, queue path, queue length, import manifest summary, Hindsight reachability, and redacted effective config.
+The report includes the project bank ID, whether it was configured or derived, current tags, queue path, queue length, import manifest summary, Hindsight reachability, observation-scope expansion or errors with remediation hints, and redacted effective config. `/hindsight:doctor` also warns when observation-scope placeholders are invalid.
 
 Run the local smoke test against a real Hindsight server:
 
@@ -243,7 +243,7 @@ export HINDSIGHT_BASE_URL=http://localhost:8888
 npm run smoke:hindsight
 ```
 
-The smoke test creates a temporary bank, retains a unique marker with `updateMode: "append"`, recalls it, and runs `reflect`. It uses the configured Hindsight server; it does not start a server. For release verification, run:
+The smoke test creates a temporary bank, retains a unique marker with `updateMode: "append"`, recalls it, and runs `reflect`. It uses the configured Hindsight server; it does not start a server and it prints step markers (`bank_ok`, `retain_ok`, `recall_ok`, `reflect_ok`) so failures identify the broken integration stage. For release verification, run:
 
 ```bash
 npm run check:release

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -78,9 +78,16 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
           ? "append supported"
           : "append unsupported"
         : "append not checked";
+      const observation = doctor.observations.error
+        ? `; observations invalid: ${doctor.observations.error}`
+        : "";
       ctx.ui.notify(
-        `Hindsight ${doctor.health.ok ? "reachable" : `unreachable: ${doctor.health.error}`}; ${append}; queue ${doctor.queueLength}; imports ${doctor.imports.count}`,
-        doctor.health.ok && doctor.capabilities?.appendUpdateMode !== false ? "info" : "warning",
+        `Hindsight ${doctor.health.ok ? "reachable" : `unreachable: ${doctor.health.error}`}; ${append}; queue ${doctor.queueLength}; imports ${doctor.imports.count}${observation}`,
+        doctor.health.ok &&
+          doctor.capabilities?.appendUpdateMode !== false &&
+          !doctor.observations.error
+          ? "info"
+          : "warning",
       );
     },
   });

--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -55,21 +55,39 @@ export function safeConfig(config: ResolvedConfig): ResolvedConfig {
   };
 }
 
-export function formatDebugReport(args: DebugReportArgs): string {
-  const sessionId = stableSessionId(args.sessionFile, args.cwd);
-  const tags = baseTags(args.cwd, sessionId);
+export function observationScopeDiagnostics(args: {
+  cwd: string;
+  sessionFile?: string;
+  projectBankId: string;
+  config: ResolvedConfig;
+}): { enabled: boolean; scopes: string[][] | null; error: string | null; action: string | null } {
   const identity = {
     ...createMemoryIdentity(args.cwd, args.config, args.sessionFile),
     projectBankId: args.projectBankId,
   };
-  let observationScopes: string[][] | { error: string } = [];
   try {
-    observationScopes = args.config.observations.enabled
-      ? expandObservationScopes(args.config.observations.scopes, identity)
-      : [];
+    return {
+      enabled: args.config.observations.enabled,
+      scopes: args.config.observations.enabled
+        ? expandObservationScopes(args.config.observations.scopes, identity)
+        : [],
+      error: null,
+      action: null,
+    };
   } catch (error) {
-    observationScopes = { error: error instanceof Error ? error.message : String(error) };
+    return {
+      enabled: args.config.observations.enabled,
+      scopes: null,
+      error: error instanceof Error ? error.message : String(error),
+      action: "Fix observations.scopes placeholders or disable observations.enabled.",
+    };
   }
+}
+
+export function formatDebugReport(args: DebugReportArgs): string {
+  const sessionId = stableSessionId(args.sessionFile, args.cwd);
+  const tags = baseTags(args.cwd, sessionId);
+  const observationScopes = observationScopeDiagnostics(args);
   const health = args.health
     ? args.health.ok
       ? "reachable"
@@ -93,10 +111,7 @@ export function formatDebugReport(args: DebugReportArgs): string {
         projectConfigured: Boolean(args.config.banks.project.mission),
         globalConfigured: Boolean(args.config.banks.global.mission),
       },
-      observations: {
-        enabled: args.config.observations.enabled,
-        scopes: observationScopes,
-      },
+      observations: observationScopes,
       overrideProjectBankId:
         "Set PI_HINDSIGHT_PROJECT_BANK_ID or .pi/hindsight.json banks.project.bankId",
       globalBankId: args.config.banks.global.enabled

--- a/extensions/memory-operations.ts
+++ b/extensions/memory-operations.ts
@@ -2,7 +2,7 @@ import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import type { HindsightCapabilities, HindsightLikeClient, ResolvedConfig } from "./types.js";
 import { checkHindsight } from "./client.js";
 import { readRetainQueue, flushRetainQueue, resolveQueuePath } from "./queue.js";
-import { formatDebugReport, safeConfig } from "./diagnostics.js";
+import { formatDebugReport, observationScopeDiagnostics, safeConfig } from "./diagnostics.js";
 import {
   buildProjectConfigPatch,
   writeProjectConfig,
@@ -200,6 +200,11 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
         ...(deps.getCapabilities?.() ? { capabilities: deps.getCapabilities() } : {}),
         queueLength: queue.length,
         imports: importManifestSummary(manifest),
+        observations: observationScopeDiagnostics({
+          cwd,
+          projectBankId: deps.getProjectBankId(),
+          config,
+        }),
       };
     },
 

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
-import { bankSelectionMessage, formatDebugReport, safeConfig } from "../extensions/diagnostics.js";
+import {
+  bankSelectionMessage,
+  formatDebugReport,
+  observationScopeDiagnostics,
+  safeConfig,
+} from "../extensions/diagnostics.js";
 
 describe("diagnostics", () => {
   it("explains automatic bank selection and override", () => {
@@ -58,6 +63,8 @@ describe("diagnostics", () => {
     expect(report.observations).toEqual({
       enabled: true,
       scopes: [["harness:pi"], [expect.stringMatching(/^repo:/)]],
+      error: null,
+      action: null,
     });
     expect(report.overrideProjectBankId).toContain("PI_HINDSIGHT_PROJECT_BANK_ID");
     expect(report.tags).toEqual(expect.arrayContaining(["source:pi"]));
@@ -98,6 +105,22 @@ describe("diagnostics", () => {
 
     expect(report.observations.enabled).toBe(true);
     expect(report.observations.scopes).toEqual([[expect.stringMatching(/^repo:/)], ["bank:bank"]]);
+    expect(report.observations.error).toBeNull();
+  });
+
+  it("reports invalid observation scope diagnostics with action", () => {
+    const result = observationScopeDiagnostics({
+      cwd: process.cwd(),
+      projectBankId: "bank",
+      config: {
+        ...DEFAULT_CONFIG,
+        observations: { enabled: true, scopes: [["user:{userId}"]] },
+      },
+    });
+
+    expect(result.scopes).toBeNull();
+    expect(result.error).toContain("Unknown observation scope placeholder");
+    expect(result.action).toContain("observations.scopes");
   });
 
   it("formats append capability diagnostics", () => {


### PR DESCRIPTION
## Summary
- add structured observation-scope diagnostics with expanded scopes, error, and remediation action
- include observation diagnostics in `/hindsight:debug`
- make `/hindsight:doctor` warn when observation-scope placeholders are invalid
- preserve existing doctor success text when observation scopes are valid
- document observation-scope remediation in debug docs and smoke-test step markers

## Reviewer
- reviewer found one output-compatibility risk; fixed before PR by appending observation text only on errors

## Verification
- `npm run check`
- `npm run typecheck:tsc`
