### PR TITLE
Reject cross-project session imports

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -181,6 +181,7 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       }
       const result = await operations.importSession({
         sessionFile,
+        cwd: ctx.cwd,
         ...importOptions(args),
       });
       ctx.ui.notify(
@@ -202,6 +203,7 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       }
       const result = await operations.importSession({
         sessionFile: current,
+        cwd: ctx.cwd,
         ...importOptions(args),
       });
       ctx.ui.notify(
@@ -221,7 +223,11 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         ctx.ui.notify("Usage: /hindsight:import-file <path> [--dry-run] [--all-leaves]", "warning");
         return;
       }
-      const result = await operations.importSession({ sessionFile: file, ...importOptions(args) });
+      const result = await operations.importSession({
+        sessionFile: file,
+        cwd: ctx.cwd,
+        ...importOptions(args),
+      });
       ctx.ui.notify(
         result.dryRun
           ? `Import preview: file=${file}; messages=${result.messageCount}; ${importDocumentSummary(result)}; write=no; checkpoint=${result.checkpointPath}; manifest unchanged=${result.manifestPath}`

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -111,6 +111,7 @@ export interface ImportSessionResult {
 
 export async function importPiSession(args: {
   sessionFile: string;
+  cwd?: string;
   bankId: string;
   client: HindsightLikeClient;
   config: ResolvedConfig;
@@ -119,7 +120,12 @@ export async function importPiSession(args: {
 }): Promise<ImportSessionResult> {
   const text = await readFile(args.sessionFile, "utf8");
   const parsed = parseImportSessionJsonl(text);
-  const cwd = parsed.cwd ?? dirname(args.sessionFile);
+  if (args.cwd && parsed.cwd && parsed.cwd !== args.cwd) {
+    throw new Error(
+      `Refusing to import session from cwd ${parsed.cwd}; current cwd is ${args.cwd}. Use project-scoped import from the matching repo.`,
+    );
+  }
+  const cwd = args.cwd ?? parsed.cwd ?? dirname(args.sessionFile);
   const sessionId = parsed.sessionId ?? stableSessionId(args.sessionFile, cwd);
   const leaves = leafIds(parsed.messages);
   const includeBranches = args.includeBranches ?? args.config.import.includeBranches;

--- a/extensions/memory-operations.ts
+++ b/extensions/memory-operations.ts
@@ -125,6 +125,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
 
     async importSession(args: {
       sessionFile: string;
+      cwd?: string;
       bank?: string;
       dryRun?: boolean;
       includeBranches?: ResolvedConfig["import"]["includeBranches"];
@@ -132,6 +133,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
       const bankId = args.bank || deps.getProjectBankId();
       const result = await importPiSession({
         sessionFile: args.sessionFile,
+        ...(args.cwd ? { cwd: args.cwd } : {}),
         bankId,
         client: deps.getClient(),
         config: deps.getConfig(),

--- a/extensions/tools.ts
+++ b/extensions/tools.ts
@@ -132,6 +132,7 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       if (!sessionFile) throw new Error("No session file available. Pass sessionFile explicitly.");
       const result = await operations.importSession({
         sessionFile,
+        cwd: ctx.cwd,
         ...(params.bank ? { bank: params.bank } : {}),
         ...(params.dryRun !== undefined ? { dryRun: params.dryRun } : {}),
         ...(params.allLeaves !== undefined

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -414,6 +414,38 @@ describe("Pi session import", () => {
     expect(result.runId).toContain(":replace:");
   });
 
+  it("rejects explicit imports from a different project cwd", async () => {
+    const current = mkdtempSync(join(tmpdir(), "pi-hindsight-import-current-"));
+    const other = mkdtempSync(join(tmpdir(), "pi-hindsight-import-other-"));
+    const sessionFile = join(other, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "cross-project", cwd: other }),
+        JSON.stringify({
+          type: "message",
+          id: "1",
+          parentId: null,
+          message: { role: "user", content: "other project" },
+        }),
+      ].join("\n"),
+    );
+
+    await expect(
+      importPiSession({
+        sessionFile,
+        cwd: current,
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+      }),
+    ).rejects.toThrow("Refusing to import session from cwd");
+  });
+
   it("discovers only sessions scoped to the current project cwd", async () => {
     const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
     const other = mkdtempSync(join(tmpdir(), "pi-hindsight-other-"));


### PR DESCRIPTION
## Summary

- Reject explicit session imports when the JSONL session cwd differs from the current Pi cwd.
- Pass ctx.cwd through tool and command import entrypoints.
- Keep direct import behavior without cwd unchanged for tests/low-level use.
- Add regression coverage for cross-project import rejection.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
