### PR TITLE
Keep next opt-out pending on cursor failure

### DIFF
--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -20,7 +20,7 @@ import {
 } from "./retain-cursor.js";
 import type { HindsightCapabilities, HindsightLikeClient, ResolvedConfig } from "./types.js";
 import {
-  consumeNextSessionRetainMode,
+  clearNextSessionRetainMode,
   getEffectiveSessionMemoryMode,
   readSessionMemoryMeta,
 } from "./session-memory-meta.js";
@@ -288,10 +288,8 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
         return { queued: false, sent: 0, remaining: 0 };
       const runtime = snapshotRuntime(ctx);
       if (!runtime) return { queued: false, sent: 0, remaining: 0 };
-      const { meta: sessionMeta, consumed: nextRetainMode } = await consumeNextSessionRetainMode(
-        runtime.cwd,
-        runtime.sessionFile,
-      );
+      const sessionMeta = await readSessionMemoryMeta(runtime.cwd, runtime.sessionFile);
+      const nextRetainMode = sessionMeta.nextRetainMode;
       const sessionMemory = getEffectiveSessionMemoryMode(sessionMeta);
       if (!sessionMemory.retain || nextRetainMode === "off") {
         try {
@@ -303,8 +301,10 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
             `Hindsight retain cursor update failed: ${(error as Error).message}`,
             "warning",
           );
+          return { queued: false, sent: 0, remaining: 0 };
         }
         if (nextRetainMode === "off") {
+          await clearNextSessionRetainMode(runtime.cwd, runtime.sessionFile);
           notify(runtime, "Hindsight skipped retain for this run due to next-opt-out.", "info");
         }
         return { queued: false, sent: 0, remaining: 0 };

--- a/extensions/session-memory-meta.ts
+++ b/extensions/session-memory-meta.ts
@@ -210,18 +210,16 @@ export async function setNextSessionRetainMode(
   return writeSessionMemoryMeta(cwd, sessionFile, { ...meta, nextRetainMode });
 }
 
-export async function consumeNextSessionRetainMode(
+export async function clearNextSessionRetainMode(
   cwd: string,
   sessionFile: string | undefined,
-): Promise<{ meta: HindsightSessionMeta; consumed: NextRetainMode }> {
+): Promise<HindsightSessionMeta> {
   const meta = await readSessionMemoryMeta(cwd, sessionFile);
-  const consumed = meta.nextRetainMode;
-  if (consumed === "normal") return { meta, consumed };
-  const next = await writeSessionMemoryMeta(cwd, sessionFile, {
+  if (meta.nextRetainMode === "normal") return meta;
+  return writeSessionMemoryMeta(cwd, sessionFile, {
     ...meta,
     nextRetainMode: "normal",
   });
-  return { meta: next, consumed };
 }
 
 export async function addSessionMemoryTag(

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -596,7 +596,7 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
     const sessionFile = join(cwd, "session.jsonl");
-    await setSessionMemoryMode(cwd, sessionFile, "read-only");
+    await setNextSessionRetainMode(cwd, sessionFile, "off");
     await addSessionMemoryTag(cwd, sessionFile, "domain:test");
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
@@ -640,13 +640,13 @@ describe("extension hooks", () => {
     expect(retainCalls[0]?.[2]).toMatchObject({ tags: expect.arrayContaining(["domain:test"]) });
   });
 
-  it("does not reject when skipped-message cursor update fails", async () => {
+  it("keeps next opt-out pending when skipped-message cursor update fails", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi", "hindsight"), { recursive: true });
     writeFileSync(join(cwd, ".pi", "hindsight", "retain-cursors.json"), "not json");
     const sessionFile = join(cwd, "session.jsonl");
-    await setSessionMemoryMode(cwd, sessionFile, "read-only");
+    await setNextSessionRetainMode(cwd, sessionFile, "off");
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
       on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
@@ -674,6 +674,11 @@ describe("extension hooks", () => {
       expect.stringContaining("Hindsight retain cursor update failed"),
       "warning",
     );
+    expect(ctx.ui.notify).not.toHaveBeenCalledWith(
+      "Hindsight skipped retain for this run due to next-opt-out.",
+      "info",
+    );
+    expect((await readSessionMemoryMeta(cwd, sessionFile)).nextRetainMode).toBe("off");
   });
 
   it("does not later retain overlapping messages skipped while read-only", async () => {

--- a/tests/session-memory-meta.test.ts
+++ b/tests/session-memory-meta.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   addSessionMemoryTag,
-  consumeNextSessionRetainMode,
+  clearNextSessionRetainMode,
   getEffectiveSessionMemoryMode,
   readSessionMemoryMeta,
   removeSessionMemoryTag,
@@ -124,15 +124,14 @@ describe("session memory metadata", () => {
     });
   });
 
-  it("persists and consumes one-turn retain opt-out", async () => {
+  it("persists and clears one-turn retain opt-out", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-meta-"));
 
     await setNextSessionRetainMode(cwd, "/tmp/session.jsonl", "off");
     expect((await readSessionMemoryMeta(cwd, "/tmp/session.jsonl")).nextRetainMode).toBe("off");
 
-    const consumed = await consumeNextSessionRetainMode(cwd, "/tmp/session.jsonl");
-    expect(consumed.consumed).toBe("off");
-    expect(consumed.meta.nextRetainMode).toBe("normal");
+    const cleared = await clearNextSessionRetainMode(cwd, "/tmp/session.jsonl");
+    expect(cleared.nextRetainMode).toBe("normal");
     expect((await readSessionMemoryMeta(cwd, "/tmp/session.jsonl")).nextRetainMode).toBe("normal");
   });
 


### PR DESCRIPTION
## Summary

- Keep `nextRetainMode=off` pending if retain-cursor marking fails during next opt-out skip.
- Clear the one-turn opt-out only after skipped messages are durably marked handled.
- Avoid emitting the skip-success notification when cursor persistence fails.
- Add regression coverage for fail-closed cursor behavior.

## Validation

- `npm run check`
- `npm run typecheck:tsc`
- Pre-PR reviewer: LGTM
