### PR TITLE
feat(tui): import bank templates during setup

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ In Pi, run:
 
 The setup TUI shows memory status, selected banks, retain queue state, import state, recent retain receipts, and editable configuration fields.
 
-If the repository has no project config yet, `/hindsight` offers guided setup before opening the advanced setup TUI. Guided setup can also be rerun later from the TUI with `g`.
+If the repository has no project config yet, `/hindsight` offers guided setup before opening the advanced setup TUI. Guided setup can also be rerun later from the TUI with `g`. During guided setup, you can paste an official Hindsight bank template JSON manifest; Pi Hindsight dry-runs it first, shows the result, and applies it only after confirmation. The same manifest can also be used with `POST /v1/default/banks/{bank_id}/import` or pasted in the Hindsight control plane bank creation dialog.
 
 Current keyboard controls:
 

--- a/extensions/bank-template-operations.ts
+++ b/extensions/bank-template-operations.ts
@@ -1,0 +1,57 @@
+import { resolveOperationBank } from "./bank-selection.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+import { isRecord } from "./client-rest.js";
+
+export type BankTemplateManifest = Record<string, unknown>;
+
+export function parseBankTemplateManifestJson(input: string): BankTemplateManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid bank template JSON: ${message}`);
+  }
+  if (!isRecord(parsed)) throw new Error("Invalid bank template JSON: manifest must be an object.");
+  return parsed;
+}
+
+export function summarizeBankTemplateImportResult(result: unknown): string {
+  if (!isRecord(result)) return JSON.stringify(result, null, 2);
+  const preferred = [
+    "dry_run",
+    "config_applied",
+    "mental_models_created",
+    "mental_models_updated",
+    "directives_created",
+    "directives_updated",
+    "operation_ids",
+  ];
+  const lines = preferred
+    .filter((key) => key in result)
+    .map((key) => `${key}: ${JSON.stringify(result[key])}`);
+  return lines.length ? lines.join("\n") : JSON.stringify(result, null, 2);
+}
+
+export function createBankTemplateOperations(deps: MemoryOperationsDeps) {
+  return {
+    async importBankTemplate(args: {
+      bank?: string;
+      manifest: BankTemplateManifest;
+      dryRun?: boolean;
+    }) {
+      const client = deps.getClient();
+      if (!client.importBankTemplate)
+        throw new Error("Hindsight client does not support bank template import.");
+      const bankId = resolveOperationBank({
+        requestedBank: args.bank,
+        config: deps.getConfig(),
+        projectBankId: deps.getProjectBankId(),
+      });
+      const result = await client.importBankTemplate(bankId, args.manifest, {
+        dryRun: args.dryRun ?? false,
+      });
+      return { bankId, result };
+    },
+  };
+}

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -90,6 +90,17 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
           signal,
         }),
       ),
+    importBankTemplate: (bankId, manifest, options) =>
+      withTimeout("hindsight importBankTemplate", timeoutMs, (signal) =>
+        rest.request(
+          `${encodeBankPath(bankId, "/import")}${options?.dryRun ? "?dry_run=true" : ""}`,
+          {
+            method: "POST",
+            signal,
+            body: JSON.stringify(manifest),
+          },
+        ),
+      ),
   };
 }
 

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -1,7 +1,15 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
-import { createMemoryOperations, type MemoryOperationsDeps } from "./memory-operation-service.js";
+import {
+  parseBankTemplateManifestJson,
+  summarizeBankTemplateImportResult,
+} from "./bank-template-operations.js";
+import {
+  createMemoryOperations,
+  type MemoryOperations,
+  type MemoryOperationsDeps,
+} from "./memory-operation-service.js";
 import type { MemoryProfile, ProjectConfigPatchInput } from "./config-writer.js";
 import type { SetupProfileChoice } from "./setup-tui-types.js";
 import type { ResolvedConfig } from "./types.js";
@@ -45,6 +53,75 @@ async function askBankId(args: {
   const value = await args.ctx.ui.input(args.title, args.fallback);
   if (value === undefined) return undefined;
   return value.trim() || args.fallback;
+}
+
+function enabledTemplateTargets(args: {
+  setupProfile: SetupProfileChoice;
+  projectBankId?: string;
+  globalBankId?: string;
+}): Array<{ label: string; bank: string }> {
+  return [
+    ...(args.setupProfile !== "global-only" && args.projectBankId
+      ? [{ label: `project (${args.projectBankId})`, bank: args.projectBankId }]
+      : []),
+    ...(args.setupProfile !== "project-only" && args.globalBankId
+      ? [{ label: `global (${args.globalBankId})`, bank: args.globalBankId }]
+      : []),
+  ];
+}
+
+async function maybeImportBankTemplate(args: {
+  ctx: ExtensionCommandContext;
+  operations: MemoryOperations;
+  setupProfile: SetupProfileChoice;
+  projectBankId?: string;
+  globalBankId?: string;
+}): Promise<void> {
+  const choice = await args.ctx.ui.select("Import Hindsight bank template JSON?", [
+    "Skip",
+    "Paste JSON manifest",
+  ]);
+  if (choice !== "Paste JSON manifest") return;
+
+  const targets = enabledTemplateTargets(args);
+  if (targets.length === 0) {
+    args.ctx.ui.notify("No enabled bank target for template import.", "warning");
+    return;
+  }
+  const targetLabel =
+    targets.length === 1
+      ? targets[0]!.label
+      : await args.ctx.ui.select(
+          "Choose template import target bank",
+          targets.map((target) => target.label),
+        );
+  if (!targetLabel) return;
+  const target = targets.find((candidate) => candidate.label === targetLabel);
+  if (!target) return;
+
+  const rawManifest = await args.ctx.ui.input("Paste bank template JSON", '{"version":"1"}');
+  if (rawManifest === undefined) return;
+  const manifest = parseBankTemplateManifestJson(rawManifest);
+  const dryRun = await args.operations.importBankTemplate({
+    bank: target.bank,
+    manifest,
+    dryRun: true,
+  });
+  const dryRunSummary = summarizeBankTemplateImportResult(dryRun.result);
+  const confirmed = await args.ctx.ui.confirm(
+    `Apply template to ${dryRun.bankId}?`,
+    `Dry run result:\n${dryRunSummary}`,
+  );
+  if (!confirmed) return;
+  const applied = await args.operations.importBankTemplate({
+    bank: target.bank,
+    manifest,
+    dryRun: false,
+  });
+  args.ctx.ui.notify(
+    `Imported bank template into ${applied.bankId}: ${summarizeBankTemplateImportResult(applied.result)}`,
+    "info",
+  );
 }
 
 export async function runGuidedSetup(args: {
@@ -100,7 +177,16 @@ export async function runGuidedSetup(args: {
   const confirmed = await args.ctx.ui.confirm("Write Pi Hindsight config?", summary);
   if (!confirmed) return false;
 
-  const result = await createMemoryOperations(args.deps).configure(args.cwd, patch);
+  const operations = createMemoryOperations(args.deps);
+  const result = await operations.configure(args.cwd, patch);
   args.ctx.ui.notify(`Wrote ${result.path}`, "info");
+
+  await maybeImportBankTemplate({
+    ctx: args.ctx,
+    operations,
+    setupProfile,
+    ...(projectBankId !== undefined ? { projectBankId } : {}),
+    ...(globalBankId !== undefined ? { globalBankId } : {}),
+  });
   return true;
 }

--- a/extensions/memory-operation-service.ts
+++ b/extensions/memory-operation-service.ts
@@ -1,5 +1,6 @@
 import type { MemoryOperationsDeps } from "./memory-operation-types.js";
 import { importMemoryProjectSessions, importMemorySession } from "./import-operations.js";
+import { createBankTemplateOperations } from "./bank-template-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
 import { createDocumentOperations } from "./memory-document-operations.js";
 import { createRecallOperations } from "./memory-recall-operations.js";
@@ -42,6 +43,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createDocumentOperations(deps),
     ...createRoutingOperations(deps),
     ...createConfigOperations(deps),
+    ...createBankTemplateOperations(deps),
     ...createImportOperations(deps),
     ...createSessionOperations(),
   };

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -238,4 +238,9 @@ export interface HindsightLikeClient {
   getBankStats?(bankId: string): Promise<unknown>;
   health?(): Promise<unknown>;
   deleteDocument?(bankId: string, documentId: string): Promise<unknown>;
+  importBankTemplate?(
+    bankId: string,
+    manifest: Record<string, unknown>,
+    options?: { dryRun?: boolean },
+  ): Promise<unknown>;
 }

--- a/tests/bank-template-operations.test.ts
+++ b/tests/bank-template-operations.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createBankTemplateOperations,
+  parseBankTemplateManifestJson,
+  summarizeBankTemplateImportResult,
+} from "../extensions/bank-template-operations.js";
+import { DEFAULT_CONFIG } from "../extensions/config-defaults.js";
+import type { MemoryOperationsDeps } from "../extensions/memory-operation-types.js";
+
+function deps() {
+  const importBankTemplate = vi.fn(async () => ({ dry_run: true, config_applied: true }));
+  const config = {
+    ...DEFAULT_CONFIG,
+    banks: {
+      ...DEFAULT_CONFIG.banks,
+      global: { ...DEFAULT_CONFIG.banks.global, enabled: true, bankId: "global-luxus" },
+    },
+  };
+  return {
+    importBankTemplate,
+    deps: {
+      getClient: () => ({
+        retain: vi.fn(),
+        recall: vi.fn(),
+        reflect: vi.fn(),
+        importBankTemplate,
+      }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    } satisfies MemoryOperationsDeps,
+  };
+}
+
+describe("bank template operations", () => {
+  it("strictly parses manifest JSON objects", () => {
+    expect(parseBankTemplateManifestJson('{"version":"1"}')).toEqual({ version: "1" });
+    expect(() => parseBankTemplateManifestJson("not json")).toThrow("Invalid bank template JSON");
+    expect(() => parseBankTemplateManifestJson("[]")).toThrow("manifest must be an object");
+  });
+
+  it("resolves bank aliases before dry-run import", async () => {
+    const fixture = deps();
+    const result = await createBankTemplateOperations(fixture.deps).importBankTemplate({
+      bank: "global",
+      manifest: { version: "1" },
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      bankId: "global-luxus",
+      result: { dry_run: true, config_applied: true },
+    });
+    expect(fixture.importBankTemplate).toHaveBeenCalledWith(
+      "global-luxus",
+      { version: "1" },
+      { dryRun: true },
+    );
+  });
+
+  it("formats dry-run summaries", () => {
+    expect(
+      summarizeBankTemplateImportResult({
+        dry_run: true,
+        config_applied: true,
+        mental_models_created: 2,
+        directives_created: 1,
+      }),
+    ).toContain("mental_models_created: 2");
+    expect(summarizeBankTemplateImportResult("ok")).toBe('"ok"');
+  });
+});

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -59,6 +59,10 @@ describe("Hindsight client adapter integration", () => {
         sendJson(res, 200, { text: "reflection" });
         return;
       }
+      if (req.method === "POST" && req.url === "/v1/default/banks/test-bank/import?dry_run=true") {
+        sendJson(res, 200, { dry_run: true, config_applied: true });
+        return;
+      }
       sendJson(res, 404, { detail: `unexpected ${req.method} ${req.url}` });
     });
 
@@ -108,9 +112,15 @@ describe("Hindsight client adapter integration", () => {
       budget: "low",
       responseSchema: { type: "object", properties: { answer: { type: "string" } } },
     });
+    const templateDryRun = await client.importBankTemplate?.(
+      "test-bank",
+      { version: "1", bank: { retain_mission: "Retain useful facts." } },
+      { dryRun: true },
+    );
 
     expect(recall).toEqual({ results: [{ text: "remembered fact" }] });
     expect(reflection).toEqual({ text: "reflection" });
+    expect(templateDryRun).toEqual({ dry_run: true, config_applied: true });
 
     expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
       "GET /v1/default/banks/test-bank/profile",
@@ -119,6 +129,7 @@ describe("Hindsight client adapter integration", () => {
       "POST /v1/default/banks/test-bank/memories",
       "POST /v1/default/banks/test-bank/memories/recall",
       "POST /v1/default/banks/test-bank/reflect",
+      "POST /v1/default/banks/test-bank/import?dry_run=true",
     ]);
 
     expect(requests[2]?.body).toMatchObject({
@@ -161,6 +172,10 @@ describe("Hindsight client adapter integration", () => {
       query: "query",
       budget: "low",
       response_schema: { type: "object", properties: { answer: { type: "string" } } },
+    });
+    expect(requests[6]?.body).toEqual({
+      version: "1",
+      bank: { retain_mission: "Retain useful facts." },
     });
   });
 });


### PR DESCRIPTION
## Summary

- add official Hindsight bank template import to the client Adapter
- add operation-service support with project/global bank alias resolution
- add strict JSON parsing and dry-run summary helpers
- offer template import during guided setup with dry-run first and explicit confirmation before apply
- document that manifests also work with the official Hindsight endpoint/control plane

## Issue

- Closes #119

## Change type

- [x] feat
- [ ] fix
- [x] docs
- [x] test
- [ ] refactor
- [ ] chore

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Verification

- [x] `npm test -- tests/bank-template-operations.test.ts tests/client-integration.test.ts tests/guided-setup.test.ts`
- [x] `npm run check`
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [x] `npm run smoke:hindsight`
- [ ] `npm run pack:verify` (not needed: no release/package changes)

## Guidance sync

- [x] No contributor workflow, verification, memory policy, source-of-truth order, or definition-of-done guidance changed.

## Notes

No 404/old-server fallback. No bundled templates. Template import is explicit, dry-run-first, and user-confirmed.
