### PR TITLE
Dedupe dead-letter queue entries

### DIFF
--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -353,15 +353,25 @@ export async function writeRetainQueue(path: string, jobs: RetainJob[]): Promise
   await rename(tmp, path);
 }
 
-async function appendDeadLetterJobs(path: string, jobs: RetainJob[]): Promise<void> {
-  if (jobs.length === 0) return;
+async function appendDeadLetterJobs(path: string, jobs: RetainJob[]): Promise<number> {
+  if (jobs.length === 0) return 0;
   const deadLetterPath = resolveDeadLetterQueuePath(path);
+  const existing = await readRetainQueueTolerant(deadLetterPath);
+  const existingIds = new Set(existing.jobs.map((job) => job.id));
+  const seen = new Set<string>();
+  const newJobs = jobs.filter((job) => {
+    if (existingIds.has(job.id) || seen.has(job.id)) return false;
+    seen.add(job.id);
+    return true;
+  });
+  if (newJobs.length === 0) return 0;
   await mkdir(dirname(deadLetterPath), { recursive: true });
   await appendFile(
     deadLetterPath,
-    jobs.map((job) => JSON.stringify(job)).join("\n") + "\n",
+    newJobs.map((job) => JSON.stringify(job)).join("\n") + "\n",
     "utf8",
   );
+  return newJobs.length;
 }
 
 export type FlushRetainQueueOptions = {
@@ -501,12 +511,12 @@ export async function flushRetainQueue(
       }
     }
     await appendMalformedQueueLines(path, parsed.malformedLines);
-    await appendDeadLetterJobs(path, deadLetteredJobs);
+    const appendedDeadLetterJobs = await appendDeadLetterJobs(path, deadLetteredJobs);
     await writeRetainQueue(path, remaining);
     return {
       sent,
       remaining: remaining.length,
-      deadLettered: deadLetteredJobs.length,
+      deadLettered: appendedDeadLetterJobs,
       malformed: parsed.malformedLines.length,
     };
   });

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -21,6 +21,7 @@ import {
   resolveMalformedQueuePath,
   resolveQueuePath,
   summarizeRetainQueue,
+  writeRetainQueue,
 } from "../extensions/queue.js";
 import type { RetainJob } from "../extensions/types.js";
 
@@ -200,6 +201,37 @@ describe("retain queue", () => {
     expect(dead[0]?.retries).toBe(1);
     expect(dead[0]?.lastError).toContain("moved to dead-letter queue");
     expect(dead[0]?.deadLetteredAt).toBeDefined();
+  });
+
+  it("does not duplicate dead-letter jobs by id", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    await enqueueRetainJob(path, job);
+    await writeRetainQueue(resolveDeadLetterQueuePath(path), [
+      {
+        ...job,
+        retries: 1,
+        lastError: "previous dead-letter append before crash",
+        deadLetteredAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const result = await flushRetainQueue(
+      path,
+      {
+        retain: async () => {
+          throw new Error("down again");
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+      { maxRetries: 1 },
+    );
+
+    expect(result).toMatchObject({ sent: 0, remaining: 0, deadLettered: 0 });
+    expect(await readRetainQueue(path)).toHaveLength(0);
+    const dead = await readDeadLetterQueue(path);
+    expect(dead).toHaveLength(1);
+    expect(dead[0]?.lastError).toBe("previous dead-letter append before crash");
   });
 
   it("redacts secrets from persisted queue errors", async () => {


### PR DESCRIPTION
## Summary

- Dedupe dead-letter queue appends by retain job ID.
- Avoid duplicate dead-letter entries after crash/retry between dead-letter append and active queue rewrite.
- Keep active queue preservation behavior when dead-letter append fails.
- Add regression coverage for duplicate-by-id dead-letter entries.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
