### PR TITLE
Design one-turn memory opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Intentionally deferred:
 
 See [`docs/risky-memory-modes.md`](docs/risky-memory-modes.md) for why persisted recall transcript messages, provider recall caching, and prompt hashtag controls remain deferred, and why command-based controls such as a future `/hindsight:next-opt-out` are preferred.
 
+See [`docs/next-opt-out-design.md`](docs/next-opt-out-design.md) for the proposed one-turn memory opt-out command design.
+
 Historical import supports importing the current Pi session, an explicit JSONL path, or all Pi session JSONL files in the current session directory that belong to the current repo/cwd. Imports write deterministic document IDs and update an import manifest so `/hindsight:debug` can show imported document count and latest import provenance. Use `/hindsight:import --dry-run`, `/hindsight:import-project-sessions --dry-run`, or `hindsight_import` with `dryRun: true` to preview documents, message counts, content sizes, tags, update mode, and target bank without writing Hindsight memory or mutating the manifest. Add `--all-leaves` or `allLeaves: true` to preview/import every branch leaf instead of only the current branch. Project session discovery intentionally avoids broad history imports: it scans only the current session file's directory and keeps only `.jsonl` session files whose parsed `cwd` exactly matches the current repo/cwd. Imports maintain `.pi/hindsight/import-checkpoint.json` by default and resume completed documents without re-retaining them when `import.resume` is enabled.
 
 Historical import examples:

--- a/docs/next-opt-out-design.md
+++ b/docs/next-opt-out-design.md
@@ -1,0 +1,154 @@
+# One-turn memory opt-out design
+
+This document defines the preferred one-turn memory control for Pi Hindsight. It intentionally avoids prompt hashtag parsing such as `#nomem`.
+
+## Problem
+
+Users sometimes need a fast way to keep the next agent run out of automatic memory retention without changing the whole session mode.
+
+Examples:
+
+- The next prompt contains throwaway sensitive material.
+- The next run is exploratory noise that should not become project memory.
+- The user wants a quick one-shot control discoverable through Pi command autocomplete.
+
+## Decision
+
+Use an explicit command:
+
+```text
+/hindsight:next-opt-out
+```
+
+Do not parse prompt hashtags.
+
+## Why command-based control
+
+Pi command autocomplete makes the command discoverable by typing `next`, `opt`, or `out`.
+
+A command is better than prompt parsing because it is:
+
+- explicit in command history
+- independent of Markdown syntax
+- testable without parsing arbitrary prose
+- less likely to be copied by agents into generated content
+- easier to reason about during import and cursor handling
+
+## Initial semantics
+
+`/hindsight:next-opt-out` applies once to the next completed agent run in the current session.
+
+It disables automatic retain for that run only.
+
+It does not disable recall. The user may still want memory context to answer the prompt, while not retaining the new prompt/result.
+
+It does not affect explicit memory tools. If an agent or user explicitly calls `hindsight_retain`, that explicit retain remains intentional and should still work.
+
+It does not affect historical import. Import reads the transcript as source material and is governed by import commands, not transient one-turn state.
+
+It stores state outside provider-visible messages, alongside existing session memory metadata.
+
+After the next completed agent run is skipped, the opt-out flag is consumed and cleared.
+
+## Interactions
+
+### `/hindsight:mode ignored`
+
+Ignored mode already disables recall and retain for the session. `next-opt-out` is redundant while ignored mode is active.
+
+### `/hindsight:mode read-only`
+
+Read-only mode already disables retain while allowing recall. `next-opt-out` is redundant while read-only mode is active.
+
+### `/hindsight:retain off`
+
+Retain off already disables automatic retain for the session. `next-opt-out` is redundant while retain is off.
+
+### Retain cursor
+
+When `next-opt-out` skips a run, the retain cursor should mark the skipped projected messages as handled. Otherwise those messages could be retained on a later overlapping `agent_end` event after the one-turn opt-out expires.
+
+This matches current read-only and ignored mode behavior.
+
+### Recall
+
+Recall remains enabled unless another session mode disables it. This keeps the command narrow and avoids surprising users who only wanted to prevent storage.
+
+A future command could add recall control explicitly, but it should not be overloaded into this first command.
+
+## Proposed user-facing behavior
+
+Command:
+
+```text
+/hindsight:next-opt-out
+```
+
+Success message:
+
+```text
+Hindsight will skip automatic retain for the next agent run in this session.
+```
+
+Session status should show pending one-turn opt-out:
+
+```text
+Hindsight session mode=normal; recall=true; retain=true; nextRetain=off; tags=none
+```
+
+When consumed, optional activity notification could say:
+
+```text
+Hindsight skipped retain for this run due to next-opt-out.
+```
+
+## Storage shape
+
+Extend session memory metadata with a non-provider-visible field:
+
+```json
+{
+  "nextRetainMode": "off"
+}
+```
+
+The default is no field or `"normal"`.
+
+Only persist fields that are active. Clearing the one-turn opt-out should remove or normalize the field.
+
+## Tests required before implementation
+
+Good tests should assert external behavior, not internal helper details.
+
+Cover:
+
+- command sets a pending one-turn retain opt-out
+- `/hindsight:session` reports pending opt-out
+- next `agent_end` skips automatic retain
+- skipped messages are added to retain cursor so they are not retained later
+- opt-out clears after one completed agent run
+- recall still runs while next retain is off
+- ignored/read-only/retain-off modes remain stronger than next opt-out
+- explicit `hindsight_retain` still queues normally
+- historical import ignores next opt-out state
+
+## Out of scope
+
+- `#nomem` or any prompt hashtag parsing
+- routing control through prompt text
+- disabling explicit retain tool calls
+- changing historical import behavior
+- provider recall cache
+- persisted recall transcript messages
+
+## Future options
+
+Possible future commands, only if real use justifies them:
+
+```text
+/hindsight:next-recall off
+/hindsight:next-mode ignored
+/hindsight:next-retain off
+```
+
+Do not add aliases until the core command proves useful.

--- a/docs/post-mvp-roadmap.md
+++ b/docs/post-mvp-roadmap.md
@@ -84,7 +84,7 @@ npm run typecheck:tsc
 
 ### PR 10: Design command-based one-turn opt-out
 
-**Status:** next.
+**Status:** completed.
 
 **Purpose:** Give users fast memory control without prompt hashtag parsing.
 
@@ -154,7 +154,7 @@ npm run format
 
 ### PR 11: Global codebase review loop
 
-**Status:** planned.
+**Status:** next.
 
 **Purpose:** Review the whole extension after MVP hardening and before more feature work.
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "docs/hindsight-core-functions.md",
     "docs/pr-roadmap.md",
     "docs/post-mvp-roadmap.md",
-    "docs/risky-memory-modes.md"
+    "docs/risky-memory-modes.md",
+    "docs/next-opt-out-design.md"
   ],
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Add one-turn memory opt-out design for future `/hindsight:next-opt-out` command.
- Specify command-based control instead of prompt hashtag parsing.
- Define initial semantics: skip automatic retain once, keep recall enabled, do not affect explicit retain or imports.
- Document retain cursor/session-mode interactions and required tests.
- Update post-MVP roadmap status and package files.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
