### PR TITLE
fix(memory): use granular bank mission fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,6 @@ Advanced project config example:
     "project": {
       "bankId": "pi-project-my-repo",
       "derive": "manual",
-      "mission": "Memory for this Pi coding project. Used as shorthand for retain, reflect, and observation missions when the specific fields below are omitted.",
       "retainMission": "Extract architecture decisions, bugs, fixes, constraints, durable preferences, and project continuity. Ignore chatter, secrets, and repeated recalled memory.",
       "reflectMission": "Help a Pi coding agent use project memory for current architecture, decisions, constraints, bugs, fixes, and continuity.",
       "observationsMission": "Identify durable project patterns, recurring constraints, and contradictions across Pi coding sessions."
@@ -314,7 +313,9 @@ Advanced project config example:
     "global": {
       "enabled": false,
       "bankId": "pi-global",
-      "mission": "Cross-project memory for durable user preferences, recurring workflows, coding habits, and stable assistant behavior."
+      "retainMission": "Extract durable cross-project user preferences, recurring workflows, coding habits, and stable assistant behavior.",
+      "reflectMission": "Help recall durable cross-project user preferences, recurring workflows, coding habits, and stable assistant behavior.",
+      "observationsMission": "Identify durable cross-project user preferences, recurring workflows, coding habits, and stable assistant behavior patterns."
     }
   },
   "recall": {
@@ -401,7 +402,7 @@ Set `retain.flushIntervalMs` to a positive interval to flush queued jobs periodi
 
 Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs` and `retain.shutdownFlushTimeoutMs`. The timeout is a soft bound checked between queued jobs so shutdown does not leave a background flush holding the queue lock. If jobs remain after shutdown, they stay on disk and are visible through `/hindsight` for later flushing.
 
-At session start, the extension shows the selected bank ID. If no bank ID is configured, it reports the automatically derived bank ID and how to override it. Project and global banks can define mission text. Use the human-friendly `mission` shorthand when one bank purpose is enough; the extension sends it to Hindsight as `retainMission`, `reflectMission`, and `observationsMission`. Use `retainMission`, `reflectMission`, or `observationsMission` when extraction, reflection, and observation consolidation need different instructions. If no mission is configured, Pi-specific defaults are used: project banks focus on repo architecture, decisions, constraints, bugs, fixes, TODOs, conventions, and project-local preferences; global banks focus on durable user preferences, recurring workflows, coding habits, and stable assistant behavior while excluding repo-specific code facts by default.
+At session start, the extension shows the selected bank ID. If no bank ID is configured, it reports the automatically derived bank ID and how to override it. Project and global banks can define Hindsight's three supported mission fields: `retainMission`, `reflectMission`, and `observationsMission`. There is no generic bank `mission` field; if no specific mission is configured, Pi-specific defaults are used. Project banks focus on repo architecture, decisions, constraints, bugs, fixes, TODOs, conventions, and project-local preferences. Global banks focus on durable user preferences, recurring workflows, coding habits, and stable assistant behavior while excluding repo-specific code facts by default.
 
 Observation scope configuration is explicit under `observations`. The extension validates and expands scope placeholders for diagnostics, passes `observations.enabled` to bank ensure as Hindsight `enableObservations`, and stores expanded scopes on queued retain jobs so retries preserve the scope policy active when the job was created. The official Hindsight client exposes retain observation scopes through batch retain, so the adapter standardizes all retain writes on `retainBatch()`. Supported placeholders are `{repoKey}`, `{sessionId}`, `{cwdHash}`, `{projectBankId}`, and `{bankId}`. `{bankId}` is an alias for the target bank ID and is clearer for explicit retain/import paths that write to a custom or global bank.
 

--- a/extensions/bank-operations.ts
+++ b/extensions/bank-operations.ts
@@ -46,11 +46,38 @@ export interface BankMissionConfig extends BankMissionSettings {
 
 function resolveBankMissions(config: BankMissionSettings, defaults: BankMissionDefaults) {
   return {
-    reflectMission: config.reflectMission ?? config.mission ?? defaults.reflectMission,
-    retainMission: config.retainMission ?? config.mission ?? defaults.retainMission,
-    observationsMission:
-      config.observationsMission ?? config.mission ?? defaults.observationsMission,
+    reflectMission: config.reflectMission ?? defaults.reflectMission,
+    retainMission: config.retainMission ?? defaults.retainMission,
+    observationsMission: config.observationsMission ?? defaults.observationsMission,
   };
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== "object" || !error) return false;
+  const fields = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    message?: unknown;
+  };
+  return (
+    fields.status === 404 ||
+    fields.statusCode === 404 ||
+    fields.code === 404 ||
+    fields.code === "404" ||
+    (typeof fields.message === "string" && /\b404\b|not found/i.test(fields.message))
+  );
+}
+
+async function bankNeedsCreate(client: HindsightLikeClient, bankId: string): Promise<boolean> {
+  if (!client.getBankProfile) return false;
+  try {
+    await client.getBankProfile(bankId);
+    return false;
+  } catch (error) {
+    if (isNotFoundError(error)) return true;
+    throw error;
+  }
 }
 
 export async function ensureProjectBank(
@@ -58,7 +85,7 @@ export async function ensureProjectBank(
   bankId: string,
   config: BankMissionConfig = {},
 ): Promise<void> {
-  if (!client.createBank) return;
+  if (!client.createBank || !(await bankNeedsCreate(client, bankId))) return;
   const missions = resolveBankMissions(config, defaultProjectBankMissions());
   await client.createBank(bankId, {
     name: bankId,
@@ -73,7 +100,7 @@ export async function ensureGlobalBank(
   bankId: string,
   config: BankMissionConfig = {},
 ): Promise<void> {
-  if (!client.createBank) return;
+  if (!client.createBank || !(await bankNeedsCreate(client, bankId))) return;
   const missions = resolveBankMissions(config, defaultGlobalBankMissions());
   await client.createBank(bankId, {
     name: bankId,

--- a/extensions/config-editing-actions.ts
+++ b/extensions/config-editing-actions.ts
@@ -35,8 +35,6 @@ export function patchForConfigEditingField(
       };
     case "projectBankId":
       return { projectBankId: value.trim() };
-    case "projectMission":
-      return { projectMission: value.trim() };
     case "projectRetainMission":
       return { projectRetainMission: value.trim() };
     case "projectReflectMission":
@@ -47,8 +45,6 @@ export function patchForConfigEditingField(
       return { enableGlobalBank: value === "Enable" };
     case "globalBankId":
       return { globalBankId: value.trim() };
-    case "globalMission":
-      return { globalMission: value.trim() };
     case "globalRetainMission":
       return { globalRetainMission: value.trim() };
     case "globalReflectMission":
@@ -108,8 +104,6 @@ export function inputDefaultForConfigEditingField(
       return "";
     case "projectBankId":
       return projectBankId;
-    case "projectMission":
-      return config.banks.project.mission ?? "";
     case "projectRetainMission":
       return config.banks.project.retainMission ?? "";
     case "projectReflectMission":
@@ -118,8 +112,6 @@ export function inputDefaultForConfigEditingField(
       return config.banks.project.observationsMission ?? "";
     case "globalBankId":
       return config.banks.global.bankId ?? DEFAULT_GLOBAL_BANK_ID;
-    case "globalMission":
-      return config.banks.global.mission ?? "";
     case "globalRetainMission":
       return config.banks.global.retainMission ?? "";
     case "globalReflectMission":

--- a/extensions/config-editing-registry.ts
+++ b/extensions/config-editing-registry.ts
@@ -2,11 +2,7 @@ import { DEFAULT_CONFIG } from "./config.js";
 import type { ResolvedConfig } from "./types.js";
 import type { ConfigScope, ConfigSource, MemoryProfile } from "./config-writer.js";
 import type { ConfigEditingField, FieldId } from "./config-editing-types.js";
-import {
-  defaultGlobalBankMissions,
-  defaultProjectBankMissions,
-  type BankMissionDefaults,
-} from "./bank-operations.js";
+import { defaultGlobalBankMissions, defaultProjectBankMissions } from "./bank-operations.js";
 import { CONFIG_FIELD_PATHS, CONFIG_FIELD_RESET_KEYS } from "./config-field-paths.js";
 export { CONFIG_FIELD_PATHS, CONFIG_FIELD_RESET_KEYS } from "./config-field-paths.js";
 
@@ -134,10 +130,6 @@ function displayLayerValue(value: unknown): string | undefined {
   return JSON.stringify(value);
 }
 
-function builtinMissionDetail(defaults: BankMissionDefaults): string {
-  return `Built-in defaults — retain: ${defaults.retainMission} reflect: ${defaults.reflectMission} observations: ${defaults.observationsMission}`;
-}
-
 function sourceFor(
   layers: { project: Record<string, unknown>; global: Record<string, unknown> },
   path: string[],
@@ -232,22 +224,12 @@ export function buildBaseConfigEditingFields(
       resetKey: "banks.project.bankId",
     }),
     textField({
-      id: "projectMission",
-      tab: "Banks",
-      label: "Project mission",
-      description: `Optional shorthand for project retain, reflect, and observation missions. Blank uses built-in defaults. ${builtinMissionDetail(projectMissionDefaults)}`,
-      value: config.banks.project.mission ?? "built-in default",
-      defaultValue: "built-in default",
-      changed: Boolean(config.banks.project.mission),
-      resetKey: "banks.project.mission",
-    }),
-    textField({
       id: "projectRetainMission",
       tab: "Banks",
       label: "Project retain mission",
       description: `Advanced. Overrides what project retain extracts. Built-in default: ${projectMissionDefaults.retainMission}`,
-      value: config.banks.project.retainMission ?? "inherit project mission/default",
-      defaultValue: "inherit project mission/default",
+      value: config.banks.project.retainMission ?? "built-in default",
+      defaultValue: "built-in default",
       changed: Boolean(config.banks.project.retainMission),
       resetKey: "banks.project.retainMission",
       advanced: true,
@@ -257,8 +239,8 @@ export function buildBaseConfigEditingFields(
       tab: "Banks",
       label: "Project reflect mission",
       description: `Advanced. Overrides how project reflect uses memories. Built-in default: ${projectMissionDefaults.reflectMission}`,
-      value: config.banks.project.reflectMission ?? "inherit project mission/default",
-      defaultValue: "inherit project mission/default",
+      value: config.banks.project.reflectMission ?? "built-in default",
+      defaultValue: "built-in default",
       changed: Boolean(config.banks.project.reflectMission),
       resetKey: "banks.project.reflectMission",
       advanced: true,
@@ -268,8 +250,8 @@ export function buildBaseConfigEditingFields(
       tab: "Banks",
       label: "Project observations mission",
       description: `Advanced. Overrides what project observation consolidation synthesizes. Built-in default: ${projectMissionDefaults.observationsMission}`,
-      value: config.banks.project.observationsMission ?? "inherit project mission/default",
-      defaultValue: "inherit project mission/default",
+      value: config.banks.project.observationsMission ?? "built-in default",
+      defaultValue: "built-in default",
       changed: Boolean(config.banks.project.observationsMission),
       resetKey: "banks.project.observationsMission",
       advanced: true,
@@ -293,22 +275,12 @@ export function buildBaseConfigEditingFields(
       resetKey: "banks.global.bankId",
     }),
     textField({
-      id: "globalMission",
-      tab: "Banks",
-      label: "Global mission",
-      description: `Optional shorthand for global retain, reflect, and observation missions. Blank uses built-in defaults. ${builtinMissionDetail(globalMissionDefaults)}`,
-      value: config.banks.global.mission ?? "built-in default",
-      defaultValue: "built-in default",
-      changed: Boolean(config.banks.global.mission),
-      resetKey: "banks.global.mission",
-    }),
-    textField({
       id: "globalRetainMission",
       tab: "Banks",
       label: "Global retain mission",
       description: `Advanced. Overrides what global retain extracts. Built-in default: ${globalMissionDefaults.retainMission}`,
-      value: config.banks.global.retainMission ?? "inherit global mission/default",
-      defaultValue: "inherit global mission/default",
+      value: config.banks.global.retainMission ?? "built-in default",
+      defaultValue: "built-in default",
       changed: Boolean(config.banks.global.retainMission),
       resetKey: "banks.global.retainMission",
       advanced: true,
@@ -318,8 +290,8 @@ export function buildBaseConfigEditingFields(
       tab: "Banks",
       label: "Global reflect mission",
       description: `Advanced. Overrides how global reflect uses memories. Built-in default: ${globalMissionDefaults.reflectMission}`,
-      value: config.banks.global.reflectMission ?? "inherit global mission/default",
-      defaultValue: "inherit global mission/default",
+      value: config.banks.global.reflectMission ?? "built-in default",
+      defaultValue: "built-in default",
       changed: Boolean(config.banks.global.reflectMission),
       resetKey: "banks.global.reflectMission",
       advanced: true,
@@ -329,8 +301,8 @@ export function buildBaseConfigEditingFields(
       tab: "Banks",
       label: "Global observations mission",
       description: `Advanced. Overrides what global observation consolidation synthesizes. Built-in default: ${globalMissionDefaults.observationsMission}`,
-      value: config.banks.global.observationsMission ?? "inherit global mission/default",
-      defaultValue: "inherit global mission/default",
+      value: config.banks.global.observationsMission ?? "built-in default",
+      defaultValue: "built-in default",
       changed: Boolean(config.banks.global.observationsMission),
       resetKey: "banks.global.observationsMission",
       advanced: true,
@@ -524,7 +496,6 @@ export function buildBaseConfigEditingFields(
 }
 export const PROJECT_ONLY_FIELD_IDS = new Set<FieldId>([
   "projectBankId",
-  "projectMission",
   "projectRetainMission",
   "projectReflectMission",
   "projectObservationsMission",
@@ -612,8 +583,12 @@ export function buildStatusFacts(
       "Global bank",
       config.banks.global.enabled ? (config.banks.global.bankId ?? "missing id") : "disabled",
     ],
-    ["Project mission", missionSummary(config.banks.project.mission)],
-    ["Global mission", missionSummary(config.banks.global.mission)],
+    ["Project retain mission", missionSummary(config.banks.project.retainMission)],
+    ["Project reflect mission", missionSummary(config.banks.project.reflectMission)],
+    ["Project observations mission", missionSummary(config.banks.project.observationsMission)],
+    ["Global retain mission", missionSummary(config.banks.global.retainMission)],
+    ["Global reflect mission", missionSummary(config.banks.global.reflectMission)],
+    ["Global observations mission", missionSummary(config.banks.global.observationsMission)],
     ["Global retain mode", config.globalRetain.mode],
     ["Recall", enabledDisabled(config.recall.enabled)],
     ["Retain", enabledDisabled(config.retain.enabled)],

--- a/extensions/config-field-paths.ts
+++ b/extensions/config-field-paths.ts
@@ -6,13 +6,11 @@ export type FieldId =
   | "timeoutMs"
   | "memoryProfile"
   | "projectBankId"
-  | "projectMission"
   | "projectRetainMission"
   | "projectReflectMission"
   | "projectObservationsMission"
   | "globalBankEnabled"
   | "globalBankId"
-  | "globalMission"
   | "globalRetainMission"
   | "globalReflectMission"
   | "globalObservationsMission"
@@ -44,13 +42,11 @@ export const CONFIG_FIELD_PATHS: Record<FieldId, string[]> = {
   timeoutMs: ["hindsight", "timeoutMs"],
   memoryProfile: ["banks", "project", "enabled"],
   projectBankId: ["banks", "project", "bankId"],
-  projectMission: ["banks", "project", "mission"],
   projectRetainMission: ["banks", "project", "retainMission"],
   projectReflectMission: ["banks", "project", "reflectMission"],
   projectObservationsMission: ["banks", "project", "observationsMission"],
   globalBankEnabled: ["banks", "global", "enabled"],
   globalBankId: ["banks", "global", "bankId"],
-  globalMission: ["banks", "global", "mission"],
   globalRetainMission: ["banks", "global", "retainMission"],
   globalReflectMission: ["banks", "global", "reflectMission"],
   globalObservationsMission: ["banks", "global", "observationsMission"],
@@ -97,7 +93,6 @@ export const CONFIG_RESET_PATHS = {
     ["banks", "project", "reflectMission"],
     ["banks", "project", "observationsMission"],
   ],
-  "banks.project.mission": [["banks", "project", "mission"]],
   "banks.project.retainMission": [["banks", "project", "retainMission"]],
   "banks.project.reflectMission": [["banks", "project", "reflectMission"]],
   "banks.project.observationsMission": [["banks", "project", "observationsMission"]],
@@ -109,7 +104,6 @@ export const CONFIG_RESET_PATHS = {
     ["banks", "global", "reflectMission"],
     ["banks", "global", "observationsMission"],
   ],
-  "banks.global.mission": [["banks", "global", "mission"]],
   "banks.global.retainMission": [["banks", "global", "retainMission"]],
   "banks.global.reflectMission": [["banks", "global", "reflectMission"]],
   "banks.global.observationsMission": [["banks", "global", "observationsMission"]],
@@ -144,13 +138,11 @@ export const CONFIG_FIELD_RESET_KEYS: Record<FieldId, ConfigResetKey> = {
   timeoutMs: "hindsight.timeoutMs",
   memoryProfile: "banks.profile",
   projectBankId: "banks.project.bankId",
-  projectMission: "banks.project.mission",
   projectRetainMission: "banks.project.retainMission",
   projectReflectMission: "banks.project.reflectMission",
   projectObservationsMission: "banks.project.observationsMission",
   globalBankEnabled: "banks.global.enabled",
   globalBankId: "banks.global.bankId",
-  globalMission: "banks.global.mission",
   globalRetainMission: "banks.global.retainMission",
   globalReflectMission: "banks.global.reflectMission",
   globalObservationsMission: "banks.global.observationsMission",

--- a/extensions/config-writer.ts
+++ b/extensions/config-writer.ts
@@ -75,12 +75,10 @@ export interface ProjectConfigPatchInput {
   apiKeyEnvVar?: string;
   directApiKey?: string;
   projectBankId?: string;
-  projectMission?: string;
   projectRetainMission?: string;
   projectReflectMission?: string;
   projectObservationsMission?: string;
   globalBankId?: string;
-  globalMission?: string;
   globalRetainMission?: string;
   globalReflectMission?: string;
   globalObservationsMission?: string;
@@ -150,9 +148,6 @@ export function buildProjectConfigPatch(input: ProjectConfigPatchInput): Record<
       project: { enabled: true, derive: "manual", bankId: input.projectBankId },
     };
   }
-  if (input.projectMission !== undefined) {
-    mergeBankPatch(patch, "project", { mission: input.projectMission });
-  }
   if (input.projectRetainMission !== undefined) {
     mergeBankPatch(patch, "project", { retainMission: input.projectRetainMission });
   }
@@ -170,9 +165,6 @@ export function buildProjectConfigPatch(input: ProjectConfigPatchInput): Record<
         ...(input.globalBankId ? { bankId: input.globalBankId, enabled: true } : {}),
       },
     };
-  }
-  if (input.globalMission !== undefined) {
-    mergeBankPatch(patch, "global", { mission: input.globalMission });
   }
   if (input.globalRetainMission !== undefined) {
     mergeBankPatch(patch, "global", { retainMission: input.globalRetainMission });

--- a/extensions/config.ts
+++ b/extensions/config.ts
@@ -324,7 +324,6 @@ function hasConfiguredRecallField(rawConfig: unknown, field: string): boolean {
 function missionFields(bankConfig: unknown) {
   if (!isRecord(bankConfig)) return {};
   return {
-    ...(typeof bankConfig.mission === "string" ? { mission: bankConfig.mission } : {}),
     ...(typeof bankConfig.retainMission === "string"
       ? { retainMission: bankConfig.retainMission }
       : {}),

--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -120,13 +120,11 @@ export function formatDebugReport(args: DebugReportArgs): string {
         : args.config.banks.project.derive,
       bankMissions: {
         projectConfigured: Boolean(
-          args.config.banks.project.mission ||
           args.config.banks.project.retainMission ||
           args.config.banks.project.reflectMission ||
           args.config.banks.project.observationsMission,
         ),
         globalConfigured: Boolean(
-          args.config.banks.global.mission ||
           args.config.banks.global.retainMission ||
           args.config.banks.global.reflectMission ||
           args.config.banks.global.observationsMission,

--- a/extensions/memory-router.ts
+++ b/extensions/memory-router.ts
@@ -149,10 +149,13 @@ export function routeMemoryCandidate(
   adapter: MemoryRouterAdapter = createMissionAwareMemoryRouter(),
 ): MemoryRouteDecision {
   const projectMission = missionSummary(
-    args.config.banks.project.mission,
-    "built-in project mission",
+    args.config.banks.project.retainMission,
+    "built-in project retain mission",
   );
-  const globalMission = missionSummary(args.config.banks.global.mission, "built-in global mission");
+  const globalMission = missionSummary(
+    args.config.banks.global.retainMission,
+    "built-in global retain mission",
+  );
   const classification = adapter.classify({
     content: args.content,
     ...(args.context ? { context: args.context } : {}),

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -11,8 +11,6 @@ export type RecallInjectionPosition = "prepend" | "append";
 export type GlobalRetainMode = "explicit-only" | "router";
 
 export interface BankMissionSettings {
-  /** Human-friendly shorthand. Used for any mission field not set explicitly. */
-  mission?: string;
   retainMission?: string;
   reflectMission?: string;
   observationsMission?: string;

--- a/tests/bank-operations.test.ts
+++ b/tests/bank-operations.test.ts
@@ -2,37 +2,29 @@ import { describe, expect, it, vi } from "vitest";
 import { ensureGlobalBank, ensureProjectBank } from "../extensions/bank-operations.js";
 import type { HindsightLikeClient } from "../extensions/types.js";
 
-function client(createBank = vi.fn(async () => undefined)): HindsightLikeClient {
+function client(
+  args: {
+    createBank?: HindsightLikeClient["createBank"];
+    getBankProfile?: HindsightLikeClient["getBankProfile"];
+  } = {},
+): HindsightLikeClient {
   return {
     retain: async () => undefined,
     recall: async () => [],
     reflect: async () => ({}),
-    createBank,
+    createBank: args.createBank ?? vi.fn(async () => undefined),
+    getBankProfile:
+      args.getBankProfile ??
+      vi.fn(async () => {
+        throw new Error("not found");
+      }),
   };
 }
 
 describe("bank operations", () => {
-  it("uses configured project mission for reflect and retain missions", async () => {
+  it("uses only explicit project mission fields for Hindsight bank missions", async () => {
     const createBank = vi.fn(async () => undefined);
-    await ensureProjectBank(client(createBank), "project-bank", { mission: "Project mission" });
-
-    expect(createBank).toHaveBeenCalledWith(
-      "project-bank",
-      expect.objectContaining({
-        name: "project-bank",
-        reflectMission: "Project mission",
-        retainMission: "Project mission",
-        observationsMission: "Project mission",
-        retainExtractionMode: "concise",
-        enableObservations: true,
-      }),
-    );
-  });
-
-  it("lets explicit project mission fields override the shorthand", async () => {
-    const createBank = vi.fn(async () => undefined);
-    await ensureProjectBank(client(createBank), "project-bank", {
-      mission: "General mission",
+    await ensureProjectBank(client({ createBank }), "project-bank", {
       retainMission: "Retain mission",
       reflectMission: "Reflect mission",
       observationsMission: "Observation mission",
@@ -46,11 +38,35 @@ describe("bank operations", () => {
         observationsMission: "Observation mission",
       }),
     );
+    const options = (createBank.mock.calls as unknown[][])[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(options).not.toHaveProperty("mission");
+  });
+
+  it("does not use generic mission shorthand for Hindsight bank missions", async () => {
+    const createBank = vi.fn(async () => undefined);
+    await ensureProjectBank(client({ createBank }), "project-bank", {
+      mission: "Generic mission",
+    } as never);
+
+    expect(createBank).toHaveBeenCalledWith(
+      "project-bank",
+      expect.objectContaining({
+        reflectMission: expect.stringContaining("project-specific architecture"),
+        retainMission: expect.stringContaining("durable project memory"),
+        observationsMission: expect.stringContaining("durable project patterns"),
+      }),
+    );
+    const options = (createBank.mock.calls as unknown[][])[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(JSON.stringify(options)).not.toContain("Generic mission");
   });
 
   it("passes configured observation enablement", async () => {
     const createBank = vi.fn(async () => undefined);
-    await ensureProjectBank(client(createBank), "project-bank", { enableObservations: false });
+    await ensureProjectBank(client({ createBank }), "project-bank", { enableObservations: false });
 
     expect(createBank).toHaveBeenCalledWith(
       "project-bank",
@@ -58,24 +74,32 @@ describe("bank operations", () => {
     );
   });
 
-  it("uses configured global mission when global bank is ensured", async () => {
+  it("uses only explicit global mission fields when global bank is created", async () => {
     const createBank = vi.fn(async () => undefined);
-    await ensureGlobalBank(client(createBank), "global-bank", { mission: "Global mission" });
+    await ensureGlobalBank(client({ createBank }), "global-bank", {
+      retainMission: "Global retain",
+      reflectMission: "Global reflect",
+      observationsMission: "Global observations",
+    });
 
     expect(createBank).toHaveBeenCalledWith(
       "global-bank",
       expect.objectContaining({
         name: "global-bank",
-        reflectMission: "Global mission",
-        retainMission: "Global mission",
-        observationsMission: "Global mission",
+        reflectMission: "Global reflect",
+        retainMission: "Global retain",
+        observationsMission: "Global observations",
       }),
     );
+    const options = (createBank.mock.calls as unknown[][])[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(options).not.toHaveProperty("mission");
   });
 
-  it("keeps default project mission when no mission is configured", async () => {
+  it("keeps default project mission when no explicit mission fields are configured", async () => {
     const createBank = vi.fn(async () => undefined);
-    await ensureProjectBank(client(createBank), "project-bank");
+    await ensureProjectBank(client({ createBank }), "project-bank");
 
     expect(createBank).toHaveBeenCalledWith(
       "project-bank",
@@ -89,7 +113,7 @@ describe("bank operations", () => {
 
   it("keeps global default mission focused on cross-project memory", async () => {
     const createBank = vi.fn(async () => undefined);
-    await ensureGlobalBank(client(createBank), "global-bank");
+    await ensureGlobalBank(client({ createBank }), "global-bank");
 
     expect(createBank).toHaveBeenCalledWith(
       "global-bank",
@@ -101,5 +125,49 @@ describe("bank operations", () => {
         enableObservations: true,
       }),
     );
+  });
+
+  it("does not overwrite missions when bank profile already exists", async () => {
+    const createBank = vi.fn(async () => undefined);
+    const getBankProfile = vi.fn(async () => ({ bankId: "project-bank" }));
+
+    await ensureProjectBank(client({ createBank, getBankProfile }), "project-bank");
+
+    expect(getBankProfile).toHaveBeenCalledWith("project-bank");
+    expect(createBank).not.toHaveBeenCalled();
+  });
+
+  it("creates bank when profile lookup confirms not found", async () => {
+    const createBank = vi.fn(async () => undefined);
+    const getBankProfile = vi.fn(async () => {
+      throw new Error("Hindsight request failed with status 404");
+    });
+
+    await ensureProjectBank(client({ createBank, getBankProfile }), "project-bank");
+
+    expect(createBank).toHaveBeenCalledWith("project-bank", expect.any(Object));
+  });
+
+  it("surfaces non-404 profile lookup failures without creating a bank", async () => {
+    const createBank = vi.fn(async () => undefined);
+    const getBankProfile = vi.fn(async () => {
+      throw new Error("Hindsight request failed with status 500");
+    });
+
+    await expect(
+      ensureProjectBank(client({ createBank, getBankProfile }), "project-bank"),
+    ).rejects.toThrow("status 500");
+
+    expect(createBank).not.toHaveBeenCalled();
+  });
+
+  it("does not create bank without profile lookup capability", async () => {
+    const createBank = vi.fn(async () => undefined);
+    const noProfileClient = client({ createBank });
+    delete noProfileClient.getBankProfile;
+
+    await ensureProjectBank(noProfileClient, "project-bank");
+
+    expect(createBank).not.toHaveBeenCalled();
   });
 });

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -39,6 +39,10 @@ describe("Hindsight client adapter integration", () => {
       const body = await readBody(req);
       requests.push({ method: req.method, url: req.url, headers: req.headers, body });
 
+      if (req.method === "GET" && req.url === "/v1/default/banks/test-bank/profile") {
+        sendJson(res, 404, { detail: "not found" });
+        return;
+      }
       if (req.method === "PUT" && req.url === "/v1/default/banks/test-bank") {
         sendJson(res, 200, { bank_id: "test-bank" });
         return;
@@ -109,6 +113,7 @@ describe("Hindsight client adapter integration", () => {
     expect(reflection).toEqual({ text: "reflection" });
 
     expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+      "GET /v1/default/banks/test-bank/profile",
       "PUT /v1/default/banks/test-bank",
       "POST /v1/default/banks/test-bank/memories",
       "POST /v1/default/banks/test-bank/memories",
@@ -116,7 +121,7 @@ describe("Hindsight client adapter integration", () => {
       "POST /v1/default/banks/test-bank/reflect",
     ]);
 
-    expect(requests[1]?.body).toMatchObject({
+    expect(requests[2]?.body).toMatchObject({
       items: [
         {
           content: "raw content",
@@ -130,8 +135,8 @@ describe("Hindsight client adapter integration", () => {
       ],
       async: true,
     });
-    expect(JSON.stringify(requests[1]?.body)).not.toContain("observation_scopes");
-    expect(requests[2]?.body).toMatchObject({
+    expect(JSON.stringify(requests[2]?.body)).not.toContain("observation_scopes");
+    expect(requests[3]?.body).toMatchObject({
       items: [
         {
           content: "scoped content",
@@ -143,8 +148,8 @@ describe("Hindsight client adapter integration", () => {
         },
       ],
     });
-    expect(JSON.stringify(requests[2]?.body)).not.toContain("observationScopes");
-    expect(requests[3]?.body).toMatchObject({
+    expect(JSON.stringify(requests[3]?.body)).not.toContain("observationScopes");
+    expect(requests[4]?.body).toMatchObject({
       query: "query",
       max_tokens: 123,
       budget: "low",
@@ -152,7 +157,7 @@ describe("Hindsight client adapter integration", () => {
       tags: ["source:pi"],
       tags_match: "any_strict",
     });
-    expect(requests[4]?.body).toMatchObject({
+    expect(requests[5]?.body).toMatchObject({
       query: "query",
       budget: "low",
       response_schema: { type: "object", properties: { answer: { type: "string" } } },

--- a/tests/config-editing-model.test.ts
+++ b/tests/config-editing-model.test.ts
@@ -28,7 +28,7 @@ describe("config editing model", () => {
     expect(fields.find((field) => field.id === "projectBankId")?.editableScopes).toEqual([
       "project",
     ]);
-    expect(fields.find((field) => field.id === "projectMission")?.editableScopes).toEqual([
+    expect(fields.find((field) => field.id === "projectRetainMission")?.editableScopes).toEqual([
       "project",
     ]);
     expect(fields.find((field) => field.id === "memoryProfile")?.editableScopes).toEqual([
@@ -67,7 +67,7 @@ describe("config editing model", () => {
       "project",
       "global",
     ]);
-    expect(fields.find((field) => field.id === "globalMission")?.editableScopes).toEqual([
+    expect(fields.find((field) => field.id === "globalRetainMission")?.editableScopes).toEqual([
       "project",
       "global",
     ]);
@@ -83,7 +83,7 @@ describe("config editing model", () => {
       choices: ["project-only", "project+global", "global-only"],
     });
     expect(queuePath).toMatchObject({ kind: "text" });
-    expect(fields.find((field) => field.id === "projectMission")).toMatchObject({
+    expect(fields.find((field) => field.id === "projectRetainMission")).toMatchObject({
       kind: "text",
       value: "built-in default",
       defaultValue: "built-in default",
@@ -108,7 +108,6 @@ describe("config editing model", () => {
       showAdvanced: true,
     }).find((tab) => tab.id === "Banks");
 
-    expect(basicBanks?.fields.map((field) => field.id)).toContain("projectMission");
     expect(basicBanks?.fields.map((field) => field.id)).not.toContain("projectRetainMission");
     expect(advancedBanks?.fields.map((field) => field.id)).toContain("projectRetainMission");
   });
@@ -116,12 +115,6 @@ describe("config editing model", () => {
   it("shows built-in mission text in mission field details", () => {
     const fields = buildConfigEditingFields(DEFAULT_CONFIG, "bank", layers());
 
-    expect(fields.find((field) => field.id === "projectMission")?.description).toContain(
-      "Extract durable project memory",
-    );
-    expect(fields.find((field) => field.id === "globalMission")?.description).toContain(
-      "Extract durable cross-project memory",
-    );
     expect(fields.find((field) => field.id === "projectRetainMission")?.description).toContain(
       "Built-in default: Extract durable project memory",
     );
@@ -134,16 +127,20 @@ describe("config editing model", () => {
           ...DEFAULT_CONFIG,
           banks: {
             ...DEFAULT_CONFIG.banks,
-            project: { ...DEFAULT_CONFIG.banks.project, mission: "Project memory mission" },
-            global: { enabled: true, bankId: "global-luxus", mission: "Global memory mission" },
+            project: { ...DEFAULT_CONFIG.banks.project, retainMission: "Project retain mission" },
+            global: {
+              enabled: true,
+              bankId: "global-luxus",
+              retainMission: "Global retain mission",
+            },
           },
         },
         "project-bank",
       ),
     ).toEqual(
       expect.arrayContaining([
-        ["Project mission", "Project memory mission"],
-        ["Global mission", "Global memory mission"],
+        ["Project retain mission", "Project retain mission"],
+        ["Global retain mission", "Global retain mission"],
       ]),
     );
   });

--- a/tests/config-writer.test.ts
+++ b/tests/config-writer.test.ts
@@ -21,27 +21,6 @@ describe("config writer", () => {
     });
   });
 
-  it("builds bank mission patches without clobbering sibling bank settings", () => {
-    expect(
-      buildProjectConfigPatch({
-        projectBankId: "bank",
-        projectMission: "Project mission",
-        globalBankId: "pi-global",
-        globalMission: "Global mission",
-      }),
-    ).toEqual({
-      banks: {
-        project: {
-          enabled: true,
-          derive: "manual",
-          bankId: "bank",
-          mission: "Project mission",
-        },
-        global: { enabled: true, bankId: "pi-global", mission: "Global mission" },
-      },
-    });
-  });
-
   it("builds granular mission override patches", () => {
     expect(
       buildProjectConfigPatch({

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -16,7 +16,7 @@ describe("resolveConfig", () => {
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
         recall: { maxTokens: 123 },
-        banks: { project: { derive: "cwd", mission: "Project mission" } },
+        banks: { project: { derive: "cwd", retainMission: "Project retain mission" } },
       }),
     );
     const config = resolveConfig(cwd, {
@@ -27,7 +27,7 @@ describe("resolveConfig", () => {
     expect(config.hindsight.baseUrl).toBe("http://h");
     expect(config.banks.project.bankId).toBe("manual-bank");
     expect(config.banks.project.derive).toBe("manual");
-    expect(config.banks.project.mission).toBe("Project mission");
+    expect(config.banks.project.retainMission).toBe("Project retain mission");
   });
 
   it("normalizes granular bank missions", () => {
@@ -43,7 +43,6 @@ describe("resolveConfig", () => {
             observationsMission: "Project observations",
           },
           global: {
-            mission: "Global shorthand",
             retainMission: "Global retain",
           },
         },
@@ -54,7 +53,6 @@ describe("resolveConfig", () => {
     expect(config.banks.project.retainMission).toBe("Project retain");
     expect(config.banks.project.reflectMission).toBe("Project reflect");
     expect(config.banks.project.observationsMission).toBe("Project observations");
-    expect(config.banks.global.mission).toBe("Global shorthand");
     expect(config.banks.global.retainMission).toBe("Global retain");
   });
 

--- a/tests/memory-router.test.ts
+++ b/tests/memory-router.test.ts
@@ -74,7 +74,7 @@ describe("memory router", () => {
           ...DEFAULT_CONFIG.banks,
           project: {
             ...DEFAULT_CONFIG.banks.project,
-            mission: "Importer checkpoint manifest architecture",
+            retainMission: "Importer checkpoint manifest architecture",
           },
         },
       },
@@ -107,8 +107,8 @@ describe("memory router", () => {
           ...DEFAULT_CONFIG,
           banks: {
             ...DEFAULT_CONFIG.banks,
-            project: { ...DEFAULT_CONFIG.banks.project, mission: "Project mission" },
-            global: { ...DEFAULT_CONFIG.banks.global, mission: "Global mission" },
+            project: { ...DEFAULT_CONFIG.banks.project, retainMission: "Project retain mission" },
+            global: { ...DEFAULT_CONFIG.banks.global, retainMission: "Global retain mission" },
           },
         },
       },
@@ -116,10 +116,10 @@ describe("memory router", () => {
     );
 
     expect(calls[0]).toMatchObject({
-      projectMission: "Project mission",
-      globalMission: "Global mission",
+      projectMission: "Project retain mission",
+      globalMission: "Global retain mission",
     });
-    expect(decision.projectMission).toBe("Project mission");
-    expect(decision.globalMission).toBe("Global mission");
+    expect(decision.projectMission).toBe("Project retain mission");
+    expect(decision.globalMission).toBe("Global retain mission");
   });
 });

--- a/tests/setup-tui.test.ts
+++ b/tests/setup-tui.test.ts
@@ -37,15 +37,15 @@ describe("setup TUI receipt facts", () => {
       "bank",
       { project: {}, global: {}, env: {} },
       [],
-      { showAdvanced: false },
+      { showAdvanced: true },
     );
     const component = createSetupComponent(
       tabs,
       theme,
-      { tabIndex: 2, selectedByTab: { Banks: 2 }, showAdvanced: false },
+      { tabIndex: 2, selectedByTab: { Banks: 2 }, showAdvanced: true },
       () => undefined,
     );
 
-    expect(component.render(100).join("\n")).toContain("Extract durable project memory");
+    expect(component.render(100).join("\n")).toContain("Extract durable project");
   });
 });


### PR DESCRIPTION
## Summary
- remove generic bank mission editing/writing/normalization
- create Hindsight banks with retain/reflect/observations missions only
- skip bank creation unless profile lookup confirms not found, preventing default mission overwrite on existing banks

## Verification
- npm run check
- npm run typecheck:tsc

## Reviews
- subagent reviewer accepted after blocker fix