### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,4 @@ jobs:
         if: >-
           startsWith(github.ref, 'refs/tags/v') ||
           (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "NPM_TOKEN secret is required to publish."
-            exit 1
-          fi
-          npm publish --provenance --access public
+        run: npm publish --provenance --access public

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ Before publishing or tagging a release:
 3. Run `npm run smoke:hindsight` locally when a configured server is available, or check the `Hindsight Integration` workflow result.
 4. Run `npm run changelog` after final Conventional Commits.
 5. Use `npm version <patch|minor|major>` so the version script stages the regenerated changelog.
-6. Push a `v*.*.*` tag to run the release workflow. Publishing requires `NPM_TOKEN`; manual dispatch can verify only or publish when `publish=true`.
+6. Push a `v*.*.*` tag to run the release workflow. Publishing uses npm trusted publishing with GitHub OIDC; manual dispatch can verify only or publish when `publish=true`.
 
 Useful targeted checks:
 


### PR DESCRIPTION
## Summary
- remove NPM_TOKEN/NODE_AUTH_TOKEN from the release workflow
- keep GitHub OIDC id-token permission for npm trusted publishing
- publish with npm provenance and public access
- update release docs for trusted publishing

## Verification
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- npm run audit:signatures
- npm run pack:verify
- subagent review accepted