### PR TITLE
feat(smoke): clean up temporary banks on success

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ export HINDSIGHT_BASE_URL=http://localhost:8888
 npm run smoke:hindsight
 ```
 
-The smoke test creates a temporary bank, retains a unique marker with `updateMode: "append"`, recalls it, and runs `reflect`. It uses the configured Hindsight server; it does not start a server and it prints JSON step markers (`bank_ok`, `retain_ok`, `recall_ok`, `reflect_ok`) with elapsed duration so failures identify the broken integration stage. In GitHub Actions it also writes a Markdown step summary. For release verification with a configured Hindsight server, run:
+The smoke test creates a temporary bank, retains a unique marker with `updateMode: "append"`, recalls it, and runs `reflect`. It deletes temporary smoke banks after success and keeps artifacts after failure for debugging; if `PI_HINDSIGHT_SMOKE_BANK_ID` points at a configured bank, cleanup is skipped. It uses the configured Hindsight server; it does not start a server and it prints JSON step markers (`bank_ok`, `retain_ok`, `recall_ok`, `reflect_ok`, `cleanup_ok`) with elapsed duration so failures identify the broken integration stage. In GitHub Actions it also writes a Markdown step summary. For release verification with a configured Hindsight server, run:
 
 ```bash
 export HINDSIGHT_BASE_URL=http://localhost:8888
@@ -466,6 +466,7 @@ Optional secret and variables:
 
 - `HINDSIGHT_API_KEY` — only if the server requires an API key
 - `HINDSIGHT_SMOKE_ATTEMPTS` — recall retry attempts, default `20`
+- `HINDSIGHT_SMOKE_CLEANUP_TIMEOUT_MS` — best-effort cleanup timeout, default `5000`
 - `PI_HINDSIGHT_SMOKE_BANK_ID` — fixed smoke bank ID; omit to use a timestamped bank
 
 ## Safety notes

--- a/scripts/smoke-helpers.mjs
+++ b/scripts/smoke-helpers.mjs
@@ -4,11 +4,14 @@ export function envValue(name, env = process.env) {
 }
 
 export function smokeConfig(env = process.env, now = Date.now()) {
+  const configuredBankId = envValue("PI_HINDSIGHT_SMOKE_BANK_ID", env);
   return {
     baseUrl: envValue("HINDSIGHT_BASE_URL", env) ?? "http://localhost:8888",
     apiKey: envValue("HINDSIGHT_API_KEY", env),
-    bankId: envValue("PI_HINDSIGHT_SMOKE_BANK_ID", env) ?? `pi-hindsight-smoke-${now}`,
+    bankId: configuredBankId ?? `pi-hindsight-smoke-${now}`,
+    bankIsTemporary: !configuredBankId,
     attempts: Number(env.HINDSIGHT_SMOKE_ATTEMPTS ?? 20),
+    cleanupTimeoutMs: Number(env.HINDSIGHT_SMOKE_CLEANUP_TIMEOUT_MS ?? 5000),
   };
 }
 
@@ -46,6 +49,60 @@ export function renderSmokeSummary(entries, { title = "Hindsight smoke test" } =
     );
   }
   return `${lines.join("\n")}\n`;
+}
+
+export async function deleteSmokeBank(config, bankId, signal) {
+  const headers = new Headers();
+  headers.set("User-Agent", "pi-hindsight-smoke/0.1.0");
+  if (config.apiKey) headers.set("Authorization", `Bearer ${config.apiKey}`);
+  const response = await fetch(
+    `${config.baseUrl.replace(/\/$/, "")}/v1/default/banks/${encodeURIComponent(bankId)}`,
+    { method: "DELETE", headers, signal },
+  );
+  const body = await response.text().catch(() => "");
+  if (!response.ok && response.status !== 404) {
+    throw new Error(`delete bank failed with status ${response.status}: ${body.slice(0, 500)}`);
+  }
+  return { status: response.status };
+}
+
+function cleanupTimeoutSignal(timeoutMs) {
+  if (typeof AbortSignal !== "undefined" && "timeout" in AbortSignal) {
+    return AbortSignal.timeout(timeoutMs);
+  }
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeoutMs).unref?.();
+  return controller.signal;
+}
+
+export async function cleanupSmokeBankOnSuccess({
+  config,
+  bankId,
+  succeeded,
+  recorder,
+  deleteBank = deleteSmokeBank,
+}) {
+  if (!succeeded) {
+    recorder.step("cleanup_skipped", { reason: "smoke_failed", bankId });
+    return { cleaned: false, reason: "smoke_failed" };
+  }
+  if (!config.bankIsTemporary) {
+    recorder.step("cleanup_skipped", { reason: "configured_bank", bankId });
+    return { cleaned: false, reason: "configured_bank" };
+  }
+  try {
+    const result = await deleteBank(
+      config,
+      bankId,
+      cleanupTimeoutSignal(config.cleanupTimeoutMs ?? 5000),
+    );
+    recorder.step("cleanup_ok", { bankId, status: result.status });
+    return { cleaned: true, status: result.status };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    recorder.step("cleanup_failed", { bankId, error: message });
+    return { cleaned: false, reason: "delete_failed", error: message };
+  }
 }
 
 export async function writeGitHubSummary(markdown, env = process.env) {

--- a/scripts/smoke-hindsight.mjs
+++ b/scripts/smoke-hindsight.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { HindsightClient } from "@vectorize-io/hindsight-client";
 import {
+  cleanupSmokeBankOnSuccess,
   createSmokeRecorder,
   renderSmokeSummary,
   retry,
@@ -12,6 +13,7 @@ import {
 const config = smokeConfig();
 const marker = smokeMarker();
 const recorder = createSmokeRecorder();
+let succeeded = false;
 
 const client = new HindsightClient({
   baseUrl: config.baseUrl,
@@ -73,6 +75,7 @@ try {
   recorder.step("reflect_ok", { responsePreview: JSON.stringify(reflection).slice(0, 300) });
 
   recorder.step("success", { bankId: config.bankId, marker });
+  succeeded = true;
 } catch (error) {
   console.error(
     JSON.stringify({
@@ -82,6 +85,7 @@ try {
   );
   process.exitCode = 1;
 } finally {
+  await cleanupSmokeBankOnSuccess({ config, bankId: config.bankId, succeeded, recorder });
   const summary = await writeGitHubSummary(renderSmokeSummary(recorder.entries()));
   if (summary.error) recorder.step("summary_failed", { error: summary.error });
 }

--- a/tests/smoke-helpers.test.mjs
+++ b/tests/smoke-helpers.test.mjs
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
+  cleanupSmokeBankOnSuccess,
   createSmokeRecorder,
   envValue,
   logStep,
@@ -24,7 +25,9 @@ describe("smoke helpers", () => {
     expect(smokeConfig({}, 123)).toMatchObject({
       baseUrl: "http://localhost:8888",
       bankId: "pi-hindsight-smoke-123",
+      bankIsTemporary: true,
       attempts: 20,
+      cleanupTimeoutMs: 5000,
     });
     expect(
       smokeConfig(
@@ -36,7 +39,14 @@ describe("smoke helpers", () => {
         },
         123,
       ),
-    ).toEqual({ baseUrl: "https://h.example", apiKey: "key", bankId: "bank", attempts: 3 });
+    ).toEqual({
+      baseUrl: "https://h.example",
+      apiKey: "key",
+      bankId: "bank",
+      bankIsTemporary: false,
+      attempts: 3,
+      cleanupTimeoutMs: 5000,
+    });
   });
 
   it("creates deterministic markers when clock/random are injected", () => {
@@ -113,5 +123,86 @@ describe("smoke helpers", () => {
     await expect(
       writeGitHubSummary("hello\n", { GITHUB_STEP_SUMMARY: join(dir, "missing", "summary.md") }),
     ).resolves.toMatchObject({ written: false, error: expect.any(String) });
+  });
+
+  it("cleans up temporary smoke bank only after success", async () => {
+    const recorder = createSmokeRecorder({ now: () => 0, output: () => undefined });
+    const deleteBank = vi.fn(async () => ({ status: 204 }));
+    await expect(
+      cleanupSmokeBankOnSuccess({
+        config: { bankIsTemporary: true },
+        bankId: "bank",
+        succeeded: true,
+        recorder,
+        deleteBank,
+      }),
+    ).resolves.toEqual({ cleaned: true, status: 204 });
+    expect(deleteBank).toHaveBeenCalledWith(
+      { bankIsTemporary: true },
+      "bank",
+      expect.any(AbortSignal),
+    );
+    expect(recorder.entries().at(-1)).toMatchObject({ step: "cleanup_ok", bankId: "bank" });
+  });
+
+  it("keeps smoke artifacts on failure or configured bank", async () => {
+    const output = vi.fn();
+    const recorder = createSmokeRecorder({ now: () => 0, output });
+    const deleteBank = vi.fn(async () => ({ status: 204 }));
+
+    await cleanupSmokeBankOnSuccess({
+      config: { bankIsTemporary: true },
+      bankId: "bank",
+      succeeded: false,
+      recorder,
+      deleteBank,
+    });
+    await cleanupSmokeBankOnSuccess({
+      config: { bankIsTemporary: false },
+      bankId: "bank",
+      succeeded: true,
+      recorder,
+      deleteBank,
+    });
+
+    expect(deleteBank).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledWith(
+      '{"step":"cleanup_skipped","durationMs":0,"reason":"smoke_failed","bankId":"bank"}',
+    );
+    expect(output).toHaveBeenCalledWith(
+      '{"step":"cleanup_skipped","durationMs":0,"reason":"configured_bank","bankId":"bank"}',
+    );
+  });
+
+  it("logs cleanup failures without throwing", async () => {
+    const recorder = createSmokeRecorder({ now: () => 0, output: () => undefined });
+    await expect(
+      cleanupSmokeBankOnSuccess({
+        config: { bankIsTemporary: true },
+        bankId: "bank",
+        succeeded: true,
+        recorder,
+        deleteBank: async () => {
+          throw new Error("boom");
+        },
+      }),
+    ).resolves.toMatchObject({ cleaned: false, reason: "delete_failed", error: "boom" });
+    expect(recorder.entries().at(-1)).toMatchObject({ step: "cleanup_failed", error: "boom" });
+  });
+
+  it("passes a bounded abort signal to cleanup", async () => {
+    const recorder = createSmokeRecorder({ now: () => 0, output: () => undefined });
+    const deleteBank = vi.fn(async (_config, _bankId, signal) => {
+      expect(signal).toBeInstanceOf(AbortSignal);
+      return { status: 204 };
+    });
+    await cleanupSmokeBankOnSuccess({
+      config: { bankIsTemporary: true, cleanupTimeoutMs: 1 },
+      bankId: "bank",
+      succeeded: true,
+      recorder,
+      deleteBank,
+    });
+    expect(deleteBank).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- mark auto-generated smoke banks as temporary and fixed configured banks as protected
- delete temporary smoke bank after successful smoke only
- keep artifacts on smoke failure and skip cleanup for configured bank IDs
- bound cleanup with abort signal and make cleanup failures non-fatal
- document cleanup policy and cleanup timeout env var

## Verification
- npm run check:coverage
- npm run check
- npm run typecheck:tsc

## Reviews
- subagent reviewer rejected first because cleanup was unbounded; fixed with cleanup timeout signal and re-review accepted