### PR TITLE
test: allow slow Windows coverage hooks

### DIFF
--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -184,7 +184,7 @@ describe("extension hooks", () => {
     expect(retainedContent).toContain("Decision still stands.");
     expect(retainedContent).not.toContain("<hindsight-memory>");
     expect(retainedContent).not.toContain("repo-specific remembered fact");
-  });
+  }, 20_000);
 
   it("flushes queued retain jobs on the configured interval", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
@@ -237,7 +237,7 @@ describe("extension hooks", () => {
       });
       mocked.client.retain.mockClear();
       await vi.advanceTimersByTimeAsync(1_000);
-      const periodicFlushWaitMs = process.platform === "win32" ? 20_000 : 5_000;
+      const periodicFlushWaitMs = process.platform === "win32" ? 60_000 : 5_000;
       await waitForCondition(async () => {
         const queue = await readRetainQueue(queuePath);
         return (
@@ -258,7 +258,7 @@ describe("extension hooks", () => {
       await handlers.session_shutdown?.[0]?.({}, ctx);
       vi.useRealTimers();
     }
-  }, 30_000);
+  }, 70_000);
 
   it("skips automatic retain once for next opt-out and advances retain cursor", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));


### PR DESCRIPTION
## Summary

- allow the recall/retain extension-hook test to exceed Vitest's default 5s under slow Windows coverage
- extend the Windows-only periodic flush polling window for coverage-heavy runs
- keep runtime behavior unchanged

## Issue

- Closes #137

## Change type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] test
- [ ] refactor
- [ ] chore

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Verification

- [x] `npm test -- tests/extension-hooks.test.ts`
- [x] `npm run check`
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [ ] `npm run pack:verify` (not needed: no release/package changes)
- [ ] `npm run smoke:hindsight` (not needed: test-only change)

## Guidance sync

- [x] No contributor workflow, verification, memory policy, source-of-truth order, or definition-of-done guidance changed.

## Notes

This addresses the Windows coverage failure seen after #138 when PR #136 added another test file and increased coverage-run load.
