### PR TITLE
ci: add release verification workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish to npm after verification
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci --engine-strict
+
+      - name: Run checks
+        run: npm run check
+
+      - name: Run coverage gate
+        run: npm run check:coverage
+
+      - name: Run TypeScript compiler fallback
+        run: npm run typecheck:tsc
+
+      - name: Verify release metadata and package install
+        run: npm run pack:verify
+
+      - name: Publish package
+        if: >-
+          startsWith(github.ref, 'refs/tags/v') ||
+          (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN secret is required to publish."
+            exit 1
+          fi
+          npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -495,10 +495,11 @@ The `version` script also regenerates and stages `CHANGELOG.md` during `npm vers
 Before publishing or tagging a release:
 
 1. Ensure `main` is synced.
-2. Run `npm run check`, `npm run check:coverage`, and `npm run typecheck:tsc`.
+2. Run `npm run check`, `npm run check:coverage`, `npm run typecheck:tsc`, and `npm run pack:verify`.
 3. Run `npm run smoke:hindsight` locally when a configured server is available, or check the `Hindsight Integration` workflow result.
 4. Run `npm run changelog` after final Conventional Commits.
 5. Use `npm version <patch|minor|major>` so the version script stages the regenerated changelog.
+6. Push a `v*.*.*` tag to run the release workflow. Publishing requires `NPM_TOKEN`; manual dispatch can verify only or publish when `publish=true`.
 
 Useful targeted checks:
 

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "typecheck:tsc": "tsc --noEmit",
     "lint": "oxlint --type-aware --type-check extensions tests",
     "lint:fix": "oxlint --type-aware --type-check --fix extensions tests",
-    "format": "oxfmt --check --no-error-on-unmatched-pattern \"extensions/**/*.ts\" \"tests/**/*.ts\" \"scripts/**/*.mjs\" \"docs/**/*.md\" \"README.md\" \"CHANGELOG.md\" \"package.json\" \"package-lock.json\" \"tsconfig.json\" \"vitest.config.ts\" \".oxfmtrc.json\" \".commitlintrc.json\" \"*.yml\" \".github/**/*.yml\"",
-    "format:fix": "oxfmt --write --no-error-on-unmatched-pattern \"extensions/**/*.ts\" \"tests/**/*.ts\" \"scripts/**/*.mjs\" \"docs/**/*.md\" \"README.md\" \"CHANGELOG.md\" \"package.json\" \"package-lock.json\" \"tsconfig.json\" \"vitest.config.ts\" \".oxfmtrc.json\" \".commitlintrc.json\" \"*.yml\" \".github/**/*.yml\"",
+    "format": "oxfmt --check --no-error-on-unmatched-pattern \"extensions/**/*.ts\" \"tests/**/*.ts\" \"tests/**/*.mjs\" \"scripts/**/*.mjs\" \"docs/**/*.md\" \"README.md\" \"CHANGELOG.md\" \"package.json\" \"package-lock.json\" \"tsconfig.json\" \"vitest.config.ts\" \".oxfmtrc.json\" \".commitlintrc.json\" \"*.yml\" \".github/**/*.yml\"",
+    "format:fix": "oxfmt --write --no-error-on-unmatched-pattern \"extensions/**/*.ts\" \"tests/**/*.ts\" \"tests/**/*.mjs\" \"scripts/**/*.mjs\" \"docs/**/*.md\" \"README.md\" \"CHANGELOG.md\" \"package.json\" \"package-lock.json\" \"tsconfig.json\" \"vitest.config.ts\" \".oxfmtrc.json\" \".commitlintrc.json\" \"*.yml\" \".github/**/*.yml\"",
     "check": "npm run format && npm run lint && npm run typecheck && npm test",
     "check:ci": "npm run check && npm run check:coverage",
-    "check:release": "npm run check && npm run typecheck:tsc && npm run smoke:hindsight",
+    "check:release": "npm run check && npm run check:coverage && npm run typecheck:tsc && npm run pack:verify && npm run smoke:hindsight",
     "install-hooks": "git rev-parse --git-dir >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
     "prepare": "npm run install-hooks",
     "precommit": "npm run check",
@@ -50,7 +50,9 @@
     "changelog": "node scripts/generate-changelog.mjs",
     "version": "npm run changelog && npm run format:fix && git add CHANGELOG.md",
     "test:coverage": "vitest run --coverage",
-    "check:coverage": "npm run test:coverage"
+    "check:coverage": "npm run test:coverage",
+    "pack:verify": "npm run release:verify && npm pack --dry-run && node scripts/install-smoke.mjs",
+    "release:verify": "node scripts/verify-release.mjs"
   },
   "dependencies": {
     "@vectorize-io/hindsight-client": "^0.5.4",

--- a/scripts/install-smoke.mjs
+++ b/scripts/install-smoke.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+async function main() {
+  const cwd = process.cwd();
+  const pack = await execFileAsync("npm", ["pack", "--json"], { cwd });
+  const [entry] = JSON.parse(pack.stdout);
+  if (!entry?.filename) throw new Error("npm pack did not return a tarball filename");
+  const tarball = join(cwd, entry.filename);
+  const dir = await mkdtemp(join(tmpdir(), "pi-hindsight-install-smoke-"));
+  try {
+    await execFileAsync("npm", ["init", "-y"], { cwd: dir });
+    await execFileAsync("npm", ["install", tarball, "--ignore-scripts"], { cwd: dir });
+    const installed = JSON.parse(
+      await readFile(join(dir, "node_modules", "@luxus", "pi-hindsight", "package.json"), "utf8"),
+    );
+    if (!installed.pi?.extensions?.includes("./extensions")) {
+      throw new Error("installed package missing pi.extensions entry");
+    }
+    await readFile(
+      join(dir, "node_modules", "@luxus", "pi-hindsight", "extensions", "index.ts"),
+      "utf8",
+    );
+    console.log(JSON.stringify({ ok: true, package: installed.name, version: installed.version }));
+  } finally {
+    await rm(tarball, { force: true });
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+
+const pkg = JSON.parse(await readFile("package.json", "utf8"));
+const version = pkg.version;
+if (!version) throw new Error("package.json missing version");
+
+const refName = process.env.GITHUB_REF_NAME;
+if (refName?.startsWith("v")) {
+  const tagVersion = refName.slice(1);
+  if (tagVersion !== version) {
+    throw new Error(`Release tag ${refName} does not match package.json version ${version}`);
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const changelog = await readFile("CHANGELOG.md", "utf8");
+const escapedVersion = escapeRegExp(version);
+const versionHeading = new RegExp(
+  `^## (?:\\[${escapedVersion}\\]|${escapedVersion})(?:\\s|$|\\])`,
+  "m",
+);
+if (!versionHeading.test(changelog)) {
+  throw new Error(`CHANGELOG.md missing release heading for ${version}`);
+}
+
+console.log(JSON.stringify({ ok: true, version, refName: refName ?? null }));

--- a/tests/verify-release.test.mjs
+++ b/tests/verify-release.test.mjs
@@ -1,0 +1,43 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const script = resolve("scripts/verify-release.mjs");
+
+async function repo(version, changelog) {
+  const dir = await mkdtemp(join(tmpdir(), "verify-release-"));
+  await writeFile(join(dir, "package.json"), JSON.stringify({ version }), "utf8");
+  await writeFile(join(dir, "CHANGELOG.md"), changelog, "utf8");
+  return dir;
+}
+
+describe("verify-release", () => {
+  it("accepts exact changelog version heading", async () => {
+    const cwd = await repo("1.2.3", "## [1.2.3] - 2026-01-01\n");
+    await expect(execFileAsync("node", [script], { cwd })).resolves.toMatchObject({
+      stdout: expect.stringContaining('"version":"1.2.3"'),
+    });
+  });
+
+  it("rejects substring changelog version heading", async () => {
+    const cwd = await repo("1.2.3", "## [11.2.3] - 2026-01-01\n");
+    await expect(execFileAsync("node", [script], { cwd })).rejects.toMatchObject({
+      stderr: expect.stringContaining("CHANGELOG.md missing release heading for 1.2.3"),
+    });
+  });
+
+  it("rejects mismatched tag version", async () => {
+    const cwd = await repo("1.2.3", "## [1.2.3] - 2026-01-01\n");
+    await expect(
+      execFileAsync("node", [script], { cwd, env: { ...process.env, GITHUB_REF_NAME: "v1.2.4" } }),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining(
+        "Release tag v1.2.4 does not match package.json version 1.2.3",
+      ),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add release workflow for version tags and manual dispatch
- verify checks, coverage, tsc fallback, package metadata, pack contents, and install smoke before publish
- guard npm publish behind version tag or manual publish=true plus NPM_TOKEN
- add release metadata verification for tag/package version and changelog heading
- document release verification path

## Verification
- npm run pack:verify
- npm run check:coverage
- npm run check
- npm run typecheck:tsc
- GITHUB_REF_NAME=v0.2.0 node scripts/verify-release.mjs fails as expected

## Reviews
- subagent reviewer rejected for missing tag/package/changelog verification; fixed and re-review accepted