### PR TITLE
feat(retain): split periodic flush bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ Advanced project config example:
   "retain": {
     "queuePath": ".pi/hindsight/retain-queue.jsonl",
     "flushIntervalMs": 30000,
+    "periodicFlushMaxJobs": 1,
+    "periodicFlushTimeoutMs": 2000,
     "updateMode": "append",
     "entities": [{ "text": "Pi", "type": "project" }],
     "content": {
@@ -410,9 +412,9 @@ Automatic retain runs in the `agent_end` hook. It stores a structured JSON proje
 
 Retain jobs are written to a JSONL queue before sending. If Hindsight is down, jobs remain on disk for later flushing. This queue-first behavior applies to both automatic retain and the explicit `hindsight_retain` tool, so manual memories are not lost during Hindsight outages. Queue operations use an in-process mutex plus a lock directory next to the queue file so multiple Pi processes do not rewrite the active queue concurrently. Stale queue locks are judged from the lock owner's `acquiredAt` timestamp, not from the waiting process age. Jobs that exceed the retry limit are moved to a sibling dead-letter file (`<queue>.dead.jsonl`) instead of retrying forever. Debug diagnostics summarize active queue jobs, malformed JSONL lines, queue read errors, dead-letter jobs, and the dead-letter path without printing raw retained content; if malformed, unreadable, or dead-lettered entries exist, inspect the queue files offline, repair permissions or malformed lines deliberately, then run `/hindsight:flush` after Hindsight is reachable.
 
-Set `retain.flushIntervalMs` to a positive interval to flush queued jobs periodically while Pi is running. The default `0` disables periodic flushing, so retain still flushes on new retain attempts, manual `/hindsight:flush`, and shutdown.
+Set `retain.flushIntervalMs` to a positive interval to flush queued jobs periodically while Pi is running. The default `0` disables periodic flushing, so retain still flushes on new retain attempts, manual `/hindsight:flush`, and shutdown. Periodic background flushes are bounded separately by `retain.periodicFlushMaxJobs` and `retain.periodicFlushTimeoutMs` so they stay small and do not borrow shutdown semantics.
 
-Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs` and `retain.shutdownFlushTimeoutMs`. The timeout is a soft bound checked between queued jobs so shutdown does not leave a background flush holding the queue lock. If jobs remain after shutdown, they stay on disk and are visible through `/hindsight` for later flushing.
+Shutdown queue flushing is intentionally bounded by `retain.shutdownFlushMaxJobs` and `retain.shutdownFlushTimeoutMs`. The timeout is a soft bound checked between queued jobs so shutdown can use a larger drain budget without leaving a background flush holding the queue lock. If jobs remain after shutdown, they stay on disk and are visible through `/hindsight` for later flushing.
 
 At session start, the extension shows the selected bank ID. If no bank ID is configured, it reports the automatically derived bank ID and how to override it. Project and global banks can define Hindsight's three supported mission fields: `retainMission`, `reflectMission`, and `observationsMission`. There is no generic bank `mission` field; if no specific mission is configured, Pi-specific defaults are used. Project banks focus on repo architecture, decisions, constraints, bugs, fixes, TODOs, conventions, and project-local preferences. Global banks focus on durable user preferences, recurring workflows, coding habits, and stable assistant behavior while excluding repo-specific code facts by default.
 

--- a/extensions/config-defaults.ts
+++ b/extensions/config-defaults.ts
@@ -81,6 +81,8 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
     entities: [],
     queuePath: ".pi/hindsight/retain-queue.jsonl",
     flushIntervalMs: 0,
+    periodicFlushMaxJobs: 1,
+    periodicFlushTimeoutMs: 2_000,
     shutdownFlushMaxJobs: 10,
     shutdownFlushTimeoutMs: 2_000,
   },

--- a/extensions/config-normalize.ts
+++ b/extensions/config-normalize.ts
@@ -265,6 +265,14 @@ export function normalizeConfig(
           ? config.retain.flushIntervalMs
           : DEFAULT_CONFIG.retain.flushIntervalMs,
       ),
+      periodicFlushMaxJobs: positiveInt(
+        config.retain?.periodicFlushMaxJobs,
+        DEFAULT_CONFIG.retain.periodicFlushMaxJobs,
+      ),
+      periodicFlushTimeoutMs: positiveInt(
+        config.retain?.periodicFlushTimeoutMs,
+        DEFAULT_CONFIG.retain.periodicFlushTimeoutMs,
+      ),
       shutdownFlushMaxJobs: positiveInt(
         config.retain?.shutdownFlushMaxJobs,
         DEFAULT_CONFIG.retain.shutdownFlushMaxJobs,

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -69,8 +69,8 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       periodicFlushActive = true;
       void flushRetainQueue(queuePath, client, {
         stopOnFirstFailure: true,
-        maxJobs: config.retain.shutdownFlushMaxJobs,
-        maxElapsedMs: config.retain.shutdownFlushTimeoutMs,
+        maxJobs: config.retain.periodicFlushMaxJobs,
+        maxElapsedMs: config.retain.periodicFlushTimeoutMs,
       })
         .catch(() => undefined)
         .finally(() => {

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -83,6 +83,8 @@ export interface ResolvedConfig {
     entities: HindsightEntityInput[];
     queuePath: string;
     flushIntervalMs: number;
+    periodicFlushMaxJobs: number;
+    periodicFlushTimeoutMs: number;
     shutdownFlushMaxJobs: number;
     shutdownFlushTimeoutMs: number;
   };

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -221,6 +221,8 @@ describe("resolveConfig", () => {
           queuePath: "",
           flushIntervalMs: -1,
           entities: [{ text: "ok" }, { text: 42 }],
+          periodicFlushMaxJobs: -1,
+          periodicFlushTimeoutMs: 0,
           shutdownFlushMaxJobs: -1,
           shutdownFlushTimeoutMs: 0,
           toolFilter: { toolCall: { include: [42] }, toolResult: { exclude: "read" } },
@@ -269,6 +271,8 @@ describe("resolveConfig", () => {
     expect(config.retain.queuePath).toBe(".pi/hindsight/retain-queue.jsonl");
     expect(config.retain.flushIntervalMs).toBe(0);
     expect(config.retain.entities).toEqual([]);
+    expect(config.retain.periodicFlushMaxJobs).toBe(1);
+    expect(config.retain.periodicFlushTimeoutMs).toBe(2_000);
     expect(config.retain.shutdownFlushMaxJobs).toBe(10);
     expect(config.retain.shutdownFlushTimeoutMs).toBe(2_000);
     expect(config.import.includeBranches).toBe("current-only");

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -192,7 +192,7 @@ describe("extension hooks", () => {
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
         hindsight: { baseUrl: "http://unused.test" },
-        retain: { flushIntervalMs: 10, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
+        retain: { flushIntervalMs: 100, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
       }),
     );
     const queuePath = resolveQueuePath(cwd, ".pi/hindsight/retain-queue.jsonl");

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -192,7 +192,7 @@ describe("extension hooks", () => {
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
         hindsight: { baseUrl: "http://unused.test" },
-        retain: { flushIntervalMs: 10 },
+        retain: { flushIntervalMs: 10, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
       }),
     );
     const queuePath = resolveQueuePath(cwd, ".pi/hindsight/retain-queue.jsonl");
@@ -223,16 +223,26 @@ describe("extension hooks", () => {
       const { default: hindsightExtension } = await import("../extensions/index.js");
       hindsightExtension(pi as any);
       await handlers.session_start?.[0]?.({}, ctx);
+      await enqueueRetainJob(queuePath, {
+        id: "queued-2",
+        bankId: "bank",
+        createdAt: new Date().toISOString(),
+        documentId: "doc-2",
+        updateMode: "append",
+        item: { content: "content-2", context: "context" },
+        retries: 0,
+      });
       mocked.client.retain.mockClear();
       await waitForCondition(() => mocked.client.retain.mock.calls.length > 0);
-      await waitForCondition(async () => (await readRetainQueue(queuePath)).length === 0);
+      await waitForCondition(async () => (await readRetainQueue(queuePath)).length === 1);
 
+      expect(mocked.client.retain).toHaveBeenCalledTimes(1);
+      expect((await readRetainQueue(queuePath)).map((job) => job.id)).toEqual(["queued-2"]);
       expect(mocked.client.retain).toHaveBeenCalledWith(
         "bank",
         "content",
         expect.objectContaining({ documentId: "doc", updateMode: "append" }),
       );
-      expect(await readRetainQueue(queuePath)).toEqual([]);
     } finally {
       await handlers.session_shutdown?.[0]?.({}, ctx);
     }


### PR DESCRIPTION
## Summary
- add retain.periodicFlushMaxJobs and retain.periodicFlushTimeoutMs
- use periodic bounds for background interval flushes
- keep shutdownFlushMaxJobs/shutdownFlushTimeoutMs for shutdown drains
- document separate periodic/shutdown flush semantics
- test config defaults/fallbacks and periodic one-job drain independent of shutdown bounds

## Verification
- npm test -- tests/config.test.ts tests/extension-hooks.test.ts
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- precommit
- subagent review accepted