### PR TITLE
Add parent session import provenance

### DIFF
--- a/extensions/import-parser.ts
+++ b/extensions/import-parser.ts
@@ -4,6 +4,7 @@ interface JsonlEntry {
   parentId?: string | null;
   timestamp?: string;
   cwd?: string;
+  parentSession?: unknown;
   message?: unknown;
 }
 
@@ -17,6 +18,8 @@ export interface ParsedMessage {
 export interface ParsedSession {
   cwd?: string;
   sessionId?: string;
+  parentSessionId?: string;
+  parentSessionFile?: string;
   sessionTimestamp?: string;
   messages: ParsedMessage[];
 }
@@ -25,10 +28,28 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function stringField(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function parentSessionInfo(value: unknown): { id?: string; file?: string } {
+  if (typeof value === "string" && value.trim()) return { file: value };
+  if (!isRecord(value)) return {};
+  const id = stringField(value, ["id", "sessionId"]);
+  const file = stringField(value, ["file", "path", "sessionFile"]);
+  return { ...(id ? { id } : {}), ...(file ? { file } : {}) };
+}
+
 export function parseImportSessionJsonl(text: string): ParsedSession {
   const messages: ParsedMessage[] = [];
   let cwd: string | undefined;
   let sessionId: string | undefined;
+  let parentSessionId: string | undefined;
+  let parentSessionFile: string | undefined;
   let sessionTimestamp: string | undefined;
   for (const line of text.split("\n")) {
     if (!line.trim()) continue;
@@ -36,6 +57,9 @@ export function parseImportSessionJsonl(text: string): ParsedSession {
     if (entry.type === "session") {
       if (typeof entry.cwd === "string") cwd = entry.cwd;
       if (typeof entry.id === "string") sessionId = entry.id;
+      const parent = parentSessionInfo(entry.parentSession);
+      if (parent.id) parentSessionId = parent.id;
+      if (parent.file) parentSessionFile = parent.file;
       if (typeof entry.timestamp === "string") sessionTimestamp = entry.timestamp;
     }
     if (entry.type !== "message" || !isRecord(entry.message)) continue;
@@ -54,6 +78,8 @@ export function parseImportSessionJsonl(text: string): ParsedSession {
   return {
     ...(cwd ? { cwd } : {}),
     ...(sessionId ? { sessionId } : {}),
+    ...(parentSessionId ? { parentSessionId } : {}),
+    ...(parentSessionFile ? { parentSessionFile } : {}),
     ...(sessionTimestamp ? { sessionTimestamp } : {}),
     messages,
   };

--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -1,5 +1,5 @@
 import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
-import { importDocumentId } from "./session.js";
+import { importDocumentId, stableSessionId } from "./session.js";
 import { baseTags } from "./banking.js";
 import { redactSecrets } from "./sanitize.js";
 import { hashImportContent, type ImportManifestEntry } from "./import-manifest.js";
@@ -45,8 +45,16 @@ interface ImportBranchBuildResult extends ImportRetainResult {
   observationScopes: string[][];
 }
 
+function resolvedParentSessionId(parsed: ParsedSession, cwd: string): string | undefined {
+  return (
+    parsed.parentSessionId ??
+    (parsed.parentSessionFile ? stableSessionId(parsed.parentSessionFile, cwd) : undefined)
+  );
+}
+
 function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranchBuildResult {
   const leafId = args.branch.leafId;
+  const parentSessionId = resolvedParentSessionId(args.parsed, args.cwd);
   const branchMessages = args.branch.messages;
   const documentId = importDocumentId(args.sessionId, leafId);
   const updateMode = args.config.import.replaceExistingImportedDocs ? "replace" : "append";
@@ -56,6 +64,10 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
       sessionFile: args.sessionFile,
       cwd: args.parsed.cwd,
       sessionId: args.sessionId,
+      ...(parentSessionId ? { parentSessionId } : {}),
+      ...(args.parsed.parentSessionFile
+        ? { parentSessionFile: args.parsed.parentSessionFile }
+        : {}),
       branchLeafId: leafId,
       messages: branchMessages.map((message) => message.data),
     },
@@ -70,6 +82,7 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
     "imported:true",
     `document:${documentId}`,
   ];
+  if (parentSessionId) tags.push(`parent:${parentSessionId}`);
   if (args.leaves.length > 1) tags.push("forked:true");
   const identity = createMemoryIdentity(args.cwd, args.config, args.sessionFile);
   const observationScopes = args.config.observations.enabled
@@ -120,6 +133,7 @@ export function previewImportBranch(args: Omit<ImportRetainArgs, "client">): Imp
 
 export async function retainImportBranch(args: ImportRetainArgs): Promise<ImportRetainResult> {
   const built = buildImportBranch(args);
+  const parentSessionId = resolvedParentSessionId(args.parsed, args.cwd);
   await args.client.retain(args.bankId, built.content, {
     context: built.context,
     documentId: built.document.documentId,
@@ -131,6 +145,10 @@ export async function retainImportBranch(args: ImportRetainArgs): Promise<Import
       imported: "true",
       cwd: args.cwd,
       session_id: args.sessionId,
+      ...(parentSessionId ? { parent_session_id: parentSessionId } : {}),
+      ...(args.parsed.parentSessionFile
+        ? { parent_session_file: args.parsed.parentSessionFile }
+        : {}),
       branch_leaf_id: built.document.leafId,
       include_branches: args.config.import.includeBranches,
       ...(args.parsed.sessionTimestamp ? { session_timestamp: args.parsed.sessionTimestamp } : {}),

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../extensions/import-sessions.js";
 import { readImportCheckpoint } from "../extensions/import-checkpoint.js";
 import { readImportManifest } from "../extensions/import-manifest.js";
+import { stableSessionId } from "../extensions/session.js";
 
 describe("Pi session import", () => {
   it("parses message entries from Pi JSONL", () => {
@@ -38,10 +39,18 @@ describe("Pi session import", () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-"));
     mkdirSync(join(dir, ".git"));
     const sessionFile = join(dir, "session.jsonl");
+    const parentSessionFile = join(dir, "parent-session.jsonl");
+    const parentSessionId = stableSessionId(parentSessionFile, dir);
     writeFileSync(
       sessionFile,
       [
-        JSON.stringify({ type: "session", id: "session-1", cwd: dir, timestamp: "s-t" }),
+        JSON.stringify({
+          type: "session",
+          id: "session-1",
+          cwd: dir,
+          timestamp: "s-t",
+          parentSession: parentSessionFile,
+        }),
         JSON.stringify({
           type: "message",
           id: "root",
@@ -110,6 +119,8 @@ describe("Pi session import", () => {
     expect(calls[0]?.[0]).toBe("bank");
     expect(calls[0]?.[1]).not.toContain("TOKEN=secret");
     expect(calls[0]?.[1]).not.toContain("old branch");
+    expect(calls[0]?.[1]).toContain(parentSessionId);
+    expect(calls[0]?.[1]).toContain(parentSessionFile);
     expect(calls[0]?.[2]).toMatchObject({
       updateMode: "replace",
       documentId: result.documentId,
@@ -121,6 +132,7 @@ describe("Pi session import", () => {
         "imported:true",
         "session:session-1",
         "branch:current",
+        `parent:${parentSessionId}`,
         expect.stringMatching(/^repo:/),
         "forked:true",
       ]),
@@ -128,6 +140,8 @@ describe("Pi session import", () => {
         pi_session_file: sessionFile,
         cwd: dir,
         session_id: "session-1",
+        parent_session_id: parentSessionId,
+        parent_session_file: parentSessionFile,
         branch_leaf_id: "current",
         session_timestamp: "s-t",
       }),


### PR DESCRIPTION
## Summary

- Parse optional `parentSession` provenance from Pi session headers.
- Derive a stable parent session ID from the parent session file when no explicit parent ID is present.
- Carry parent provenance into historical import content, tags, and metadata.
- Add regression coverage for parent session import provenance.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
