### PR TITLE
Tolerate malformed import lines

### DIFF
--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -49,10 +49,16 @@ function importOptions(args: unknown): {
   };
 }
 
-function importDocumentSummary(result: { documents: { updateMode: string; status: string }[] }) {
+function importDocumentSummary(result: {
+  documents: { updateMode: string; status: string }[];
+  malformedLineCount?: number;
+}) {
   const modes = [...new Set(result.documents.map((document) => document.updateMode))].join(",");
   const statuses = [...new Set(result.documents.map((document) => document.status))].join(",");
-  return `documents=${result.documents.length}; update=${modes || "n/a"}; status=${statuses || "n/a"}`;
+  const malformed = result.malformedLineCount
+    ? `; malformedLines=${result.malformedLineCount}`
+    : "";
+  return `documents=${result.documents.length}; update=${modes || "n/a"}; status=${statuses || "n/a"}${malformed}`;
 }
 
 function queueIssueSummary(queue?: {
@@ -280,8 +286,8 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       });
       ctx.ui.notify(
         result.dryRun
-          ? `Project import preview: sessions=${result.sessionFiles.length}/${result.scanned}; documents=${result.documentCount}; messages=${result.messageCount}; write=no`
-          : `Imported project sessions: sessions=${result.sessionFiles.length}/${result.scanned}; documents=${result.documentCount}; messages=${result.messageCount}`,
+          ? `Project import preview: sessions=${result.sessionFiles.length}/${result.scanned}; documents=${result.documentCount}; messages=${result.messageCount}; malformedLines=${result.malformedLineCount}; write=no`
+          : `Imported project sessions: sessions=${result.sessionFiles.length}/${result.scanned}; documents=${result.documentCount}; messages=${result.messageCount}; malformedLines=${result.malformedLineCount}`,
         "info",
       );
     },

--- a/extensions/import-parser.ts
+++ b/extensions/import-parser.ts
@@ -21,6 +21,7 @@ export interface ParsedSession {
   parentSessionId?: string;
   parentSessionFile?: string;
   sessionTimestamp?: string;
+  malformedLineCount: number;
   messages: ParsedMessage[];
 }
 
@@ -51,9 +52,21 @@ export function parseImportSessionJsonl(text: string): ParsedSession {
   let parentSessionId: string | undefined;
   let parentSessionFile: string | undefined;
   let sessionTimestamp: string | undefined;
+  let malformedLineCount = 0;
   for (const line of text.split("\n")) {
     if (!line.trim()) continue;
-    const entry = JSON.parse(line) as JsonlEntry;
+    let entry: JsonlEntry;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!isRecord(parsed)) {
+        malformedLineCount += 1;
+        continue;
+      }
+      entry = parsed as JsonlEntry;
+    } catch {
+      malformedLineCount += 1;
+      continue;
+    }
     if (entry.type === "session") {
       if (typeof entry.cwd === "string") cwd = entry.cwd;
       if (typeof entry.id === "string") sessionId = entry.id;
@@ -81,17 +94,20 @@ export function parseImportSessionJsonl(text: string): ParsedSession {
     ...(parentSessionId ? { parentSessionId } : {}),
     ...(parentSessionFile ? { parentSessionFile } : {}),
     ...(sessionTimestamp ? { sessionTimestamp } : {}),
+    malformedLineCount,
     messages,
   };
 }
 
 export function parsePiSessionJsonl(text: string): {
   cwd?: string;
+  malformedLineCount: number;
   messages: Record<string, unknown>[];
 } {
   const parsed = parseImportSessionJsonl(text);
   return {
     ...(parsed.cwd ? { cwd: parsed.cwd } : {}),
+    malformedLineCount: parsed.malformedLineCount,
     messages: parsed.messages.map((message) => message.data),
   };
 }

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -81,6 +81,7 @@ export interface ImportProjectSessionsResult {
   messageCount: number;
   documentCount: number;
   dryRun: boolean;
+  malformedLineCount: number;
 }
 
 export interface ImportSessionDocumentResult {
@@ -106,6 +107,7 @@ export interface ImportSessionResult {
   manifestPath: string;
   checkpointPath: string;
   runId: string;
+  malformedLineCount: number;
   documents: ImportSessionDocumentResult[];
 }
 
@@ -273,6 +275,7 @@ export async function importPiSession(args: {
     manifestPath,
     checkpointPath,
     runId,
+    malformedLineCount: parsed.malformedLineCount,
     documents,
   };
 }
@@ -321,5 +324,6 @@ export async function importProjectSessions(args: {
     messageCount: imported.reduce((count, result) => count + result.messageCount, 0),
     documentCount: imported.reduce((count, result) => count + result.documents.length, 0),
     dryRun: Boolean(args.dryRun),
+    malformedLineCount: imported.reduce((count, result) => count + result.malformedLineCount, 0),
   };
 }

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -27,11 +27,13 @@ describe("Pi session import", () => {
           timestamp: "t",
           message: { role: "user", content: "hi" },
         }),
+        "{not json}",
         JSON.stringify({ type: "custom", data: {} }),
       ].join("\n"),
     );
     expect(parsed.cwd).toBe("/repo");
     expect(parsed.messages).toHaveLength(1);
+    expect(parsed.malformedLineCount).toBe(1);
     expect(parsed.messages[0]).toMatchObject({ id: "1", role: "user", content: "hi" });
   });
 
@@ -51,6 +53,7 @@ describe("Pi session import", () => {
           timestamp: "s-t",
           parentSession: parentSessionFile,
         }),
+        "{bad json}",
         JSON.stringify({
           type: "message",
           id: "root",
@@ -88,6 +91,7 @@ describe("Pi session import", () => {
       },
     });
     expect(result.messageCount).toBe(2);
+    expect(result.malformedLineCount).toBe(1);
     expect(result.documentId).toBe("pi-import:session-1:leaf:current");
     expect(result.documents).toEqual([
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- Skip and count malformed Pi session JSONL lines during import parsing.
- Keep valid session metadata/messages flowing through direct import and project discovery.
- Surface malformed line counts in import results and command summaries.
- Keep retain content hashes based on valid retained messages only.
- Add regression coverage for malformed import lines.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
