### PR TITLE
test: raise global coverage thresholds

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,10 +16,10 @@ export default defineConfig({
         "extensions/timeout.ts",
       ],
       thresholds: {
-        statements: 60,
-        branches: 60,
-        functions: 60,
-        lines: 60,
+        statements: 70,
+        branches: 70,
+        functions: 70,
+        lines: 70,
         "extensions/queue.ts": {
           statements: 80,
           branches: 75,


### PR DESCRIPTION
## Summary
- raise global Vitest coverage thresholds from 60% to 70%
- keep existing per-file thresholds unchanged

## Verification
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- subagent review accepted