### PR TITLE
refactor(smoke): extract helper utilities

### DIFF
--- a/scripts/smoke-helpers.mjs
+++ b/scripts/smoke-helpers.mjs
@@ -1,0 +1,42 @@
+export function envValue(name, env = process.env) {
+  const value = env[name]?.trim();
+  return value ? value : undefined;
+}
+
+export function smokeConfig(env = process.env, now = Date.now()) {
+  return {
+    baseUrl: envValue("HINDSIGHT_BASE_URL", env) ?? "http://localhost:8888",
+    apiKey: envValue("HINDSIGHT_API_KEY", env),
+    bankId: envValue("PI_HINDSIGHT_SMOKE_BANK_ID", env) ?? `pi-hindsight-smoke-${now}`,
+    attempts: Number(env.HINDSIGHT_SMOKE_ATTEMPTS ?? 20),
+  };
+}
+
+export function smokeMarker(now = Date.now(), random = Math.random()) {
+  return `pi-hindsight-smoke-${now}-${random.toString(16).slice(2)}`;
+}
+
+export function logStep(step, data = {}, output = console.log) {
+  output(JSON.stringify({ step, ...data }));
+}
+
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function retry(fn, predicate, options) {
+  const { attempts, delayMs, onWait = () => undefined, failureMessage } = options;
+  let last;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    last = await fn();
+    if (predicate(last)) return last;
+    onWait({ attempt, delayMs, last });
+    await sleep(delayMs);
+  }
+  const preview = JSON.stringify(last).slice(0, 1000);
+  throw new Error(
+    failureMessage
+      ? failureMessage({ attempts, last, preview })
+      : `retry predicate failed after ${attempts} attempts: ${preview}`,
+  );
+}

--- a/scripts/smoke-hindsight.mjs
+++ b/scripts/smoke-hindsight.mjs
@@ -1,50 +1,40 @@
 #!/usr/bin/env node
 import { HindsightClient } from "@vectorize-io/hindsight-client";
+import { logStep, retry, smokeConfig, smokeMarker } from "./smoke-helpers.mjs";
 
-function envValue(name) {
-  const value = process.env[name]?.trim();
-  return value ? value : undefined;
-}
-
-const baseUrl = envValue("HINDSIGHT_BASE_URL") ?? "http://localhost:8888";
-const apiKey = envValue("HINDSIGHT_API_KEY");
-const bankId = envValue("PI_HINDSIGHT_SMOKE_BANK_ID") ?? `pi-hindsight-smoke-${Date.now()}`;
-const marker = `pi-hindsight-smoke-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+const config = smokeConfig();
+const marker = smokeMarker();
 
 const client = new HindsightClient({
-  baseUrl,
-  ...(apiKey ? { apiKey } : {}),
+  baseUrl: config.baseUrl,
+  ...(config.apiKey ? { apiKey: config.apiKey } : {}),
   userAgent: "pi-hindsight-smoke/0.1.0",
 });
 
-function log(step, data = {}) {
-  console.log(JSON.stringify({ step, ...data }));
-}
-
 try {
-  log("start", { baseUrl, bankId });
-  await client.createBank(bankId, {
-    name: bankId,
+  logStep("start", { baseUrl: config.baseUrl, bankId: config.bankId });
+  await client.createBank(config.bankId, {
+    name: config.bankId,
     reflectMission: "Smoke-test bank for Pi Hindsight extension development.",
     retainMission:
       "Retain exact smoke-test markers as durable facts. Preserve marker strings verbatim.",
     retainExtractionMode: "verbose",
     enableObservations: true,
   });
-  log("bank_ok");
+  logStep("bank_ok");
 
-  await client.retain(bankId, `Smoke marker: ${marker}`, {
+  await client.retain(config.bankId, `Smoke marker: ${marker}`, {
     context: "Pi Hindsight smoke test",
     documentId: `pi-smoke:${marker}`,
     updateMode: "append",
     tags: ["source:pi", "test:smoke"],
     metadata: { marker },
   });
-  log("retain_ok", { marker });
+  logStep("retain_ok", { marker });
 
   const recall = await retry(
     async () =>
-      client.recall(bankId, marker, {
+      client.recall(config.bankId, marker, {
         budget: "mid",
         maxTokens: 1000,
         tags: ["test:smoke"],
@@ -53,19 +43,28 @@ try {
         maxSourceFactsTokens: 2000,
       }),
     (result) => JSON.stringify(result).includes(marker),
-    Number(process.env.HINDSIGHT_SMOKE_ATTEMPTS ?? 20),
-    2000,
+    {
+      attempts: config.attempts,
+      delayMs: 2000,
+      onWait: ({ attempt, delayMs }) => logStep("recall_wait", { attempt, delayMs }),
+      failureMessage: ({ attempts, preview }) =>
+        `recall did not contain retained marker after ${attempts} attempts: ${preview}`,
+    },
   );
-  log("recall_ok", { containsMarker: JSON.stringify(recall).includes(marker) });
+  logStep("recall_ok", { containsMarker: JSON.stringify(recall).includes(marker) });
 
-  const reflection = await client.reflect(bankId, `What smoke marker was retained? ${marker}`, {
-    budget: "low",
-    tags: ["test:smoke"],
-    tagsMatch: "any_strict",
-  });
-  log("reflect_ok", { responsePreview: JSON.stringify(reflection).slice(0, 300) });
+  const reflection = await client.reflect(
+    config.bankId,
+    `What smoke marker was retained? ${marker}`,
+    {
+      budget: "low",
+      tags: ["test:smoke"],
+      tagsMatch: "any_strict",
+    },
+  );
+  logStep("reflect_ok", { responsePreview: JSON.stringify(reflection).slice(0, 300) });
 
-  log("success", { bankId, marker });
+  logStep("success", { bankId: config.bankId, marker });
 } catch (error) {
   console.error(
     JSON.stringify({
@@ -74,17 +73,4 @@ try {
     }),
   );
   process.exitCode = 1;
-}
-
-async function retry(fn, predicate, attempts, delayMs) {
-  let last;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    last = await fn();
-    if (predicate(last)) return last;
-    log("recall_wait", { attempt, delayMs });
-    await new Promise((resolve) => setTimeout(resolve, delayMs));
-  }
-  throw new Error(
-    `recall did not contain retained marker after ${attempts} attempts: ${JSON.stringify(last).slice(0, 1000)}`,
-  );
 }

--- a/tests/smoke-helpers.test.mjs
+++ b/tests/smoke-helpers.test.mjs
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { envValue, logStep, retry, smokeConfig, smokeMarker } from "../scripts/smoke-helpers.mjs";
+
+describe("smoke helpers", () => {
+  it("normalizes empty env values", () => {
+    expect(envValue("KEY", { KEY: " value " })).toBe("value");
+    expect(envValue("KEY", { KEY: "   " })).toBeUndefined();
+    expect(envValue("KEY", {})).toBeUndefined();
+  });
+
+  it("builds smoke config with defaults and overrides", () => {
+    expect(smokeConfig({}, 123)).toMatchObject({
+      baseUrl: "http://localhost:8888",
+      bankId: "pi-hindsight-smoke-123",
+      attempts: 20,
+    });
+    expect(
+      smokeConfig(
+        {
+          HINDSIGHT_BASE_URL: " https://h.example ",
+          HINDSIGHT_API_KEY: " key ",
+          PI_HINDSIGHT_SMOKE_BANK_ID: " bank ",
+          HINDSIGHT_SMOKE_ATTEMPTS: "3",
+        },
+        123,
+      ),
+    ).toEqual({ baseUrl: "https://h.example", apiKey: "key", bankId: "bank", attempts: 3 });
+  });
+
+  it("creates deterministic markers when clock/random are injected", () => {
+    expect(smokeMarker(123, 0.5)).toBe("pi-hindsight-smoke-123-8");
+  });
+
+  it("logs JSON step lines", () => {
+    const output = vi.fn();
+    logStep("retain_ok", { marker: "m" }, output);
+    expect(output).toHaveBeenCalledWith('{"step":"retain_ok","marker":"m"}');
+  });
+
+  it("retries until predicate passes", async () => {
+    vi.useFakeTimers();
+    const fn = vi.fn(async () => fn.mock.calls.length);
+    const onWait = vi.fn();
+    const resultPromise = retry(fn, (value) => value === 3, { attempts: 4, delayMs: 10, onWait });
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(resultPromise).resolves.toBe(3);
+    expect(onWait).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("throws after retry attempts are exhausted", async () => {
+    await expect(
+      retry(
+        async () => "no",
+        () => false,
+        { attempts: 2, delayMs: 0 },
+      ),
+    ).rejects.toThrow("retry predicate failed after 2 attempts");
+  });
+
+  it("supports caller-specific failure messages", async () => {
+    await expect(
+      retry(
+        async () => "no",
+        () => false,
+        {
+          attempts: 2,
+          delayMs: 0,
+          failureMessage: ({ attempts, preview }) => `custom ${attempts}: ${preview}`,
+        },
+      ),
+    ).rejects.toThrow('custom 2: "no"');
+  });
+});


### PR DESCRIPTION
## Summary
- extract smoke env/config, marker, JSON step logging, sleep, and retry helpers
- keep current smoke behavior and step names unchanged
- preserve old recall failure wording via helper callback
- add helper unit tests for env parsing, config, marker, logging, retry success/failure

## Verification
- npm run check:coverage
- npm run check
- npm run typecheck:tsc

## Reviews
- subagent reviewer rejected behavior-change in retry error text; fixed and re-review accepted