### PR TITLE
Preserve rich retain payloads

### DIFF
--- a/extensions/messages.ts
+++ b/extensions/messages.ts
@@ -24,6 +24,7 @@ function textFromContent(
     includeText: boolean;
     includeThinking: boolean;
     includeToolCall: boolean;
+    includeUnknownJson?: boolean;
     toolCallFilter?: { include?: string[]; exclude?: string[] };
   },
 ): string {
@@ -44,10 +45,44 @@ function textFromContent(
         }
         if (p.type === "image") return options.includeText ? "[image omitted]" : "";
       }
-      return options.includeText ? JSON.stringify(part) : "";
+      return options.includeText && options.includeUnknownJson !== false
+        ? JSON.stringify(part)
+        : "";
     })
     .filter(Boolean)
     .join("\n");
+}
+
+function projectContent(
+  content: unknown,
+  options: {
+    includeText: boolean;
+    includeThinking: boolean;
+    includeToolCall: boolean;
+    toolCallFilter?: { include?: string[]; exclude?: string[] };
+  },
+): unknown {
+  if (typeof content === "string") return options.includeText ? content : "";
+  if (!Array.isArray(content)) return options.includeText ? (content ?? "") : "";
+  const projected = content
+    .map((part) => {
+      if (part && typeof part === "object" && "type" in part) {
+        const p = part as Record<string, unknown>;
+        if (p.type === "text") return options.includeText ? part : undefined;
+        if (p.type === "thinking") return options.includeThinking ? part : undefined;
+        if (p.type === "toolCall") {
+          if (!options.includeToolCall) return undefined;
+          const name = stringValue(p.name, "unknown");
+          if (options.toolCallFilter && !toolAllowed(name, options.toolCallFilter))
+            return undefined;
+          return part;
+        }
+        if (p.type === "image") return options.includeText ? part : undefined;
+      }
+      return options.includeText ? part : undefined;
+    })
+    .filter((part): part is unknown => part !== undefined);
+  return projected.length ? projected : "";
 }
 
 function stripFields(record: Record<string, unknown>, fields: string[]): Record<string, unknown> {
@@ -76,10 +111,43 @@ export function projectMessage(
   const base: Record<string, unknown> = {
     role,
     timestamp: messageTimestamp(m),
+    content: projectContent(m.content, {
+      includeText: !isAssistant || includeAssistantText,
+      includeThinking: isAssistant && includeThinking,
+      includeToolCall: isAssistant && includeToolCall,
+      ...(retain ? { toolCallFilter: retain.toolFilter.toolCall } : {}),
+    }),
+  };
+  if (role === "toolResult") {
+    base.toolName = m.toolName;
+    base.isError = m.isError;
+  }
+  if (role === "assistant") {
+    base.model = m.model;
+    base.stopReason = m.stopReason;
+  }
+  return stripFields(base, retain?.strip.message ?? []);
+}
+
+export function projectMessageText(
+  message: AgentMessage,
+  config?: ResolvedConfig,
+): Record<string, unknown> {
+  const m = message as unknown as Record<string, unknown>;
+  const role = stringValue(m.role, "unknown");
+  const retain = config?.retain;
+  const isAssistant = role === "assistant";
+  const includeAssistantText = retain?.content.assistant.includes("text") ?? true;
+  const includeThinking = retain?.content.assistant.includes("thinking") ?? false;
+  const includeToolCall = retain?.content.assistant.includes("toolCall") ?? true;
+  const base: Record<string, unknown> = {
+    role,
+    timestamp: messageTimestamp(m),
     content: textFromContent(m.content, {
       includeText: !isAssistant || includeAssistantText,
       includeThinking: isAssistant && includeThinking,
       includeToolCall: isAssistant && includeToolCall,
+      includeUnknownJson: false,
       ...(retain ? { toolCallFilter: retain.toolFilter.toolCall } : {}),
     }),
   };

--- a/extensions/recall.ts
+++ b/extensions/recall.ts
@@ -8,7 +8,7 @@ import type {
   ResolvedConfig,
   TagsMatch,
 } from "./types.js";
-import { projectMessage } from "./messages.js";
+import { projectMessageText } from "./messages.js";
 import { createMemoryIdentity } from "./memory-identity.js";
 
 export interface RecallScope {
@@ -49,7 +49,7 @@ function messageRole(message: AgentMessage): string {
 }
 
 function messageContent(message: AgentMessage): string {
-  const content = projectMessage(message).content;
+  const content = projectMessageText(message).content;
   return typeof content === "string" ? content : JSON.stringify(content ?? "");
 }
 

--- a/tests/recall-format.test.ts
+++ b/tests/recall-format.test.ts
@@ -86,6 +86,41 @@ describe("recall formatting", () => {
     ).toBe("current Pi coding task");
   });
 
+  it("keeps recall queries text-oriented for rich content", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "look at this" },
+          { type: "image", mimeType: "image/png", data: "base64-secret" },
+          { type: "custom", payload: { nested: true } },
+        ],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "running command" },
+          { type: "toolCall", name: "bash", arguments: { command: "echo hi" } },
+        ],
+        timestamp: 2,
+      },
+    ] as unknown as AgentMessage[];
+
+    const query = composeRecallQuery(messages, {
+      roles: ["user", "assistant"],
+      contextTurns: 2,
+      maxQueryChars: 500,
+    });
+
+    expect(query).toContain("user: look at this");
+    expect(query).toContain("[image omitted]");
+    expect(query).toContain("assistant: running command");
+    expect(query).toContain("[toolCall bash]");
+    expect(query).not.toContain("base64-secret");
+    expect(query).not.toContain('"type"');
+  });
+
   it("adds deterministic context hints", () => {
     const messages = [
       { role: "user", content: "ship it", timestamp: 1 },

--- a/tests/retain.test.ts
+++ b/tests/retain.test.ts
@@ -97,7 +97,12 @@ describe("buildRetainJob", () => {
       bankId: "bank",
       messages: [baseMessage] as AgentEndEvent["messages"],
     });
-    expect(toolOnly?.item.content).toContain("[toolCall bash]");
+    const toolOnlyRetained = JSON.parse(toolOnly?.item.content ?? "[]") as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(toolOnlyRetained[0]?.content).toEqual([
+      { type: "toolCall", name: "bash", arguments: { command: "echo hi" } },
+    ]);
     expect(toolOnly?.item.content).not.toContain("assistant text");
 
     const thinkingOnly = buildRetainJob({
@@ -112,9 +117,14 @@ describe("buildRetainJob", () => {
       bankId: "bank",
       messages: [baseMessage] as AgentEndEvent["messages"],
     });
-    expect(thinkingOnly?.item.content).toContain("private thought");
+    const thinkingOnlyRetained = JSON.parse(thinkingOnly?.item.content ?? "[]") as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(thinkingOnlyRetained[0]?.content).toEqual([
+      { type: "thinking", thinking: "private thought" },
+    ]);
     expect(thinkingOnly?.item.content).not.toContain("assistant text");
-    expect(thinkingOnly?.item.content).not.toContain("[toolCall bash]");
+    expect(thinkingOnly?.item.content).not.toContain("toolCall");
   });
 
   it("filters excluded assistant tool calls without dropping assistant text", () => {
@@ -130,9 +140,39 @@ describe("buildRetainJob", () => {
       },
     ] as unknown as AgentEndEvent["messages"];
     const job = buildRetainJob({ config: DEFAULT_CONFIG, cwd: "/repo", bankId: "bank", messages });
-    expect(job?.item.content).toContain("keep this");
-    expect(job?.item.content).toContain("[toolCall bash]");
+    const retained = JSON.parse(job?.item.content ?? "[]") as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(retained[0]?.content).toEqual([
+      { type: "text", text: "keep this" },
+      { type: "toolCall", name: "bash", arguments: { command: "echo ok" } },
+    ]);
     expect(job?.item.content).not.toContain("hindsight_recall");
+  });
+
+  it("preserves rich user content instead of flattening to text", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "see image" },
+          { type: "image", mimeType: "image/png", url: "file:///tmp/screenshot.png" },
+          { type: "custom", payload: { nested: true } },
+        ],
+        timestamp: Date.now(),
+      },
+    ] as unknown as AgentEndEvent["messages"];
+
+    const job = buildRetainJob({ config: DEFAULT_CONFIG, cwd: "/repo", bankId: "bank", messages });
+    const retained = JSON.parse(job?.item.content ?? "[]") as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+
+    expect(retained[0]?.content).toEqual([
+      { type: "text", text: "see image" },
+      { type: "image", mimeType: "image/png", url: "file:///tmp/screenshot.png" },
+      { type: "custom", payload: { nested: true } },
+    ]);
   });
 
   it("strips configured fields", () => {


### PR DESCRIPTION
## Summary

- Preserve rich Pi message content in retained JSON instead of flattening arrays to strings.
- Keep assistant/user/tool filtering behavior while retaining selected structured parts.
- Add a separate text projection path for recall queries so recall remains conservative and text-oriented.
- Add regression tests for rich retained payloads and rich recall query formatting.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
