### PR TITLE
feat(tui): add setup flow state machine

### DIFF
--- a/extensions/setup-flow.ts
+++ b/extensions/setup-flow.ts
@@ -1,0 +1,176 @@
+import { Key, matchesKey } from "@mariozechner/pi-tui";
+import type { ConfigEditingField, ConfigEditingTab } from "./config-editing-model.js";
+import type {
+  SetupActionId,
+  SetupProfileChoice,
+  SetupStep,
+  SetupTemplateChoice,
+  SetupUiState,
+} from "./setup-tui-types.js";
+
+export type SetupIntent =
+  | { type: "close" }
+  | { type: "chooseDeployment" }
+  | { type: "toggleAdvanced" }
+  | { type: "moveTab"; delta: number }
+  | { type: "moveSelection"; delta: number }
+  | { type: "resetSelectedField" }
+  | { type: "editSelectedField" }
+  | { type: "startGuidedSetup" }
+  | { type: "chooseProfile"; profile: SetupProfileChoice }
+  | { type: "chooseTemplate"; template: SetupTemplateChoice }
+  | { type: "back" }
+  | { type: "finish" };
+
+export type SetupResult =
+  | { kind: "state"; state: SetupUiState }
+  | { kind: "action"; action: SetupActionId | null; state: SetupUiState };
+
+function defaultStep(step: SetupStep | undefined): SetupStep {
+  return step ?? "config";
+}
+
+function normalizedTabIndex(tabs: ConfigEditingTab[], tabIndex: number): number {
+  if (tabs.length === 0) return 0;
+  return Math.min(Math.max(0, tabIndex), tabs.length - 1);
+}
+
+function selectedIndexForTab(tab: ConfigEditingTab | undefined, state: SetupUiState): number {
+  if (!tab) return 0;
+  return Math.min(state.selectedByTab[tab.id] ?? 0, Math.max(0, tab.fields.length - 1));
+}
+
+function withState(state: SetupUiState): SetupResult {
+  return { kind: "state", state };
+}
+
+function withAction(action: SetupActionId | null, state: SetupUiState): SetupResult {
+  return { kind: "action", action, state };
+}
+
+function nextStep(step: SetupStep): SetupStep {
+  if (step === "profile") return "banks";
+  if (step === "banks") return "template";
+  if (step === "template") return "review";
+  if (step === "review") return "done";
+  return step;
+}
+
+function previousStep(step: SetupStep): SetupStep {
+  if (step === "profile") return "config";
+  if (step === "banks") return "profile";
+  if (step === "template") return "banks";
+  if (step === "review") return "template";
+  if (step === "done") return "review";
+  return step;
+}
+
+export function normalizeSetupUiState(tabs: ConfigEditingTab[], state: SetupUiState): SetupUiState {
+  const tabIndex = normalizedTabIndex(tabs, state.tabIndex);
+  const tab = tabs[tabIndex];
+  const selectedByTab = { ...state.selectedByTab };
+  if (tab) selectedByTab[tab.id] = selectedIndexForTab(tab, { ...state, tabIndex, selectedByTab });
+  return {
+    ...state,
+    step: defaultStep(state.step),
+    tabIndex,
+    selectedByTab,
+  };
+}
+
+export function currentSetupTab(
+  tabs: ConfigEditingTab[],
+  state: SetupUiState,
+): ConfigEditingTab | undefined {
+  return tabs[normalizedTabIndex(tabs, state.tabIndex)];
+}
+
+export function selectedSetupIndex(tabs: ConfigEditingTab[], state: SetupUiState): number {
+  return selectedIndexForTab(currentSetupTab(tabs, state), normalizeSetupUiState(tabs, state));
+}
+
+export function selectedSetupField(
+  tabs: ConfigEditingTab[],
+  state: SetupUiState,
+): ConfigEditingField | undefined {
+  const normalized = normalizeSetupUiState(tabs, state);
+  return currentSetupTab(tabs, normalized)?.fields[selectedSetupIndex(tabs, normalized)];
+}
+
+export function setupIntentFromInput(data: string): SetupIntent | undefined {
+  if (matchesKey(data, Key.escape) || data === "q") return { type: "close" };
+  if (data === "d") return { type: "chooseDeployment" };
+  if (matchesKey(data, Key.left) || data === "h" || data === "<") {
+    return { type: "moveTab", delta: -1 };
+  }
+  if (matchesKey(data, Key.right) || data === "l" || data === ">") {
+    return { type: "moveTab", delta: 1 };
+  }
+  if (matchesKey(data, Key.up) || data === "k") return { type: "moveSelection", delta: -1 };
+  if (matchesKey(data, Key.down) || data === "j") return { type: "moveSelection", delta: 1 };
+  if (data === "r") return { type: "resetSelectedField" };
+  if (data === "a") return { type: "toggleAdvanced" };
+  if (matchesKey(data, Key.enter)) return { type: "editSelectedField" };
+  return undefined;
+}
+
+export function applySetupIntent(
+  tabs: ConfigEditingTab[],
+  state: SetupUiState,
+  intent: SetupIntent,
+): SetupResult {
+  const normalized = normalizeSetupUiState(tabs, state);
+  if (intent.type === "close") return withAction(null, normalized);
+  if (intent.type === "chooseDeployment") return withAction("choose-deployment", normalized);
+  if (intent.type === "toggleAdvanced") return withAction("toggle-advanced", normalized);
+  if (intent.type === "finish") return withAction("done", { ...normalized, step: "done" });
+  if (intent.type === "startGuidedSetup") return withState({ ...normalized, step: "profile" });
+  if (intent.type === "chooseProfile") {
+    return withState({
+      ...normalized,
+      profileChoice: intent.profile,
+      step: nextStep("profile"),
+    });
+  }
+  if (intent.type === "chooseTemplate") {
+    return withState({
+      ...normalized,
+      templateChoice: intent.template,
+      step: nextStep("template"),
+    });
+  }
+  if (intent.type === "back") {
+    return withState({ ...normalized, step: previousStep(defaultStep(normalized.step)) });
+  }
+
+  const tab = currentSetupTab(tabs, normalized);
+  if (!tab || tabs.length === 0) return withState(normalized);
+
+  if (intent.type === "moveTab") {
+    const tabIndex = (normalized.tabIndex + intent.delta + tabs.length) % tabs.length;
+    const nextTab = tabs[tabIndex];
+    const selectedByTab = { ...normalized.selectedByTab };
+    if (nextTab)
+      selectedByTab[nextTab.id] = selectedIndexForTab(nextTab, { ...normalized, tabIndex });
+    return withState({ ...normalized, tabIndex, selectedByTab });
+  }
+
+  if (intent.type === "moveSelection") {
+    if (tab.fields.length === 0) return withState(normalized);
+    const index = selectedIndexForTab(tab, normalized);
+    return withState({
+      ...normalized,
+      selectedByTab: {
+        ...normalized.selectedByTab,
+        [tab.id]: (index + intent.delta + tab.fields.length) % tab.fields.length,
+      },
+    });
+  }
+
+  const field = selectedSetupField(tabs, normalized);
+  if (intent.type === "resetSelectedField") {
+    return field?.changed ? withAction(`reset:${field.id}`, normalized) : withState(normalized);
+  }
+  if (intent.type === "editSelectedField") return withAction(field?.id ?? null, normalized);
+  return withState(normalized);
+}

--- a/extensions/setup-tui-render.ts
+++ b/extensions/setup-tui-render.ts
@@ -1,13 +1,15 @@
 import { DynamicBorder } from "@mariozechner/pi-coding-agent";
-import {
-  Key,
-  matchesKey,
-  truncateToWidth,
-  visibleWidth,
-  type Component,
-} from "@mariozechner/pi-tui";
-import type { ConfigEditingField, ConfigEditingTab } from "./config-editing-model.js";
+import { truncateToWidth, visibleWidth, type Component } from "@mariozechner/pi-tui";
+import type { ConfigEditingTab } from "./config-editing-model.js";
 import type { RetainReceipt } from "./retain-receipts.js";
+import {
+  applySetupIntent,
+  currentSetupTab,
+  normalizeSetupUiState,
+  selectedSetupField,
+  selectedSetupIndex,
+  setupIntentFromInput,
+} from "./setup-flow.js";
 import {
   RECEIPT_FACT_LIMIT,
   type SetupActionId,
@@ -84,39 +86,12 @@ export function createSetupComponent(
   state: SetupUiState,
   done: (action: SetupActionId | null) => void,
 ): Component {
-  state.tabIndex = Math.min(Math.max(0, state.tabIndex), Math.max(0, tabs.length - 1));
-
-  function currentTab(): ConfigEditingTab {
-    return tabs[state.tabIndex] ?? tabs[0]!;
-  }
-
-  function selectedIndex(): number {
-    const tab = currentTab();
-    return Math.min(state.selectedByTab[tab.id] ?? 0, Math.max(0, tab.fields.length - 1));
-  }
-
-  function setSelectedIndex(index: number): void {
-    state.selectedByTab[currentTab().id] = index;
-  }
-
-  function selectedField(): ConfigEditingField | undefined {
-    return currentTab().fields[selectedIndex()];
-  }
-
-  function moveTab(delta: number): void {
-    state.tabIndex = (state.tabIndex + delta + tabs.length) % tabs.length;
-    setSelectedIndex(selectedIndex());
-  }
-
-  function moveSelection(delta: number): void {
-    const fields = currentTab().fields;
-    if (fields.length === 0) return;
-    setSelectedIndex((selectedIndex() + delta + fields.length) % fields.length);
-  }
+  Object.assign(state, normalizeSetupUiState(tabs, state));
 
   return {
     render(width: number): string[] {
-      const tab = currentTab();
+      Object.assign(state, normalizeSetupUiState(tabs, state));
+      const tab = currentSetupTab(tabs, state) ?? tabs[0]!;
       const lines: string[] = [];
       const innerWidth = Math.max(0, width - 2);
       const changedCount = tabs.reduce(
@@ -182,7 +157,7 @@ export function createSetupComponent(
       }
 
       for (const [index, field] of tab.fields.entries()) {
-        const isSelected = index === selectedIndex();
+        const isSelected = index === selectedSetupIndex(tabs, state);
         const marker = isSelected ? theme.fg("accent", "→") : " ";
         const dirty = field.changed ? theme.fg("warning", "*") : " ";
         const label = isSelected
@@ -195,7 +170,7 @@ export function createSetupComponent(
         );
       }
 
-      const detailField = selectedField();
+      const detailField = selectedSetupField(tabs, state);
       if (detailField) {
         lines.push(boxed("", width, theme));
         lines.push(boxed(theme.fg("accent", theme.bold("Details")), width, theme));
@@ -230,42 +205,11 @@ export function createSetupComponent(
       return lines.map((line) => truncateToWidth(line, width));
     },
     handleInput(data: string): void {
-      if (matchesKey(data, Key.escape) || data === "q") {
-        done(null);
-        return;
-      }
-      if (data === "d") {
-        done("choose-deployment");
-        return;
-      }
-      if (matchesKey(data, Key.left) || data === "h" || data === "<") {
-        moveTab(-1);
-        return;
-      }
-      if (matchesKey(data, Key.right) || data === "l" || data === ">") {
-        moveTab(1);
-        return;
-      }
-      if (matchesKey(data, Key.up) || data === "k") {
-        moveSelection(-1);
-        return;
-      }
-      if (matchesKey(data, Key.down) || data === "j") {
-        moveSelection(1);
-        return;
-      }
-      if (data === "r") {
-        const field = selectedField();
-        if (field?.changed) done(`reset:${field.id}`);
-        return;
-      }
-      if (data === "a") {
-        done("toggle-advanced");
-        return;
-      }
-      if (matchesKey(data, Key.enter)) {
-        done(selectedField()?.id ?? null);
-      }
+      const intent = setupIntentFromInput(data);
+      if (!intent) return;
+      const result = applySetupIntent(tabs, state, intent);
+      Object.assign(state, result.state);
+      if (result.kind === "action") done(result.action);
     },
     invalidate(): void {},
   };

--- a/extensions/setup-tui-types.ts
+++ b/extensions/setup-tui-types.ts
@@ -7,10 +7,19 @@ export type SetupActionId =
   | "toggle-advanced"
   | "done";
 
+export type SetupStep = "config" | "profile" | "banks" | "template" | "review" | "done";
+
+export type SetupProfileChoice = "project-only" | "project-global" | "global-only";
+
+export type SetupTemplateChoice = "none" | "paste-json";
+
 export type SetupUiState = {
+  step?: SetupStep;
   tabIndex: number;
   selectedByTab: Partial<Record<TabId, number>>;
   showAdvanced?: boolean;
+  profileChoice?: SetupProfileChoice;
+  templateChoice?: SetupTemplateChoice;
 };
 
 export type ThemeLike = {

--- a/extensions/setup-tui.ts
+++ b/extensions/setup-tui.ts
@@ -7,7 +7,23 @@ import { handleDeployment, handleFieldEdit, handleResetFieldAction } from "./set
 import type { SetupActionId, SetupUiState, ThemeLike } from "./setup-tui-types.js";
 
 export { buildRetainReceiptStatusFacts, createSetupComponent } from "./setup-tui-render.js";
-export type { SetupActionId, SetupUiState, ThemeLike } from "./setup-tui-types.js";
+export {
+  applySetupIntent,
+  currentSetupTab,
+  normalizeSetupUiState,
+  selectedSetupField,
+  selectedSetupIndex,
+  setupIntentFromInput,
+} from "./setup-flow.js";
+export type { SetupIntent, SetupResult } from "./setup-flow.js";
+export type {
+  SetupActionId,
+  SetupProfileChoice,
+  SetupStep,
+  SetupTemplateChoice,
+  SetupUiState,
+  ThemeLike,
+} from "./setup-tui-types.js";
 
 async function showSetupTui(
   ctx: ExtensionCommandContext,

--- a/tests/setup-flow.test.ts
+++ b/tests/setup-flow.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { ConfigEditingField, ConfigEditingTab } from "../extensions/config-editing-model.js";
+import {
+  applySetupIntent,
+  selectedSetupField,
+  selectedSetupIndex,
+  setupIntentFromInput,
+} from "../extensions/setup-tui.js";
+import type { SetupUiState } from "../extensions/setup-tui.js";
+
+function field(id: ConfigEditingField["id"], changed = false): ConfigEditingField {
+  return {
+    id,
+    tab: "Connection",
+    label: id,
+    description: `${id} description`,
+    value: "value",
+    defaultValue: "default",
+    source: changed ? "project" : "default",
+    editableScopes: ["project"],
+    changed,
+    resetKey: id === "timeoutMs" ? "hindsight.timeoutMs" : "hindsight.baseUrl",
+    kind: id === "timeoutMs" ? "positive-int" : "text",
+  };
+}
+
+function tabs(): ConfigEditingTab[] {
+  return [
+    { id: "Status", fields: [] },
+    { id: "Connection", fields: [field("baseUrl", true), field("timeoutMs")] },
+    { id: "Banks", fields: [field("projectBankId")] },
+  ];
+}
+
+describe("setup flow state", () => {
+  it("maps setup keystrokes to behavior-neutral intents", () => {
+    expect(setupIntentFromInput("q")).toEqual({ type: "close" });
+    expect(setupIntentFromInput("d")).toEqual({ type: "chooseDeployment" });
+    expect(setupIntentFromInput("h")).toEqual({ type: "moveTab", delta: -1 });
+    expect(setupIntentFromInput("l")).toEqual({ type: "moveTab", delta: 1 });
+    expect(setupIntentFromInput("j")).toEqual({ type: "moveSelection", delta: 1 });
+    expect(setupIntentFromInput("k")).toEqual({ type: "moveSelection", delta: -1 });
+    expect(setupIntentFromInput("a")).toEqual({ type: "toggleAdvanced" });
+    expect(setupIntentFromInput("r")).toEqual({ type: "resetSelectedField" });
+    expect(setupIntentFromInput("x")).toBeUndefined();
+  });
+
+  it("moves tabs and field selection without rendering knowledge", () => {
+    const state: SetupUiState = { tabIndex: 1, selectedByTab: { Connection: 0 } };
+
+    const movedField = applySetupIntent(tabs(), state, { type: "moveSelection", delta: 1 });
+    expect(movedField.kind).toBe("state");
+    expect(selectedSetupIndex(tabs(), movedField.state)).toBe(1);
+    expect(selectedSetupField(tabs(), movedField.state)?.id).toBe("timeoutMs");
+
+    const movedTab = applySetupIntent(tabs(), movedField.state, { type: "moveTab", delta: 1 });
+    expect(movedTab.kind).toBe("state");
+    expect(movedTab.state.tabIndex).toBe(2);
+    expect(selectedSetupField(tabs(), movedTab.state)?.id).toBe("projectBankId");
+  });
+
+  it("returns explicit actions for edit, reset, deployment, and close", () => {
+    const state: SetupUiState = { tabIndex: 1, selectedByTab: { Connection: 0 } };
+
+    expect(applySetupIntent(tabs(), state, { type: "editSelectedField" })).toMatchObject({
+      kind: "action",
+      action: "baseUrl",
+    });
+    expect(applySetupIntent(tabs(), state, { type: "resetSelectedField" })).toMatchObject({
+      kind: "action",
+      action: "reset:baseUrl",
+    });
+    expect(applySetupIntent(tabs(), state, { type: "chooseDeployment" })).toMatchObject({
+      kind: "action",
+      action: "choose-deployment",
+    });
+    expect(applySetupIntent(tabs(), state, { type: "close" })).toMatchObject({
+      kind: "action",
+      action: null,
+    });
+
+    const unchangedState: SetupUiState = { tabIndex: 1, selectedByTab: { Connection: 1 } };
+    expect(applySetupIntent(tabs(), unchangedState, { type: "resetSelectedField" })).toMatchObject({
+      kind: "state",
+    });
+  });
+
+  it("records guided setup profile and template choices for future onboarding", () => {
+    const initial: SetupUiState = { tabIndex: 0, selectedByTab: {} };
+
+    const started = applySetupIntent(tabs(), initial, { type: "startGuidedSetup" });
+    expect(started.state.step).toBe("profile");
+
+    const profiled = applySetupIntent(tabs(), started.state, {
+      type: "chooseProfile",
+      profile: "project-global",
+    });
+    expect(profiled.state).toMatchObject({ step: "banks", profileChoice: "project-global" });
+
+    const templated = applySetupIntent(
+      tabs(),
+      { ...profiled.state, step: "template" },
+      {
+        type: "chooseTemplate",
+        template: "paste-json",
+      },
+    );
+    expect(templated.state).toMatchObject({ step: "review", templateChoice: "paste-json" });
+
+    const backedUp = applySetupIntent(tabs(), templated.state, { type: "back" });
+    expect(backedUp.state.step).toBe("template");
+
+    expect(applySetupIntent(tabs(), templated.state, { type: "finish" })).toMatchObject({
+      kind: "action",
+      action: "done",
+      state: { step: "done" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a pure setup flow Module for TUI state transitions and keyboard-to-intent mapping
- export `SetupStep`, `SetupIntent`, `SetupResult`, profile choice, and template choice seams for future guided setup
- keep current `/hindsight` render behavior while delegating input/state changes out of the renderer
- add focused tests for navigation, explicit actions, profile choices, and template choices

## Issue

- Closes #117

## Change type

- [x] feat
- [ ] fix
- [ ] docs
- [x] test
- [x] refactor
- [ ] chore

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Verification

- [x] `npm test -- tests/setup-flow.test.ts tests/setup-tui.test.ts`
- [x] `npm run check`
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [ ] `npm run pack:verify` (not needed: no release/package changes)
- [ ] `npm run smoke:hindsight` (not needed: no memory-path behavior changes)

## Guidance sync

- [x] No contributor workflow, verification, memory policy, source-of-truth order, or definition-of-done guidance changed.

## Notes

No memory-path behavior changed. Current `/hindsight` UI behavior should remain unchanged; this adds the state/intent seam needed by first-run setup and bank-template import slices.
