### PR TITLE
Isolate ephemeral session identity

### DIFF
--- a/extensions/session.ts
+++ b/extensions/session.ts
@@ -1,8 +1,10 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { basename } from "node:path";
 
+const EPHEMERAL_PROCESS_SESSION_ID = randomUUID();
+
 export function stableSessionId(sessionFile: string | undefined, cwd: string): string {
-  const basis = sessionFile || `ephemeral:${cwd}`;
+  const basis = sessionFile || `ephemeral:${cwd}:${EPHEMERAL_PROCESS_SESSION_ID}`;
   return createHash("sha256").update(basis).digest("hex").slice(0, 16);
 }
 

--- a/tests/banking.test.ts
+++ b/tests/banking.test.ts
@@ -9,7 +9,7 @@ import {
   findRepoRoot,
   recallScopeTags,
 } from "../extensions/banking.js";
-import { liveDocumentId } from "../extensions/session.js";
+import { liveDocumentId, stableSessionId } from "../extensions/session.js";
 
 describe("banking/session identity", () => {
   it("derives stable project bank from repo root", () => {
@@ -29,5 +29,13 @@ describe("banking/session identity", () => {
     );
     expect(baseTags("/repo", "s1")).toContain("session:s1");
     expect(recallScopeTags("/repo")).toEqual([expect.stringMatching(/^repo:/)]);
+  });
+
+  it("separates missing-session-file identities from cwd-only repo identity", () => {
+    const first = stableSessionId(undefined, "/repo");
+    const second = stableSessionId(undefined, "/repo");
+
+    expect(first).toBe(second);
+    expect(first).not.toBe(stableSessionId("ephemeral:/repo", "/repo"));
   });
 });


### PR DESCRIPTION
## Summary

- Isolate missing-session-file identities with a process-scoped ephemeral salt.
- Keep real session-file identities deterministic and unchanged.
- Avoid collapsing all no-session-file work in a repo onto the old cwd-only live document/session metadata ID.
- Add regression coverage for ephemeral identity behavior.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
