### PR TITLE
Record next opt-out implementation

### DIFF
--- a/docs/next-opt-out-design.md
+++ b/docs/next-opt-out-design.md
@@ -14,6 +14,8 @@ Examples:
 
 ## Decision
 
+Implemented in PR #55.
+
 Use an explicit command:
 
 ```text
@@ -34,7 +36,7 @@ A command is better than prompt parsing because it is:
 - less likely to be copied by agents into generated content
 - easier to reason about during import and cursor handling
 
-## Initial semantics
+## Current semantics
 
 `/hindsight:next-opt-out` applies once to the next completed agent run in the current session.
 
@@ -76,7 +78,7 @@ Recall remains enabled unless another session mode disables it. This keeps the c
 
 A future command could add recall control explicitly, but it should not be overloaded into this first command.
 
-## Proposed user-facing behavior
+## User-facing behavior
 
 Command:
 
@@ -87,7 +89,7 @@ Command:
 Success message:
 
 ```text
-Hindsight will skip automatic retain for the next agent run in this session.
+Hindsight will skip automatic retain for the next agent run in this session. nextRetain=off
 ```
 
 Session status should show pending one-turn opt-out:
@@ -96,7 +98,7 @@ Session status should show pending one-turn opt-out:
 Hindsight session mode=normal; recall=true; retain=true; nextRetain=off; tags=none
 ```
 
-When consumed, optional activity notification could say:
+When consumed, the activity notification says:
 
 ```text
 Hindsight skipped retain for this run due to next-opt-out.
@@ -112,24 +114,28 @@ Extend session memory metadata with a non-provider-visible field:
 }
 ```
 
-The default is no field or `"normal"`.
+The default is `"normal"`.
 
-Only persist fields that are active. Clearing the one-turn opt-out should remove or normalize the field.
+Clearing the one-turn opt-out normalizes the field back to `"normal"`.
 
-## Tests required before implementation
+## Implemented tests
 
-Good tests should assert external behavior, not internal helper details.
+Tests assert external behavior, not internal helper details.
 
-Cover:
+Covered:
 
-- command sets a pending one-turn retain opt-out
-- `/hindsight:session` reports pending opt-out
+- session metadata persists and consumes a one-turn retain opt-out
 - next `agent_end` skips automatic retain
 - skipped messages are added to retain cursor so they are not retained later
 - opt-out clears after one completed agent run
+
+Remaining useful regression coverage:
+
+- command handler sets a pending one-turn retain opt-out
+- `/hindsight:session` reports pending opt-out
 - recall still runs while next retain is off
 - ignored/read-only/retain-off modes remain stronger than next opt-out
-- explicit `hindsight_retain` still queues normally
+- explicit `hindsight_retain` still queues normally while next opt-out is pending
 - historical import ignores next opt-out state
 
 ## Out of scope

--- a/docs/post-mvp-roadmap.md
+++ b/docs/post-mvp-roadmap.md
@@ -96,7 +96,7 @@ Preferred command shape:
 /hindsight:next-opt-out
 ```
 
-Possible aliases or future variants:
+Possible future variants, not currently implemented:
 
 ```text
 /hindsight:next-retain off
@@ -111,15 +111,15 @@ Reason for a dedicated command:
 - It is explicit in the command history.
 - It can have precise behavior and tests.
 
-Open design questions:
+Resolved design decisions:
 
-- Should the next turn disable retain only, recall only, or both?
-- Should the command apply to the next user prompt, the next agent run, or the next completed retain delta?
-- How should it interact with `/hindsight:mode read-only|ignored`?
-- Should the setting survive process restart, or be in-memory only?
-- Should it affect historical imports? Default answer should be no.
+- The command disables automatic retain only.
+- It applies to the next completed agent run.
+- Session-wide modes such as `read-only`, `ignored`, and `/hindsight:retain off` remain stronger than this one-turn flag.
+- The flag is persisted in session metadata until consumed.
+- It does not affect historical imports.
 
-Initial recommendation:
+Implemented command:
 
 ```text
 /hindsight:next-opt-out
@@ -136,15 +136,22 @@ Behavior:
 
 **Scope:**
 
-- Write the design and test plan first.
-- Implement only after the exact behavior is accepted.
+- Document the design and test plan first.
+- Implement the exact accepted behavior only.
 - Do not implement hashtag parsing.
 
-**Acceptance criteria for design PR:**
+**Acceptance criteria:**
 
 - The command name and one-turn semantics are documented.
 - Import/cursor/session-mode interactions are specified.
 - The out-of-scope list explicitly rejects prompt hashtags for now.
+
+**Implemented outcome:**
+
+- PR #55 added `/hindsight:next-opt-out`.
+- The command sets `nextRetainMode=off` in non-provider-visible session metadata.
+- The next `agent_end` skips automatic retain, marks skipped messages in the retain cursor, clears the flag, and leaves recall, import, and explicit retain unchanged.
+- `/hindsight:session` reports `nextRetain`.
 
 **Checks:**
 
@@ -236,7 +243,7 @@ Why deferred:
 
 Safe alternative:
 
-- Use explicit commands such as `/hindsight:mode`, `/hindsight:retain`, and a future `/hindsight:next-opt-out`.
+- Use explicit commands such as `/hindsight:mode`, `/hindsight:retain`, and `/hindsight:next-opt-out`.
 
 ### Linked hosts / multi-Hindsight-server routing
 


### PR DESCRIPTION
## Summary

- Record that `/hindsight:next-opt-out` shipped in PR #55.
- Update the one-turn opt-out design doc from proposed/future language to current behavior.
- Clarify actual implemented test coverage and remaining useful regression coverage.
- Update the roadmap PR10 section with implementation outcome.

## Validation

- `npm run format`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
