### PR TITLE
Redact secrets from memory errors

### DIFF
--- a/extensions/capabilities.ts
+++ b/extensions/capabilities.ts
@@ -1,3 +1,4 @@
+import { redactError } from "./sanitize.js";
 import type {
   HindsightCapabilities,
   HindsightLikeClient,
@@ -51,7 +52,7 @@ export async function detectAppendCapability(
     });
     return { appendUpdateMode: true, checkedAt, probeDocumentId: documentId };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = redactError(error);
     const appendUnsupported = isAppendUnsupportedError(error);
     return {
       appendUpdateMode: !appendUnsupported,

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -1,4 +1,5 @@
 import { HindsightClient } from "@vectorize-io/hindsight-client";
+import { redactError } from "./sanitize.js";
 import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
 
 async function withTimeout<T>(
@@ -73,6 +74,6 @@ export async function checkHindsight(
     else await client.recall(bankId, "health check", { maxTokens: 1, budget: "low" });
     return { ok: true };
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    return { ok: false, error: redactError(error) };
   }
 }

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -18,6 +18,7 @@ import {
   upsertImportManifestEntries,
 } from "./import-manifest.js";
 import { previewImportBranch, retainImportBranch } from "./import-retain.js";
+import { redactError } from "./sanitize.js";
 
 export { parseImportSessionJsonl, parsePiSessionJsonl } from "./import-parser.js";
 export { selectImportBranches } from "./import-branches.js";
@@ -214,7 +215,7 @@ export async function importPiSession(args: {
       });
     } catch (error) {
       const failedAt = new Date().toISOString();
-      const message = error instanceof Error ? error.message : String(error);
+      const message = redactError(error);
       checkpoint.documents[preview.document.documentId] = {
         documentId: preview.document.documentId,
         leafId: preview.document.leafId,

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -21,6 +21,7 @@ import {
 import type { HindsightCapabilities, HindsightLikeClient, ResolvedConfig } from "./types.js";
 import { getEffectiveSessionMemoryMode, readSessionMemoryMeta } from "./session-memory-meta.js";
 import { writeLastRecallSnapshot } from "./recall-visibility.js";
+import { redactError } from "./sanitize.js";
 
 export type RuntimeCtx = {
   cwd: string;
@@ -166,11 +167,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           });
         } catch (error) {
           setMemoryStatus(runtime, "recall-failed");
-          notify(
-            runtime,
-            `Hindsight project bank ensure failed: ${error instanceof Error ? error.message : String(error)}`,
-            "warning",
-          );
+          notify(runtime, `Hindsight project bank ensure failed: ${redactError(error)}`, "warning");
         }
       }
       if (config.banks.global.enabled && config.banks.global.bankId) {
@@ -181,11 +178,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           });
         } catch (error) {
           setMemoryStatus(runtime, "recall-failed");
-          notify(
-            runtime,
-            `Hindsight global bank ensure failed: ${error instanceof Error ? error.message : String(error)}`,
-            "warning",
-          );
+          notify(runtime, `Hindsight global bank ensure failed: ${redactError(error)}`, "warning");
         }
       }
       const capabilityProbeBankId = config.banks.project.enabled
@@ -198,11 +191,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           capabilities = await detectAppendCapability(client, capabilityProbeBankId);
         } catch (error) {
           setMemoryStatus(runtime, "recall-failed");
-          notify(
-            runtime,
-            `Hindsight capability check failed: ${error instanceof Error ? error.message : String(error)}`,
-            "warning",
-          );
+          notify(runtime, `Hindsight capability check failed: ${redactError(error)}`, "warning");
         }
       }
       setMemoryStatus(runtime, "idle");
@@ -343,11 +332,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
         return result;
       } catch (error) {
         setMemoryStatus(runtime, "retain-failed");
-        notify(
-          runtime,
-          `Hindsight retain queue failed: ${error instanceof Error ? error.message : String(error)}`,
-          "warning",
-        );
+        notify(runtime, `Hindsight retain queue failed: ${redactError(error)}`, "warning");
         return { queued: false, sent: 0, remaining: 0 };
       }
     },

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -25,6 +25,36 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function redactQueueError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const text = message
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[REDACTED]")
+    .replace(/\b(sk-[A-Za-z0-9_-]{12,})\b/g, "[REDACTED_API_KEY]")
+    .replace(/\b(ghp_[A-Za-z0-9_]{12,})\b/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(
+      /\b([A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*\s*=\s*)[^\s\n"',}]+/gi,
+      "$1[REDACTED]",
+    )
+    .replace(
+      /\b((?:api[_-]?key|token|secret|password|authorization)\s*:\s*)["']?[^\s\n"',}]+["']?/gi,
+      "$1[REDACTED]",
+    )
+    .replace(
+      /(["'](?:api[_-]?key|token|secret|password|authorization)["']\s*:\s*)["'][^"']+["']/gi,
+      '$1"[REDACTED]"',
+    )
+    .replace(/\b((?:Cookie|Set-Cookie)\s*:\s*)[^\r\n]+/gi, "$1[REDACTED]")
+    .replace(/(https?:\/\/)([^\s/@]+):([^\s/@]+)@/gi, "$1[REDACTED]@");
+  return text.replace(/https?:\/\/[^\s"'<>]+/gi, (url) =>
+    url.replace(/([?&])([^=&#\s]+)=([^&#\s]+)/g, (match, separator, key) => {
+      if (!/(?:token|key|secret|password|api[_-]?key|apikey)/i.test(String(key))) {
+        return String(match);
+      }
+      return `${String(separator)}${String(key)}=[REDACTED]`;
+    }),
+  );
+}
+
 async function removeDirectory(path: string): Promise<void> {
   await rm(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 });
 }
@@ -448,16 +478,17 @@ export async function flushRetainQueue(
         await client.retain(job.bankId, job.item.content, options);
         sent += 1;
       } catch (error) {
+        const errorMessage = redactQueueError(error);
         const retries = job.retries + 1;
         const deadLetter = retries >= maxRetries;
         const failedJob = {
           ...job,
           retries,
-          lastError: error instanceof Error ? error.message : String(error),
+          lastError: errorMessage,
           ...(deadLetter
             ? {
                 deadLetteredAt: new Date().toISOString(),
-                lastError: `${error instanceof Error ? error.message : String(error)}; retry limit reached, moved to dead-letter queue`,
+                lastError: `${errorMessage}; retry limit reached, moved to dead-letter queue`,
               }
             : {}),
         };

--- a/extensions/sanitize.ts
+++ b/extensions/sanitize.ts
@@ -6,12 +6,37 @@ const SECRET_PATTERNS: Array<[RegExp, string]> = [
     /\b([A-Z0-9_]*(?:API_KEY|TOKEN|SECRET|PASSWORD)[A-Z0-9_]*\s*=\s*)[^\s\n"',}]+/gi,
     "$1[REDACTED]",
   ],
+  [
+    /\b((?:api[_-]?key|token|secret|password|authorization)\s*:\s*)["']?[^\s\n"',}]+["']?/gi,
+    "$1[REDACTED]",
+  ],
+  [
+    /(["'](?:api[_-]?key|token|secret|password|authorization)["']\s*:\s*)["'][^"']+["']/gi,
+    '$1"[REDACTED]"',
+  ],
+  [/\b((?:Cookie|Set-Cookie)\s*:\s*)[^\r\n]+/gi, "$1[REDACTED]"],
   [/(https?:\/\/)([^\s/@]+):([^\s/@]+)@/gi, "$1[REDACTED]@"],
 ];
 
+const SENSITIVE_QUERY_PARAM = /(?:token|key|secret|password|api[_-]?key|apikey)/i;
+
+function redactUrlQuerySecrets(input: string): string {
+  return input.replace(/https?:\/\/[^\s"'<>]+/gi, (url) =>
+    url.replace(/([?&])([^=&#\s]+)=([^&#\s]+)/g, (match, separator, key) => {
+      if (!SENSITIVE_QUERY_PARAM.test(String(key))) return String(match);
+      return `${String(separator)}${String(key)}=[REDACTED]`;
+    }),
+  );
+}
+
 export function redactSecrets(input: string): string {
-  return SECRET_PATTERNS.reduce(
-    (text, [pattern, replacement]) => text.replace(pattern, replacement),
+  const text = SECRET_PATTERNS.reduce(
+    (current, [pattern, replacement]) => current.replace(pattern, replacement),
     input,
   );
+  return redactUrlQuerySecrets(text);
+}
+
+export function redactError(error: unknown): string {
+  return redactSecrets(error instanceof Error ? error.message : String(error));
 }

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -202,6 +202,35 @@ describe("retain queue", () => {
     expect(dead[0]?.deadLetteredAt).toBeDefined();
   });
 
+  it("redacts secrets from persisted queue errors", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    await enqueueRetainJob(path, job);
+
+    await flushRetainQueue(
+      path,
+      {
+        retain: async () => {
+          throw new Error(
+            'failed Cookie: sid=secret123456\npassword: hunter2\n{"token":"jsonsecret123456"}\nhttps://example.com/callback?ok=1&access_token=querysecret123456',
+          );
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+      { maxRetries: 2 },
+    );
+
+    const [queued] = await readRetainQueue(path);
+    expect(queued?.lastError).toContain("Cookie: [REDACTED]");
+    expect(queued?.lastError).toContain("password: [REDACTED]");
+    expect(queued?.lastError).toContain('"token":"[REDACTED]"');
+    expect(queued?.lastError).toContain("access_token=[REDACTED]");
+    expect(queued?.lastError).not.toContain("secret123456");
+    expect(queued?.lastError).not.toContain("hunter2");
+    expect(queued?.lastError).not.toContain("jsonsecret");
+    expect(queued?.lastError).not.toContain("querysecret");
+  });
+
   it("keeps exhausted jobs active when dead-letter append fails", async () => {
     const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
     await enqueueRetainJob(path, job);

--- a/tests/sanitize.test.ts
+++ b/tests/sanitize.test.ts
@@ -1,12 +1,38 @@
 import { describe, expect, it } from "vitest";
-import { redactSecrets } from "../extensions/sanitize.js";
+import { redactError, redactSecrets } from "../extensions/sanitize.js";
 
 describe("redactSecrets", () => {
   it("redacts common credentials", () => {
-    const text =
-      "Authorization: Bearer abcdefghijklmnopqrstuvwxyz API_KEY=supersecret sk-abcdefghijklmnopqrstuvwxyz";
+    const text = [
+      "Authorization: Bearer abcdefghijklmnopqrstuvwxyz",
+      "API_KEY=supersecret",
+      "sk-abcdefghijklmnopqrstuvwxyz",
+      "ghp_abcdefghijklmnopqrstuvwxyz",
+      "password: hunter2",
+      "apiKey: supersecret123456",
+      '"token":"jsonsecret123456"',
+      "Cookie: sid=secret123456789; other=x",
+      "Set-Cookie: sid=secret123456789; Path=/",
+      "https://user:pass@example.com/path",
+      "https://example.com/callback?ok=1&access_token=secret123456789&api_key=othersecret123456",
+    ].join("\n");
+
     const redacted = redactSecrets(text);
+
     expect(redacted).not.toContain("abcdefghijklmnopqrstuvwxyz");
+    expect(redacted).not.toContain("supersecret");
+    expect(redacted).not.toContain("hunter2");
+    expect(redacted).not.toContain("jsonsecret");
+    expect(redacted).not.toContain("sid=secret");
+    expect(redacted).not.toContain("user:pass");
+    expect(redacted).not.toContain("access_token=secret");
+    expect(redacted).not.toContain("api_key=othersecret");
     expect(redacted).toContain("[REDACTED");
+  });
+
+  it("redacts error messages", () => {
+    expect(redactError(new Error("request failed: password: hunter2"))).toBe(
+      "request failed: password: [REDACTED]",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Expand secret redaction for cookie headers, JSON/YAML-style secret fields, and URL query secrets.
- Sanitize errors surfaced through health/capability checks and lifecycle notifications.
- Sanitize import failure records before writing checkpoint/result data.
- Sanitize queue `lastError`/dead-letter errors before persistence.
- Add regression tests for common credential forms and persisted queue errors.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
