### PR TITLE
Isolate append capability probe memory

### DIFF
--- a/extensions/capabilities.ts
+++ b/extensions/capabilities.ts
@@ -44,7 +44,7 @@ export async function detectAppendCapability(
       documentId,
       updateMode: "append",
       context: "Pi Hindsight append capability detection",
-      tags: ["source:pi", "test:capability", "feature:append-probe"],
+      tags: ["source:pi-hindsight-diagnostic", "test:capability", "feature:append-probe"],
       metadata: {
         source: "pi-hindsight",
         capability: "append-update-mode",

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -35,7 +35,7 @@ describe("append capabilities", () => {
         async: true,
         documentId: "pi-hindsight-capability:append:bank",
         updateMode: "append",
-        tags: ["source:pi", "test:capability", "feature:append-probe"],
+        tags: ["source:pi-hindsight-diagnostic", "test:capability", "feature:append-probe"],
       },
     ]);
   });


### PR DESCRIPTION
## Summary

- Remove the broad `source:pi` recall tag from append capability probe memory.
- Use a dedicated diagnostic source tag instead.
- Keep probe diagnosable through stable document ID, context, metadata, and diagnostic tags.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
