### PR TITLE
fix(queue): validate strict queue item shape

### DIFF
--- a/extensions/jsonl-queue-store.ts
+++ b/extensions/jsonl-queue-store.ts
@@ -39,16 +39,13 @@ export class JsonlQueueStore<T> {
   }
 
   async readStrict(): Promise<T[]> {
-    try {
-      const text = await readFile(this.path, "utf8");
-      return text
-        .split("\n")
-        .filter(Boolean)
-        .map((line) => JSON.parse(line) as T);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
-      throw error;
+    const parsed = await this.readTolerant();
+    if (parsed.malformedLines.length > 0) {
+      throw new Error(
+        `Malformed queue file ${this.path}: ${parsed.malformedLines.length} invalid line(s)`,
+      );
     }
+    return parsed.jobs;
   }
 
   async readTolerant(): Promise<ParsedJsonlQueue<T>> {
@@ -81,8 +78,9 @@ export class JsonlQueueStore<T> {
       let malformed = 0;
       for (const line of text.split("\n").filter(Boolean)) {
         try {
-          JSON.parse(line) as T;
-          valid += 1;
+          const parsed = JSON.parse(line) as unknown;
+          if (this.isItem(parsed)) valid += 1;
+          else malformed += 1;
         } catch {
           malformed += 1;
         }

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -126,9 +126,26 @@ describe("retain queue", () => {
     await expect(readRetainQueue(path)).rejects.toThrow();
   });
 
+  it("rejects valid JSON with invalid retain job shape in strict reads", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    writeFileSync(
+      path,
+      `${JSON.stringify({ id: "wrong-shape" })}\n${JSON.stringify(job)}\n`,
+      "utf8",
+    );
+
+    await expect(readRetainQueue(path)).rejects.toThrow(
+      `Malformed queue file ${path}: 1 invalid line(s)`,
+    );
+  });
+
   it("summarizes active and dead-letter queues without throwing on malformed lines", async () => {
     const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
-    writeFileSync(path, `{not json}\n${JSON.stringify(job)}\n`, "utf8");
+    writeFileSync(
+      path,
+      `{not json}\n${JSON.stringify({ id: "wrong-shape" })}\n${JSON.stringify(job)}\n`,
+      "utf8",
+    );
     writeFileSync(
       resolveDeadLetterQueuePath(path),
       `{bad}\n${JSON.stringify({ ...job, id: "dead" })}\n`,
@@ -138,7 +155,7 @@ describe("retain queue", () => {
     await expect(readRetainQueue(path)).rejects.toThrow();
     const summary = await summarizeRetainQueue(path);
 
-    expect(summary.active).toMatchObject({ path, valid: 1, malformed: 1, error: null });
+    expect(summary.active).toMatchObject({ path, valid: 1, malformed: 2, error: null });
     expect(summary.deadLetter).toMatchObject({
       path: resolveDeadLetterQueuePath(path),
       valid: 1,


### PR DESCRIPTION
## Summary
- make strict queue reads reuse tolerant parsing and reject malformed lines
- treat valid JSON with invalid RetainJob shape as malformed
- include queue path and invalid line count in strict-read errors
- count wrong-shape JSON as malformed in queue summaries
- preserve tolerant flush/quarantine behavior

## Verification
- npm test -- tests/queue.test.ts
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- precommit
- subagent review accepted