### PR TITLE
refactor(queue): extract lock and jsonl store

### DIFF
--- a/extensions/jsonl-queue-store.ts
+++ b/extensions/jsonl-queue-store.ts
@@ -1,0 +1,114 @@
+import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export interface JsonlQueueFileSummary {
+  path: string;
+  valid: number;
+  malformed: number;
+  error: string | null;
+}
+
+export interface ParsedJsonlQueue<T> {
+  jobs: T[];
+  malformedLines: string[];
+}
+
+export class JsonlQueueStore<T> {
+  constructor(
+    readonly path: string,
+    private readonly isItem: (value: unknown) => value is T,
+  ) {}
+
+  async count(): Promise<number> {
+    try {
+      return (await readFile(this.path, "utf8")).split("\n").filter(Boolean).length;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
+      throw error;
+    }
+  }
+
+  async append(items: T[]): Promise<void> {
+    if (items.length === 0) return;
+    await mkdir(dirname(this.path), { recursive: true });
+    await appendFile(
+      this.path,
+      items.map((item) => JSON.stringify(item)).join("\n") + "\n",
+      "utf8",
+    );
+  }
+
+  async readStrict(): Promise<T[]> {
+    try {
+      const text = await readFile(this.path, "utf8");
+      return text
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as T);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+  }
+
+  async readTolerant(): Promise<ParsedJsonlQueue<T>> {
+    try {
+      const text = await readFile(this.path, "utf8");
+      const jobs: T[] = [];
+      const malformedLines: string[] = [];
+      for (const line of text.split("\n").filter(Boolean)) {
+        try {
+          const parsed = JSON.parse(line) as unknown;
+          if (this.isItem(parsed)) jobs.push(parsed);
+          else malformedLines.push(line);
+        } catch {
+          malformedLines.push(line);
+        }
+      }
+      return { jobs, malformedLines };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { jobs: [], malformedLines: [] };
+      }
+      throw error;
+    }
+  }
+
+  async summarize(): Promise<JsonlQueueFileSummary> {
+    try {
+      const text = await readFile(this.path, "utf8");
+      let valid = 0;
+      let malformed = 0;
+      for (const line of text.split("\n").filter(Boolean)) {
+        try {
+          JSON.parse(line) as T;
+          valid += 1;
+        } catch {
+          malformed += 1;
+        }
+      }
+      return { path: this.path, valid, malformed, error: null };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { path: this.path, valid: 0, malformed: 0, error: null };
+      }
+      return {
+        path: this.path,
+        valid: 0,
+        malformed: 0,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async replace(items: T[]): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true });
+    const tmp = `${this.path}.tmp`;
+    await writeFile(
+      tmp,
+      items.map((item) => JSON.stringify(item)).join("\n") + (items.length ? "\n" : ""),
+      "utf8",
+    );
+    await rename(tmp, this.path);
+  }
+}

--- a/extensions/queue-lock.ts
+++ b/extensions/queue-lock.ts
@@ -1,0 +1,206 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const queueLocks = new Map<string, Promise<void>>();
+
+const LOCK_RETRY_MS = 25;
+const LOCK_TIMEOUT_MS = 5_000;
+const LOCK_STALE_MS = 30_000;
+
+export const RETAIN_QUEUE_LOCK = {
+  retryMs: LOCK_RETRY_MS,
+  timeoutMs: LOCK_TIMEOUT_MS,
+  staleMs: LOCK_STALE_MS,
+};
+
+export interface QueueLockOwner {
+  pid?: number;
+  acquiredAt?: string;
+  token?: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function removeDirectory(path: string): Promise<void> {
+  await rm(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 });
+}
+
+async function writeQueueHeartbeat(lockPath: string, token: string): Promise<void> {
+  const heartbeatPath = `${lockPath}/heartbeat-${token}`;
+  const tmpPath = `${heartbeatPath}.${process.pid}.tmp`;
+  await writeFile(tmpPath, new Date().toISOString(), "utf8");
+  await rename(tmpPath, heartbeatPath);
+}
+
+async function writeQueueLockOwner(lockPath: string, token: string): Promise<void> {
+  const ownerPath = `${lockPath}/owner`;
+  const tmpPath = `${ownerPath}.${process.pid}.${token}.tmp`;
+  await writeFile(
+    tmpPath,
+    JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), token }),
+    "utf8",
+  );
+  await rename(tmpPath, ownerPath);
+  await writeQueueHeartbeat(lockPath, token);
+}
+
+function startQueueLockHeartbeat(lockPath: string, token: string): NodeJS.Timeout {
+  const heartbeatMs = Math.max(1, Math.min(5_000, Math.floor(RETAIN_QUEUE_LOCK.staleMs / 2)));
+  const heartbeat = setInterval(() => {
+    void writeQueueHeartbeat(lockPath, token).catch(() => undefined);
+  }, heartbeatMs);
+  heartbeat.unref?.();
+  return heartbeat;
+}
+
+export function isQueueLockOwnerStale(
+  owner: QueueLockOwner | undefined,
+  now = Date.now(),
+  staleMs = RETAIN_QUEUE_LOCK.staleMs,
+): boolean {
+  if (!owner) return true;
+  const acquiredAt = owner.acquiredAt ? Date.parse(owner.acquiredAt) : Number.NaN;
+  return !Number.isFinite(acquiredAt) || now - acquiredAt > staleMs;
+}
+
+async function readQueueLockOwner(lockPath: string): Promise<QueueLockOwner | undefined> {
+  try {
+    return JSON.parse(await readFile(`${lockPath}/owner`, "utf8")) as QueueLockOwner;
+  } catch {
+    return undefined;
+  }
+}
+
+async function isOwnerlessLockDirectoryStale(lockPath: string): Promise<boolean> {
+  try {
+    const info = await stat(lockPath);
+    return Date.now() - info.mtimeMs > RETAIN_QUEUE_LOCK.staleMs;
+  } catch {
+    return true;
+  }
+}
+
+async function isQueueLockStale(lockPath: string, owner: QueueLockOwner): Promise<boolean> {
+  if (!owner.token) return isQueueLockOwnerStale(owner);
+  try {
+    const heartbeat = await stat(`${lockPath}/heartbeat-${owner.token}`);
+    return Date.now() - heartbeat.mtimeMs > RETAIN_QUEUE_LOCK.staleMs;
+  } catch {
+    return isQueueLockOwnerStale(owner);
+  }
+}
+
+async function removeLockIfOwned(lockPath: string, token: string): Promise<void> {
+  const owner = await readQueueLockOwner(lockPath);
+  if (owner?.token === token) await removeDirectory(lockPath);
+}
+
+function staleClaimPath(lockPath: string): string {
+  return `${lockPath}.stale-claim`;
+}
+
+async function isStaleCleanupClaimActive(lockPath: string): Promise<boolean> {
+  const claimPath = staleClaimPath(lockPath);
+  try {
+    const info = await stat(claimPath);
+    if (Date.now() - info.mtimeMs <= RETAIN_QUEUE_LOCK.staleMs) return true;
+    await removeDirectory(claimPath);
+    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function withStaleCleanupClaim<T>(
+  lockPath: string,
+  fn: () => Promise<T>,
+): Promise<T | undefined> {
+  const claimPath = staleClaimPath(lockPath);
+  try {
+    await mkdir(claimPath, { recursive: false });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") return undefined;
+    throw error;
+  }
+  try {
+    return await fn();
+  } finally {
+    await removeDirectory(claimPath);
+  }
+}
+
+async function removeLockIfStillStale(lockPath: string): Promise<boolean> {
+  return (
+    (await withStaleCleanupClaim(lockPath, async () => {
+      const owner = await readQueueLockOwner(lockPath);
+      const stale = owner
+        ? await isQueueLockStale(lockPath, owner)
+        : await isOwnerlessLockDirectoryStale(lockPath);
+      if (!stale) return false;
+      await removeDirectory(lockPath);
+      return true;
+    })) ?? false
+  );
+}
+
+async function acquireFileLock(path: string): Promise<() => Promise<void>> {
+  const lockPath = `${path}.lock`;
+  const started = Date.now();
+  await mkdir(dirname(path), { recursive: true });
+  while (true) {
+    if (await isStaleCleanupClaimActive(lockPath)) {
+      if (Date.now() - started > RETAIN_QUEUE_LOCK.timeoutMs)
+        throw new Error(`Timed out waiting for retain queue lock ${lockPath}`);
+      await sleep(RETAIN_QUEUE_LOCK.retryMs);
+      continue;
+    }
+    const token = randomUUID();
+    try {
+      await mkdir(lockPath, { recursive: false });
+      try {
+        await writeQueueLockOwner(lockPath, token);
+      } catch (error) {
+        await removeDirectory(lockPath);
+        if (["ENOENT", "EINVAL"].includes((error as NodeJS.ErrnoException).code ?? "")) continue;
+        throw error;
+      }
+      const heartbeat = startQueueLockHeartbeat(lockPath, token);
+      return async () => {
+        clearInterval(heartbeat);
+        await removeLockIfOwned(lockPath, token);
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      if (await removeLockIfStillStale(lockPath)) continue;
+      if (Date.now() - started > RETAIN_QUEUE_LOCK.timeoutMs)
+        throw new Error(`Timed out waiting for retain queue lock ${lockPath}`);
+      await sleep(RETAIN_QUEUE_LOCK.retryMs);
+    }
+  }
+}
+
+export async function withQueueLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const previous = queueLocks.get(path) ?? Promise.resolve();
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const lock = previous.catch(() => undefined).then(() => next);
+  queueLocks.set(path, lock);
+  await previous.catch(() => undefined);
+  const releaseFileLock = await acquireFileLock(path);
+  try {
+    return await fn();
+  } finally {
+    try {
+      await releaseFileLock();
+    } finally {
+      release();
+      if (queueLocks.get(path) === lock) queueLocks.delete(path);
+    }
+  }
+}

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -1,211 +1,16 @@
-import { randomUUID } from "node:crypto";
-import { appendFile, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { appendFile, mkdir } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 import type { HindsightLikeClient, RetainJob } from "./types.js";
 import { deliverRetainJob, redactQueueError } from "./queue-delivery.js";
+import { JsonlQueueStore, type JsonlQueueFileSummary } from "./jsonl-queue-store.js";
+import {
+  RETAIN_QUEUE_LOCK,
+  isQueueLockOwnerStale,
+  type QueueLockOwner,
+  withQueueLock,
+} from "./queue-lock.js";
 
-const queueLocks = new Map<string, Promise<void>>();
-
-const LOCK_RETRY_MS = 25;
-const LOCK_TIMEOUT_MS = 5_000;
-const LOCK_STALE_MS = 30_000;
-
-export const RETAIN_QUEUE_LOCK = {
-  retryMs: LOCK_RETRY_MS,
-  timeoutMs: LOCK_TIMEOUT_MS,
-  staleMs: LOCK_STALE_MS,
-};
-
-export interface QueueLockOwner {
-  pid?: number;
-  acquiredAt?: string;
-  token?: string;
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function removeDirectory(path: string): Promise<void> {
-  await rm(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 });
-}
-
-async function writeQueueHeartbeat(lockPath: string, token: string): Promise<void> {
-  const heartbeatPath = `${lockPath}/heartbeat-${token}`;
-  const tmpPath = `${heartbeatPath}.${process.pid}.tmp`;
-  await writeFile(tmpPath, new Date().toISOString(), "utf8");
-  await rename(tmpPath, heartbeatPath);
-}
-
-async function writeQueueLockOwner(lockPath: string, token: string): Promise<void> {
-  const ownerPath = `${lockPath}/owner`;
-  const tmpPath = `${ownerPath}.${process.pid}.${token}.tmp`;
-  await writeFile(
-    tmpPath,
-    JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString(), token }),
-    "utf8",
-  );
-  await rename(tmpPath, ownerPath);
-  await writeQueueHeartbeat(lockPath, token);
-}
-
-function startQueueLockHeartbeat(lockPath: string, token: string): NodeJS.Timeout {
-  const heartbeatMs = Math.max(1, Math.min(5_000, Math.floor(RETAIN_QUEUE_LOCK.staleMs / 2)));
-  const heartbeat = setInterval(() => {
-    void writeQueueHeartbeat(lockPath, token).catch(() => undefined);
-  }, heartbeatMs);
-  heartbeat.unref?.();
-  return heartbeat;
-}
-
-export function isQueueLockOwnerStale(
-  owner: QueueLockOwner | undefined,
-  now = Date.now(),
-  staleMs = RETAIN_QUEUE_LOCK.staleMs,
-): boolean {
-  if (!owner) return true;
-  const acquiredAt = owner.acquiredAt ? Date.parse(owner.acquiredAt) : Number.NaN;
-  return !Number.isFinite(acquiredAt) || now - acquiredAt > staleMs;
-}
-
-async function readQueueLockOwner(lockPath: string): Promise<QueueLockOwner | undefined> {
-  try {
-    return JSON.parse(await readFile(`${lockPath}/owner`, "utf8")) as QueueLockOwner;
-  } catch {
-    return undefined;
-  }
-}
-
-async function isOwnerlessLockDirectoryStale(lockPath: string): Promise<boolean> {
-  try {
-    const info = await stat(lockPath);
-    return Date.now() - info.mtimeMs > RETAIN_QUEUE_LOCK.staleMs;
-  } catch {
-    return true;
-  }
-}
-
-async function isQueueLockStale(lockPath: string, owner: QueueLockOwner): Promise<boolean> {
-  if (!owner.token) return isQueueLockOwnerStale(owner);
-  try {
-    const heartbeat = await stat(`${lockPath}/heartbeat-${owner.token}`);
-    return Date.now() - heartbeat.mtimeMs > RETAIN_QUEUE_LOCK.staleMs;
-  } catch {
-    return isQueueLockOwnerStale(owner);
-  }
-}
-
-async function removeLockIfOwned(lockPath: string, token: string): Promise<void> {
-  const owner = await readQueueLockOwner(lockPath);
-  if (owner?.token === token) await removeDirectory(lockPath);
-}
-
-function staleClaimPath(lockPath: string): string {
-  return `${lockPath}.stale-claim`;
-}
-
-async function isStaleCleanupClaimActive(lockPath: string): Promise<boolean> {
-  const claimPath = staleClaimPath(lockPath);
-  try {
-    const info = await stat(claimPath);
-    if (Date.now() - info.mtimeMs <= RETAIN_QUEUE_LOCK.staleMs) return true;
-    await removeDirectory(claimPath);
-    return false;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
-    throw error;
-  }
-}
-
-async function withStaleCleanupClaim<T>(
-  lockPath: string,
-  fn: () => Promise<T>,
-): Promise<T | undefined> {
-  const claimPath = staleClaimPath(lockPath);
-  try {
-    await mkdir(claimPath, { recursive: false });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "EEXIST") return undefined;
-    throw error;
-  }
-  try {
-    return await fn();
-  } finally {
-    await removeDirectory(claimPath);
-  }
-}
-
-async function removeLockIfStillStale(lockPath: string): Promise<boolean> {
-  return (
-    (await withStaleCleanupClaim(lockPath, async () => {
-      const owner = await readQueueLockOwner(lockPath);
-      const stale = owner
-        ? await isQueueLockStale(lockPath, owner)
-        : await isOwnerlessLockDirectoryStale(lockPath);
-      if (!stale) return false;
-      await removeDirectory(lockPath);
-      return true;
-    })) ?? false
-  );
-}
-
-async function acquireFileLock(path: string): Promise<() => Promise<void>> {
-  const lockPath = `${path}.lock`;
-  const started = Date.now();
-  await mkdir(dirname(path), { recursive: true });
-  while (true) {
-    if (await isStaleCleanupClaimActive(lockPath)) {
-      if (Date.now() - started > RETAIN_QUEUE_LOCK.timeoutMs)
-        throw new Error(`Timed out waiting for retain queue lock ${lockPath}`);
-      await sleep(RETAIN_QUEUE_LOCK.retryMs);
-      continue;
-    }
-    const token = randomUUID();
-    try {
-      await mkdir(lockPath, { recursive: false });
-      try {
-        await writeQueueLockOwner(lockPath, token);
-      } catch (error) {
-        await removeDirectory(lockPath);
-        if (["ENOENT", "EINVAL"].includes((error as NodeJS.ErrnoException).code ?? "")) continue;
-        throw error;
-      }
-      const heartbeat = startQueueLockHeartbeat(lockPath, token);
-      return async () => {
-        clearInterval(heartbeat);
-        await removeLockIfOwned(lockPath, token);
-      };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      if (await removeLockIfStillStale(lockPath)) continue;
-      if (Date.now() - started > RETAIN_QUEUE_LOCK.timeoutMs)
-        throw new Error(`Timed out waiting for retain queue lock ${lockPath}`);
-      await sleep(RETAIN_QUEUE_LOCK.retryMs);
-    }
-  }
-}
-
-async function withQueueLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
-  const previous = queueLocks.get(path) ?? Promise.resolve();
-  let release!: () => void;
-  const next = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const lock = previous.catch(() => undefined).then(() => next);
-  queueLocks.set(path, lock);
-  await previous.catch(() => undefined);
-  const releaseFileLock = await acquireFileLock(path);
-  try {
-    return await fn();
-  } finally {
-    try {
-      await releaseFileLock();
-    } finally {
-      release();
-      if (queueLocks.get(path) === lock) queueLocks.delete(path);
-    }
-  }
-}
+export { RETAIN_QUEUE_LOCK, isQueueLockOwnerStale, type QueueLockOwner } from "./queue-lock.js";
 
 export function resolveQueuePath(cwd: string, queuePath: string): string {
   return isAbsolute(queuePath) ? queuePath : join(cwd, queuePath);
@@ -224,23 +29,14 @@ export interface EnqueueRetainJobResult {
   currentLength: number;
 }
 
-async function countQueuedLines(path: string): Promise<number> {
-  try {
-    return (await readFile(path, "utf8")).split("\n").filter(Boolean).length;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
-    throw error;
-  }
-}
-
 export async function enqueueRetainJobWithStats(
   path: string,
   job: RetainJob,
 ): Promise<EnqueueRetainJobResult> {
   return withQueueLock(path, async () => {
-    const previousLength = await countQueuedLines(path);
-    await mkdir(dirname(path), { recursive: true });
-    await appendFile(path, `${JSON.stringify(job)}\n`, "utf8");
+    const store = retainQueueStore(path);
+    const previousLength = await store.count();
+    await store.append([job]);
     return { previousLength, currentLength: previousLength + 1 };
   });
 }
@@ -250,78 +46,30 @@ export async function enqueueRetainJob(path: string, job: RetainJob): Promise<vo
 }
 
 export async function readRetainQueue(path: string): Promise<RetainJob[]> {
-  try {
-    const text = await readFile(path, "utf8");
-    return text
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as RetainJob);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-    throw error;
-  }
+  return retainQueueStore(path).readStrict();
 }
 
 export async function readDeadLetterQueue(path: string): Promise<RetainJob[]> {
   return readRetainQueue(resolveDeadLetterQueuePath(path));
 }
 
-export interface RetainQueueFileSummary {
-  path: string;
-  valid: number;
-  malformed: number;
-  error: string | null;
-}
+export type RetainQueueFileSummary = JsonlQueueFileSummary;
 
 export interface RetainQueueSummary {
   active: RetainQueueFileSummary;
   deadLetter: RetainQueueFileSummary;
 }
 
-async function summarizeQueueFile(path: string): Promise<RetainQueueFileSummary> {
-  try {
-    const text = await readFile(path, "utf8");
-    let valid = 0;
-    let malformed = 0;
-    for (const line of text.split("\n").filter(Boolean)) {
-      try {
-        JSON.parse(line) as RetainJob;
-        valid += 1;
-      } catch {
-        malformed += 1;
-      }
-    }
-    return { path, valid, malformed, error: null };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { path, valid: 0, malformed: 0, error: null };
-    }
-    return {
-      path,
-      valid: 0,
-      malformed: 0,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
-
 export async function summarizeRetainQueue(path: string): Promise<RetainQueueSummary> {
   const [active, deadLetter] = await Promise.all([
-    summarizeQueueFile(path),
-    summarizeQueueFile(resolveDeadLetterQueuePath(path)),
+    retainQueueStore(path).summarize(),
+    retainQueueStore(resolveDeadLetterQueuePath(path)).summarize(),
   ]);
   return { active, deadLetter };
 }
 
 export async function writeRetainQueue(path: string, jobs: RetainJob[]): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp`;
-  await writeFile(
-    tmp,
-    jobs.map((job) => JSON.stringify(job)).join("\n") + (jobs.length ? "\n" : ""),
-    "utf8",
-  );
-  await rename(tmp, path);
+  await retainQueueStore(path).replace(jobs);
 }
 
 async function appendDeadLetterJobs(path: string, jobs: RetainJob[]): Promise<number> {
@@ -336,12 +84,7 @@ async function appendDeadLetterJobs(path: string, jobs: RetainJob[]): Promise<nu
     return true;
   });
   if (newJobs.length === 0) return 0;
-  await mkdir(dirname(deadLetterPath), { recursive: true });
-  await appendFile(
-    deadLetterPath,
-    newJobs.map((job) => JSON.stringify(job)).join("\n") + "\n",
-    "utf8",
-  );
+  await retainQueueStore(deadLetterPath).append(newJobs);
   return newJobs.length;
 }
 
@@ -357,11 +100,6 @@ export interface FlushRetainQueueResult {
   remaining: number;
   deadLettered: number;
   malformed: number;
-}
-
-interface ParsedQueueFile {
-  jobs: RetainJob[];
-  malformedLines: string[];
 }
 
 function isRetainJob(value: unknown): value is RetainJob {
@@ -381,27 +119,12 @@ function isRetainJob(value: unknown): value is RetainJob {
   );
 }
 
-async function readRetainQueueTolerant(path: string): Promise<ParsedQueueFile> {
-  try {
-    const text = await readFile(path, "utf8");
-    const jobs: RetainJob[] = [];
-    const malformedLines: string[] = [];
-    for (const line of text.split("\n").filter(Boolean)) {
-      try {
-        const parsed = JSON.parse(line) as unknown;
-        if (isRetainJob(parsed)) jobs.push(parsed);
-        else malformedLines.push(line);
-      } catch {
-        malformedLines.push(line);
-      }
-    }
-    return { jobs, malformedLines };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { jobs: [], malformedLines: [] };
-    }
-    throw error;
-  }
+function retainQueueStore(path: string): JsonlQueueStore<RetainJob> {
+  return new JsonlQueueStore(path, isRetainJob);
+}
+
+async function readRetainQueueTolerant(path: string) {
+  return retainQueueStore(path).readTolerant();
 }
 
 async function appendMalformedQueueLines(path: string, lines: string[]): Promise<void> {


### PR DESCRIPTION
## Summary
- move retain queue lock/heartbeat/stale cleanup into queue-lock module
- move JSONL queue storage operations into JsonlQueueStore
- keep queue.ts focused on retain queue policy, delivery, retries, malformed quarantine, and dead-letter decisions
- preserve queue public exports through queue.ts

## Verification
- npm run check
- npm run typecheck:tsc

## Reviews
- subagent reviewer accepted; redundant mkdir cleanup applied