### PR TITLE
Clarify no-bank diagnostics

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -4,6 +4,7 @@ import type { MemoryOperationsDeps } from "./memory-operations.js";
 import { createMemoryOperations } from "./memory-operations.js";
 import { runHindsightSetupTui } from "./setup-tui.js";
 import type { SessionMemoryMode } from "./session-memory-meta.js";
+import { memoryProfile } from "./diagnostics.js";
 
 function firstArg(args: unknown): string | undefined {
   if (Array.isArray(args)) return typeof args[0] === "string" ? args[0] : undefined;
@@ -97,11 +98,7 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       const bank = status.config.banks.project.enabled
         ? status.bankId
         : (status.config.banks.global.bankId ?? "none");
-      const profile = status.config.banks.project.enabled
-        ? status.config.banks.global.enabled
-          ? "project+global"
-          : "project-only"
-        : "global-only";
+      const profile = memoryProfile(status.config);
       const queueIssue = queueIssueSummary(status.queue);
       ctx.ui.notify(
         `Hindsight ${status.config.enabled ? "on" : "off"}; profile ${profile}; bank ${bank}; queue ${status.queueLength}; imports ${status.imports.count}${queueIssue}`,

--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -45,8 +45,10 @@ export function bankSelectionMessage(projectBankId: string, config: ResolvedConf
   return `Hindsight bank auto-selected: ${projectBankId}. Override with PI_HINDSIGHT_PROJECT_BANK_ID or .pi/hindsight.json banks.project.bankId.`;
 }
 
-function memoryProfile(config: ResolvedConfig): "project-only" | "project+global" | "global-only" {
-  if (!config.banks.project.enabled) return "global-only";
+export function memoryProfile(
+  config: ResolvedConfig,
+): "project-only" | "project+global" | "global-only" | "none" {
+  if (!config.banks.project.enabled) return config.banks.global.enabled ? "global-only" : "none";
   if (config.banks.global.enabled) return "project+global";
   return "project-only";
 }

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -302,6 +302,40 @@ describe("hindsight commands", () => {
     );
   });
 
+  it("reports no-bank profile without calling it global-only", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-commands-"));
+    const commands = new Map<string, { handler: (args: unknown, ctx: any) => Promise<void> }>();
+    registerCommands(
+      {
+        registerCommand: (
+          name: string,
+          command: { handler: (args: unknown, ctx: any) => Promise<void> },
+        ) => {
+          commands.set(name, command);
+        },
+      } as any,
+      {
+        getClient: () => client(),
+        getConfig: () => ({
+          ...DEFAULT_CONFIG,
+          banks: {
+            project: { enabled: false, derive: "repo" },
+            global: { enabled: false },
+          },
+        }),
+        getProjectBankId: () => "bank",
+      },
+    );
+    const ctx = { cwd, ui: { notify: vi.fn(), setStatus: vi.fn() }, sessionManager: {} };
+
+    await commands.get("hindsight:status")?.handler([], ctx);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("profile none; bank none"),
+      "info",
+    );
+  });
+
   it("warns when doctor cannot read the retain queue", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-commands-"));
     writeFileSync(join(cwd, "not-a-dir"), "file blocks queue directory");

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -100,6 +100,26 @@ describe("diagnostics", () => {
     expect(report.memoryRoutes).toEqual({ recall: ["global"], autoRetain: null });
   });
 
+  it("formats disabled bank routes without calling them global-only", () => {
+    const report = JSON.parse(
+      formatDebugReport({
+        cwd: process.cwd(),
+        projectBankId: "project-bank",
+        config: {
+          ...DEFAULT_CONFIG,
+          banks: {
+            project: { enabled: false, derive: "repo" },
+            global: { enabled: false },
+          },
+        },
+        queueLength: 0,
+      }),
+    ) as Record<string, unknown>;
+
+    expect(report.memoryProfile).toBe("none");
+    expect(report.memoryRoutes).toEqual({ recall: [], autoRetain: null });
+  });
+
   it("formats observation scope diagnostics", () => {
     const report = JSON.parse(
       formatDebugReport({


### PR DESCRIPTION
## Summary

- Report disabled project+global banks as `memoryProfile: "none"` instead of misleading `global-only`.
- Reuse the diagnostics memory profile helper in `/hindsight:status`.
- Add command/debug regression coverage for the no-bank profile.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
