### PR TITLE
docs: require live proof for memory path changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@
 - [ ] `npm run check:coverage`
 - [ ] `npm run typecheck:tsc`
 - [ ] `npm run pack:verify` (release/package changes)
-- [ ] `npm run smoke:hindsight` (live Hindsight behavior changes, if credentials are available)
+- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes; document unavailable live proof)
 
 ## Guidance sync
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,13 +216,15 @@ If release or package dependencies changed, also run:
 npm run audit:signatures
 ```
 
-If live Hindsight integration behavior changed, also run the configured-server smoke test when credentials are available:
+If memory-path behavior changed, also prove the live Hindsight path before merging. Memory-path behavior includes retain payloads, recall queries/formatting, reflect calls, bank selection or creation, queue delivery, import delivery, Adapter transport, smoke helpers, and release packaging that can affect installed runtime behavior.
+
+Preferred proof is a configured-server smoke test:
 
 ```bash
 npm run smoke:hindsight
 ```
 
-GitHub Actions has a `Hindsight Integration` workflow that runs on PRs, nightly schedule, and manual dispatch. It runs live smoke only when `HINDSIGHT_INTEGRATION_ENABLED=true`; then it uses `HINDSIGHT_BASE_URL` and optional `HINDSIGHT_API_KEY` secrets. Otherwise it skips cleanly.
+GitHub Actions has a `Hindsight Integration` workflow that runs on PRs, nightly schedule, and manual dispatch. It runs live smoke only when `HINDSIGHT_INTEGRATION_ENABLED=true`; then it uses `HINDSIGHT_BASE_URL` and optional `HINDSIGHT_API_KEY` secrets. Otherwise it skips cleanly. For memory-path PRs, do not treat an unconfigured skip as proof; either run the smoke test locally with credentials, confirm a configured workflow pass, or document why live proof is unavailable and what lower-level checks cover the risk.
 
 ## Common mistakes to avoid
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,13 +82,15 @@ For release-path or packaging changes, also run:
 npm run pack:verify
 ```
 
-For live Hindsight integration changes, run a configured smoke test when credentials are available:
+For memory-path behavior changes, prove the live Hindsight path before merging. Memory-path behavior includes retain payloads, recall queries/formatting, reflect calls, bank selection or creation, queue delivery, import delivery, Adapter transport, smoke helpers, and release packaging that can affect installed runtime behavior.
+
+Preferred proof is a configured smoke test:
 
 ```bash
 npm run smoke:hindsight
 ```
 
-The GitHub `Hindsight Integration` workflow skips cleanly unless `HINDSIGHT_INTEGRATION_ENABLED=true` is configured.
+The GitHub `Hindsight Integration` workflow skips cleanly unless `HINDSIGHT_INTEGRATION_ENABLED=true` is configured. For memory-path PRs, do not treat an unconfigured skip as proof; either run the smoke test locally with credentials, confirm a configured workflow pass, or document why live proof is unavailable and what lower-level checks cover the risk.
 
 ## Commit messages
 
@@ -135,7 +137,7 @@ Before opening or marking a PR ready:
 - [ ] I ran `npm run check:coverage` when touching critical paths.
 - [ ] I ran `npm run typecheck:tsc`.
 - [ ] I ran `npm run audit:signatures` when touching release/package dependencies.
-- [ ] I ran `npm run smoke:hindsight` when live Hindsight behavior changed and credentials were available.
+- [ ] I ran `npm run smoke:hindsight` or confirmed a configured `Hindsight Integration` pass when memory-path behavior changed; if unavailable, I documented the limitation.
 
 ## Architecture guidance
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Before publishing or tagging a release:
 
 1. Ensure `main` is synced.
 2. Run `npm run check`, `npm run check:coverage`, `npm run typecheck:tsc`, `npm run audit:signatures`, and `npm run pack:verify`.
-3. Run `npm run smoke:hindsight` locally when a configured server is available, or check the `Hindsight Integration` workflow result.
+3. For memory-path changes, run `npm run smoke:hindsight` locally or confirm a configured `Hindsight Integration` workflow pass. An unconfigured workflow skip is not release proof for memory-path changes; document any unavailable live proof.
 4. Run `npm run changelog` after final Conventional Commits.
 5. Use `npm version <patch|minor|major>` so the version script stages the regenerated changelog.
 6. Push a `v*.*.*` tag to run the release workflow. Publishing uses npm trusted publishing with GitHub OIDC; manual dispatch can verify only or publish when `publish=true`.


### PR DESCRIPTION
## Summary
- define memory-path changes that require live Hindsight proof
- clarify that an unconfigured live-smoke skip is not proof for memory-path PRs
- sync AGENTS.md, CONTRIBUTING.md, README release checklist, and PR template

## Verification
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- subagent review accepted

## Smoke policy
Docs-only change; no live Hindsight behavior changed.