### PR TITLE
Filter recall artifacts from imports

### DIFF
--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -4,6 +4,7 @@ import { baseTags } from "./banking.js";
 import { redactSecrets } from "./sanitize.js";
 import { hashImportContent, type ImportManifestEntry } from "./import-manifest.js";
 import { createMemoryIdentity } from "./memory-identity.js";
+import { isInjectedHindsightMemory } from "./messages.js";
 import { expandObservationScopes } from "./observation-scopes.js";
 import type { ImportBranch } from "./import-branches.js";
 import type { ParsedSession } from "./import-parser.js";
@@ -55,7 +56,9 @@ function resolvedParentSessionId(parsed: ParsedSession, cwd: string): string | u
 function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranchBuildResult {
   const leafId = args.branch.leafId;
   const parentSessionId = resolvedParentSessionId(args.parsed, args.cwd);
-  const branchMessages = args.branch.messages;
+  const branchMessages = args.branch.messages.filter(
+    (message) => !isInjectedHindsightMemory(message.data),
+  );
   const documentId = importDocumentId(args.sessionId, leafId);
   const updateMode = args.config.import.replaceExistingImportedDocs ? "replace" : "append";
   const contentRaw = JSON.stringify(

--- a/extensions/messages.ts
+++ b/extensions/messages.ts
@@ -162,14 +162,15 @@ export function projectMessageText(
   return stripFields(base, retain?.strip.message ?? []);
 }
 
-function isInjectedHindsightMemory(message: AgentMessage): boolean {
-  return textFromContent((message as unknown as { content?: unknown }).content, {
+export function isInjectedHindsightMemory(message: unknown): boolean {
+  const record = message as { content?: unknown; customType?: unknown; type?: unknown };
+  if (record.customType === "hindsight-recall" || record.type === "hindsight-recall") return true;
+  const text = textFromContent(record.content, {
     includeText: true,
     includeThinking: false,
     includeToolCall: true,
-  })
-    .trim()
-    .startsWith("<hindsight-memory>");
+  }).trim();
+  return text.startsWith("<hindsight-memory>") || text.startsWith("<hindsight_memories>");
 }
 
 function toolResultContent(

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -63,6 +63,33 @@ describe("Pi session import", () => {
         }),
         JSON.stringify({
           type: "message",
+          id: "recall-memory",
+          parentId: "root",
+          timestamp: "t-recall",
+          message: {
+            role: "assistant",
+            content: "<hindsight-memory>persisted recall</hindsight-memory>",
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "legacy-recall-memory",
+          parentId: "recall-memory",
+          timestamp: "t-legacy-recall",
+          message: {
+            role: "assistant",
+            content: "<hindsight_memories>legacy recall</hindsight_memories>",
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "custom-recall-memory",
+          parentId: "legacy-recall-memory",
+          timestamp: "t-custom-recall",
+          message: { role: "assistant", customType: "hindsight-recall", content: "custom recall" },
+        }),
+        JSON.stringify({
+          type: "message",
           id: "old",
           parentId: "root",
           timestamp: "t2",
@@ -71,7 +98,7 @@ describe("Pi session import", () => {
         JSON.stringify({
           type: "message",
           id: "current",
-          parentId: "root",
+          parentId: "custom-recall-memory",
           timestamp: "t3",
           message: { role: "assistant", content: "TOKEN=secret" },
         }),
@@ -123,6 +150,9 @@ describe("Pi session import", () => {
     expect(calls[0]?.[0]).toBe("bank");
     expect(calls[0]?.[1]).not.toContain("TOKEN=secret");
     expect(calls[0]?.[1]).not.toContain("old branch");
+    expect(calls[0]?.[1]).not.toContain("<hindsight-memory>");
+    expect(calls[0]?.[1]).not.toContain("<hindsight_memories>");
+    expect(calls[0]?.[1]).not.toContain("custom recall");
     expect(calls[0]?.[1]).toContain(parentSessionId);
     expect(calls[0]?.[1]).toContain(parentSessionFile);
     expect(calls[0]?.[2]).toMatchObject({


### PR DESCRIPTION
## Summary

- Share recall-artifact detection with historical import.
- Filter persisted `<hindsight-memory>`, `<hindsight_memories>`, and `hindsight-recall` custom message artifacts before import retain.
- Keep import hashes, counts, checkpoint, manifest, and retained content based only on valid non-recall messages.
- Add regression coverage for import recall-artifact filtering.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
