### PR TITLE
feat(smoke): add timings and GitHub summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ export HINDSIGHT_BASE_URL=http://localhost:8888
 npm run smoke:hindsight
 ```
 
-The smoke test creates a temporary bank, retains a unique marker with `updateMode: "append"`, recalls it, and runs `reflect`. It uses the configured Hindsight server; it does not start a server and it prints step markers (`bank_ok`, `retain_ok`, `recall_ok`, `reflect_ok`) so failures identify the broken integration stage. For release verification with a configured Hindsight server, run:
+The smoke test creates a temporary bank, retains a unique marker with `updateMode: "append"`, recalls it, and runs `reflect`. It uses the configured Hindsight server; it does not start a server and it prints JSON step markers (`bank_ok`, `retain_ok`, `recall_ok`, `reflect_ok`) with elapsed duration so failures identify the broken integration stage. In GitHub Actions it also writes a Markdown step summary. For release verification with a configured Hindsight server, run:
 
 ```bash
 export HINDSIGHT_BASE_URL=http://localhost:8888

--- a/scripts/smoke-helpers.mjs
+++ b/scripts/smoke-helpers.mjs
@@ -20,6 +20,46 @@ export function logStep(step, data = {}, output = console.log) {
   output(JSON.stringify({ step, ...data }));
 }
 
+export function createSmokeRecorder({ now = Date.now, output = console.log } = {}) {
+  const startedAt = now();
+  const steps = [];
+  return {
+    step(name, data = {}) {
+      const durationMs = now() - startedAt;
+      const entry = { step: name, durationMs, ...data };
+      steps.push(entry);
+      logStep(name, { durationMs, ...data }, output);
+      return entry;
+    },
+    entries() {
+      return [...steps];
+    },
+  };
+}
+
+export function renderSmokeSummary(entries, { title = "Hindsight smoke test" } = {}) {
+  const lines = [`## ${title}`, "", "| Step | Duration | Details |", "| --- | ---: | --- |"];
+  for (const entry of entries) {
+    const { step, durationMs, ...details } = entry;
+    lines.push(
+      `| ${step} | ${durationMs}ms | ${Object.keys(details).length ? `\`${JSON.stringify(details).replaceAll("`", "\\`")}\`` : ""} |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function writeGitHubSummary(markdown, env = process.env) {
+  const path = env.GITHUB_STEP_SUMMARY;
+  if (!path) return { written: false };
+  try {
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(path, markdown, "utf8");
+    return { written: true };
+  } catch (error) {
+    return { written: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
 export function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/scripts/smoke-hindsight.mjs
+++ b/scripts/smoke-hindsight.mjs
@@ -1,9 +1,17 @@
 #!/usr/bin/env node
 import { HindsightClient } from "@vectorize-io/hindsight-client";
-import { logStep, retry, smokeConfig, smokeMarker } from "./smoke-helpers.mjs";
+import {
+  createSmokeRecorder,
+  renderSmokeSummary,
+  retry,
+  smokeConfig,
+  smokeMarker,
+  writeGitHubSummary,
+} from "./smoke-helpers.mjs";
 
 const config = smokeConfig();
 const marker = smokeMarker();
+const recorder = createSmokeRecorder();
 
 const client = new HindsightClient({
   baseUrl: config.baseUrl,
@@ -12,7 +20,7 @@ const client = new HindsightClient({
 });
 
 try {
-  logStep("start", { baseUrl: config.baseUrl, bankId: config.bankId });
+  recorder.step("start", { baseUrl: config.baseUrl, bankId: config.bankId });
   await client.createBank(config.bankId, {
     name: config.bankId,
     reflectMission: "Smoke-test bank for Pi Hindsight extension development.",
@@ -21,7 +29,7 @@ try {
     retainExtractionMode: "verbose",
     enableObservations: true,
   });
-  logStep("bank_ok");
+  recorder.step("bank_ok");
 
   await client.retain(config.bankId, `Smoke marker: ${marker}`, {
     context: "Pi Hindsight smoke test",
@@ -30,7 +38,7 @@ try {
     tags: ["source:pi", "test:smoke"],
     metadata: { marker },
   });
-  logStep("retain_ok", { marker });
+  recorder.step("retain_ok", { marker });
 
   const recall = await retry(
     async () =>
@@ -46,12 +54,12 @@ try {
     {
       attempts: config.attempts,
       delayMs: 2000,
-      onWait: ({ attempt, delayMs }) => logStep("recall_wait", { attempt, delayMs }),
+      onWait: ({ attempt, delayMs }) => recorder.step("recall_wait", { attempt, delayMs }),
       failureMessage: ({ attempts, preview }) =>
         `recall did not contain retained marker after ${attempts} attempts: ${preview}`,
     },
   );
-  logStep("recall_ok", { containsMarker: JSON.stringify(recall).includes(marker) });
+  recorder.step("recall_ok", { containsMarker: JSON.stringify(recall).includes(marker) });
 
   const reflection = await client.reflect(
     config.bankId,
@@ -62,9 +70,9 @@ try {
       tagsMatch: "any_strict",
     },
   );
-  logStep("reflect_ok", { responsePreview: JSON.stringify(reflection).slice(0, 300) });
+  recorder.step("reflect_ok", { responsePreview: JSON.stringify(reflection).slice(0, 300) });
 
-  logStep("success", { bankId: config.bankId, marker });
+  recorder.step("success", { bankId: config.bankId, marker });
 } catch (error) {
   console.error(
     JSON.stringify({
@@ -73,4 +81,7 @@ try {
     }),
   );
   process.exitCode = 1;
+} finally {
+  const summary = await writeGitHubSummary(renderSmokeSummary(recorder.entries()));
+  if (summary.error) recorder.step("summary_failed", { error: summary.error });
 }

--- a/tests/smoke-helpers.test.mjs
+++ b/tests/smoke-helpers.test.mjs
@@ -1,5 +1,17 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { envValue, logStep, retry, smokeConfig, smokeMarker } from "../scripts/smoke-helpers.mjs";
+import {
+  createSmokeRecorder,
+  envValue,
+  logStep,
+  renderSmokeSummary,
+  retry,
+  smokeConfig,
+  smokeMarker,
+  writeGitHubSummary,
+} from "../scripts/smoke-helpers.mjs";
 
 describe("smoke helpers", () => {
   it("normalizes empty env values", () => {
@@ -70,5 +82,36 @@ describe("smoke helpers", () => {
         },
       ),
     ).rejects.toThrow('custom 2: "no"');
+  });
+
+  it("records timed steps while preserving JSONL output", () => {
+    const output = vi.fn();
+    let now = 100;
+    const recorder = createSmokeRecorder({ now: () => now, output });
+    now = 125;
+    recorder.step("retain_ok", { marker: "m" });
+
+    expect(output).toHaveBeenCalledWith('{"step":"retain_ok","durationMs":25,"marker":"m"}');
+    expect(recorder.entries()).toEqual([{ step: "retain_ok", durationMs: 25, marker: "m" }]);
+  });
+
+  it("renders GitHub summary markdown", () => {
+    expect(renderSmokeSummary([{ step: "retain_ok", durationMs: 25, marker: "m" }])).toContain(
+      "| retain_ok | 25ms | `",
+    );
+  });
+
+  it("writes GitHub summary when configured", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "smoke-summary-"));
+    const path = join(dir, "summary.md");
+
+    await expect(writeGitHubSummary("hello\n", { GITHUB_STEP_SUMMARY: path })).resolves.toEqual({
+      written: true,
+    });
+    await expect(readFile(path, "utf8")).resolves.toBe("hello\n");
+    await expect(writeGitHubSummary("hello\n", {})).resolves.toEqual({ written: false });
+    await expect(
+      writeGitHubSummary("hello\n", { GITHUB_STEP_SUMMARY: join(dir, "missing", "summary.md") }),
+    ).resolves.toMatchObject({ written: false, error: expect.any(String) });
   });
 });


### PR DESCRIPTION
## Summary
- add per-step smoke timings while preserving JSONL step output
- write a Markdown GitHub step summary when GITHUB_STEP_SUMMARY is available
- make summary writes best-effort so reporting cannot fail or mask smoke results
- document timing/summary behavior

## Verification
- npm run check:coverage
- npm run check
- npm run typecheck:tsc

## Reviews
- subagent reviewer rejected first because summary writes could fail/mask smoke result; fixed and re-review accepted