### PR TITLE
refactor(client): separate REST transport fallback

### DIFF
--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -1,0 +1,88 @@
+import type { ResolvedConfig } from "./types.js";
+
+export interface HindsightRestTransport {
+  request(path: string, init?: RequestInit): Promise<unknown>;
+}
+
+export interface HindsightHealthResponse {
+  status?: string;
+}
+
+export interface HindsightReflectResponse {
+  text?: string;
+  result?: unknown;
+}
+
+export interface HindsightRestError extends Error {
+  status?: number;
+  body?: unknown;
+}
+
+function baseUrl(config: ResolvedConfig): string {
+  return config.hindsight.baseUrl.replace(/\/$/, "");
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function assertRestObject(value: unknown, operation: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${operation} returned non-object response`);
+  return value;
+}
+
+export function assertHealthResponse(value: unknown): HindsightHealthResponse {
+  return isRecord(value) ? (value as HindsightHealthResponse) : {};
+}
+
+export function assertReflectResponse(value: unknown): HindsightReflectResponse {
+  return assertRestObject(value, "hindsight reflect") as HindsightReflectResponse;
+}
+
+export function createHindsightRestTransport(config: ResolvedConfig): HindsightRestTransport {
+  return {
+    async request(path, init = {}) {
+      const headers = new Headers(init.headers);
+      headers.set("User-Agent", "pi-hindsight/0.1.0");
+      if (!headers.has("Content-Type") && init.body)
+        headers.set("Content-Type", "application/json");
+      if (config.hindsight.apiKey)
+        headers.set("Authorization", `Bearer ${config.hindsight.apiKey}`);
+      const response = await fetch(`${baseUrl(config)}${path}`, { ...init, headers });
+      const body = (await response.json().catch(() => undefined)) as unknown;
+      if (!response.ok) {
+        const error = new Error(
+          `Hindsight request failed with status ${response.status}: ${JSON.stringify(body)}`,
+        ) as HindsightRestError;
+        error.status = response.status;
+        error.body = body;
+        throw error;
+      }
+      return body;
+    },
+  };
+}
+
+export function reflectRequestBody(
+  query: string,
+  options: {
+    context?: string;
+    budget?: string;
+    responseSchema?: unknown;
+    tags?: string[];
+    tagsMatch?: string;
+  } = {},
+): Record<string, unknown> {
+  return {
+    query,
+    ...(options.context ? { context: options.context } : {}),
+    budget: options.budget ?? "low",
+    ...(options.responseSchema ? { response_schema: options.responseSchema } : {}),
+    ...(options.tags ? { tags: options.tags } : {}),
+    ...(options.tagsMatch ? { tags_match: options.tagsMatch } : {}),
+  };
+}
+
+export function encodeBankPath(bankId: string, suffix: string): string {
+  return `/v1/default/banks/${encodeURIComponent(bankId)}${suffix}`;
+}

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -1,43 +1,50 @@
 import { HindsightClient } from "@vectorize-io/hindsight-client";
 import { redactError } from "./sanitize.js";
 import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
+import {
+  assertHealthResponse,
+  assertReflectResponse,
+  createHindsightRestTransport,
+  encodeBankPath,
+  reflectRequestBody,
+} from "./client-rest.js";
+import { withTimeout } from "./timeout.js";
 
-async function fetchJson(
-  config: ResolvedConfig,
-  path: string,
-  init: RequestInit = {},
-): Promise<unknown> {
-  const headers = new Headers(init.headers);
-  headers.set("User-Agent", "pi-hindsight/0.1.0");
-  if (config.hindsight.apiKey) headers.set("Authorization", `Bearer ${config.hindsight.apiKey}`);
-  const response = await fetch(`${config.hindsight.baseUrl.replace(/\/$/, "")}${path}`, {
-    ...init,
-    headers,
-  });
-  const body = (await response.json().catch(() => undefined)) as unknown;
-  if (!response.ok) throw new Error(`Hindsight request failed with status ${response.status}`);
-  return body;
+type ReflectOptions = Parameters<HindsightLikeClient["reflect"]>[2];
+
+function retainBatchItem(content: string, options: Parameters<HindsightLikeClient["retain"]>[2]) {
+  return {
+    content,
+    ...(options?.timestamp ? { timestamp: options.timestamp } : {}),
+    ...(options?.context ? { context: options.context } : {}),
+    ...(options?.metadata ? { metadata: options.metadata } : {}),
+    ...(options?.documentId ? { document_id: options.documentId } : {}),
+    ...(options?.entities?.length ? { entities: options.entities } : {}),
+    ...(options?.tags ? { tags: options.tags } : {}),
+    ...(options?.observationScopes?.length
+      ? { observation_scopes: options.observationScopes }
+      : {}),
+    ...(options?.updateMode ? { update_mode: options.updateMode } : {}),
+  };
 }
 
-async function withTimeout<T>(
-  promise: Promise<T>,
-  timeoutMs: number,
-  operation: string,
-): Promise<T> {
-  let timer: NodeJS.Timeout | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(
-          () => reject(new Error(`${operation} timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
+async function reflect(
+  args: {
+    raw: HindsightClient;
+    rest: ReturnType<typeof createHindsightRestTransport>;
+    bankId: string;
+    query: string;
+    options: ReflectOptions;
+  },
+  signal: AbortSignal,
+): Promise<unknown> {
+  if (!args.options?.responseSchema) return args.raw.reflect(args.bankId, args.query, args.options);
+  const response = await args.rest.request(encodeBankPath(args.bankId, "/reflect"), {
+    method: "POST",
+    signal,
+    body: JSON.stringify(reflectRequestBody(args.query, args.options)),
+  });
+  return assertReflectResponse(response);
 }
 
 export function createHindsightClient(config: ResolvedConfig): HindsightLikeClient {
@@ -46,92 +53,42 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
     ...(config.hindsight.apiKey ? { apiKey: config.hindsight.apiKey } : {}),
     userAgent: "pi-hindsight/0.1.0",
   });
+  const rest = createHindsightRestTransport(config);
   const timeoutMs = config.hindsight.timeoutMs;
-  const reflectWithResponseSchema = async (
-    bankId: string,
-    query: string,
-    options: Parameters<HindsightLikeClient["reflect"]>[2],
-  ): Promise<unknown> => {
-    if (!options?.responseSchema) return raw.reflect(bankId, query, options);
-    const response = await fetch(
-      `${config.hindsight.baseUrl.replace(/\/$/, "")}/v1/default/banks/${encodeURIComponent(bankId)}/reflect`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(config.hindsight.apiKey
-            ? { Authorization: `Bearer ${config.hindsight.apiKey}` }
-            : {}),
-          "User-Agent": "pi-hindsight/0.1.0",
-        },
-        body: JSON.stringify({
-          query,
-          ...(options.context ? { context: options.context } : {}),
-          budget: options.budget ?? "low",
-          response_schema: options.responseSchema,
-          ...(options.tags ? { tags: options.tags } : {}),
-          ...(options.tagsMatch ? { tags_match: options.tagsMatch } : {}),
-        }),
-      },
-    );
-    const body = (await response.json().catch(() => undefined)) as unknown;
-    if (!response.ok) {
-      throw new Error(
-        `hindsight reflect failed with status ${response.status}: ${JSON.stringify(body)}`,
-      );
-    }
-    return body;
-  };
   return {
     retain: (bankId, content, options) =>
-      withTimeout(
+      withTimeout("hindsight retain", timeoutMs, () =>
         raw.retainBatch(
           bankId,
-          [
-            {
-              content,
-              ...(options?.timestamp ? { timestamp: options.timestamp } : {}),
-              ...(options?.context ? { context: options.context } : {}),
-              ...(options?.metadata ? { metadata: options.metadata } : {}),
-              ...(options?.documentId ? { document_id: options.documentId } : {}),
-              ...(options?.entities?.length ? { entities: options.entities } : {}),
-              ...(options?.tags ? { tags: options.tags } : {}),
-              ...(options?.observationScopes?.length
-                ? { observation_scopes: options.observationScopes }
-                : {}),
-              ...(options?.updateMode ? { update_mode: options.updateMode } : {}),
-            },
-          ],
+          [retainBatchItem(content, options)],
           options?.async !== undefined ? { async: options.async } : {},
         ),
-        timeoutMs,
-        "hindsight retain",
       ),
     retainBatch: (...args) =>
-      withTimeout(raw.retainBatch(...args), timeoutMs, "hindsight retainBatch"),
-    recall: (...args) => withTimeout(raw.recall(...args), timeoutMs, "hindsight recall"),
-    reflect: (...args) =>
-      withTimeout(reflectWithResponseSchema(...args), timeoutMs, "hindsight reflect"),
-    createBank: (...args) =>
-      withTimeout(raw.createBank(...args), timeoutMs, "hindsight createBank"),
-    getBankProfile: (...args) =>
-      withTimeout(raw.getBankProfile(...args), timeoutMs, "hindsight getBankProfile"),
-    getBankStats: (bankId) =>
-      withTimeout(
-        fetchJson(config, `/v1/default/banks/${encodeURIComponent(bankId)}/stats`),
-        timeoutMs,
-        "hindsight getBankStats",
+      withTimeout("hindsight retainBatch", timeoutMs, () => raw.retainBatch(...args)),
+    recall: (...args) => withTimeout("hindsight recall", timeoutMs, () => raw.recall(...args)),
+    reflect: (bankId, query, options) =>
+      withTimeout("hindsight reflect", timeoutMs, (signal) =>
+        reflect({ raw, rest, bankId, query, options }, signal),
       ),
-    health: () => withTimeout(fetchJson(config, "/health"), timeoutMs, "hindsight health"),
+    createBank: (...args) =>
+      withTimeout("hindsight createBank", timeoutMs, () => raw.createBank(...args)),
+    getBankProfile: (...args) =>
+      withTimeout("hindsight getBankProfile", timeoutMs, () => raw.getBankProfile(...args)),
+    getBankStats: (bankId) =>
+      withTimeout("hindsight getBankStats", timeoutMs, (signal) =>
+        rest.request(encodeBankPath(bankId, "/stats"), { signal }),
+      ),
+    health: () =>
+      withTimeout("hindsight health", timeoutMs, async (signal) =>
+        assertHealthResponse(await rest.request("/health", { signal })),
+      ),
     deleteDocument: (bankId, documentId) =>
-      withTimeout(
-        fetchJson(
-          config,
-          `/v1/default/banks/${encodeURIComponent(bankId)}/documents/${encodeURIComponent(documentId)}`,
-          { method: "DELETE" },
-        ),
-        timeoutMs,
-        "hindsight deleteDocument",
+      withTimeout("hindsight deleteDocument", timeoutMs, (signal) =>
+        rest.request(`${encodeBankPath(bankId, "/documents")}/${encodeURIComponent(documentId)}`, {
+          method: "DELETE",
+          signal,
+        }),
       ),
   };
 }

--- a/extensions/timeout.ts
+++ b/extensions/timeout.ts
@@ -1,0 +1,19 @@
+export async function withTimeout<T>(
+  operation: string,
+  timeoutMs: number,
+  fn: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(new Error(`${operation} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
+    return await Promise.race([fn(controller.signal), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertHealthResponse,
+  assertReflectResponse,
+  encodeBankPath,
+  reflectRequestBody,
+} from "../extensions/client-rest.js";
+
+describe("Hindsight REST transport helpers", () => {
+  it("maps reflect response schema options to Hindsight REST request shape", () => {
+    expect(
+      reflectRequestBody("query", {
+        context: "ctx",
+        budget: "mid",
+        responseSchema: { type: "object" },
+        tags: ["source:pi"],
+        tagsMatch: "any_strict",
+      }),
+    ).toEqual({
+      query: "query",
+      context: "ctx",
+      budget: "mid",
+      response_schema: { type: "object" },
+      tags: ["source:pi"],
+      tags_match: "any_strict",
+    });
+  });
+
+  it("encodes bank ids in REST paths", () => {
+    expect(encodeBankPath("bank/id", "/reflect")).toBe("/v1/default/banks/bank%2Fid/reflect");
+  });
+
+  it("asserts REST fallback response shapes", () => {
+    expect(assertHealthResponse({ status: "ok" })).toEqual({ status: "ok" });
+    expect(assertHealthResponse(null)).toEqual({});
+    expect(assertHealthResponse("ok")).toEqual({});
+    expect(assertReflectResponse({ text: "answer" })).toEqual({ text: "answer" });
+    expect(() => assertReflectResponse(null)).toThrow("non-object response");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
         "extensions/config*.ts",
         "extensions/memory-lifecycle*.ts",
         "extensions/client.ts",
+        "extensions/client-rest.ts",
+        "extensions/timeout.ts",
       ],
       thresholds: {
         statements: 60,
@@ -35,6 +37,18 @@ export default defineConfig({
           branches: 60,
           functions: 55,
           lines: 65,
+        },
+        "extensions/client-rest.ts": {
+          statements: 70,
+          branches: 65,
+          functions: 70,
+          lines: 70,
+        },
+        "extensions/timeout.ts": {
+          statements: 80,
+          branches: 75,
+          functions: 80,
+          lines: 80,
         },
       },
     },


### PR DESCRIPTION
## Summary
- split raw REST fallback helpers from the official Hindsight SDK adapter
- add abortable timeout helper for REST fallback calls
- add response-shape assertions for REST health/reflect fallback responses
- add REST helper contract tests and extend coverage gates to client-rest/timeout

## Verification
- npm run check:coverage
- npm run check
- npm run typecheck:tsc

## Reviews
- subagent reviewer rejected for missing coverage/response assertions; fixed and re-review accepted