### PR TITLE
test: cover changelog generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 
 ### Documentation
 
+- refresh changelog generation ([cd9593a](https://github.com/luxus/pi-hindsight/commit/cd9593afb698c4bf98511f4dd8718ac2d2b07dd7))
 - mark global review loop complete ([e4a9318](https://github.com/luxus/pi-hindsight/commit/e4a9318b4a3c7c5deac7787468c563d2e4313912))
 - record upstream retain issue ([c3de5aa](https://github.com/luxus/pi-hindsight/commit/c3de5aaa07c82ff7ef16f6f7c26ac221aadefa31))
 - clarify release verification ([4f2de2c](https://github.com/luxus/pi-hindsight/commit/4f2de2c3821a59e17fa3600ab79f02fc4f991e63))
@@ -85,6 +86,7 @@
 
 ### Chores
 
+- remove unused changelog dependency ([ad3cd3a](https://github.com/luxus/pi-hindsight/commit/ad3cd3a6a5618b9588e159055582542a5bdffddf))
 - prepare package release metadata ([7b7deea](https://github.com/luxus/pi-hindsight/commit/7b7deea8075502940e2523426042bafce0de98cc))
 - ignore local agent skill files ([fd4d30e](https://github.com/luxus/pi-hindsight/commit/fd4d30eeaea7224cd8ce3c9e2213c7d7b9502833))
 

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -24,7 +24,12 @@ const packageJson = JSON.parse(await readFile("package.json", "utf8"));
 const repoUrl = String(packageJson.repository?.url ?? "")
   .replace(/^git\+/, "")
   .replace(/\.git$/, "");
-const { stdout: latestCommitDate } = await execFileAsync("git", ["log", "-1", "--format=%cs"]);
+const { stdout: latestCommitDate } = await execFileAsync("git", [
+  "log",
+  "--no-merges",
+  "-1",
+  "--format=%cs",
+]);
 const releaseDate = latestCommitDate.trim();
 const { stdout } = await execFileAsync("git", ["log", "--no-merges", "--format=%H%x00%s"]);
 const groups = new Map(sections.map(([, section]) => [section, []]));

--- a/tests/changelog-generator.test.ts
+++ b/tests/changelog-generator.test.ts
@@ -1,0 +1,69 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const generatorPath = resolve("scripts/generate-changelog.mjs");
+
+async function git(cwd: string, args: string[]) {
+  await execFileAsync("git", args, { cwd });
+}
+
+async function commit(cwd: string, message: string, date: string) {
+  await execFileAsync("git", ["commit", "--allow-empty", "-m", message], {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: `${date}T00:00:00Z`,
+      GIT_COMMITTER_DATE: `${date}T00:00:00Z`,
+    },
+  });
+}
+
+describe("generate-changelog", () => {
+  it("is deterministic, skips merge commits, and groups conventional and squash subjects", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "pi-hindsight-changelog-"));
+    try {
+      await git(cwd, ["init"]);
+      await git(cwd, ["config", "user.email", "test@example.com"]);
+      await git(cwd, ["config", "user.name", "Test User"]);
+      await git(cwd, ["checkout", "-b", "main"]);
+      await writeFile(
+        join(cwd, "package.json"),
+        JSON.stringify({
+          name: "example",
+          version: "1.2.3",
+          repository: { url: "git+https://example.test/repo.git" },
+        }),
+      );
+      await git(cwd, ["add", "package.json"]);
+      await commit(cwd, "feat: add memory", "2024-01-01");
+      await commit(cwd, "Fix squash title", "2024-01-02");
+      await git(cwd, ["checkout", "-b", "topic"]);
+      await commit(cwd, "fix: repair queue", "2024-01-03");
+      await git(cwd, ["checkout", "main"]);
+      await git(cwd, ["merge", "--no-ff", "topic", "-m", "Merge pull request #1"]);
+
+      await execFileAsync("node", [generatorPath], { cwd });
+      const first = await readFile(join(cwd, "CHANGELOG.md"), "utf8");
+      await execFileAsync("node", [generatorPath], { cwd });
+      const second = await readFile(join(cwd, "CHANGELOG.md"), "utf8");
+
+      expect(second).toBe(first);
+      expect(first).toContain("## 1.2.3 (2024-01-03)");
+      expect(first).toContain("### Features");
+      expect(first).toContain("- add memory ([");
+      expect(first).toContain("### Bug Fixes");
+      expect(first).toContain("- repair queue ([");
+      expect(first).toContain("### Other Changes");
+      expect(first).toContain("- Fix squash title ([");
+      expect(first).not.toContain("Merge pull request #1");
+      expect(first).toContain("https://example.test/repo/commit/");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add regression coverage for changelog generation
- verify deterministic output, merge exclusion, conventional grouping, squash-title fallback, and commit links
- use latest non-merge commit date for release heading

## Validation
- npm test -- tests/changelog-generator.test.ts
- npm run check
- npm run typecheck:tsc
- pre-PR reviewer: LGTM
