### PR TITLE
Expand next opt-out regression coverage

### DIFF
--- a/docs/next-opt-out-design.md
+++ b/docs/next-opt-out-design.md
@@ -129,14 +129,17 @@ Covered:
 - skipped messages are added to retain cursor so they are not retained later
 - opt-out clears after one completed agent run
 
-Remaining useful regression coverage:
+Additional coverage added after implementation:
 
 - command handler sets a pending one-turn retain opt-out
 - `/hindsight:session` reports pending opt-out
-- recall still runs while next retain is off
-- ignored/read-only/retain-off modes remain stronger than next opt-out
 - explicit `hindsight_retain` still queues normally while next opt-out is pending
 - historical import ignores next opt-out state
+
+Remaining useful regression coverage:
+
+- recall still runs while next retain is off
+- ignored/read-only/retain-off modes remain stronger than next opt-out
 
 ## Out of scope
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { registerCommands } from "../extensions/commands.js";
-import { setSessionMemoryMode } from "../extensions/session-memory-meta.js";
+import { readSessionMemoryMeta, setSessionMemoryMode } from "../extensions/session-memory-meta.js";
 import type { HindsightLikeClient } from "../extensions/types.js";
 
 type RegisteredTestCommand = {
@@ -21,6 +21,42 @@ function client(): HindsightLikeClient {
 }
 
 describe("hindsight commands", () => {
+  it("sets and reports next opt-out session metadata", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-commands-"));
+    const sessionFile = join(cwd, "session.jsonl");
+    const commands = new Map<string, RegisteredTestCommand>();
+    registerCommands(
+      {
+        registerCommand: (name: string, command: RegisteredTestCommand) => {
+          commands.set(name, command);
+        },
+      } as any,
+      {
+        getClient: () => client(),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "bank",
+      },
+    );
+    const ctx = {
+      cwd,
+      ui: { notify: vi.fn(), setStatus: vi.fn() },
+      sessionManager: { getSessionFile: () => sessionFile },
+    };
+
+    await commands.get("hindsight:next-opt-out")?.handler([], ctx);
+
+    expect((await readSessionMemoryMeta(cwd, sessionFile)).nextRetainMode).toBe("off");
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      "Hindsight will skip automatic retain for the next agent run in this session. nextRetain=off",
+      "info",
+    );
+
+    vi.mocked(ctx.ui.notify).mockClear();
+    await commands.get("hindsight:session")?.handler([], ctx);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("nextRetain=off"), "info");
+  });
+
   it("registers argument completions for fixed command arguments", async () => {
     const commands = new Map<string, RegisteredTestCommand>();
     registerCommands(

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -554,6 +554,43 @@ describe("extension hooks", () => {
     );
   });
 
+  it("explicit retain works while next opt-out is pending and does not consume it", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-tools-"));
+    mkdirSync(join(cwd, ".git"));
+    const sessionFile = join(cwd, "session.jsonl");
+    await setNextSessionRetainMode(cwd, sessionFile, "off");
+    const tools: Record<string, any> = {};
+    const pi = {
+      on: vi.fn(),
+      registerTool: vi.fn((tool: any) => {
+        tools[tool.name] = tool;
+      }),
+      registerCommand: vi.fn(),
+    };
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => sessionFile },
+    };
+
+    const { default: hindsightExtension } = await import("../extensions/index.js");
+    hindsightExtension(pi as any);
+    await tools.hindsight_retain.execute(
+      "tool-call",
+      { content: "Explicit memory", context: "test" },
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    expect(mocked.client.retain).toHaveBeenCalledWith(
+      expect.any(String),
+      "Explicit memory",
+      expect.objectContaining({ updateMode: "append" }),
+    );
+    expect((await readSessionMemoryMeta(cwd, sessionFile)).nextRetainMode).toBe("off");
+  });
+
   it("honors session read-only mode and manual tags", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -14,6 +14,7 @@ import {
 import { readImportCheckpoint } from "../extensions/import-checkpoint.js";
 import { readImportManifest } from "../extensions/import-manifest.js";
 import { stableSessionId } from "../extensions/session.js";
+import { setNextSessionRetainMode } from "../extensions/session-memory-meta.js";
 
 describe("Pi session import", () => {
   it("parses message entries from Pi JSONL", () => {
@@ -320,6 +321,44 @@ describe("Pi session import", () => {
       version: 1,
       imports: {},
     });
+  });
+
+  it("historical import ignores pending next opt-out session state", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    await setNextSessionRetainMode(dir, sessionFile, "off");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-next-opt-out", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "1",
+          parentId: null,
+          message: { role: "user", content: "import me anyway" },
+        }),
+      ].join("\n"),
+    );
+    const calls: unknown[][] = [];
+
+    const result = await importPiSession({
+      sessionFile,
+      cwd: dir,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      client: {
+        retain: async (...args: unknown[]) => {
+          calls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[1]).toContain("import me anyway");
+    expect(result.documents[0]?.status).toBe("completed");
   });
 
   it("resumes completed checkpoint documents without duplicate retain", async () => {


### PR DESCRIPTION
## Summary

- Add regression coverage for `/hindsight:next-opt-out` command handler and `/hindsight:session` reporting.
- Cover explicit `hindsight_retain` while next opt-out is pending.
- Cover historical import ignoring pending next opt-out state.
- Update design doc test-coverage notes.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
