### PR TITLE
docs: update hardening status

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,12 @@ Recently completed release-hardening work:
 - roadmap/docs now match the implementation that already exists
 - focused Hindsight best-practice regression tests cover core memory invariants
 - documented configuration starts with memory profiles and minimal project config
-- outage, dead-letter, queue-lock, and append capability behavior is documented and tested
+- outage, dead-letter, queue-lock, malformed queue recovery, and append capability behavior is documented and tested
 - bank mission and observation-scope defaults are tuned for memory quality
-- historical import previews show document counts, update modes, checkpoint paths, and manifest behavior
-- packaging and live smoke-test paths are verified for release readiness
+- historical import previews show document counts, update modes, checkpoint paths, manifest behavior, and project-session cwd normalization
+- packaging, trusted publishing, audit signatures, dependency review, Dependabot, and live smoke-test paths are verified for release readiness
+- CI runs checks across Ubuntu, macOS, and Windows; critical-path coverage gates now include queue, lock, JSONL queue store, import, config, lifecycle, and transport Modules
+- memory router eval fixtures cover balanced project/global/both/skip cases without changing the default `explicit-only` global retain policy
 
 Intentionally deferred:
 
@@ -161,7 +163,7 @@ See [`docs/risky-memory-modes.md`](docs/risky-memory-modes.md) for why persisted
 
 See [`docs/next-opt-out-design.md`](docs/next-opt-out-design.md) for the implemented one-turn memory opt-out command design.
 
-Historical import supports importing the current Pi session, an explicit JSONL path, or all Pi session JSONL files in the current session directory that belong to the current repo/cwd. Imports write deterministic document IDs and update an import manifest that is summarized in `/hindsight`. Use `/hindsight:import --dry-run`, `/hindsight:import-project-sessions --dry-run`, or `hindsight_import` with `dryRun: true` to preview documents, message counts, content sizes, tags, update mode, and target bank without writing Hindsight memory or mutating the manifest. Add `--all-leaves` or `allLeaves: true` to preview/import every branch leaf instead of only the current branch. Project session discovery intentionally avoids broad history imports: it scans only the current session file's directory and keeps only `.jsonl` session files whose parsed `cwd` exactly matches the current repo/cwd. Imports maintain `.pi/hindsight/import-checkpoint.json` by default and resume completed documents without re-retaining them when `import.resume` is enabled.
+Historical import supports importing the current Pi session, an explicit JSONL path, or all Pi session JSONL files in the current session directory that belong to the current repo/cwd. Imports write deterministic document IDs and update an import manifest that is summarized in `/hindsight`. Use `/hindsight:import --dry-run`, `/hindsight:import-project-sessions --dry-run`, or `hindsight_import` with `dryRun: true` to preview documents, message counts, content sizes, tags, update mode, and target bank without writing Hindsight memory or mutating the manifest. Add `--all-leaves` or `allLeaves: true` to preview/import every branch leaf instead of only the current branch. Project session discovery intentionally avoids broad history imports: it scans only the current session file's directory and keeps only `.jsonl` session files whose parsed `cwd` normalizes to the current repo/cwd. Equivalent path forms such as trailing separators, `.` segments, `..` traversal back to the repo, and resolved absolute paths are treated as the same project. Imports maintain `.pi/hindsight/import-checkpoint.json` by default and resume completed documents without re-retaining them when `import.resume` is enabled.
 
 Historical import examples:
 
@@ -433,7 +435,7 @@ Pi window notifications are configurable under `notifications`. Startup bank sel
 
 ## Debug and smoke tests
 
-Critical-path coverage thresholds are configured in `vitest.config.ts` for queue, config, lifecycle, and transport modules. Run them with `npm run check:coverage`; CI runs this after the normal fast check.
+Critical-path coverage thresholds are configured in `vitest.config.ts` for queue, queue lock, JSONL queue store, import, config, lifecycle, and transport Modules. Run them with `npm run check:coverage`; CI runs this after the normal fast check.
 
 Use `/hindsight` inside Pi to inspect what the extension believes. The TUI status view includes memory health, selected banks, recent explicit retain receipts, retain queue path, import status, and key configuration state. Advanced one-off diagnostics remain available through tests and explicit tools rather than separate status/debug/doctor commands.
 

--- a/docs/architecture-todos.md
+++ b/docs/architecture-todos.md
@@ -1,6 +1,6 @@
-# Architecture TODOs
+# Architecture Notes
 
-These are deferred deepening opportunities identified after the mission/global-memory work.
+These notes record deepening work completed after the mission/global-memory pass and the remaining conditions for reopening broader architecture changes.
 
 ## Memory routing
 

--- a/docs/post-mvp-roadmap.md
+++ b/docs/post-mvp-roadmap.md
@@ -202,6 +202,24 @@ npm run typecheck:tsc
 npm run smoke:hindsight # when live behavior changes and server is available
 ```
 
+## Completed hardening follow-up
+
+After the MVP hardening pass and global review loop, a second small-PR hardening pass closed the remaining roadmap/report gaps without changing the default memory policy.
+
+Completed outcomes:
+
+- Cross-platform CI now runs normal checks on Ubuntu, macOS, and Windows.
+- Dependency review, Dependabot, npm audit signatures, trusted publishing, and GitHub default CodeQL cover the supply-chain/release path.
+- The release workflow publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC and no npm token in the workflow.
+- Live smoke covers the official Hindsight client, extension Adapter, memory operations service, import flow, GitHub step summary output, and successful temporary-bank cleanup.
+- Memory-path PRs must prove the live path with local smoke or a configured `Hindsight Integration` pass; an unconfigured skip is not proof.
+- Coverage gates were raised and now include queue, queue lock, JSONL queue store, import, config, lifecycle, and transport Modules.
+- Repeated stress tests cover queue lock contention, malformed queue recovery, retry/dead-letter rollover, and import project-cwd path normalization.
+- Config editing parse/default/patch behavior moved into the config editing registry so settings have better Locality.
+- Router evaluation fixtures now cover balanced project/global/both/skip cases while `globalRetain.mode = "explicit-only"` remains the default.
+
+Remaining explicit deferred ideas below still require a new design discussion before implementation.
+
 ## Explicitly deferred ideas
 
 These remain deferred and should not be implemented without a new design discussion.

--- a/docs/pr-roadmap.md
+++ b/docs/pr-roadmap.md
@@ -345,6 +345,6 @@ When an LLM agent continues this work:
 3. Preserve all Hindsight invariants above.
 4. Update README only for user-visible behavior.
 5. Add or update tests for memory routing, IDs, queueing, retain payloads, recall injection, or import behavior.
-6. Run `npm run check` and `npm run typecheck:tsc` before calling the PR done.
-7. If live Hindsight behavior changed, also run `npm run smoke:hindsight` when credentials are available.
+6. Run `npm run check`, `npm run check:coverage`, and `npm run typecheck:tsc` before calling the PR done.
+7. If memory-path behavior changed, prove the live path with `npm run smoke:hindsight` or a configured `Hindsight Integration` pass; an unconfigured skip is not proof.
 8. Do not add deferred ideas unless the user explicitly reopens scope.


### PR DESCRIPTION
## Summary
- update README status to reflect completed hardening slices
- document import cwd normalization and expanded critical-path coverage scope
- record completed follow-up hardening in the post-MVP roadmap
- update roadmap handoff checks and architecture notes

## Verification
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- subagent review accepted

## Smoke policy
Docs-only change; no memory-path runtime behavior changed.