### PR TITLE
Clarify release verification

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,10 +48,10 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       inputs.run_smoke == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/README.md
+++ b/README.md
@@ -243,11 +243,15 @@ export HINDSIGHT_BASE_URL=http://localhost:8888
 npm run smoke:hindsight
 ```
 
-The smoke test creates a temporary bank, retains a unique marker with `updateMode: "append"`, recalls it, and runs `reflect`. It uses the configured Hindsight server; it does not start a server and it prints step markers (`bank_ok`, `retain_ok`, `recall_ok`, `reflect_ok`) so failures identify the broken integration stage. For release verification, run:
+The smoke test creates a temporary bank, retains a unique marker with `updateMode: "append"`, recalls it, and runs `reflect`. It uses the configured Hindsight server; it does not start a server and it prints step markers (`bank_ok`, `retain_ok`, `recall_ok`, `reflect_ok`) so failures identify the broken integration stage. For release verification with a configured Hindsight server, run:
 
 ```bash
+export HINDSIGHT_BASE_URL=http://localhost:8888
+# export HINDSIGHT_API_KEY=... # if needed
 npm run check:release
 ```
+
+`check:release` runs the normal check suite, the `tsc` fallback typecheck, and the live smoke test. If no live server is available, run `npm run check` and `npm run typecheck:tsc`, then use the manual GitHub Actions `smoke-configured-server` job when credentials are available.
 
 GitHub Actions runs normal checks on PRs/pushes. The live Hindsight smoke job is manual (`workflow_dispatch`) and requires repository secrets:
 
@@ -281,7 +285,15 @@ That runs formatting (`oxfmt`), linting (`oxlint` with type-aware checks), `tsgo
 npm run changelog
 ```
 
-The `version` script also regenerates and stages `CHANGELOG.md` during `npm version`.
+The `version` script also regenerates and stages `CHANGELOG.md` during `npm version`. Do not hand-edit generated release entries as the source of truth; make Conventional Commits and regenerate the changelog before release.
+
+Before publishing or tagging a release:
+
+1. Ensure `main` is synced.
+2. Run `npm run check` and `npm run typecheck:tsc`.
+3. Run `npm run smoke:hindsight` or the manual `smoke-configured-server` workflow when a configured server is available.
+4. Run `npm run changelog` after final Conventional Commits.
+5. Use `npm version <patch|minor|major>` so the version script stages the regenerated changelog.
 
 Useful targeted checks:
 


### PR DESCRIPTION
## Summary
- clarify `check:release` requires a configured live Hindsight server
- document fallback release verification when live smoke credentials are unavailable
- add a concise pre-release checklist for checks, smoke, changelog, and versioning
- update the smoke workflow action versions to match the main check job

## Reviewer
- reviewer found no blockers

## Verification
- `npm run check`
- `npm run typecheck:tsc`
