### PR TITLE
fix(release): use luxusai npm scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ For local development, install a checkout path instead:
 pi install /path/to/pi-hindsight
 ```
 
-Planned npm package name: `@luxus/pi-hindsight`.
+Npm package name: `@luxusai/pi-hindsight`.
 
 ## Configuration
 

--- a/docs/pr-roadmap.md
+++ b/docs/pr-roadmap.md
@@ -1,6 +1,6 @@
 # PR Roadmap
 
-This roadmap records the completed MVP hardening plan for `@luxus/pi-hindsight`. See `docs/post-mvp-roadmap.md` for the current post-MVP roadmap.
+This roadmap records the completed MVP hardening plan for `@luxusai/pi-hindsight`. See `docs/post-mvp-roadmap.md` for the current post-MVP roadmap.
 
 The goal is to keep the extension simple by default while preserving enough flexibility for real Pi and Hindsight workflows. The roadmap is intentionally ordered so a human or LLM agent can pick the next PR without re-planning the whole project.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@luxus/pi-hindsight",
+  "name": "@luxusai/pi-hindsight",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@luxus/pi-hindsight",
+      "name": "@luxusai/pi-hindsight",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@luxus/pi-hindsight",
+  "name": "@luxusai/pi-hindsight",
   "version": "0.1.0",
   "description": "Pi extension for durable Hindsight-backed long-term memory.",
   "keywords": [

--- a/scripts/install-smoke.mjs
+++ b/scripts/install-smoke.mjs
@@ -17,16 +17,15 @@ async function main() {
   try {
     await execFileAsync("npm", ["init", "-y"], { cwd: dir });
     await execFileAsync("npm", ["install", tarball, "--ignore-scripts"], { cwd: dir });
+    const packageJson = JSON.parse(await readFile(join(cwd, "package.json"), "utf8"));
+    const packagePath = String(packageJson.name).split("/");
     const installed = JSON.parse(
-      await readFile(join(dir, "node_modules", "@luxus", "pi-hindsight", "package.json"), "utf8"),
+      await readFile(join(dir, "node_modules", ...packagePath, "package.json"), "utf8"),
     );
     if (!installed.pi?.extensions?.includes("./extensions")) {
       throw new Error("installed package missing pi.extensions entry");
     }
-    await readFile(
-      join(dir, "node_modules", "@luxus", "pi-hindsight", "extensions", "index.ts"),
-      "utf8",
-    );
+    await readFile(join(dir, "node_modules", ...packagePath, "extensions", "index.ts"), "utf8");
     console.log(JSON.stringify({ ok: true, package: installed.name, version: installed.version }));
   } finally {
     await rm(tarball, { force: true });

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -192,7 +192,7 @@ describe("extension hooks", () => {
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
         hindsight: { baseUrl: "http://unused.test" },
-        retain: { flushIntervalMs: 3_000, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
+        retain: { flushIntervalMs: 1_000, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
       }),
     );
     const queuePath = resolveQueuePath(cwd, ".pi/hindsight/retain-queue.jsonl");
@@ -222,6 +222,7 @@ describe("extension hooks", () => {
     try {
       const { default: hindsightExtension } = await import("../extensions/index.js");
       hindsightExtension(pi as any);
+      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
       await handlers.session_start?.[0]?.({}, ctx);
       await enqueueRetainJob(queuePath, {
         id: "queued-2",
@@ -233,8 +234,9 @@ describe("extension hooks", () => {
         retries: 0,
       });
       mocked.client.retain.mockClear();
-      await waitForCondition(() => mocked.client.retain.mock.calls.length > 0, 5_000);
-      await waitForCondition(async () => (await readRetainQueue(queuePath)).length === 1, 5_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await waitForCondition(() => mocked.client.retain.mock.calls.length > 0);
+      await waitForCondition(async () => (await readRetainQueue(queuePath)).length === 1);
 
       expect(mocked.client.retain).toHaveBeenCalledTimes(1);
       expect((await readRetainQueue(queuePath)).map((job) => job.id)).toEqual(["queued-2"]);
@@ -245,8 +247,9 @@ describe("extension hooks", () => {
       );
     } finally {
       await handlers.session_shutdown?.[0]?.({}, ctx);
+      vi.useRealTimers();
     }
-  }, 10_000);
+  });
 
   it("skips automatic retain once for next opt-out and advances retain cursor", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));


### PR DESCRIPTION
## Summary
- rename package from @luxus/pi-hindsight to @luxusai/pi-hindsight
- update package lock and docs references
- make install smoke derive installed package path from package.json name

## Verification
- npm run audit:signatures
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- npm run pack:verify