### PR TITLE
Tolerate malformed retain queue lines

### DIFF
--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -214,6 +214,10 @@ export function resolveDeadLetterQueuePath(path: string): string {
   return `${path}.dead.jsonl`;
 }
 
+export function resolveMalformedQueuePath(path: string): string {
+  return `${path}.malformed.jsonl`;
+}
+
 export interface EnqueueRetainJobResult {
   previousLength: number;
   currentLength: number;
@@ -341,6 +345,72 @@ export interface FlushRetainQueueResult {
   sent: number;
   remaining: number;
   deadLettered: number;
+  malformed: number;
+}
+
+interface ParsedQueueFile {
+  jobs: RetainJob[];
+  malformedLines: string[];
+}
+
+function isRetainJob(value: unknown): value is RetainJob {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  const item = record.item as Record<string, unknown> | undefined;
+  return (
+    typeof record.id === "string" &&
+    typeof record.bankId === "string" &&
+    typeof record.documentId === "string" &&
+    (record.updateMode === "append" || record.updateMode === "replace") &&
+    typeof record.retries === "number" &&
+    !!item &&
+    typeof item === "object" &&
+    typeof item.content === "string" &&
+    typeof item.context === "string"
+  );
+}
+
+async function readRetainQueueTolerant(path: string): Promise<ParsedQueueFile> {
+  try {
+    const text = await readFile(path, "utf8");
+    const jobs: RetainJob[] = [];
+    const malformedLines: string[] = [];
+    for (const line of text.split("\n").filter(Boolean)) {
+      try {
+        const parsed = JSON.parse(line) as unknown;
+        if (isRetainJob(parsed)) jobs.push(parsed);
+        else malformedLines.push(line);
+      } catch {
+        malformedLines.push(line);
+      }
+    }
+    return { jobs, malformedLines };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { jobs: [], malformedLines: [] };
+    }
+    throw error;
+  }
+}
+
+async function appendMalformedQueueLines(path: string, lines: string[]): Promise<void> {
+  if (lines.length === 0) return;
+  const malformedPath = resolveMalformedQueuePath(path);
+  await mkdir(dirname(malformedPath), { recursive: true });
+  const quarantinedAt = new Date().toISOString();
+  await appendFile(
+    malformedPath,
+    lines
+      .map((line) =>
+        JSON.stringify({
+          quarantinedAt,
+          sourceQueue: path,
+          line,
+        }),
+      )
+      .join("\n") + "\n",
+    "utf8",
+  );
 }
 
 export async function flushRetainQueue(
@@ -354,7 +424,8 @@ export async function flushRetainQueue(
     const maxJobs = resolvedOptions.maxJobs ?? Number.POSITIVE_INFINITY;
     const maxElapsedMs = resolvedOptions.maxElapsedMs ?? Number.POSITIVE_INFINITY;
     const started = Date.now();
-    const jobs = await readRetainQueue(path);
+    const parsed = await readRetainQueueTolerant(path);
+    const jobs = parsed.jobs;
     const remaining: RetainJob[] = [];
     const deadLetteredJobs: RetainJob[] = [];
     let sent = 0;
@@ -398,8 +469,14 @@ export async function flushRetainQueue(
         }
       }
     }
+    await appendMalformedQueueLines(path, parsed.malformedLines);
     await appendDeadLetterJobs(path, deadLetteredJobs);
     await writeRetainQueue(path, remaining);
-    return { sent, remaining: remaining.length, deadLettered: deadLetteredJobs.length };
+    return {
+      sent,
+      remaining: remaining.length,
+      deadLettered: deadLetteredJobs.length,
+      malformed: parsed.malformedLines.length,
+    };
   });
 }

--- a/extensions/retain-durable.ts
+++ b/extensions/retain-durable.ts
@@ -9,8 +9,8 @@ import type {
 import {
   enqueueRetainJobWithStats,
   flushRetainQueue,
-  readRetainQueue,
   resolveQueuePath,
+  summarizeRetainQueue,
 } from "./queue.js";
 import { redactSecrets } from "./sanitize.js";
 import { resolveRetainDocumentTarget } from "./capabilities.js";
@@ -76,8 +76,13 @@ export async function retainDurably(args: RetainDurablyArgs): Promise<RetainDura
   const queuePath = resolveQueuePath(args.cwd, args.config.retain.queuePath);
   const enqueueResult = await enqueueRetainJobWithStats(queuePath, buildDurableRetainJob(args));
   if (enqueueResult.previousLength > 0) {
-    const remaining = (await readRetainQueue(queuePath)).length;
-    return { enqueued: true, sent: 0, remaining, deadLettered: 0 };
+    const summary = await summarizeRetainQueue(queuePath);
+    return {
+      enqueued: true,
+      sent: 0,
+      remaining: summary.active.valid + summary.active.malformed,
+      deadLettered: 0,
+    };
   }
   const result = await flushRetainQueue(queuePath, args.client, { maxJobs: 1 });
   return { enqueued: true, ...result };

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -18,6 +18,7 @@ import {
   readRetainQueue,
   RETAIN_QUEUE_LOCK,
   resolveDeadLetterQueuePath,
+  resolveMalformedQueuePath,
   resolveQueuePath,
   summarizeRetainQueue,
 } from "../extensions/queue.js";
@@ -113,6 +114,28 @@ describe("retain queue", () => {
       malformed: 1,
       error: null,
     });
+  });
+
+  it("quarantines malformed active lines and flushes valid queued jobs", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    writeFileSync(path, `{not json}\nnull\n{"id":"wrong-shape"}\n${JSON.stringify(job)}\n`, "utf8");
+    const calls: unknown[] = [];
+
+    const result = await flushRetainQueue(path, {
+      retain: async (...args: unknown[]) => {
+        calls.push(args);
+      },
+      recall: async () => [],
+      reflect: async () => ({}),
+    });
+
+    expect(result).toMatchObject({ sent: 1, remaining: 0, deadLettered: 0, malformed: 3 });
+    expect(calls).toHaveLength(1);
+    expect(await readRetainQueue(path)).toHaveLength(0);
+    const malformed = readFileSync(resolveMalformedQueuePath(path), "utf8");
+    expect(malformed).toContain("{not json}");
+    expect(malformed).toContain("null");
+    expect(malformed).toContain("wrong-shape");
   });
 
   it("forwards queued observation scopes to retain", async () => {

--- a/tests/retain-durable.test.ts
+++ b/tests/retain-durable.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { createMemoryOperations } from "../extensions/memory-operations.js";
 import {
@@ -140,6 +140,27 @@ describe("durable explicit retain", () => {
     expect(queued[0]?.retries).toBe(1);
     expect(queued.slice(1).every((queuedJob) => queuedJob.retries === 0)).toBe(true);
     expect(await readDeadLetterQueue(queuePath)).toHaveLength(0);
+  });
+
+  it("keeps explicit retain queued when existing backlog contains malformed lines", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
+    const config = testConfig();
+    const queuePath = resolveQueuePath(cwd, config.retain.queuePath);
+    mkdirSync(dirname(queuePath), { recursive: true });
+    writeFileSync(queuePath, "{bad json}\n", "utf8");
+    const operations = createMemoryOperations({
+      getClient: () => client(async () => undefined),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    });
+
+    const result = await operations.retainExplicit({
+      cwd,
+      content: "Decision with malformed backlog",
+      context: "unit test explicit retain",
+    });
+
+    expect(result).toMatchObject({ enqueued: true, sent: 0, remaining: 2, deadLettered: 0 });
   });
 
   it("does not burn retries when explicit retains race during an outage", async () => {


### PR DESCRIPTION
## Summary

- Tolerate malformed active retain queue lines during flush.
- Quarantine invalid JSON and wrong-shape JSON records to `<queue>.malformed.jsonl`.
- Continue flushing valid queued jobs under the existing queue lock.
- Keep explicit retain queued when an existing backlog contains malformed lines.
- Add regression tests for malformed queue flushing and explicit retain with malformed backlog.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
