### PR TITLE
test: stabilize periodic flush hook wait

### DIFF
--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -237,8 +237,15 @@ describe("extension hooks", () => {
       });
       mocked.client.retain.mockClear();
       await vi.advanceTimersByTimeAsync(1_000);
-      await waitForCondition(() => mocked.client.retain.mock.calls.length > 0, 5_000);
-      await waitForCondition(async () => (await readRetainQueue(queuePath)).length === 1, 5_000);
+      const periodicFlushWaitMs = process.platform === "win32" ? 20_000 : 5_000;
+      await waitForCondition(async () => {
+        const queue = await readRetainQueue(queuePath);
+        return (
+          mocked.client.retain.mock.calls.length === 1 &&
+          queue.length === 1 &&
+          queue[0]?.id === "queued-2"
+        );
+      }, periodicFlushWaitMs);
 
       expect(mocked.client.retain).toHaveBeenCalledTimes(1);
       expect((await readRetainQueue(queuePath)).map((job) => job.id)).toEqual(["queued-2"]);
@@ -251,7 +258,7 @@ describe("extension hooks", () => {
       await handlers.session_shutdown?.[0]?.({}, ctx);
       vi.useRealTimers();
     }
-  }, 20_000);
+  }, 30_000);
 
   it("skips automatic retain once for next opt-out and advances retain cursor", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));


### PR DESCRIPTION
## Summary

- stabilize the periodic flush hook test on Windows
- wait for the final observable state: one retain call and `queued-2` remaining in the queue
- give Windows a longer polling window for slower file IO under full-suite CI

## Issue

- Closes #137

## Change type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] test
- [ ] refactor
- [ ] chore

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Verification

- [x] `npm test -- tests/extension-hooks.test.ts`
- [x] `npm run check`
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [ ] `npm run pack:verify` (not needed: no release/package changes)
- [ ] `npm run smoke:hindsight` (not needed: test-only change)

## Guidance sync

- [x] No contributor workflow, verification, memory policy, source-of-truth order, or definition-of-done guidance changed.

## Notes

This fixes the Windows CI blocker seen on #136. Runtime code is untouched.
