### PR TITLE
Tolerate corrupt import sidecars

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -83,6 +83,10 @@ function hasQueueIssue(queue?: {
   );
 }
 
+function importIssueSummary(imports?: { error?: string | null }): string {
+  return imports?.error ? `; import manifest unreadable: ${imports.error}` : "";
+}
+
 function compactText(value: string, maxLength: number): string {
   const compact = value.replace(/\s+/g, " ").trim();
   return compact.length <= maxLength ? compact : `${compact.slice(0, Math.max(0, maxLength - 1))}…`;
@@ -100,9 +104,10 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         : (status.config.banks.global.bankId ?? "none");
       const profile = memoryProfile(status.config);
       const queueIssue = queueIssueSummary(status.queue);
+      const importIssue = importIssueSummary(status.imports);
       ctx.ui.notify(
-        `Hindsight ${status.config.enabled ? "on" : "off"}; profile ${profile}; bank ${bank}; queue ${status.queueLength}; imports ${status.imports.count}${queueIssue}`,
-        hasQueueIssue(status.queue) ? "warning" : "info",
+        `Hindsight ${status.config.enabled ? "on" : "off"}; profile ${profile}; bank ${bank}; queue ${status.queueLength}; imports ${status.imports.count}${queueIssue}${importIssue}`,
+        hasQueueIssue(status.queue) || Boolean(status.imports.error) ? "warning" : "info",
       );
     },
   });
@@ -120,12 +125,14 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         ? `; observations invalid: ${doctor.observations.error}`
         : "";
       const queueIssue = queueIssueSummary(doctor.queue);
+      const importIssue = importIssueSummary(doctor.imports);
       ctx.ui.notify(
-        `Hindsight ${doctor.health.ok ? "reachable" : `unreachable: ${doctor.health.error}`}; ${append}; queue ${doctor.queueLength}; imports ${doctor.imports.count}${observation}${queueIssue}`,
+        `Hindsight ${doctor.health.ok ? "reachable" : `unreachable: ${doctor.health.error}`}; ${append}; queue ${doctor.queueLength}; imports ${doctor.imports.count}${observation}${queueIssue}${importIssue}`,
         doctor.health.ok &&
           doctor.capabilities?.appendUpdateMode !== false &&
           !doctor.observations.error &&
-          !hasQueueIssue(doctor.queue)
+          !hasQueueIssue(doctor.queue) &&
+          !doctor.imports.error
           ? "info"
           : "warning",
       );

--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -24,6 +24,8 @@ export interface DebugReportArgs {
   deadLetterMalformedLines?: number;
   deadLetterReadError?: string | null;
   importManifestPath?: string;
+  importManifestError?: string | null;
+  importManifestAction?: string | null;
   importCount?: number;
   latestImport?: ImportManifestEntry;
   health?: { ok: boolean; error?: string };
@@ -169,6 +171,11 @@ export function formatDebugReport(args: DebugReportArgs): string {
         : { appendUpdateMode: "not checked" },
       imports: {
         manifestPath: args.importManifestPath ?? args.config.import.manifestPath,
+        error: args.importManifestError ?? null,
+        action: args.importManifestError
+          ? (args.importManifestAction ??
+            "Move or repair the import manifest, then rerun the import command.")
+          : null,
         count: args.importCount ?? 0,
         latest: args.latestImport
           ? {

--- a/extensions/import-checkpoint.ts
+++ b/extensions/import-checkpoint.ts
@@ -28,6 +28,12 @@ export interface ImportCheckpoint {
   documents: Record<string, ImportCheckpointDocument>;
 }
 
+export interface ImportCheckpointReadResult {
+  checkpoint?: ImportCheckpoint;
+  error: string | null;
+  action: string | null;
+}
+
 export function resolveImportCheckpointPath(cwd: string, checkpointPath: string): string {
   return isAbsolute(checkpointPath) ? checkpointPath : join(cwd, checkpointPath);
 }
@@ -51,16 +57,55 @@ export function importRunId(args: {
     .replace(/\s+/g, "_");
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isImportCheckpointDocument(value: unknown): value is ImportCheckpointDocument {
+  if (!isPlainRecord(value)) return false;
+  return (
+    typeof value.documentId === "string" &&
+    typeof value.leafId === "string" &&
+    typeof value.contentHash === "string" &&
+    typeof value.messageCount === "number" &&
+    (value.status === "pending" ||
+      value.status === "completed" ||
+      value.status === "failed" ||
+      value.status === "skipped") &&
+    typeof value.updatedAt === "string"
+  );
+}
+
 export async function readImportCheckpoint(path: string): Promise<ImportCheckpoint | undefined> {
   try {
     const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
-      throw new Error("import checkpoint must be a JSON object");
-    const record = parsed as ImportCheckpoint;
-    return { ...record, version: 1, documents: record.documents ?? {} };
+    if (!isPlainRecord(parsed)) throw new Error("import checkpoint must be a JSON object");
+    const record = parsed as unknown as ImportCheckpoint;
+    if (record.documents !== undefined && !isPlainRecord(record.documents)) {
+      throw new Error("import checkpoint documents must be a JSON object");
+    }
+    const documents = record.documents ?? {};
+    for (const [documentId, document] of Object.entries(documents)) {
+      if (!isImportCheckpointDocument(document) || document.documentId !== documentId) {
+        throw new Error(`import checkpoint document ${documentId} is invalid`);
+      }
+    }
+    return { ...record, version: 1, documents };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
     throw error;
+  }
+}
+
+export async function readImportCheckpointSafe(path: string): Promise<ImportCheckpointReadResult> {
+  try {
+    const checkpoint = await readImportCheckpoint(path);
+    return { ...(checkpoint ? { checkpoint } : {}), error: null, action: null };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+      action: `Move or repair ${path}, then rerun the import command. The next successful import can recreate the checkpoint.`,
+    };
   }
 }
 

--- a/extensions/import-manifest.ts
+++ b/extensions/import-manifest.ts
@@ -22,6 +22,12 @@ export interface ImportManifest {
   imports: Record<string, ImportManifestEntry>;
 }
 
+export interface ImportManifestReadResult {
+  manifest: ImportManifest;
+  error: string | null;
+  action: string | null;
+}
+
 export function resolveImportManifestPath(cwd: string, manifestPath: string): string {
   return isAbsolute(manifestPath) ? manifestPath : join(cwd, manifestPath);
 }
@@ -30,16 +36,57 @@ export function hashImportContent(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isImportManifestEntry(value: unknown): value is ImportManifestEntry {
+  if (!isPlainRecord(value)) return false;
+  return (
+    typeof value.documentId === "string" &&
+    typeof value.bankId === "string" &&
+    typeof value.sourceFile === "string" &&
+    typeof value.importedAt === "string" &&
+    typeof value.contentHash === "string" &&
+    typeof value.messageCount === "number" &&
+    typeof value.leafId === "string" &&
+    typeof value.sessionId === "string" &&
+    typeof value.cwd === "string" &&
+    (value.includeBranches === "current-only" || value.includeBranches === "all-leaves") &&
+    (value.updateMode === "append" || value.updateMode === "replace")
+  );
+}
+
 export async function readImportManifest(path: string): Promise<ImportManifest> {
   try {
     const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
-      throw new Error("manifest must be a JSON object");
+    if (!isPlainRecord(parsed)) throw new Error("manifest must be a JSON object");
     const record = parsed as Partial<ImportManifest>;
-    return { version: 1, imports: record.imports ?? {} };
+    if (record.imports !== undefined && !isPlainRecord(record.imports)) {
+      throw new Error("manifest imports must be a JSON object");
+    }
+    const imports = record.imports ?? {};
+    for (const [documentId, entry] of Object.entries(imports)) {
+      if (!isImportManifestEntry(entry) || entry.documentId !== documentId) {
+        throw new Error(`manifest import entry ${documentId} is invalid`);
+      }
+    }
+    return { version: 1, imports };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { version: 1, imports: {} };
     throw error;
+  }
+}
+
+export async function readImportManifestSafe(path: string): Promise<ImportManifestReadResult> {
+  try {
+    return { manifest: await readImportManifest(path), error: null, action: null };
+  } catch (error) {
+    return {
+      manifest: { version: 1, imports: {} },
+      error: error instanceof Error ? error.message : String(error),
+      action: `Move or repair ${path}, then rerun the import command. New successful imports will recreate the manifest.`,
+    };
   }
 }
 
@@ -54,7 +101,7 @@ export async function upsertImportManifestEntries(
   path: string,
   entries: ImportManifestEntry[],
 ): Promise<ImportManifest> {
-  const manifest = await readImportManifest(path);
+  const manifest = (await readImportManifestSafe(path)).manifest;
   for (const entry of entries) manifest.imports[entry.documentId] = entry;
   await writeImportManifest(path, manifest);
   return manifest;

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -7,7 +7,7 @@ import { leafIds, selectImportBranches } from "./import-branches.js";
 import {
   createImportCheckpoint,
   importRunId,
-  readImportCheckpoint,
+  readImportCheckpointSafe,
   resolveImportCheckpointPath,
   writeImportCheckpoint,
   type ImportCheckpoint,
@@ -144,7 +144,7 @@ export async function importPiSession(args: {
   const importConfig = { ...args.config, import: { ...args.config.import, includeBranches } };
   const now = new Date().toISOString();
   const existingCheckpoint = args.config.import.resume
-    ? await readImportCheckpoint(checkpointPath)
+    ? (await readImportCheckpointSafe(checkpointPath)).checkpoint
     : undefined;
   let checkpoint: ImportCheckpoint =
     existingCheckpoint?.runId === runId

--- a/extensions/memory-operations.ts
+++ b/extensions/memory-operations.ts
@@ -11,7 +11,7 @@ import {
 import { importPiSession, importProjectSessions } from "./import-sessions.js";
 import {
   importManifestSummary,
-  readImportManifest,
+  readImportManifestSafe,
   resolveImportManifestPath,
 } from "./import-manifest.js";
 import { recallScopeTags } from "./banking.js";
@@ -180,33 +180,43 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     async status(cwd: string) {
       const config = deps.getConfig();
       const queuePath = resolveQueuePath(cwd, config.retain.queuePath);
-      const [queue, manifest] = await Promise.all([
+      const [queue, manifestRead] = await Promise.all([
         summarizeRetainQueue(queuePath),
-        readImportManifest(resolveImportManifestPath(cwd, config.import.manifestPath)),
+        readImportManifestSafe(resolveImportManifestPath(cwd, config.import.manifestPath)),
       ]);
+      const manifest = manifestRead.manifest;
       return {
         config,
         bankId: deps.getProjectBankId(),
         queueLength: queue.active.valid,
         queue,
-        imports: importManifestSummary(manifest),
+        imports: {
+          ...importManifestSummary(manifest),
+          error: manifestRead.error,
+          action: manifestRead.action,
+        },
       };
     },
 
     async doctor(cwd: string) {
       const config = deps.getConfig();
       const queuePath = resolveQueuePath(cwd, config.retain.queuePath);
-      const [health, queue, manifest] = await Promise.all([
+      const [health, queue, manifestRead] = await Promise.all([
         checkHindsight(deps.getClient(), deps.getProjectBankId()),
         summarizeRetainQueue(queuePath),
-        readImportManifest(resolveImportManifestPath(cwd, config.import.manifestPath)),
+        readImportManifestSafe(resolveImportManifestPath(cwd, config.import.manifestPath)),
       ]);
+      const manifest = manifestRead.manifest;
       return {
         health,
         ...(deps.getCapabilities?.() ? { capabilities: deps.getCapabilities() } : {}),
         queueLength: queue.active.valid,
         queue,
-        imports: importManifestSummary(manifest),
+        imports: {
+          ...importManifestSummary(manifest),
+          error: manifestRead.error,
+          action: manifestRead.action,
+        },
         observations: observationScopeDiagnostics({
           cwd,
           projectBankId: deps.getProjectBankId(),
@@ -227,8 +237,8 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
         checkHindsight(deps.getClient(), deps.getProjectBankId()),
       ]);
       const manifestPath = resolveImportManifestPath(ctx.cwd, config.import.manifestPath);
-      const manifest = await readImportManifest(manifestPath);
-      const imports = importManifestSummary(manifest);
+      const manifestRead = await readImportManifestSafe(manifestPath);
+      const imports = importManifestSummary(manifestRead.manifest);
       const sessionFile = ctx.sessionManager.getSessionFile?.();
       const capabilities = deps.getCapabilities?.();
       return {
@@ -249,6 +259,8 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
           importManifestPath: manifestPath,
           importCount: imports.count,
           ...(imports.latest ? { latestImport: imports.latest } : {}),
+          importManifestError: manifestRead.error,
+          importManifestAction: manifestRead.action,
           health,
           ...(capabilities ? { capabilities } : {}),
         }),

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -336,6 +336,45 @@ describe("hindsight commands", () => {
     );
   });
 
+  it("warns on corrupt import manifest in status and debug", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-commands-"));
+    mkdirSync(join(cwd, ".pi", "hindsight"), { recursive: true });
+    writeFileSync(
+      join(cwd, ".pi/hindsight/import-manifest.json"),
+      JSON.stringify({ imports: "bad" }),
+    );
+    const commands = new Map<string, { handler: (args: unknown, ctx: any) => Promise<void> }>();
+    registerCommands(
+      {
+        registerCommand: (
+          name: string,
+          command: { handler: (args: unknown, ctx: any) => Promise<void> },
+        ) => {
+          commands.set(name, command);
+        },
+      } as any,
+      {
+        getClient: () => client(),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "bank",
+      },
+    );
+    const ctx = { cwd, ui: { notify: vi.fn(), setStatus: vi.fn() }, sessionManager: {} };
+
+    await commands.get("hindsight:status")?.handler([], ctx);
+    await commands.get("hindsight:debug")?.handler([], ctx);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("import manifest unreadable:"),
+      "warning",
+    );
+    const debugCall = vi
+      .mocked(ctx.ui.notify)
+      .mock.calls.find(([message]) => String(message).includes('"imports"'));
+    expect(String(debugCall?.[0])).toContain('"error"');
+    expect(String(debugCall?.[0])).toContain('"action"');
+  });
+
   it("warns when doctor cannot read the retain queue", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-commands-"));
     writeFileSync(join(cwd, "not-a-dir"), "file blocks queue directory");

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -446,6 +446,46 @@ describe("Pi session import", () => {
     ).rejects.toThrow("Refusing to import session from cwd");
   });
 
+  it("recreates corrupt manifest and checkpoint files during import", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-"));
+    mkdirSync(join(dir, ".pi", "hindsight"), { recursive: true });
+    writeFileSync(
+      join(dir, ".pi/hindsight/import-manifest.json"),
+      JSON.stringify({ imports: "bad" }),
+    );
+    writeFileSync(
+      join(dir, ".pi/hindsight/import-checkpoint.json"),
+      JSON.stringify({ runId: "will-not-matter", documents: "bad" }),
+    );
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "corrupt-sidecars", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "1",
+          parentId: null,
+          message: { role: "user", content: "recover import sidecars" },
+        }),
+      ].join("\n"),
+    );
+
+    const result = await importPiSession({
+      sessionFile,
+      cwd: dir,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      client: { retain: async () => undefined, recall: async () => [], reflect: async () => ({}) },
+    });
+
+    await expect(readImportManifest(result.manifestPath)).resolves.toMatchObject({ version: 1 });
+    await expect(readImportCheckpoint(result.checkpointPath)).resolves.toMatchObject({
+      version: 1,
+    });
+    expect(result.documents[0]?.status).toBe("completed");
+  });
+
   it("discovers only sessions scoped to the current project cwd", async () => {
     const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
     const other = mkdtempSync(join(tmpdir(), "pi-hindsight-other-"));


### PR DESCRIPTION
## Summary

- Add safe import manifest/checkpoint readers that report repair actions instead of crashing diagnostics.
- Validate manifest/checkpoint shape, including malformed-but-valid JSON sidecars.
- Let successful imports recreate corrupt manifest/checkpoint sidecars.
- Surface import manifest errors in status/debug output.
- Add regression tests for corrupt import sidecars.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
