### PR TITLE
test(hooks): prevent Windows timer leak

### DIFF
--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -63,6 +63,8 @@ describe("extension hooks", () => {
   });
 
   afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
     if (originalHome === undefined) {
       delete process.env.HOME;
     } else {
@@ -249,7 +251,7 @@ describe("extension hooks", () => {
       await handlers.session_shutdown?.[0]?.({}, ctx);
       vi.useRealTimers();
     }
-  });
+  }, 20_000);
 
   it("skips automatic retain once for next opt-out and advances retain cursor", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));


### PR DESCRIPTION
## Summary
- give the periodic flush hook test a scoped timeout for slow Windows coverage runs
- clear fake timers and restore real timers in extension hook test cleanup
- prevent a timed-out periodic interval from leaking retain calls into the next test

## Verification
- npm test -- tests/extension-hooks.test.ts
- npm run check
- npm run check:coverage
- npm run typecheck:tsc
- subagent review accepted

## Smoke policy
Tests-only change; no memory-path runtime behavior changed.