### PR TITLE
Remove obsolete compatibility wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Recently completed release-hardening work:
 - roadmap/docs now match the implementation that already exists
 - focused Hindsight best-practice regression tests cover core memory invariants
 - documented configuration starts with memory profiles and minimal project config
-- outage, dead-letter, queue-lock, and append-compatibility behavior is documented and tested
+- outage, dead-letter, queue-lock, and append capability behavior is documented and tested
 - bank mission and observation-scope defaults are tuned for memory quality
 - historical import previews show document counts, update modes, checkpoint paths, and manifest behavior
 - packaging and live smoke-test paths are verified for release readiness
@@ -200,7 +200,7 @@ Defaults can be overridden by:
 2. `.pi/hindsight.json` in the current repo
 3. environment variables
 
-Config is normalized after merging. Unknown fields are ignored, invalid enum values fall back to defaults, and removed/reserved MVP fields do not affect behavior.
+Config is normalized after merging. Unknown fields are ignored, and invalid values fall back to defaults.
 
 ### Minimal configuration path
 
@@ -414,7 +414,7 @@ export HINDSIGHT_BASE_URL=http://localhost:8888
 npm run check:release
 ```
 
-`check:release` runs the normal check suite, the `tsc` compatibility typecheck, and the live smoke test. If no live server is available, run `npm run check` and `npm run typecheck:tsc`, then use the manual GitHub Actions `smoke-configured-server` job when credentials are available.
+`check:release` runs the normal check suite, the secondary `tsc` typecheck, and the live smoke test. If no live server is available, run `npm run check` and `npm run typecheck:tsc`, then use the manual GitHub Actions `smoke-configured-server` job when credentials are available.
 
 GitHub Actions runs normal checks on PRs/pushes. The live Hindsight smoke job is manual (`workflow_dispatch`) and requires repository secrets:
 

--- a/docs/pr-roadmap.md
+++ b/docs/pr-roadmap.md
@@ -1,6 +1,6 @@
 # PR Roadmap
 
-This roadmap is the current implementation guide for `@luxus/pi-hindsight`. It supersedes the older, implementation-phase checklist in `docs/next-changes-plan.md`, which is now useful mainly as historical context.
+This roadmap records the completed MVP hardening plan for `@luxus/pi-hindsight`. See `docs/post-mvp-roadmap.md` for the current post-MVP roadmap.
 
 The goal is to keep the extension simple by default while preserving enough flexibility for real Pi and Hindsight workflows. The roadmap is intentionally ordered so a human or LLM agent can pick the next PR without re-planning the whole project.
 
@@ -80,7 +80,7 @@ Implemented and expected to stay:
 **Scope:**
 
 - Add this roadmap.
-- Mark `docs/next-changes-plan.md` as historical/superseded.
+- Replace the older implementation checklist with this roadmap.
 - Update README status from early scaffold to working MVP/pre-release.
 - Add a compact feature-status section with implemented, planned, and deferred items.
 - Link README to this roadmap for implementation order.
@@ -89,7 +89,6 @@ Implemented and expected to stay:
 
 - `README.md`
 - `docs/pr-roadmap.md`
-- `docs/next-changes-plan.md`
 
 **Acceptance criteria:**
 

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -52,7 +52,7 @@ describe("append capabilities", () => {
     expect(capabilities.error).toContain("append unsupported");
   });
 
-  it("detects append validation errors from old servers", async () => {
+  it("detects append validation errors from servers without append support", async () => {
     const error = new Error(
       `retain failed: [{"loc":["body","items",0,"update_mode"],"msg":"Input should be 'replace'","input":"append"}]`,
     );


### PR DESCRIPTION
## Summary

- Remove obsolete compatibility/legacy wording after append fallback removal.
- Update completed roadmap references now that the old next-change checklist is gone.
- Rename append capability test wording to describe current supported behavior.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
