### PR TITLE
feat: expose release readiness memory controls

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run TypeScript compiler fallback
         run: npm run typecheck:tsc
 
+      - name: Verify package contents
+        run: npm pack --dry-run
+
   smoke-configured-server:
     runs-on: ubuntu-latest
     needs: [check]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@
 - update changelog ([5c35c36](https://github.com/luxus/pi-hindsight/commit/5c35c36cbec4fea1b4139c371db52a5cbf80d384))
 - generate changelog ([433e90c](https://github.com/luxus/pi-hindsight/commit/433e90ce1dfa757c0cf24a7e988f43ee892ea468))
 
+### Tests
+
+- cover changelog generator ([48769c4](https://github.com/luxus/pi-hindsight/commit/48769c4457c6ab74c4a75952f112cb6f0a4b84af))
+
 ### CI
 
 - update workflow actions to v6 ([0803e43](https://github.com/luxus/pi-hindsight/commit/0803e4334966aa477b928e5bdd5ad583d62d474a))

--- a/README.md
+++ b/README.md
@@ -189,10 +189,16 @@ Run Pi with the local package or extension:
 pi -e ./extensions/index.ts
 ```
 
-Or install the package path:
+Or install the published package:
 
 ```bash
-pi install /Users/luxus/projects/pi-hindsight
+pi install @luxus/pi-hindsight
+```
+
+For local development, install a checkout path instead:
+
+```bash
+pi install /path/to/pi-hindsight
 ```
 
 Published package name: `@luxus/pi-hindsight`.
@@ -201,11 +207,11 @@ Published package name: `@luxus/pi-hindsight`.
 
 Defaults can be overridden by:
 
-1. `~/.pi/agent/hindsight.json`
-2. `.pi/hindsight.json` in the current repo
+1. `~/.pi/agent/hindsight.json` or `~/.pi/agent/hindsight.jsonc`
+2. `.pi/hindsight.json` or `.pi/hindsight.jsonc` in the current repo
 3. environment variables
 
-Config is normalized after merging. Unknown fields are ignored, and invalid values fall back to defaults.
+If both `.json` and `.jsonc` exist at the same scope, `.json` wins. Config is normalized after merging. Unknown fields are ignored, and invalid values fall back to defaults.
 
 ### Minimal configuration path
 
@@ -313,6 +319,7 @@ Advanced project config example:
     "globalQueryPreamble": "Global memory lookup for durable user preferences, recurring workflows, coding habits, and cross-project context.",
     "includeDateInQuery": false,
     "includeRepoHintsInQuery": true,
+    "queryTimestamp": "2024-05-01T00:00:00Z",
     "storeLastRecall": false,
     "lastRecallPath": ".pi/hindsight/last-recall.json",
     "topK": 8,
@@ -325,7 +332,9 @@ Advanced project config example:
   },
   "retain": {
     "queuePath": ".pi/hindsight/retain-queue.jsonl",
+    "flushIntervalMs": 30000,
     "updateMode": "append",
+    "entities": [{ "text": "Pi", "type": "project" }],
     "content": {
       "user": ["text"],
       "assistant": ["text", "toolCall"],
@@ -372,11 +381,13 @@ Advanced project config example:
 
 ## Memory behavior
 
-Automatic recall runs in the `context` hook and injects an ephemeral `<hindsight-memory>` message into the provider context. Project bank recall is scoped by the current repo tag. If a global bank is enabled, global recall uses an explicit non-repo `source:pi` scope so cross-project memories can be found without requiring the current repo tag. The `project+global` profile queries both banks and labels recalled blocks by source; `global-only` queries only the global bank. Recall defaults to `recall.types: ["observation"]` because observations are Hindsight's consolidated, deduplicated memory layer; set `recall.types` to include `world` or `experience`, or to an empty list, only when you explicitly want lower-level raw memory types. Recall query composition is deterministic and bank-aware: selected messages are role-labeled, bounded by `recall.roles`, `recall.contextTurns`, and `recall.maxQueryChars`, and can include `recall.projectQueryPreamble` / `recall.globalQueryPreamble`, optional `recall.includeDateInQuery`, and repo hints controlled by `recall.includeRepoHintsInQuery`. Slow recalls are bounded by `recall.timeoutMs`. `recall.topK` limits injected results per bank. Recall visibility is sidecar-only and opt-in: set `recall.storeLastRecall: true` to write the latest recall snapshot to `recall.lastRecallPath`, then inspect it with `/hindsight:last-recall` or `/hindsight:last-recall --json`. The default snapshot path is ignored by this repository; custom paths should be added to your own ignore rules. Snapshots contain recalled memory and query excerpts, so enable this only when local disk visibility is acceptable. Snapshots are not inserted into provider context or automatic retain by this extension. `/hindsight:recall-cleanup` scans the current Pi session transcript for accidentally persisted `<hindsight-memory>` blocks and reports matching line numbers. Pruning requires an explicit offline file path: `/hindsight:recall-cleanup <session.jsonl> --prune` removes matching injected-memory JSONL lines after writing a unique `.hindsight-recall-prune.*.bak` backup next to the session file. The default recall budget is `mid`, and the default injection position is `append`: recall is inserted near the end of provider context, before the current user message when present, so fresh memory does not change the beginning of the provider prompt and break prompt caching. `prepend` remains configurable for users who explicitly prefer memory before the transcript, but it can reduce prompt-cache hits because every recalled block changes the prompt prefix. The injected memory block is not written to the Pi transcript by this extension.
+Automatic recall runs in the `context` hook and injects an ephemeral `<hindsight-memory>` message into the provider context. Project bank recall is scoped by the current repo tag. If a global bank is enabled, global recall uses an explicit non-repo `source:pi` scope so cross-project memories can be found without requiring the current repo tag. The `project+global` profile queries both banks and labels recalled blocks by source; `global-only` queries only the global bank. Recall defaults to `recall.types: ["observation"]` because observations are Hindsight's consolidated, deduplicated memory layer; set `recall.types` to include `world` or `experience`, or to an empty list, only when you explicitly want lower-level raw memory types. Set `recall.queryTimestamp` only when recall should be anchored to a specific point in time; otherwise omit it so Hindsight uses the current request time. Recall query composition is deterministic and bank-aware: selected messages are role-labeled, bounded by `recall.roles`, `recall.contextTurns`, and `recall.maxQueryChars`, and can include `recall.projectQueryPreamble` / `recall.globalQueryPreamble`, optional `recall.includeDateInQuery`, and repo hints controlled by `recall.includeRepoHintsInQuery`. Slow recalls are bounded by `recall.timeoutMs`. `recall.topK` limits injected results per bank. Recall visibility is sidecar-only and opt-in: set `recall.storeLastRecall: true` to write the latest recall snapshot to `recall.lastRecallPath`, then inspect it with `/hindsight:last-recall` or `/hindsight:last-recall --json`. The default snapshot path is ignored by this repository; custom paths should be added to your own ignore rules. Snapshots contain recalled memory and query excerpts, so enable this only when local disk visibility is acceptable. Snapshots are not inserted into provider context or automatic retain by this extension. `/hindsight:recall-cleanup` scans the current Pi session transcript for accidentally persisted `<hindsight-memory>` blocks and reports matching line numbers. Pruning requires an explicit offline file path: `/hindsight:recall-cleanup <session.jsonl> --prune` removes matching injected-memory JSONL lines after writing a unique `.hindsight-recall-prune.*.bak` backup next to the session file. The default recall budget is `mid`, and the default injection position is `append`: recall is inserted near the end of provider context, before the current user message when present, so fresh memory does not change the beginning of the provider prompt and break prompt caching. `prepend` remains configurable for users who explicitly prefer memory before the transcript, but it can reduce prompt-cache hits because every recalled block changes the prompt prefix. The injected memory block is not written to the Pi transcript by this extension.
 
-Automatic retain runs in the `agent_end` hook. It stores a structured JSON projection of new messages, not a summary. The retain projection is controlled by `retain.content`, `retain.toolFilter`, and `retain.strip`; defaults keep user/assistant text, assistant tool calls, and tool result errors while excluding recursive Hindsight tool output and noisy read/search results. Live sessions use stable `documentId` values and `updateMode: "append"`. When retain is enabled and either project auto-retain or a configured global-only explicit retain route is available, startup probes append support with a deterministic `pi-hindsight-capability:append:<bank>` document tagged `test:capability` and `feature:append-probe`. If append is known unsupported, retain fails clearly because append support is required for live sessions. A persisted retain cursor under `.pi/hindsight/retain-cursors.json` prevents duplicate appends when Pi provides overlapping transcripts, including after extension restart. Explicit retain tool tags are merged with the base `source:pi`, repo, and session tags so manually retained memories remain visible to default project recall. Per-session governance is stored outside provider-visible messages under `.pi/hindsight/session-meta/`. `/hindsight:mode normal|read-only|ignored` controls whether a session recalls and/or retains memory, `/hindsight:retain on|off` toggles retain for the session, and `/hindsight:tag add|remove <tag>` merges manual tags into automatic retain jobs.
+Automatic retain runs in the `agent_end` hook. It stores a structured JSON projection of new messages, not a summary. The retain projection is controlled by `retain.content`, `retain.toolFilter`, and `retain.strip`; defaults keep user/assistant text, assistant tool calls, tool result errors, and per-message timestamps while excluding recursive Hindsight tool output and noisy read/search results. Live sessions use stable `documentId` values and `updateMode: "append"`. When retain is enabled and either project auto-retain or a configured global-only explicit retain route is available, startup probes append support with a deterministic `pi-hindsight-capability:append:<bank>` document tagged `test:capability` and `feature:append-probe`. If append is known unsupported, retain fails clearly because append support is required for live sessions. A persisted retain cursor under `.pi/hindsight/retain-cursors.json` prevents duplicate appends when Pi provides overlapping transcripts, including after extension restart. Explicit retain tool tags are merged with the base `source:pi`, repo, and session tags so manually retained memories remain visible to default project recall. Configure `retain.entities` to attach known entity hints to automatic retain jobs, or pass `entities` to the explicit `hindsight_retain` tool for one-off memories. Per-session governance is stored outside provider-visible messages under `.pi/hindsight/session-meta/`. `/hindsight:mode normal|read-only|ignored` controls whether a session recalls and/or retains memory, `/hindsight:retain on|off` toggles retain for the session, and `/hindsight:tag add|remove <tag>` merges manual tags into automatic retain jobs.
 
 Retain jobs are written to a JSONL queue before sending. If Hindsight is down, jobs remain on disk for later flushing. This queue-first behavior applies to both automatic retain and the explicit `hindsight_retain` tool, so manual memories are not lost during Hindsight outages. Queue operations use an in-process mutex plus a lock directory next to the queue file so multiple Pi processes do not rewrite the active queue concurrently. Stale queue locks are judged from the lock owner's `acquiredAt` timestamp, not from the waiting process age. Jobs that exceed the retry limit are moved to a sibling dead-letter file (`<queue>.dead.jsonl`) instead of retrying forever. Debug diagnostics summarize active queue jobs, malformed JSONL lines, queue read errors, dead-letter jobs, and the dead-letter path without printing raw retained content; if malformed, unreadable, or dead-lettered entries exist, inspect the queue files offline, repair permissions or malformed lines deliberately, then run `/hindsight:flush` after Hindsight is reachable.
+
+Set `retain.flushIntervalMs` to a positive interval to flush queued jobs periodically while Pi is running. The default `0` disables periodic flushing, so retain still flushes on new retain attempts, manual `/hindsight:flush`, and shutdown.
 
 Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs` and `retain.shutdownFlushTimeoutMs`. The timeout is a soft bound checked between queued jobs so shutdown does not leave a background flush holding the queue lock. If jobs remain after shutdown, they stay on disk and are visible through `/hindsight:debug` queue length for later flushing.
 
@@ -390,6 +401,8 @@ The footer status is configurable with two independent knobs:
 - `status.detail`: `minimal`, `project`, `activity`, or `verbose`
 
 Emoji mode uses `🧠` when Hindsight is connected and `🤯` after failed recall/retain/bank access. `status.detail: "minimal"` hides all text after the icon. `status.detail: "project"` shows the bank ID, `"activity"` shows bank ID plus recall/retain activity, and `"verbose"` shows project, bank ID, and activity. `status.maxLength` caps displayed text, and `status.showActivity` controls whether recall/retain activity replaces the idle text.
+
+Explicit tools expose advanced Hindsight fields conservatively. `hindsight_recall` accepts `queryTimestamp`, `hindsight_retain` accepts `entities`, and `hindsight_reflect` accepts `responseSchema` for structured reflection output.
 
 Pi window notifications are configurable under `notifications`. Startup bank selection messages are on by default. Recall and retain activity notifications are off by default and can be enabled with `notifications.recall` and `notifications.retain`. Activity notifications report counts and target banks, not raw recalled memory or retained content.
 

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -30,6 +30,41 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
     userAgent: "pi-hindsight/0.1.0",
   });
   const timeoutMs = config.hindsight.timeoutMs;
+  const reflectWithResponseSchema = async (
+    bankId: string,
+    query: string,
+    options: Parameters<HindsightLikeClient["reflect"]>[2],
+  ): Promise<unknown> => {
+    if (!options?.responseSchema) return raw.reflect(bankId, query, options);
+    const response = await fetch(
+      `${config.hindsight.baseUrl.replace(/\/$/, "")}/v1/default/banks/${encodeURIComponent(bankId)}/reflect`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(config.hindsight.apiKey
+            ? { Authorization: `Bearer ${config.hindsight.apiKey}` }
+            : {}),
+          "User-Agent": "pi-hindsight/0.1.0",
+        },
+        body: JSON.stringify({
+          query,
+          ...(options.context ? { context: options.context } : {}),
+          budget: options.budget ?? "low",
+          response_schema: options.responseSchema,
+          ...(options.tags ? { tags: options.tags } : {}),
+          ...(options.tagsMatch ? { tags_match: options.tagsMatch } : {}),
+        }),
+      },
+    );
+    const body = (await response.json().catch(() => undefined)) as unknown;
+    if (!response.ok) {
+      throw new Error(
+        `hindsight reflect failed with status ${response.status}: ${JSON.stringify(body)}`,
+      );
+    }
+    return body;
+  };
   return {
     retain: (bankId, content, options) =>
       withTimeout(
@@ -42,6 +77,7 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
               ...(options?.context ? { context: options.context } : {}),
               ...(options?.metadata ? { metadata: options.metadata } : {}),
               ...(options?.documentId ? { document_id: options.documentId } : {}),
+              ...(options?.entities?.length ? { entities: options.entities } : {}),
               ...(options?.tags ? { tags: options.tags } : {}),
               ...(options?.observationScopes?.length
                 ? { observation_scopes: options.observationScopes }
@@ -57,7 +93,8 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
     retainBatch: (...args) =>
       withTimeout(raw.retainBatch(...args), timeoutMs, "hindsight retainBatch"),
     recall: (...args) => withTimeout(raw.recall(...args), timeoutMs, "hindsight recall"),
-    reflect: (...args) => withTimeout(raw.reflect(...args), timeoutMs, "hindsight reflect"),
+    reflect: (...args) =>
+      withTimeout(reflectWithResponseSchema(...args), timeoutMs, "hindsight reflect"),
     createBank: (...args) =>
       withTimeout(raw.createBank(...args), timeoutMs, "hindsight createBank"),
     getBankProfile: (...args) =>

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { ResolvedConfig } from "./types.js";
+import type { HindsightEntityInput, ResolvedConfig } from "./types.js";
 
 const DEFAULT_CONFIG: ResolvedConfig = {
   enabled: true,
@@ -62,7 +62,9 @@ const DEFAULT_CONFIG: ResolvedConfig = {
     },
     strip: { message: ["usage", "cost", "responseId"], topLevel: ["id", "parentId"] },
     redactSecrets: true,
+    entities: [],
     queuePath: ".pi/hindsight/retain-queue.jsonl",
+    flushIntervalMs: 0,
     shutdownFlushMaxJobs: 10,
     shutdownFlushTimeoutMs: 2_000,
   },
@@ -99,9 +101,88 @@ function merge<T>(base: T, patch: unknown): T {
   return out as T;
 }
 
+function stripJsonComments(text: string): string {
+  let out = "";
+  let inString = false;
+  let quote = "";
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+    if (inString) {
+      out += char;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) inString = false;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      inString = true;
+      quote = char;
+      out += char;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      while (index < text.length && text[index] !== "\n") index += 1;
+      out += "\n";
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      index += 2;
+      while (index < text.length && !(text[index] === "*" && text[index + 1] === "/")) {
+        if (text[index] === "\n") out += "\n";
+        index += 1;
+      }
+      index += 1;
+      continue;
+    }
+    out += char;
+  }
+  return out;
+}
+
+function stripTrailingCommas(text: string): string {
+  let out = "";
+  let inString = false;
+  let quote = "";
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      out += char;
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) inString = false;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      inString = true;
+      quote = char;
+      out += char;
+      continue;
+    }
+    if (char === ",") {
+      let nextIndex = index + 1;
+      while (/\s/.test(text[nextIndex] ?? "")) nextIndex += 1;
+      if (text[nextIndex] === "}" || text[nextIndex] === "]") continue;
+    }
+    out += char;
+  }
+  return out;
+}
+
+function parseJsonWithComments(text: string): unknown {
+  return JSON.parse(stripTrailingCommas(stripJsonComments(text))) as unknown;
+}
+
 function readJson(path: string): unknown {
   if (!existsSync(path)) return undefined;
-  return JSON.parse(readFileSync(path, "utf8")) as unknown;
+  return parseJsonWithComments(readFileSync(path, "utf8"));
+}
+
+function readConfigFile(basePath: string): unknown {
+  const json = readJson(`${basePath}.json`);
+  return json === undefined ? readJson(`${basePath}.jsonc`) : json;
 }
 
 function envBool(env: NodeJS.ProcessEnv, name: string): boolean | undefined {
@@ -184,6 +265,21 @@ function optionalStringArray(value: unknown): string[] | undefined {
   return Array.isArray(value) && value.every((item) => typeof item === "string")
     ? value
     : undefined;
+}
+
+function entityArray(value: unknown, fallback: HindsightEntityInput[]): HindsightEntityInput[] {
+  if (!Array.isArray(value)) return fallback;
+  const entities = value
+    .map((item) => {
+      if (!isRecord(item) || typeof item.text !== "string" || item.text.length === 0)
+        return undefined;
+      return {
+        text: item.text,
+        ...(typeof item.type === "string" && item.type.length > 0 ? { type: item.type } : {}),
+      } satisfies HindsightEntityInput;
+    })
+    .filter((item): item is HindsightEntityInput => Boolean(item));
+  return entities.length === value.length ? entities : fallback;
 }
 
 function toolNameFilter(
@@ -322,6 +418,14 @@ export function normalizeConfig(
         config.recall?.includeFactsInDebug,
         DEFAULT_CONFIG.recall.includeFactsInDebug,
       ),
+      ...(optionalString(config.recall?.queryTimestamp, DEFAULT_CONFIG.recall.queryTimestamp)
+        ? {
+            queryTimestamp: stringValue(
+              config.recall?.queryTimestamp,
+              DEFAULT_CONFIG.recall.queryTimestamp ?? "",
+            ),
+          }
+        : {}),
     },
     retain: {
       enabled: bool(config.retain?.enabled, DEFAULT_CONFIG.retain.enabled),
@@ -359,7 +463,15 @@ export function normalizeConfig(
         topLevel: stringArray(config.retain?.strip?.topLevel, DEFAULT_CONFIG.retain.strip.topLevel),
       },
       redactSecrets: bool(config.retain?.redactSecrets, DEFAULT_CONFIG.retain.redactSecrets),
+      entities: entityArray(config.retain?.entities, DEFAULT_CONFIG.retain.entities),
       queuePath: stringValue(config.retain?.queuePath, DEFAULT_CONFIG.retain.queuePath),
+      flushIntervalMs: Math.max(
+        0,
+        typeof config.retain?.flushIntervalMs === "number" &&
+          Number.isInteger(config.retain.flushIntervalMs)
+          ? config.retain.flushIntervalMs
+          : DEFAULT_CONFIG.retain.flushIntervalMs,
+      ),
       shutdownFlushMaxJobs: positiveInt(
         config.retain?.shutdownFlushMaxJobs,
         DEFAULT_CONFIG.retain.shutdownFlushMaxJobs,
@@ -412,10 +524,10 @@ export function resolveConfig(cwd: string, env: NodeJS.ProcessEnv = process.env)
   let rawConfig: Record<string, unknown> = {};
   let config = DEFAULT_CONFIG;
   const home = env.HOME;
-  const homeConfig = home ? readJson(join(home, ".pi", "agent", "hindsight.json")) : undefined;
+  const homeConfig = home ? readConfigFile(join(home, ".pi", "agent", "hindsight")) : undefined;
   rawConfig = merge(rawConfig, homeConfig);
   config = merge(config, homeConfig);
-  const projectConfig = readJson(join(cwd, ".pi", "hindsight.json"));
+  const projectConfig = readConfigFile(join(cwd, ".pi", "hindsight"));
   rawConfig = merge(rawConfig, projectConfig);
   config = merge(config, projectConfig);
 

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -80,13 +80,42 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
   let client: HindsightLikeClient = createHindsightClient(config);
   let projectBankId = deriveProjectBankId(initialCwd, config);
   let capabilities: HindsightCapabilities | undefined;
+  let periodicFlush: NodeJS.Timeout | undefined;
+  let periodicFlushActive = false;
   const retainedBySession = new Map<string, Set<string>>();
 
+  const stopPeriodicFlush = () => {
+    if (!periodicFlush) return;
+    clearInterval(periodicFlush);
+    periodicFlush = undefined;
+  };
+
   const reloadConfig = (cwd: string) => {
+    stopPeriodicFlush();
     config = resolveConfig(cwd);
     client = createHindsightClient(config);
     projectBankId = deriveProjectBankId(cwd, config);
     capabilities = undefined;
+  };
+
+  const startPeriodicFlush = (runtime: RuntimeSnapshot) => {
+    stopPeriodicFlush();
+    if (!config.enabled || !config.retain.enabled || config.retain.flushIntervalMs <= 0) return;
+    const queuePath = resolveQueuePath(runtime.cwd, config.retain.queuePath);
+    periodicFlush = setInterval(() => {
+      if (periodicFlushActive) return;
+      periodicFlushActive = true;
+      void flushRetainQueue(queuePath, client, {
+        stopOnFirstFailure: true,
+        maxJobs: config.retain.shutdownFlushMaxJobs,
+        maxElapsedMs: config.retain.shutdownFlushTimeoutMs,
+      })
+        .catch(() => undefined)
+        .finally(() => {
+          periodicFlushActive = false;
+        });
+    }, config.retain.flushIntervalMs);
+    periodicFlush.unref?.();
   };
 
   const setMemoryStatus = (
@@ -198,6 +227,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           notify(runtime, `Hindsight capability check failed: ${redactError(error)}`, "warning");
         }
       }
+      startPeriodicFlush(runtime);
       setMemoryStatus(runtime, "idle");
       if (config.notifications.startup)
         notify(runtime, bankSelectionMessage(projectBankId, config), "info");
@@ -347,6 +377,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
     },
 
     async shutdown(ctx: RuntimeCtx): Promise<void> {
+      stopPeriodicFlush();
       if (!config.enabled || !config.retain.enabled) return;
       const runtime = snapshotRuntime(ctx);
       if (!runtime) return;

--- a/extensions/memory-operations.ts
+++ b/extensions/memory-operations.ts
@@ -61,7 +61,13 @@ function diagnosticHealthBankId(config: ResolvedConfig, projectBankId: string): 
 
 export function createMemoryOperations(deps: MemoryOperationsDeps) {
   return {
-    async recall(cwd: string, query: string, bank?: string, sessionFile?: string) {
+    async recall(
+      cwd: string,
+      query: string,
+      bank?: string,
+      sessionFile?: string,
+      queryTimestamp?: string,
+    ) {
       const meta = await readSessionMemoryMeta(cwd, sessionFile);
       if (!getEffectiveSessionMemoryMode(meta).recall)
         throw new Error("Hindsight recall is disabled for this session");
@@ -70,6 +76,9 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
       const result = await deps.getClient().recall(bankId, query, {
         budget: config.recall.budget,
         maxTokens: config.recall.maxTokens,
+        ...(queryTimestamp || config.recall.queryTimestamp
+          ? { queryTimestamp: queryTimestamp ?? config.recall.queryTimestamp }
+          : {}),
         tags: recallTagsForBank(cwd, config, deps.getProjectBankId(), bankId),
         tagsMatch: "any_strict",
       });
@@ -83,6 +92,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
       context: string;
       bank?: string;
       tags?: string[];
+      entities?: ResolvedConfig["retain"]["entities"];
     }) {
       const meta = await readSessionMemoryMeta(args.cwd, args.sessionFile);
       if (!getEffectiveSessionMemoryMode(meta).retain)
@@ -117,6 +127,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
         },
         source: "tool",
         ...(observationScopes.length ? { observationScopes } : {}),
+        ...(args.entities?.length ? { entities: args.entities } : {}),
         ...(capabilities ? { capabilities } : {}),
       });
       return { bankId, tags, ...result, queued: result.enqueued };
@@ -172,12 +183,19 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
       return { bankId, ...result };
     },
 
-    async reflect(cwd: string, query: string, context?: string, bank?: string) {
+    async reflect(
+      cwd: string,
+      query: string,
+      context?: string,
+      bank?: string,
+      responseSchema?: Record<string, unknown>,
+    ) {
       const config = deps.getConfig();
       const bankId = bank || deps.getProjectBankId();
       const result = await deps.getClient().reflect(bankId, query, {
         ...(context ? { context } : {}),
         budget: config.recall.budget,
+        ...(responseSchema ? { responseSchema } : {}),
         tags: recallTagsForBank(cwd, config, deps.getProjectBankId(), bankId),
         tagsMatch: "any_strict",
       });

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -480,6 +480,7 @@ export async function flushRetainQueue(
           ...(job.item.timestamp ? { timestamp: job.item.timestamp } : {}),
           ...(job.item.metadata ? { metadata: job.item.metadata } : {}),
           ...(job.item.async !== undefined ? { async: job.item.async } : {}),
+          ...(job.item.entities?.length ? { entities: job.item.entities } : {}),
           ...(job.item.tags ? { tags: job.item.tags } : {}),
           ...(job.item.observationScopes ? { observationScopes: job.item.observationScopes } : {}),
           documentId: job.documentId,

--- a/extensions/recall.ts
+++ b/extensions/recall.ts
@@ -178,6 +178,9 @@ export async function recallForContext(args: {
           budget: args.config.recall.budget,
           maxTokens: args.config.recall.maxTokens,
           types: args.config.recall.types,
+          ...(args.config.recall.queryTimestamp
+            ? { queryTimestamp: args.config.recall.queryTimestamp }
+            : {}),
           ...(scope.tags ? { tags: scope.tags } : {}),
           ...(scope.tagsMatch ? { tagsMatch: scope.tagsMatch } : {}),
         }),

--- a/extensions/retain-durable.ts
+++ b/extensions/retain-durable.ts
@@ -31,6 +31,7 @@ export interface RetainDurablyArgs {
   source: DurableRetainSource;
   timestamp?: string;
   observationScopes?: string[][];
+  entities?: RetainJob["item"]["entities"];
   capabilities?: HindsightCapabilities;
 }
 
@@ -60,6 +61,9 @@ export function buildDurableRetainJob(args: Omit<RetainDurablyArgs, "client">): 
       context: args.context,
       timestamp: args.timestamp ?? new Date().toISOString(),
       async: args.config.retain.async,
+      ...((args.entities?.length ?? args.config.retain.entities.length)
+        ? { entities: [...args.config.retain.entities, ...(args.entities ?? [])] }
+        : {}),
       tags: args.tags,
       metadata: {
         source: "pi-hindsight",

--- a/extensions/retain.ts
+++ b/extensions/retain.ts
@@ -55,6 +55,7 @@ export function buildRetainJob(args: {
       context: contextLabel(args.cwd, args.sessionFile),
       timestamp: new Date().toISOString(),
       async: args.config.retain.async,
+      ...(args.config.retain.entities.length ? { entities: args.config.retain.entities } : {}),
       tags: [...new Set([...baseTags(args.cwd, sessionId), ...(args.extraTags ?? [])])],
       metadata: {
         cwd: args.cwd,

--- a/extensions/tools.ts
+++ b/extensions/tools.ts
@@ -15,6 +15,9 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       bank: Type.Optional(
         Type.String({ description: "Optional bank id. Defaults to project bank." }),
       ),
+      queryTimestamp: Type.Optional(
+        Type.String({ description: "Optional ISO timestamp for time-scoped recall." }),
+      ),
     }),
     async execute(_id, params, _signal, _onUpdate, ctx) {
       const sessionFile = ctx.sessionManager.getSessionFile?.();
@@ -23,6 +26,7 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         params.query,
         params.bank,
         sessionFile,
+        params.queryTimestamp,
       );
       return {
         content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -44,6 +48,14 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         Type.String({ description: "Optional bank id. Defaults to project bank." }),
       ),
       tags: Type.Optional(Type.Array(Type.String())),
+      entities: Type.Optional(
+        Type.Array(
+          Type.Object({
+            text: Type.String(),
+            type: Type.Optional(Type.String()),
+          }),
+        ),
+      ),
     }),
     async execute(_id, params, _signal, _onUpdate, ctx) {
       const sessionFile = ctx.sessionManager.getSessionFile?.();
@@ -54,6 +66,7 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         ...(sessionFile ? { sessionFile } : {}),
         ...(params.bank ? { bank: params.bank } : {}),
         ...(params.tags ? { tags: params.tags } : {}),
+        ...(params.entities ? { entities: params.entities } : {}),
       });
       const deadLetterStatus = result.deadLettered
         ? ` ${result.deadLettered} job${result.deadLettered === 1 ? "" : "s"} moved to dead-letter queue; run /hindsight:debug to inspect.`
@@ -162,6 +175,7 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
       query: Type.String(),
       context: Type.Optional(Type.String()),
       bank: Type.Optional(Type.String()),
+      responseSchema: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
     }),
     async execute(_id, params, _signal, _onUpdate, ctx) {
       const { bankId, result } = await operations.reflect(
@@ -169,6 +183,7 @@ export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
         params.query,
         params.context,
         params.bank,
+        params.responseSchema,
       );
       return {
         content: [

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -9,6 +9,11 @@ export type StatusDetail = "minimal" | "project" | "activity" | "verbose";
 export type RecallRole = "user" | "assistant" | "tool" | "system";
 export type RecallInjectionPosition = "prepend" | "append";
 
+export interface HindsightEntityInput {
+  text: string;
+  type?: string;
+}
+
 export interface ResolvedConfig {
   enabled: boolean;
   hindsight: { baseUrl: string; apiKey?: string; apiKeyRef?: string; timeoutMs: number };
@@ -41,6 +46,7 @@ export interface ResolvedConfig {
     injectionMode: "context";
     injectionPosition: RecallInjectionPosition;
     includeFactsInDebug: boolean;
+    queryTimestamp?: string;
   };
   observations: {
     enabled: boolean;
@@ -64,7 +70,9 @@ export interface ResolvedConfig {
       topLevel: string[];
     };
     redactSecrets: boolean;
+    entities: HindsightEntityInput[];
     queuePath: string;
+    flushIntervalMs: number;
     shutdownFlushMaxJobs: number;
     shutdownFlushTimeoutMs: number;
   };
@@ -125,6 +133,7 @@ export interface RetainJob {
     tags?: string[];
     metadata?: Record<string, string>;
     observationScopes?: string[][];
+    entities?: HindsightEntityInput[];
   };
   retries: number;
   lastError?: string;
@@ -149,6 +158,7 @@ export interface HindsightLikeClient {
       metadata?: Record<string, string>;
       documentId?: string;
       async?: boolean;
+      entities?: HindsightEntityInput[];
       tags?: string[];
       updateMode?: UpdateMode;
       observationScopes?: string[][];
@@ -176,6 +186,7 @@ export interface HindsightLikeClient {
       types?: string[];
       maxTokens?: number;
       budget?: Budget;
+      queryTimestamp?: string;
       tags?: string[];
       tagsMatch?: TagsMatch;
     },
@@ -186,6 +197,7 @@ export interface HindsightLikeClient {
     options?: {
       context?: string;
       budget?: Budget;
+      responseSchema?: Record<string, unknown>;
       tags?: string[];
       tagsMatch?: TagsMatch;
     },

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -84,6 +84,7 @@ describe("Hindsight client adapter integration", () => {
       updateMode: "append",
       async: true,
       metadata: { source: "test" },
+      entities: [{ text: "Alice", type: "person" }],
     });
     await client.retain("test-bank", "scoped content", {
       context: "scoped ctx",
@@ -97,8 +98,12 @@ describe("Hindsight client adapter integration", () => {
       tagsMatch: "any_strict",
       maxTokens: 123,
       budget: "low",
+      queryTimestamp: "2024-01-01T00:00:00Z",
     });
-    const reflection = await client.reflect("test-bank", "query", { budget: "low" });
+    const reflection = await client.reflect("test-bank", "query", {
+      budget: "low",
+      responseSchema: { type: "object", properties: { answer: { type: "string" } } },
+    });
 
     expect(recall).toEqual({ results: [{ text: "remembered fact" }] });
     expect(reflection).toEqual({ text: "reflection" });
@@ -120,6 +125,7 @@ describe("Hindsight client adapter integration", () => {
           update_mode: "append",
           tags: ["source:pi"],
           metadata: { source: "test" },
+          entities: [{ text: "Alice", type: "person" }],
         },
       ],
       async: true,
@@ -142,8 +148,14 @@ describe("Hindsight client adapter integration", () => {
       query: "query",
       max_tokens: 123,
       budget: "low",
+      query_timestamp: "2024-01-01T00:00:00Z",
       tags: ["source:pi"],
       tags_match: "any_strict",
+    });
+    expect(requests[4]?.body).toMatchObject({
+      query: "query",
+      budget: "low",
+      response_schema: { type: "object", properties: { answer: { type: "string" } } },
     });
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -125,6 +125,31 @@ describe("resolveConfig", () => {
     expect(config.recall.includeRepoHintsInQuery).toBe(false);
   });
 
+  it("reads JSONC config and release API knobs", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.jsonc"),
+      `{
+        // comments are allowed in JSONC config
+        "recall": {
+          "queryTimestamp": "2024-05-01T00:00:00Z",
+          "queryPreamble": "literal comma, } stays",
+        },
+        "retain": {
+          "flushIntervalMs": 30000,
+          "entities": [{ "text": "Pi", "type": "project" }],
+        },
+      }`,
+    );
+
+    const config = resolveConfig(cwd);
+    expect(config.recall.queryTimestamp).toBe("2024-05-01T00:00:00Z");
+    expect(config.recall.queryPreamble).toBe("literal comma, } stays");
+    expect(config.retain.flushIntervalMs).toBe(30_000);
+    expect(config.retain.entities).toEqual([{ text: "Pi", type: "project" }]);
+  });
+
   it("maps generic query preamble to bank-specific preambles when specific fields are absent", () => {
     const cwd = tmp();
     mkdirSync(join(cwd, ".pi"));
@@ -161,10 +186,13 @@ describe("resolveConfig", () => {
           topK: -1,
           timeoutMs: 0,
           injectionPosition: "middle",
+          queryTimestamp: 42,
         },
         observations: { enabled: true, scopes: [["repo:{repoKey}"], []] },
         retain: {
           queuePath: "",
+          flushIntervalMs: -1,
+          entities: [{ text: "ok" }, { text: 42 }],
           shutdownFlushMaxJobs: -1,
           shutdownFlushTimeoutMs: 0,
           toolFilter: { toolCall: { include: [42] }, toolResult: { exclude: "read" } },
@@ -202,12 +230,15 @@ describe("resolveConfig", () => {
     expect(config.recall.topK).toBe(8);
     expect(config.recall.timeoutMs).toBe(10_000);
     expect(config.recall.injectionPosition).toBe("append");
+    expect(config.recall.queryTimestamp).toBeUndefined();
     expect(config.retain.content.toolResult).toEqual(["error"]);
     expect(config.retain.toolFilter.toolCall.exclude).toContain("hindsight_retain");
     expect(config.retain.toolFilter.toolResult.exclude).toContain("hindsight_recall");
     expect(config.retain.toolFilter.toolResult.exclude).toContain("read");
     expect(config.retain.strip.message).toContain("usage");
     expect(config.retain.queuePath).toBe(".pi/hindsight/retain-queue.jsonl");
+    expect(config.retain.flushIntervalMs).toBe(0);
+    expect(config.retain.entities).toEqual([]);
     expect(config.retain.shutdownFlushMaxJobs).toBe(10);
     expect(config.retain.shutdownFlushTimeoutMs).toBe(2_000);
     expect(config.import.includeBranches).toBe("current-only");

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -12,6 +12,14 @@ import {
 } from "../extensions/session-memory-meta.js";
 import type { RetainJob } from "../extensions/types.js";
 
+async function waitForCondition(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) throw new Error("timed out waiting for condition");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 const mocked = vi.hoisted(() => ({
   client: {
     retain: vi.fn(async (..._args: unknown[]) => undefined),
@@ -39,6 +47,7 @@ vi.mock("../extensions/bank-operations.js", () => ({
 
 describe("extension hooks", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     mocked.client.recall.mockImplementation(async (..._args: unknown[]) => ({
       results: [{ text: "repo-specific remembered fact" }],
@@ -107,6 +116,59 @@ describe("extension hooks", () => {
     expect(retainedContent).toContain("Decision still stands.");
     expect(retainedContent).not.toContain("<hindsight-memory>");
     expect(retainedContent).not.toContain("repo-specific remembered fact");
+  });
+
+  it("flushes queued retain jobs on the configured interval", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({
+        hindsight: { baseUrl: "http://unused.test" },
+        retain: { flushIntervalMs: 10 },
+      }),
+    );
+    const queuePath = resolveQueuePath(cwd, ".pi/hindsight/retain-queue.jsonl");
+    await enqueueRetainJob(queuePath, {
+      id: "queued",
+      bankId: "bank",
+      createdAt: new Date().toISOString(),
+      documentId: "doc",
+      updateMode: "append",
+      item: { content: "content", context: "context" },
+      retries: 0,
+    });
+    const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
+    const pi = {
+      on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
+        handlers[name] = [...(handlers[name] ?? []), handler];
+      }),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+    };
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => join(cwd, "session.jsonl") },
+    };
+
+    try {
+      const { default: hindsightExtension } = await import("../extensions/index.js");
+      hindsightExtension(pi as any);
+      await handlers.session_start?.[0]?.({}, ctx);
+      mocked.client.retain.mockClear();
+      await waitForCondition(() => mocked.client.retain.mock.calls.length > 0);
+
+      expect(mocked.client.retain).toHaveBeenCalledWith(
+        "bank",
+        "content",
+        expect.objectContaining({ documentId: "doc", updateMode: "append" }),
+      );
+      expect(await readRetainQueue(queuePath)).toEqual([]);
+    } finally {
+      await handlers.session_shutdown?.[0]?.({}, ctx);
+    }
   });
 
   it("skips automatic retain once for next opt-out and advances retain cursor", async () => {

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -81,4 +81,52 @@ describe("memory operations", () => {
 
     expect(checkedBanks).toEqual(["global-bank", "global-bank"]);
   });
+
+  it("passes query timestamps, explicit entities, and reflect response schemas", async () => {
+    const calls: Array<{ method: string; options?: unknown }> = [];
+    const operations = createMemoryOperations({
+      getClient: () => ({
+        retain: async (_bank, _content, options) => {
+          calls.push({ method: "retain", options });
+        },
+        recall: async (_bank, _query, options) => {
+          calls.push({ method: "recall", options });
+          return [];
+        },
+        reflect: async (_bank, _query, options) => {
+          calls.push({ method: "reflect", options });
+          return {};
+        },
+      }),
+      getConfig: () => ({
+        ...DEFAULT_CONFIG,
+        recall: { ...DEFAULT_CONFIG.recall, queryTimestamp: "2024-01-01T00:00:00Z" },
+        retain: { ...DEFAULT_CONFIG.retain, async: false },
+      }),
+      getProjectBankId: () => "project-bank",
+    });
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ops-"));
+
+    await operations.recall(cwd, "query", undefined, undefined, "2024-02-01T00:00:00Z");
+    await operations.retainExplicit({
+      cwd,
+      content: "content",
+      context: "context",
+      entities: [{ text: "Alice", type: "person" }],
+    });
+    await operations.reflect(cwd, "query", undefined, undefined, {
+      type: "object",
+      properties: { answer: { type: "string" } },
+    });
+
+    expect(calls.find((call) => call.method === "recall")?.options).toMatchObject({
+      queryTimestamp: "2024-02-01T00:00:00Z",
+    });
+    expect(calls.find((call) => call.method === "retain")?.options).toMatchObject({
+      entities: [{ text: "Alice", type: "person" }],
+    });
+    expect(calls.find((call) => call.method === "reflect")?.options).toMatchObject({
+      responseSchema: { type: "object", properties: { answer: { type: "string" } } },
+    });
+  });
 });

--- a/tests/retain.test.ts
+++ b/tests/retain.test.ts
@@ -5,8 +5,9 @@ import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
 
 describe("buildRetainJob", () => {
   it("stores structured JSON with append mode and context", () => {
+    const timestamp = Date.UTC(2024, 0, 2, 3, 4, 5);
     const messages = [
-      { role: "user", content: "API_KEY=secret", timestamp: Date.now() },
+      { role: "user", content: "API_KEY=secret", timestamp },
     ] as unknown as AgentEndEvent["messages"];
     const job = buildRetainJob({
       config: DEFAULT_CONFIG,
@@ -20,7 +21,26 @@ describe("buildRetainJob", () => {
     expect(job?.item.context).toContain("Pi coding session");
     expect(job?.item.async).toBe(true);
     expect(job?.item.content).not.toContain("API_KEY=secret");
-    expect(JSON.parse(job?.item.content ?? "[]")[0].role).toBe("user");
+    const retained = JSON.parse(job?.item.content ?? "[]") as Array<Record<string, unknown>>;
+    expect(retained[0]?.role).toBe("user");
+    expect(retained[0]?.timestamp).toBe("2024-01-02T03:04:05.000Z");
+  });
+
+  it("adds configured entities to automatic retain jobs", () => {
+    const messages = [
+      { role: "user", content: "remember Pi", timestamp: Date.now() },
+    ] as unknown as AgentEndEvent["messages"];
+    const job = buildRetainJob({
+      config: {
+        ...DEFAULT_CONFIG,
+        retain: { ...DEFAULT_CONFIG.retain, entities: [{ text: "Pi", type: "project" }] },
+      },
+      cwd: "/repo",
+      bankId: "bank",
+      messages,
+    });
+
+    expect(job?.item.entities).toEqual([{ text: "Pi", type: "project" }]);
   });
 
   it("expands observation scopes into retain jobs", () => {


### PR DESCRIPTION
## Summary
- add release-readiness memory controls: JSONC config, retain entities, recall query timestamps, reflect response schemas, periodic queue flush
- preserve/test per-message timestamps in retained JSON and document advanced knobs
- add `npm pack --dry-run` to CI and public install guidance

## Validation
- npm run check
- npm run typecheck:tsc
- npm pack --dry-run
- npm publish --dry-run
- pre-PR reviewer: LGTM
