### PR TITLE
test(release): isolate tag env in verification tests

### DIFF
--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -192,7 +192,7 @@ describe("extension hooks", () => {
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
         hindsight: { baseUrl: "http://unused.test" },
-        retain: { flushIntervalMs: 1_000, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
+        retain: { flushIntervalMs: 3_000, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
       }),
     );
     const queuePath = resolveQueuePath(cwd, ".pi/hindsight/retain-queue.jsonl");
@@ -233,8 +233,8 @@ describe("extension hooks", () => {
         retries: 0,
       });
       mocked.client.retain.mockClear();
-      await waitForCondition(() => mocked.client.retain.mock.calls.length > 0, 1_500);
-      await waitForCondition(async () => (await readRetainQueue(queuePath)).length === 1);
+      await waitForCondition(() => mocked.client.retain.mock.calls.length > 0, 5_000);
+      await waitForCondition(async () => (await readRetainQueue(queuePath)).length === 1, 5_000);
 
       expect(mocked.client.retain).toHaveBeenCalledTimes(1);
       expect((await readRetainQueue(queuePath)).map((job) => job.id)).toEqual(["queued-2"]);
@@ -246,7 +246,7 @@ describe("extension hooks", () => {
     } finally {
       await handlers.session_shutdown?.[0]?.({}, ctx);
     }
-  });
+  }, 10_000);
 
   it("skips automatic retain once for next opt-out and advances retain cursor", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));

--- a/tests/verify-release.test.mjs
+++ b/tests/verify-release.test.mjs
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 const script = resolve("scripts/verify-release.mjs");
+const testEnv = { ...process.env, GITHUB_REF_NAME: "" };
 
 async function repo(version, changelog) {
   const dir = await mkdtemp(join(tmpdir(), "verify-release-"));
@@ -18,14 +19,14 @@ async function repo(version, changelog) {
 describe("verify-release", () => {
   it("accepts exact changelog version heading", async () => {
     const cwd = await repo("1.2.3", "## [1.2.3] - 2026-01-01\n");
-    await expect(execFileAsync("node", [script], { cwd })).resolves.toMatchObject({
+    await expect(execFileAsync("node", [script], { cwd, env: testEnv })).resolves.toMatchObject({
       stdout: expect.stringContaining('"version":"1.2.3"'),
     });
   });
 
   it("rejects substring changelog version heading", async () => {
     const cwd = await repo("1.2.3", "## [11.2.3] - 2026-01-01\n");
-    await expect(execFileAsync("node", [script], { cwd })).rejects.toMatchObject({
+    await expect(execFileAsync("node", [script], { cwd, env: testEnv })).rejects.toMatchObject({
       stderr: expect.stringContaining("CHANGELOG.md missing release heading for 1.2.3"),
     });
   });
@@ -33,7 +34,7 @@ describe("verify-release", () => {
   it("rejects mismatched tag version", async () => {
     const cwd = await repo("1.2.3", "## [1.2.3] - 2026-01-01\n");
     await expect(
-      execFileAsync("node", [script], { cwd, env: { ...process.env, GITHUB_REF_NAME: "v1.2.4" } }),
+      execFileAsync("node", [script], { cwd, env: { ...testEnv, GITHUB_REF_NAME: "v1.2.4" } }),
     ).rejects.toMatchObject({
       stderr: expect.stringContaining(
         "Release tag v1.2.4 does not match package.json version 1.2.3",


### PR DESCRIPTION
## Summary
- clear GITHUB_REF_NAME for release-verification unit tests that use fixture package versions
- keep explicit mismatched-tag coverage by setting the tag only for that test
- fixes release workflow failure when tests run from a version tag

## Verification
- npm test -- tests/verify-release.test.mjs
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- npm run pack:verify