### PR TITLE
chore(package): declare compatibility contract

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --engine-strict
 
       - name: Run checks
         run: npm run check
@@ -60,7 +60,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --engine-strict
 
       - name: Run configured Hindsight smoke test
         env:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This package adds a Pi extension that can recall relevant project memory before 
 
 The extension is heavily inspired by [`noctuid/pi-hindsight`](https://github.com/noctuid/pi-hindsight). Many product ideas, memory lifecycle choices, and Pi/Hindsight integration patterns started from that extension and were adapted here with stricter project isolation, queue durability, diagnostics, and release-hardening goals.
 
+## Compatibility
+
+Supported runtime and package ranges are declared in `package.json` and enforced in CI with `npm ci --engine-strict`.
+
+- Node.js: `>=22 <25`
+- npm: `>=10 <12`
+- Pi peer package: `@mariozechner/pi-coding-agent >=0.70.2 <0.71.0`
+- TypeBox peer package: `typebox >=1.0.55 <2`
+
+Development dependencies pin the tested Pi package and native TypeScript preview build so local checks and CI resolve the same compatibility baseline.
+
 ## Hindsight mental model
 
 **[Hindsight](https://hindsight.vectorize.io/) is a memory system that separates storage, retrieval, and reasoning.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,19 +14,23 @@
       "devDependencies": {
         "@commitlint/cli": "^20.5.2",
         "@commitlint/config-conventional": "^20.5.0",
-        "@mariozechner/pi-coding-agent": "*",
+        "@mariozechner/pi-coding-agent": "0.70.2",
         "@types/node": "^22.15.3",
-        "@typescript/native-preview": "^7.0.0-dev.20260426.1",
+        "@typescript/native-preview": "7.0.0-dev.20260426.1",
         "oxfmt": "^0.46.0",
         "oxlint": "^1.61.0",
         "oxlint-tsgolint": "^0.22.0",
-        "typebox": "^1.0.55",
+        "typebox": "1.1.33",
         "typescript": "^5.8.3",
         "vitest": "^3.1.2"
       },
+      "engines": {
+        "node": ">=22 <25",
+        "npm": ">=10 <12"
+      },
       "peerDependencies": {
-        "@mariozechner/pi-coding-agent": "*",
-        "typebox": "*"
+        "@mariozechner/pi-coding-agent": ">=0.70.2 <0.71.0",
+        "typebox": ">=1.0.55 <2"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -56,19 +56,23 @@
   "devDependencies": {
     "@commitlint/cli": "^20.5.2",
     "@commitlint/config-conventional": "^20.5.0",
-    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-coding-agent": "0.70.2",
     "@types/node": "^22.15.3",
-    "@typescript/native-preview": "^7.0.0-dev.20260426.1",
+    "@typescript/native-preview": "7.0.0-dev.20260426.1",
     "oxfmt": "^0.46.0",
     "oxlint": "^1.61.0",
     "oxlint-tsgolint": "^0.22.0",
-    "typebox": "^1.0.55",
+    "typebox": "1.1.33",
     "typescript": "^5.8.3",
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "typebox": "*"
+    "@mariozechner/pi-coding-agent": ">=0.70.2 <0.71.0",
+    "typebox": ">=1.0.55 <2"
+  },
+  "engines": {
+    "node": ">=22 <25",
+    "npm": ">=10 <12"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary
- declare supported Node/npm engines
- replace wildcard Pi and TypeBox ranges with bounded compatibility ranges
- pin tested dev baselines, including native TypeScript preview
- enforce engines in CI installs
- document compatibility in README

## Verification
- npm ci --engine-strict --ignore-scripts
- npm run check
- npm run typecheck:tsc
- npm pack --dry-run

## Reviews
- subagent reviewer accepted