### PR TITLE
feat(tui): add guided memory setup

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,8 @@ In Pi, run:
 
 The setup TUI shows memory status, selected banks, retain queue state, import state, recent retain receipts, and editable configuration fields.
 
+If the repository has no project config yet, `/hindsight` offers guided setup before opening the advanced setup TUI. Guided setup can also be rerun later from the TUI with `g`.
+
 Current keyboard controls:
 
 - `h`/`l` or `<`/`>`: switch tabs
@@ -44,6 +46,7 @@ Current keyboard controls:
 - `Enter`: edit selected setting
 - `r`: remove the selected setting's active override
 - `d`: deployment setup
+- `g`: rerun guided setup
 
 ## 4. Pick a memory profile
 

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -1,0 +1,106 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { createMemoryOperations, type MemoryOperationsDeps } from "./memory-operation-service.js";
+import type { MemoryProfile, ProjectConfigPatchInput } from "./config-writer.js";
+import type { SetupProfileChoice } from "./setup-tui-types.js";
+import type { ResolvedConfig } from "./types.js";
+
+export function hasProjectHindsightConfig(cwd: string): boolean {
+  return (
+    existsSync(join(cwd, ".pi", "hindsight.json")) ||
+    existsSync(join(cwd, ".pi", "hindsight.jsonc"))
+  );
+}
+
+export function setupProfileChoiceToMemoryProfile(choice: SetupProfileChoice): MemoryProfile {
+  return choice === "project-global" ? "project+global" : choice;
+}
+
+export function buildGuidedSetupPatch(args: {
+  profile: SetupProfileChoice;
+  projectBankId?: string;
+  globalBankId?: string;
+  config: ResolvedConfig;
+}): ProjectConfigPatchInput {
+  const memoryProfile = setupProfileChoiceToMemoryProfile(args.profile);
+  return {
+    memoryProfile,
+    ...(memoryProfile !== "global-only" && args.projectBankId?.trim()
+      ? { projectBankId: args.projectBankId.trim() }
+      : {}),
+    ...(memoryProfile !== "project-only" && args.globalBankId?.trim()
+      ? { globalBankId: args.globalBankId.trim() }
+      : args.config.banks.global.bankId && memoryProfile !== "project-only"
+        ? { globalBankId: args.config.banks.global.bankId }
+        : {}),
+  };
+}
+
+async function askBankId(args: {
+  ctx: ExtensionCommandContext;
+  title: string;
+  fallback: string;
+}): Promise<string | undefined> {
+  const value = await args.ctx.ui.input(args.title, args.fallback);
+  if (value === undefined) return undefined;
+  return value.trim() || args.fallback;
+}
+
+export async function runGuidedSetup(args: {
+  ctx: ExtensionCommandContext;
+  deps: MemoryOperationsDeps;
+  cwd: string;
+}): Promise<boolean> {
+  const profile = await args.ctx.ui.select("Choose memory profile", [
+    "project-only",
+    "project+global",
+    "global-only",
+  ]);
+  if (!profile) return false;
+
+  const setupProfile = (
+    profile === "project+global" ? "project-global" : profile
+  ) as SetupProfileChoice;
+  const config = args.deps.getConfig();
+  const projectBankId =
+    setupProfile === "global-only"
+      ? undefined
+      : await askBankId({
+          ctx: args.ctx,
+          title: "Project bank ID",
+          fallback: config.banks.project.bankId ?? args.deps.getProjectBankId(),
+        });
+  if (setupProfile !== "global-only" && projectBankId === undefined) return false;
+
+  const globalBankId =
+    setupProfile === "project-only"
+      ? undefined
+      : await askBankId({
+          ctx: args.ctx,
+          title: "Global bank ID",
+          fallback: config.banks.global.bankId ?? "",
+        });
+  if (setupProfile !== "project-only" && !globalBankId) {
+    args.ctx.ui.notify("Global bank ID required for global memory profiles.", "warning");
+    return false;
+  }
+
+  const patch = buildGuidedSetupPatch({
+    profile: setupProfile,
+    ...(projectBankId !== undefined ? { projectBankId } : {}),
+    ...(globalBankId !== undefined ? { globalBankId } : {}),
+    config,
+  });
+  const summary = [
+    `Profile: ${setupProfileChoiceToMemoryProfile(setupProfile)}`,
+    ...(projectBankId ? [`Project bank: ${projectBankId}`] : []),
+    ...(globalBankId ? [`Global bank: ${globalBankId}`] : []),
+  ].join("\n");
+  const confirmed = await args.ctx.ui.confirm("Write Pi Hindsight config?", summary);
+  if (!confirmed) return false;
+
+  const result = await createMemoryOperations(args.deps).configure(args.cwd, patch);
+  args.ctx.ui.notify(`Wrote ${result.path}`, "info");
+  return true;
+}

--- a/extensions/setup-flow.ts
+++ b/extensions/setup-flow.ts
@@ -11,6 +11,7 @@ import type {
 export type SetupIntent =
   | { type: "close" }
   | { type: "chooseDeployment" }
+  | { type: "guidedSetup" }
   | { type: "toggleAdvanced" }
   | { type: "moveTab"; delta: number }
   | { type: "moveSelection"; delta: number }
@@ -100,6 +101,7 @@ export function selectedSetupField(
 export function setupIntentFromInput(data: string): SetupIntent | undefined {
   if (matchesKey(data, Key.escape) || data === "q") return { type: "close" };
   if (data === "d") return { type: "chooseDeployment" };
+  if (data === "g") return { type: "guidedSetup" };
   if (matchesKey(data, Key.left) || data === "h" || data === "<") {
     return { type: "moveTab", delta: -1 };
   }
@@ -122,6 +124,7 @@ export function applySetupIntent(
   const normalized = normalizeSetupUiState(tabs, state);
   if (intent.type === "close") return withAction(null, normalized);
   if (intent.type === "chooseDeployment") return withAction("choose-deployment", normalized);
+  if (intent.type === "guidedSetup") return withAction("guided-setup", normalized);
   if (intent.type === "toggleAdvanced") return withAction("toggle-advanced", normalized);
   if (intent.type === "finish") return withAction("done", { ...normalized, step: "done" });
   if (intent.type === "startGuidedSetup") return withState({ ...normalized, step: "profile" });

--- a/extensions/setup-tui-render.ts
+++ b/extensions/setup-tui-render.ts
@@ -194,7 +194,7 @@ export function createSetupComponent(
         boxed(
           theme.fg(
             "dim",
-            ` h/l or </> tabs · j/k move · enter edit · r reset · a advanced ${state.showAdvanced ? "on" : "off"} · d deployment · q close `,
+            ` h/l or </> tabs · j/k move · enter edit · r reset · a advanced ${state.showAdvanced ? "on" : "off"} · d deployment · g guided · q close `,
           ),
           width,
           theme,

--- a/extensions/setup-tui-types.ts
+++ b/extensions/setup-tui-types.ts
@@ -4,6 +4,7 @@ export type SetupActionId =
   | FieldId
   | `reset:${FieldId}`
   | "choose-deployment"
+  | "guided-setup"
   | "toggle-advanced"
   | "done";
 

--- a/extensions/setup-tui.ts
+++ b/extensions/setup-tui.ts
@@ -1,6 +1,7 @@
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import type { FieldId } from "./config-editing-model.js";
 import type { MemoryOperationsDeps } from "./memory-operation-service.js";
+import { hasProjectHindsightConfig, runGuidedSetup } from "./guided-setup.js";
 import { buildSetupTabs } from "./setup-tui-facts.js";
 import { createSetupComponent } from "./setup-tui-render.js";
 import { handleDeployment, handleFieldEdit, handleResetFieldAction } from "./setup-tui-actions.js";
@@ -51,6 +52,15 @@ export async function runHindsightSetupTui(
   deps: MemoryOperationsDeps,
 ): Promise<void> {
   const state: SetupUiState = { tabIndex: 0, selectedByTab: {} };
+  if (!hasProjectHindsightConfig(ctx.cwd)) {
+    const choice = await ctx.ui.select("No project Hindsight config found", [
+      "Guided setup",
+      "Open advanced setup",
+      "Skip",
+    ]);
+    if (choice === "Guided setup") await runGuidedSetup({ ctx, deps, cwd: ctx.cwd });
+    if (choice === "Skip" || !choice) return;
+  }
   while (true) {
     const config = deps.getConfig();
     const projectBankId = deps.getProjectBankId();
@@ -58,6 +68,7 @@ export async function runHindsightSetupTui(
     if (!action || action === "done") return;
     try {
       if (action === "choose-deployment") await handleDeployment(ctx, deps, config);
+      else if (action === "guided-setup") await runGuidedSetup({ ctx, deps, cwd: ctx.cwd });
       else if (action === "toggle-advanced") {
         state.showAdvanced = !state.showAdvanced;
         state.selectedByTab = {};

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -1,0 +1,92 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config-defaults.js";
+import {
+  buildGuidedSetupPatch,
+  hasProjectHindsightConfig,
+  setupProfileChoiceToMemoryProfile,
+} from "../extensions/guided-setup.js";
+
+const configuredGlobal = {
+  ...DEFAULT_CONFIG,
+  banks: {
+    ...DEFAULT_CONFIG.banks,
+    global: { ...DEFAULT_CONFIG.banks.global, bankId: "global-luxus" },
+  },
+};
+
+describe("guided setup", () => {
+  it("detects project config files", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-guided-"));
+    expect(hasProjectHindsightConfig(cwd)).toBe(false);
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(join(cwd, ".pi", "not-hindsight.json"), "{}", { flag: "wx" });
+    expect(hasProjectHindsightConfig(cwd)).toBe(false);
+  });
+
+  it("detects json and jsonc project config files", () => {
+    const jsonCwd = mkdtempSync(join(tmpdir(), "pi-hindsight-guided-json-"));
+    const jsoncCwd = mkdtempSync(join(tmpdir(), "pi-hindsight-guided-jsonc-"));
+    mkdirSync(join(jsonCwd, ".pi"));
+    mkdirSync(join(jsoncCwd, ".pi"));
+    writeFileSync(join(jsonCwd, ".pi", "hindsight.json"), "{}", { flag: "wx" });
+    writeFileSync(join(jsoncCwd, ".pi", "hindsight.jsonc"), "{}", { flag: "wx" });
+
+    expect(hasProjectHindsightConfig(jsonCwd)).toBe(true);
+    expect(hasProjectHindsightConfig(jsoncCwd)).toBe(true);
+  });
+
+  it("maps setup profile choices to config writer profiles", () => {
+    expect(setupProfileChoiceToMemoryProfile("project-only")).toBe("project-only");
+    expect(setupProfileChoiceToMemoryProfile("project-global")).toBe("project+global");
+    expect(setupProfileChoiceToMemoryProfile("global-only")).toBe("global-only");
+  });
+
+  it("builds profile and bank patches without inventing global bank IDs", () => {
+    expect(
+      buildGuidedSetupPatch({
+        profile: "project-only",
+        projectBankId: "project-bank",
+        config: DEFAULT_CONFIG,
+      }),
+    ).toEqual({ memoryProfile: "project-only", projectBankId: "project-bank" });
+
+    expect(
+      buildGuidedSetupPatch({
+        profile: "project-global",
+        projectBankId: "project-bank",
+        globalBankId: "global-luxus",
+        config: DEFAULT_CONFIG,
+      }),
+    ).toEqual({
+      memoryProfile: "project+global",
+      projectBankId: "project-bank",
+      globalBankId: "global-luxus",
+    });
+
+    expect(
+      buildGuidedSetupPatch({
+        profile: "global-only",
+        projectBankId: "ignored-project",
+        globalBankId: "global-luxus",
+        config: DEFAULT_CONFIG,
+      }),
+    ).toEqual({ memoryProfile: "global-only", globalBankId: "global-luxus" });
+  });
+
+  it("uses existing configured global bank ID when profile enables global memory", () => {
+    expect(
+      buildGuidedSetupPatch({
+        profile: "project-global",
+        projectBankId: "project-bank",
+        config: configuredGlobal,
+      }),
+    ).toEqual({
+      memoryProfile: "project+global",
+      projectBankId: "project-bank",
+      globalBankId: "global-luxus",
+    });
+  });
+});

--- a/tests/setup-flow.test.ts
+++ b/tests/setup-flow.test.ts
@@ -36,6 +36,7 @@ describe("setup flow state", () => {
   it("maps setup keystrokes to behavior-neutral intents", () => {
     expect(setupIntentFromInput("q")).toEqual({ type: "close" });
     expect(setupIntentFromInput("d")).toEqual({ type: "chooseDeployment" });
+    expect(setupIntentFromInput("g")).toEqual({ type: "guidedSetup" });
     expect(setupIntentFromInput("h")).toEqual({ type: "moveTab", delta: -1 });
     expect(setupIntentFromInput("l")).toEqual({ type: "moveTab", delta: 1 });
     expect(setupIntentFromInput("j")).toEqual({ type: "moveSelection", delta: 1 });


### PR DESCRIPTION
## Summary

- add first-run guided setup when `/hindsight` opens without project config
- add `g` shortcut to rerun guided setup from the setup TUI
- support project-only, project+global, and global-only profile choices with explicit bank ID prompts
- write config through existing operation/config writer seams
- document the guided setup path

## Issue

- Closes #118

## Change type

- [x] feat
- [ ] fix
- [x] docs
- [x] test
- [ ] refactor
- [ ] chore

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Verification

- [x] `npm test -- tests/guided-setup.test.ts tests/setup-flow.test.ts tests/setup-tui.test.ts`
- [x] `npm run check`
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [ ] `npm run pack:verify` (not needed: no release/package changes)
- [ ] `npm run smoke:hindsight` (not needed: setup/config UI only; no memory-path retain/recall/import behavior changes)

## Guidance sync

- [x] No contributor workflow, verification, memory policy, source-of-truth order, or definition-of-done guidance changed.

## Notes

Bank template import stays out of scope for #119.
