### PR TITLE
ci: add dependency review and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - needs-triage
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - needs-triage

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -192,7 +192,7 @@ describe("extension hooks", () => {
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
         hindsight: { baseUrl: "http://unused.test" },
-        retain: { flushIntervalMs: 100, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
+        retain: { flushIntervalMs: 1_000, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
       }),
     );
     const queuePath = resolveQueuePath(cwd, ".pi/hindsight/retain-queue.jsonl");
@@ -233,7 +233,7 @@ describe("extension hooks", () => {
         retries: 0,
       });
       mocked.client.retain.mockClear();
-      await waitForCondition(() => mocked.client.retain.mock.calls.length > 0);
+      await waitForCondition(() => mocked.client.retain.mock.calls.length > 0, 1_500);
       await waitForCondition(async () => (await readRetainQueue(queuePath)).length === 1);
 
       expect(mocked.client.retain).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- add a PR-only Dependency Review workflow
- grant read-only contents and pull-request permissions
- run GitHub dependency-review action after checkout
- add weekly Dependabot version updates for npm and GitHub Actions with needs-triage labels
- stabilize periodic flush test for slower Windows runners

## Verification
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- precommit
- subagent review accepted