### PR TITLE
test(router): expand evaluation fixtures

### DIFF
--- a/docs/architecture-todos.md
+++ b/docs/architecture-todos.md
@@ -6,7 +6,7 @@ These are deferred deepening opportunities identified after the mission/global-m
 
 - Keep `globalRetain.mode = "explicit-only"` as the default.
 - Router mode is explicit opt-in and now routes automatic retain through a mission-aware Adapter before enqueueing project/global/both/skip writes.
-- Evaluation fixtures cover project/global/both/skip decisions. Future work: expand fixtures and add an LLM-backed Adapter behind the same Interface if heuristic quality is not enough.
+- Evaluation fixtures cover balanced project/global/both/skip decisions across style, identity, workflow, implementation, delivery, and ephemeral artifact cases. Future work: add an LLM-backed Adapter behind the same Interface only if heuristic quality is not enough.
 
 ## Config editing
 

--- a/tests/fixtures/memory-router-evals.json
+++ b/tests/fixtures/memory-router-evals.json
@@ -7,9 +7,37 @@
     "expectedSignals": ["global"]
   },
   {
+    "name": "global identity preference",
+    "content": "Kai's nickname is Jadorey and pronouns should be remembered for future sessions.",
+    "context": "Stable user identity across sessions.",
+    "expectedRoute": "global",
+    "expectedSignals": ["global"]
+  },
+  {
+    "name": "cross-project workflow habit",
+    "content": "User always wants small reviewed work chunks handled autonomously everywhere unless risky.",
+    "context": "Durable workflow preference for all workspaces.",
+    "expectedRoute": "global",
+    "expectedSignals": ["global"]
+  },
+  {
     "name": "project implementation decision",
     "content": "In this repo, import delivery should preserve deterministic document IDs and use replace mode for historical reimports.",
     "context": "Architecture decision for pi-hindsight importer implementation.",
+    "expectedRoute": "project",
+    "expectedSignals": ["project"]
+  },
+  {
+    "name": "project bug fix",
+    "content": "Fix the queue lock stale-owner check in queue-lock.ts so the waiter age does not decide lock expiry.",
+    "context": "Bug fix scoped to this repository implementation.",
+    "expectedRoute": "project",
+    "expectedSignals": ["project"]
+  },
+  {
+    "name": "project delivery state",
+    "content": "PR 109 raised coverage gates for queue, lock, JSONL store, and import Modules.",
+    "context": "Repository delivery state from current work.",
     "expectedRoute": "project",
     "expectedSignals": ["project"]
   },
@@ -21,9 +49,37 @@
     "expectedSignals": ["global", "project"]
   },
   {
+    "name": "global style constrained to repo config",
+    "content": "User prefers terse status notifications for this extension config and TUI workflow.",
+    "context": "Preference plus project implementation context.",
+    "expectedRoute": "both",
+    "expectedSignals": ["global", "project"]
+  },
+  {
+    "name": "identity inside project issue",
+    "content": "User nickname Jadorey should appear in this repo's import issue template examples.",
+    "context": "Identity-like fact appears inside project delivery context.",
+    "expectedRoute": "both",
+    "expectedSignals": ["global", "project"]
+  },
+  {
     "name": "temporary screenshot artifact",
     "content": "Temporary screenshot saved under /var/folders/abc/Screenshot 2026-05-02.png while debugging UI.",
     "context": "Ephemeral artifact path, not durable memory.",
+    "expectedRoute": "skip",
+    "expectedSignals": ["skip"]
+  },
+  {
+    "name": "temporary command scratch",
+    "content": "Temporary debug note: npm test output was pasted only to inspect a transient failure.",
+    "context": "Ephemeral troubleshooting scratch, not durable memory.",
+    "expectedRoute": "skip",
+    "expectedSignals": ["skip"]
+  },
+  {
+    "name": "screenshot only note",
+    "content": "Screenshot shows a modal during one-off UI debugging.",
+    "context": "Short-lived visual artifact.",
     "expectedRoute": "skip",
     "expectedSignals": ["skip"]
   }

--- a/tests/memory-router.test.ts
+++ b/tests/memory-router.test.ts
@@ -22,6 +22,27 @@ const routerEvalFixtures = JSON.parse(
 ) as RouterEvalFixture[];
 
 describe("memory router", () => {
+  it("keeps eval fixtures balanced across all route outcomes", () => {
+    expect(routerEvalFixtures).toHaveLength(12);
+    expect(new Set(routerEvalFixtures.map((fixture) => fixture.name)).size).toBe(
+      routerEvalFixtures.length,
+    );
+    expect(routerEvalFixtures.map((fixture) => fixture.expectedRoute).sort()).toEqual([
+      "both",
+      "both",
+      "both",
+      "global",
+      "global",
+      "global",
+      "project",
+      "project",
+      "project",
+      "skip",
+      "skip",
+      "skip",
+    ]);
+  });
+
   it.each(routerEvalFixtures)(
     "classifies eval fixture: $name",
     ({ content, context, expectedRoute, expectedSignals }) => {
@@ -33,6 +54,7 @@ describe("memory router", () => {
 
       expect(decision.route).toBe(expectedRoute);
       expect(decision.signals).toEqual(expect.arrayContaining(expectedSignals));
+      expect(decision.matchedSignals.length).toBeGreaterThanOrEqual(expectedSignals.length);
       expect(decision.writes).toEqual([]);
     },
   );


### PR DESCRIPTION
## Summary
- expand router eval fixtures to 12 balanced project/global/both/skip cases
- assert fixture balance and unique fixture names
- keep router runtime heuristics and explicit-only default unchanged
- update architecture TODO to reflect expanded fixture coverage

## Verification
- npm test -- tests/memory-router.test.ts
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- subagent review accepted

## Smoke policy
No memory-path runtime behavior changed; tests/docs only.