### PR TITLE
docs: use GitHub Issues as task ledger

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 -
 
+## Issue
+
+- Closes/updates #
+
 ## Change type
 
 - [ ] feat
@@ -34,4 +38,4 @@
 
 ## Notes
 
-Mention any ADR conflicts, skipped checks, live-smoke limitations, or follow-up issues.
+Mention any ADR conflicts, skipped checks, live-smoke limitations, or follow-up issues. Track follow-ups in GitHub Issues, not hidden local TODOs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,12 @@ The extension must be:
 
 Human and agent guidance must stay aligned. When changing source-of-truth order, contributor workflow, verification expectations, memory policy, or definition-of-done criteria, update `CONTRIBUTING.md` and this file together. `CONTEXT.md` is the shared vocabulary for both human-facing and agent-facing docs.
 
+### Work tracking
+
+GitHub Issues are the project task ledger. Use `gh` for backlog items, roadmap slices, current multi-step work, blockers, follow-ups, and done/close updates. Do not use harness-private or local hidden TODO systems as the source of truth for project work. If work needs tracking, create or update a GitHub issue before continuing.
+
+When starting from a report, review, plan, or research note, convert accepted work into GitHub issues and delete or archive the scratch note after the issues carry the actionable content. When finishing work, update or close the relevant issue with the verification performed and any follow-up issue numbers.
+
 ## Hard rules
 
 ### Retain rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,14 @@ Keep each PR focused on one vertical slice. A good PR has:
 
 Avoid combining architecture changes, product behavior, and release automation in the same PR unless they are inseparable.
 
+## Work tracking
+
+GitHub Issues are the project task ledger for backlog items, current work, blockers, decisions, and follow-ups. Use the `gh` CLI from this repository to create, read, comment on, label, assign, and close issues.
+
+Do not rely on local scratch files, private harness TODOs, chat-only plans, or hidden task lists as the source of truth for project work. If a change needs tracking, create or update a GitHub issue before continuing. If a report or review produces useful work, move the accepted items into GitHub issues and remove or archive the scratch report once the issues carry the actionable content.
+
+Every PR should reference the issue it advances. If a follow-up remains, add it as an issue or as a comment on the existing issue rather than leaving it only in a local note.
+
 ## Memory invariants
 
 Every code change must preserve these rules:
@@ -128,6 +136,7 @@ A change is done only when:
 Before opening or marking a PR ready:
 
 - [ ] I used project terms from `CONTEXT.md`.
+- [ ] I linked or updated the relevant GitHub issue, including follow-ups or blockers.
 - [ ] I kept the diff focused.
 - [ ] I preserved Retain, Recall, Reflect, bank isolation, queue-first, and redaction invariants.
 - [ ] I added or updated tests for meaningful behavior.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,8 @@
 # Issue tracker: GitHub
 
-Issues and PRDs for this repo live as GitHub issues for `luxus/pi-hindsight`. Use the `gh` CLI for all operations.
+Issues, PRDs, roadmap slices, current work, blockers, and follow-ups for this repo live as GitHub issues for `luxus/pi-hindsight`. Use the `gh` CLI for all operations.
+
+GitHub Issues are the project task ledger. Do not use harness-private TODOs, chat-only plans, local scratch reports, or hidden task lists as the source of truth for project work. If work needs tracking, create or update an issue before continuing.
 
 ## Conventions
 
@@ -12,6 +14,14 @@ Issues and PRDs for this repo live as GitHub issues for `luxus/pi-hindsight`. Us
 - **Close**: `gh issue close <number> --comment "..."`.
 
 Infer the repo from `git remote -v`; `gh` does this automatically when run inside this clone.
+
+## Progress conventions
+
+- Start work by fetching the relevant issue or creating one if none exists.
+- Record meaningful progress as issue comments when it affects scope, risk, blockers, or next steps.
+- Convert accepted report/review findings into issues; delete or archive the scratch report after the issues carry the actionable content.
+- Track follow-ups as new issues or comments on the parent issue, not as hidden local TODOs.
+- Close the issue with a comment that names the PR/commit and verification performed.
 
 ## When a skill says "publish to the issue tracker"
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,6 +59,12 @@ Or install the checkout path:
 pi install /path/to/pi-hindsight
 ```
 
+## Work tracking
+
+Use GitHub Issues as the project task ledger. Backlog items, current work, blockers, decisions, and follow-ups should be visible in issues or issue comments. Do not rely on local scratch files, chat-only plans, or private harness TODOs as the source of truth for project work.
+
+When a report or review creates actionable work, turn accepted items into issues and remove or archive the scratch file after the issues carry the work.
+
 ## Coverage gates
 
 Critical-path coverage thresholds are configured in `vitest.config.ts` for:

--- a/docs/post-mvp-roadmap.md
+++ b/docs/post-mvp-roadmap.md
@@ -1,6 +1,6 @@
 # Post-MVP Roadmap
 
-This roadmap starts after the MVP hardening pass in `docs/pr-roadmap.md`. The goal is to keep Pi Hindsight simple and Hindsight-correct while improving inspectability and user control.
+This roadmap records the completed post-MVP hardening pass after `docs/pr-roadmap.md`. Current and future work lives in GitHub Issues; treat this file as historical context, not the task ledger.
 
 ## Product rule
 
@@ -184,7 +184,7 @@ npm run format
 
 **Acceptance criteria:**
 
-- Findings are recorded in an issue or review document.
+- Findings are recorded in a GitHub issue or issue comment.
 - Every accepted finding has either a fix, test, doc update, or explicit no-action decision.
 - The loop stops only when remaining findings are deferred/non-blocking.
 

--- a/docs/pr-roadmap.md
+++ b/docs/pr-roadmap.md
@@ -1,8 +1,8 @@
 # PR Roadmap
 
-This roadmap records the completed MVP hardening plan for `@luxusai/pi-hindsight`. See `docs/post-mvp-roadmap.md` for the current post-MVP roadmap.
+This roadmap records the completed MVP hardening plan for `@luxusai/pi-hindsight`. Current and future work lives in GitHub Issues; treat this file as historical context, not the task ledger.
 
-The goal is to keep the extension simple by default while preserving enough flexibility for real Pi and Hindsight workflows. The roadmap is intentionally ordered so a human or LLM agent can pick the next PR without re-planning the whole project.
+The goal is to keep the extension simple by default while preserving enough flexibility for real Pi and Hindsight workflows.
 
 ## Product line
 


### PR DESCRIPTION
## Summary

- document GitHub Issues as the project task ledger in agent, contributor, and development docs
- update issue-tracker guidance with progress conventions
- add PR-template tracking field and follow-up guidance
- mark roadmap docs as historical context instead of current task source

## Issue

- Closes #134

## Change type

- [ ] feat
- [ ] fix
- [x] docs
- [ ] test
- [ ] refactor
- [ ] chore

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [ ] `npm run pack:verify` (not needed: no release/package changes)
- [ ] `npm run smoke:hindsight` (not needed: no memory-path behavior changes)

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Notes

Deep research report scratch files were untracked local files. They were deleted from the working tree and are not part of this PR diff.
