### PR TITLE
ci: run checks across operating systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,12 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    name: check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "check": "npm run format && npm run lint && npm run typecheck && npm test",
     "check:ci": "npm run check && npm run check:coverage",
     "check:release": "npm run check && npm run check:coverage && npm run typecheck:tsc && npm run pack:verify && npm run smoke:hindsight",
-    "install-hooks": "git rev-parse --git-dir >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
+    "install-hooks": "node scripts/install-hooks.mjs",
     "prepare": "npm run install-hooks",
     "precommit": "npm run check",
     "test": "vitest run",

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -1,0 +1,8 @@
+import { execFileSync } from "node:child_process";
+
+try {
+  execFileSync("git", ["rev-parse", "--git-dir"], { stdio: "ignore" });
+  execFileSync("git", ["config", "core.hooksPath", ".githooks"], { stdio: "ignore" });
+} catch {
+  // Not running inside a Git checkout, or Git is unavailable. Package installs should not fail.
+}

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -227,10 +227,8 @@ describe("hindsight commands", () => {
 
     await commands.get("hindsight:last-recall")?.handler(["--json"], ctx);
 
-    expect(ctx.ui.notify).toHaveBeenCalledWith(
-      expect.stringContaining(`"path": "${join(cwd, ".pi", "hindsight", "last-recall.json")}"`),
-      "info",
-    );
+    const json = JSON.parse(ctx.ui.notify.mock.calls[0]?.[0]);
+    expect(json.path).toBe(join(cwd, ".pi", "hindsight", "last-recall.json"));
   });
 
   it("refuses to prune explicit active session transcript", async () => {

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -156,7 +156,8 @@ describe("Pi session import", () => {
     expect(calls[0]?.[1]).not.toContain("<hindsight_memories>");
     expect(calls[0]?.[1]).not.toContain("custom recall");
     expect(calls[0]?.[1]).toContain(parentSessionId);
-    expect(calls[0]?.[1]).toContain(parentSessionFile);
+    const retainedContent = calls[0]?.[1] as string;
+    expect(JSON.parse(retainedContent).parentSessionFile).toBe(parentSessionFile);
     expect(calls[0]?.[2]).toMatchObject({
       updateMode: "replace",
       documentId: result.documentId,

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import {
   enqueueRetainJob,
   flushRetainQueue,
@@ -36,11 +37,14 @@ const job: RetainJob = {
   retries: 0,
 };
 
+const require = createRequire(import.meta.url);
+const viteNodeBin = require.resolve("vite-node/vite-node.mjs");
+
 function runWorker(mode: string, path: string, id: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(
-      "node_modules/.bin/vite-node",
-      ["tests/fixtures/queue-worker.mjs", mode, path, id],
+      process.execPath,
+      [viteNodeBin, "tests/fixtures/queue-worker.mjs", mode, path, id],
       {
         cwd: process.cwd(),
         stdio: ["ignore", "pipe", "pipe"],

--- a/tests/session-memory-meta.test.ts
+++ b/tests/session-memory-meta.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import {
   addSessionMemoryTag,
   clearNextSessionRetainMode,
@@ -145,6 +145,6 @@ describe("session memory metadata", () => {
     await removeSessionMemoryTag(cwd, undefined, "domain:test");
     meta = await readSessionMemoryMeta(cwd);
     expect(meta.tags).toEqual([]);
-    expect(sessionMetaPath(cwd)).toContain(".pi/hindsight/session-meta/");
+    expect(sessionMetaPath(cwd)).toContain([".pi", "hindsight", "session-meta", ""].join(sep));
   });
 });


### PR DESCRIPTION
## Summary
- run the check workflow on Ubuntu, macOS, and Windows
- keep Node 24 setup and npm engine-strict install on every OS
- keep existing check, coverage, tsc fallback, and package dry-run steps

## Verification
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- subagent review accepted