### PR TITLE
Health-check active diagnostics bank

### DIFF
--- a/extensions/memory-operations.ts
+++ b/extensions/memory-operations.ts
@@ -52,6 +52,12 @@ function recallTagsForBank(
     : recallScopeTags(cwd);
 }
 
+function diagnosticHealthBankId(config: ResolvedConfig, projectBankId: string): string {
+  if (config.banks.project.enabled) return projectBankId;
+  if (config.banks.global.enabled && config.banks.global.bankId) return config.banks.global.bankId;
+  return projectBankId;
+}
+
 export function createMemoryOperations(deps: MemoryOperationsDeps) {
   return {
     async recall(cwd: string, query: string, bank?: string, sessionFile?: string) {
@@ -201,8 +207,9 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     async doctor(cwd: string) {
       const config = deps.getConfig();
       const queuePath = resolveQueuePath(cwd, config.retain.queuePath);
+      const healthBankId = diagnosticHealthBankId(config, deps.getProjectBankId());
       const [health, queue, manifestRead] = await Promise.all([
-        checkHindsight(deps.getClient(), deps.getProjectBankId()),
+        checkHindsight(deps.getClient(), healthBankId),
         summarizeRetainQueue(queuePath),
         readImportManifestSafe(resolveImportManifestPath(cwd, config.import.manifestPath)),
       ]);
@@ -232,9 +239,10 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     async debug(ctx: ExtensionCommandContext) {
       const config = deps.getConfig();
       const queuePath = resolveQueuePath(ctx.cwd, config.retain.queuePath);
+      const healthBankId = diagnosticHealthBankId(config, deps.getProjectBankId());
       const [queue, health] = await Promise.all([
         summarizeRetainQueue(queuePath),
-        checkHindsight(deps.getClient(), deps.getProjectBankId()),
+        checkHindsight(deps.getClient(), healthBankId),
       ]);
       const manifestPath = resolveImportManifestPath(ctx.cwd, config.import.manifestPath);
       const manifestRead = await readImportManifestSafe(manifestPath);

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -54,4 +54,31 @@ describe("memory operations", () => {
       global: { enabled: false },
     });
   });
+
+  it("checks the active global bank in global-only diagnostics", async () => {
+    const checkedBanks: string[] = [];
+    const operations = createMemoryOperations({
+      getClient: () => ({
+        ...client(),
+        getBankProfile: async (bankId: string) => {
+          checkedBanks.push(bankId);
+          return {};
+        },
+      }),
+      getConfig: () => ({
+        ...DEFAULT_CONFIG,
+        banks: {
+          project: { enabled: false, derive: "repo" },
+          global: { enabled: true, bankId: "global-bank" },
+        },
+      }),
+      getProjectBankId: () => "project-bank",
+    });
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ops-"));
+
+    await operations.doctor(cwd);
+    await operations.debug({ cwd, ui: {} as any, sessionManager: {} as any } as any);
+
+    expect(checkedBanks).toEqual(["global-bank", "global-bank"]);
+  });
 });


### PR DESCRIPTION
## Summary

- Make `/hindsight:doctor` and `/hindsight:debug` health-check the active diagnostics bank.
- Use the configured global bank for global-only profiles instead of the unused derived project bank.
- Keep project-enabled diagnostics checking the project bank.
- Add regression coverage for global-only diagnostics bank selection.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
