### PR TITLE
Add one-turn retain opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Implemented:
   - `/hindsight:session`
   - `/hindsight:mode`
   - `/hindsight:retain`
+  - `/hindsight:next-opt-out`
   - `/hindsight:tag`
 - tests for config, bank derivation, stable document IDs, sanitization, recall formatting, retain payloads, diagnostics, client request shapes, extension hook placement, historical import, import manifests, and queue replay
 
@@ -147,9 +148,9 @@ Intentionally deferred:
 - bank administration UI beyond setup guidance
 - OpenClaw-style multitenant dynamic routing
 
-See [`docs/risky-memory-modes.md`](docs/risky-memory-modes.md) for why persisted recall transcript messages, provider recall caching, and prompt hashtag controls remain deferred, and why command-based controls such as a future `/hindsight:next-opt-out` are preferred.
+See [`docs/risky-memory-modes.md`](docs/risky-memory-modes.md) for why persisted recall transcript messages, provider recall caching, and prompt hashtag controls remain deferred, and why command-based controls such as `/hindsight:next-opt-out` are preferred.
 
-See [`docs/next-opt-out-design.md`](docs/next-opt-out-design.md) for the proposed one-turn memory opt-out command design.
+See [`docs/next-opt-out-design.md`](docs/next-opt-out-design.md) for the implemented one-turn memory opt-out command design.
 
 Historical import supports importing the current Pi session, an explicit JSONL path, or all Pi session JSONL files in the current session directory that belong to the current repo/cwd. Imports write deterministic document IDs and update an import manifest so `/hindsight:debug` can show imported document count and latest import provenance. Use `/hindsight:import --dry-run`, `/hindsight:import-project-sessions --dry-run`, or `hindsight_import` with `dryRun: true` to preview documents, message counts, content sizes, tags, update mode, and target bank without writing Hindsight memory or mutating the manifest. Add `--all-leaves` or `allLeaves: true` to preview/import every branch leaf instead of only the current branch. Project session discovery intentionally avoids broad history imports: it scans only the current session file's directory and keeps only `.jsonl` session files whose parsed `cwd` exactly matches the current repo/cwd. Imports maintain `.pi/hindsight/import-checkpoint.json` by default and resume completed documents without re-retaining them when `import.resume` is enabled.
 

--- a/docs/risky-memory-modes.md
+++ b/docs/risky-memory-modes.md
@@ -91,9 +91,9 @@ Safe alternative:
   - `/hindsight:mode read-only`
   - `/hindsight:mode ignored`
   - `/hindsight:retain off`
-- Design a future command-based one-turn opt-out instead of hashtag parsing.
+- Use `/hindsight:next-opt-out` for command-based one-turn automatic retain opt-out instead of hashtag parsing.
 
-Preferred future direction:
+Implemented one-turn direction:
 
 ```text
 /hindsight:next-opt-out
@@ -106,7 +106,7 @@ Why this is better:
 - The behavior can be tested without parsing arbitrary user prose.
 - It does not conflict with Markdown.
 
-Initial semantics, if implemented later:
+Current semantics:
 
 - Applies once to the next agent run in the current session.
 - Disables automatic retain for that run.
@@ -123,11 +123,11 @@ Use commands for policy. Do not hide policy in prompt text.
 
 ## Decision summary
 
-| Feature                              | Status   | Safe alternative                                           |
-| ------------------------------------ | -------- | ---------------------------------------------------------- |
-| Persisted recall transcript messages | Deferred | ephemeral recall + last-recall sidecar                     |
-| Provider recall cache                | Deferred | fresh recall per turn + local inspection snapshot          |
-| `#nomem` / prompt hashtag controls   | Deferred | explicit commands; future `/hindsight:next-opt-out` design |
+| Feature                              | Status   | Safe alternative                                    |
+| ------------------------------------ | -------- | --------------------------------------------------- |
+| Persisted recall transcript messages | Deferred | ephemeral recall + last-recall sidecar              |
+| Provider recall cache                | Deferred | fresh recall per turn + local inspection snapshot   |
+| `#nomem` / prompt hashtag controls   | Deferred | explicit commands such as `/hindsight:next-opt-out` |
 
 ## Reopening criteria
 

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -298,7 +298,7 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
     handler: async (_args, ctx) => {
       const result = await operations.session(ctx.cwd, sessionFile(ctx));
       ctx.ui.notify(
-        `Hindsight session mode=${result.meta.mode}; recall=${result.effective.recall}; retain=${result.effective.retain}; tags=${result.meta.tags.join(",") || "none"}`,
+        `Hindsight session mode=${result.meta.mode}; recall=${result.effective.recall}; retain=${result.effective.retain}; nextRetain=${result.meta.nextRetainMode}; tags=${result.meta.tags.join(",") || "none"}`,
         "info",
       );
     },
@@ -316,6 +316,17 @@ export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       const result = await operations.setSessionMode(ctx.cwd, sessionFile(ctx), mode);
       ctx.ui.notify(
         `Hindsight session mode=${result.meta.mode}; recall=${result.effective.recall}; retain=${result.effective.retain}`,
+        "info",
+      );
+    },
+  });
+
+  pi.registerCommand("hindsight:next-opt-out", {
+    description: "Skip automatic retain for the next agent run in this session.",
+    handler: async (_args, ctx) => {
+      const result = await operations.setNextRetainOff(ctx.cwd, sessionFile(ctx));
+      ctx.ui.notify(
+        `Hindsight will skip automatic retain for the next agent run in this session. nextRetain=${result.meta.nextRetainMode}`,
         "info",
       );
     },

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -19,7 +19,11 @@ import {
   readRetainFingerprints,
 } from "./retain-cursor.js";
 import type { HindsightCapabilities, HindsightLikeClient, ResolvedConfig } from "./types.js";
-import { getEffectiveSessionMemoryMode, readSessionMemoryMeta } from "./session-memory-meta.js";
+import {
+  consumeNextSessionRetainMode,
+  getEffectiveSessionMemoryMode,
+  readSessionMemoryMeta,
+} from "./session-memory-meta.js";
 import { writeLastRecallSnapshot } from "./recall-visibility.js";
 import { redactError } from "./sanitize.js";
 
@@ -284,10 +288,12 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
         return { queued: false, sent: 0, remaining: 0 };
       const runtime = snapshotRuntime(ctx);
       if (!runtime) return { queued: false, sent: 0, remaining: 0 };
-      const sessionMemory = getEffectiveSessionMemoryMode(
-        await readSessionMemoryMeta(runtime.cwd, runtime.sessionFile),
+      const { meta: sessionMeta, consumed: nextRetainMode } = await consumeNextSessionRetainMode(
+        runtime.cwd,
+        runtime.sessionFile,
       );
-      if (!sessionMemory.retain) {
+      const sessionMemory = getEffectiveSessionMemoryMode(sessionMeta);
+      if (!sessionMemory.retain || nextRetainMode === "off") {
         try {
           await markRetainedMessages(runtime, event.messages);
         } catch (error) {
@@ -297,6 +303,9 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
             `Hindsight retain cursor update failed: ${(error as Error).message}`,
             "warning",
           );
+        }
+        if (nextRetainMode === "off") {
+          notify(runtime, "Hindsight skipped retain for this run due to next-opt-out.", "info");
         }
         return { queued: false, sent: 0, remaining: 0 };
       }

--- a/extensions/memory-operations.ts
+++ b/extensions/memory-operations.ts
@@ -26,6 +26,7 @@ import {
   getEffectiveSessionMemoryMode,
   readSessionMemoryMeta,
   removeSessionMemoryTag,
+  setNextSessionRetainMode,
   setSessionMemoryMode,
   setSessionRetainEnabled,
   type SessionMemoryMode,
@@ -299,6 +300,11 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
 
     async setSessionRetain(cwd: string, sessionFile: string | undefined, enabled: boolean) {
       const meta = await setSessionRetainEnabled(cwd, sessionFile, enabled);
+      return { meta, effective: getEffectiveSessionMemoryMode(meta) };
+    },
+
+    async setNextRetainOff(cwd: string, sessionFile: string | undefined) {
+      const meta = await setNextSessionRetainMode(cwd, sessionFile, "off");
       return { meta, effective: getEffectiveSessionMemoryMode(meta) };
     },
 

--- a/extensions/session-memory-meta.ts
+++ b/extensions/session-memory-meta.ts
@@ -5,11 +5,13 @@ import { stableSessionId } from "./session.js";
 
 export type SessionMemoryMode = "normal" | "read-only" | "ignored";
 export type SessionMemorySwitch = "normal" | "off";
+export type NextRetainMode = "normal" | "off";
 
 export interface HindsightSessionMeta {
   retained: boolean;
   recallMode: SessionMemorySwitch;
   retainMode: SessionMemorySwitch;
+  nextRetainMode: NextRetainMode;
   mode: SessionMemoryMode;
   tags: string[];
   createdAt: string;
@@ -37,6 +39,7 @@ export function defaultSessionMemoryMeta(): HindsightSessionMeta {
     retained: true,
     recallMode: "normal",
     retainMode: "normal",
+    nextRetainMode: "normal",
     mode: "normal",
     tags: [],
     createdAt: now,
@@ -50,6 +53,7 @@ export function failClosedSessionMemoryMeta(): HindsightSessionMeta {
     retained: false,
     recallMode: "off",
     retainMode: "off",
+    nextRetainMode: "normal",
     mode: "ignored",
     tags: [],
     createdAt: now,
@@ -99,6 +103,7 @@ function isSessionMemoryMetaRecord(value: unknown): value is SessionMemoryMetaRe
     typeof record.retained === "boolean" &&
     isSwitch(record.recallMode) &&
     isSwitch(record.retainMode) &&
+    (record.nextRetainMode === undefined || isSwitch(record.nextRetainMode)) &&
     isMode(record.mode) &&
     Array.isArray(record.tags) &&
     typeof record.createdAt === "string" &&
@@ -112,6 +117,7 @@ export function normalizeSessionMemoryMeta(value: unknown): HindsightSessionMeta
     retained: value.retained,
     recallMode: value.recallMode,
     retainMode: value.retainMode,
+    nextRetainMode: value.nextRetainMode ?? "normal",
     mode: value.mode,
     tags: normalizeSessionTags(value.tags),
     createdAt: value.createdAt,
@@ -193,6 +199,29 @@ export async function setSessionRetainEnabled(
     retained: enabled,
     retainMode: enabled ? "normal" : "off",
   });
+}
+
+export async function setNextSessionRetainMode(
+  cwd: string,
+  sessionFile: string | undefined,
+  nextRetainMode: NextRetainMode,
+): Promise<HindsightSessionMeta> {
+  const meta = await readSessionMemoryMeta(cwd, sessionFile);
+  return writeSessionMemoryMeta(cwd, sessionFile, { ...meta, nextRetainMode });
+}
+
+export async function consumeNextSessionRetainMode(
+  cwd: string,
+  sessionFile: string | undefined,
+): Promise<{ meta: HindsightSessionMeta; consumed: NextRetainMode }> {
+  const meta = await readSessionMemoryMeta(cwd, sessionFile);
+  const consumed = meta.nextRetainMode;
+  if (consumed === "normal") return { meta, consumed };
+  const next = await writeSessionMemoryMeta(cwd, sessionFile, {
+    ...meta,
+    nextRetainMode: "normal",
+  });
+  return { meta: next, consumed };
 }
 
 export async function addSessionMemoryTag(

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -3,7 +3,12 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { enqueueRetainJob, readRetainQueue, resolveQueuePath } from "../extensions/queue.js";
-import { addSessionMemoryTag, setSessionMemoryMode } from "../extensions/session-memory-meta.js";
+import {
+  addSessionMemoryTag,
+  readSessionMemoryMeta,
+  setNextSessionRetainMode,
+  setSessionMemoryMode,
+} from "../extensions/session-memory-meta.js";
 import type { RetainJob } from "../extensions/types.js";
 
 const mocked = vi.hoisted(() => ({
@@ -101,6 +106,63 @@ describe("extension hooks", () => {
     expect(retainedContent).toContain("Decision still stands.");
     expect(retainedContent).not.toContain("<hindsight-memory>");
     expect(retainedContent).not.toContain("repo-specific remembered fact");
+  });
+
+  it("skips automatic retain once for next opt-out and advances retain cursor", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi"));
+    const sessionFile = join(cwd, "session.jsonl");
+    await setNextSessionRetainMode(cwd, sessionFile, "off");
+    const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
+    const pi = {
+      on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
+        handlers[name] = [...(handlers[name] ?? []), handler];
+      }),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+    };
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => sessionFile },
+    };
+
+    const { default: hindsightExtension } = await import("../extensions/index.js");
+    hindsightExtension(pi as any);
+    await handlers.session_start?.[0]?.({}, ctx);
+    mocked.client.retain.mockClear();
+
+    const skippedMessages = [
+      { role: "user", content: "Do not retain this", timestamp: 1 },
+      { role: "assistant", content: "Skipped answer", timestamp: 2 },
+    ];
+    await handlers.agent_end?.[0]?.({ messages: skippedMessages }, ctx);
+
+    expect(mocked.client.retain).not.toHaveBeenCalled();
+    expect((await readSessionMemoryMeta(cwd, sessionFile)).nextRetainMode).toBe("normal");
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      "Hindsight skipped retain for this run due to next-opt-out.",
+      "info",
+    );
+
+    await handlers.agent_end?.[0]?.(
+      {
+        messages: [
+          ...skippedMessages,
+          { role: "user", content: "Retain this later", timestamp: 3 },
+          { role: "assistant", content: "Retained answer", timestamp: 4 },
+        ],
+      },
+      ctx,
+    );
+
+    expect(mocked.client.retain).toHaveBeenCalledTimes(1);
+    const retainedContent = mocked.client.retain.mock.calls[0]?.[1] as string;
+    expect(retainedContent).not.toContain("Do not retain this");
+    expect(retainedContent).not.toContain("Skipped answer");
+    expect(retainedContent).toContain("Retain this later");
+    expect(retainedContent).toContain("Retained answer");
   });
 
   it("writes opt-in last recall snapshot to sidecar", async () => {

--- a/tests/session-memory-meta.test.ts
+++ b/tests/session-memory-meta.test.ts
@@ -4,9 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   addSessionMemoryTag,
+  consumeNextSessionRetainMode,
   getEffectiveSessionMemoryMode,
   readSessionMemoryMeta,
   removeSessionMemoryTag,
+  setNextSessionRetainMode,
   setSessionMemoryMode,
   setSessionRetainEnabled,
   sessionMetaPath,
@@ -120,6 +122,18 @@ describe("session memory metadata", () => {
       recall: true,
       retain: false,
     });
+  });
+
+  it("persists and consumes one-turn retain opt-out", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-meta-"));
+
+    await setNextSessionRetainMode(cwd, "/tmp/session.jsonl", "off");
+    expect((await readSessionMemoryMeta(cwd, "/tmp/session.jsonl")).nextRetainMode).toBe("off");
+
+    const consumed = await consumeNextSessionRetainMode(cwd, "/tmp/session.jsonl");
+    expect(consumed.consumed).toBe("off");
+    expect(consumed.meta.nextRetainMode).toBe("normal");
+    expect((await readSessionMemoryMeta(cwd, "/tmp/session.jsonl")).nextRetainMode).toBe("normal");
   });
 
   it("adds and removes sanitized tags", async () => {


### PR DESCRIPTION
## Summary

- Add `/hindsight:next-opt-out` to skip automatic retain for the next agent run.
- Persist one-turn `nextRetainMode` session metadata outside provider-visible messages.
- Consume and clear the opt-out during `agent_end`, mark skipped messages in the retain cursor, and leave recall/import/explicit retain unaffected.
- Show `nextRetain` in `/hindsight:session`.
- Update docs now that the command is implemented.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
