### PR TITLE
feat(tui): flush retain queue from setup

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,6 +45,7 @@ Current keyboard controls:
 - `j`/`k`: move between settings
 - `Enter`: edit selected setting
 - `r`: remove the selected setting's active override
+- `f`: flush queued retain jobs
 - `d`: deployment setup
 - `g`: rerun guided setup
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -8,7 +8,7 @@
 /hindsight
 ```
 
-Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. It also exposes setup/config editing actions.
+Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI.
 
 ## Setup and config
 

--- a/extensions/command-maintenance.ts
+++ b/extensions/command-maintenance.ts
@@ -8,6 +8,7 @@ import {
   firstNonFlagArg,
   sessionFile,
 } from "./command-utils.js";
+import { flushRetainQueueNotifyLevel, formatFlushRetainQueueResult } from "./flush-presenter.js";
 
 type Operations = ReturnType<typeof createMemoryOperations>;
 
@@ -106,10 +107,7 @@ export function maintenanceCommandOperations(operations: Operations): CommandOpe
         description: "Flush queued retain jobs.",
         handler: async (_args, ctx) => {
           const result = await operations.flush(ctx.cwd);
-          ctx.ui.notify(
-            `Hindsight flushed ${result.sent}; dead-lettered ${result.deadLettered}; remaining ${result.remaining}`,
-            result.remaining || result.deadLettered ? "warning" : "info",
-          );
+          ctx.ui.notify(formatFlushRetainQueueResult(result), flushRetainQueueNotifyLevel(result));
         },
       },
     },

--- a/extensions/flush-presenter.ts
+++ b/extensions/flush-presenter.ts
@@ -1,0 +1,9 @@
+import type { FlushRetainQueueResult } from "./queue.js";
+
+export function formatFlushRetainQueueResult(result: FlushRetainQueueResult): string {
+  return `Hindsight flushed ${result.sent}; dead-lettered ${result.deadLettered}; remaining ${result.remaining}`;
+}
+
+export function flushRetainQueueNotifyLevel(result: FlushRetainQueueResult): "info" | "warning" {
+  return result.remaining || result.deadLettered ? "warning" : "info";
+}

--- a/extensions/setup-flow.ts
+++ b/extensions/setup-flow.ts
@@ -12,6 +12,7 @@ export type SetupIntent =
   | { type: "close" }
   | { type: "chooseDeployment" }
   | { type: "guidedSetup" }
+  | { type: "flushQueue" }
   | { type: "toggleAdvanced" }
   | { type: "moveTab"; delta: number }
   | { type: "moveSelection"; delta: number }
@@ -102,6 +103,7 @@ export function setupIntentFromInput(data: string): SetupIntent | undefined {
   if (matchesKey(data, Key.escape) || data === "q") return { type: "close" };
   if (data === "d") return { type: "chooseDeployment" };
   if (data === "g") return { type: "guidedSetup" };
+  if (data === "f") return { type: "flushQueue" };
   if (matchesKey(data, Key.left) || data === "h" || data === "<") {
     return { type: "moveTab", delta: -1 };
   }
@@ -125,6 +127,7 @@ export function applySetupIntent(
   if (intent.type === "close") return withAction(null, normalized);
   if (intent.type === "chooseDeployment") return withAction("choose-deployment", normalized);
   if (intent.type === "guidedSetup") return withAction("guided-setup", normalized);
+  if (intent.type === "flushQueue") return withAction("flush-queue", normalized);
   if (intent.type === "toggleAdvanced") return withAction("toggle-advanced", normalized);
   if (intent.type === "finish") return withAction("done", { ...normalized, step: "done" });
   if (intent.type === "startGuidedSetup") return withState({ ...normalized, step: "profile" });

--- a/extensions/setup-tui-render.ts
+++ b/extensions/setup-tui-render.ts
@@ -194,7 +194,7 @@ export function createSetupComponent(
         boxed(
           theme.fg(
             "dim",
-            ` h/l or </> tabs · j/k move · enter edit · r reset · a advanced ${state.showAdvanced ? "on" : "off"} · d deployment · g guided · q close `,
+            ` h/l or </> tabs · j/k move · enter edit · r reset · f flush · a advanced ${state.showAdvanced ? "on" : "off"} · d deployment · g guided · q close `,
           ),
           width,
           theme,

--- a/extensions/setup-tui-types.ts
+++ b/extensions/setup-tui-types.ts
@@ -5,6 +5,7 @@ export type SetupActionId =
   | `reset:${FieldId}`
   | "choose-deployment"
   | "guided-setup"
+  | "flush-queue"
   | "toggle-advanced"
   | "done";
 

--- a/extensions/setup-tui.ts
+++ b/extensions/setup-tui.ts
@@ -1,6 +1,7 @@
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import type { FieldId } from "./config-editing-model.js";
-import type { MemoryOperationsDeps } from "./memory-operation-service.js";
+import { createMemoryOperations, type MemoryOperationsDeps } from "./memory-operation-service.js";
+import { flushRetainQueueNotifyLevel, formatFlushRetainQueueResult } from "./flush-presenter.js";
 import { hasProjectHindsightConfig, runGuidedSetup } from "./guided-setup.js";
 import { buildSetupTabs } from "./setup-tui-facts.js";
 import { createSetupComponent } from "./setup-tui-render.js";
@@ -69,7 +70,10 @@ export async function runHindsightSetupTui(
     try {
       if (action === "choose-deployment") await handleDeployment(ctx, deps, config);
       else if (action === "guided-setup") await runGuidedSetup({ ctx, deps, cwd: ctx.cwd });
-      else if (action === "toggle-advanced") {
+      else if (action === "flush-queue") {
+        const result = await createMemoryOperations(deps).flush(ctx.cwd);
+        ctx.ui.notify(formatFlushRetainQueueResult(result), flushRetainQueueNotifyLevel(result));
+      } else if (action === "toggle-advanced") {
         state.showAdvanced = !state.showAdvanced;
         state.selectedByTab = {};
       } else if (action.startsWith("reset:")) {

--- a/tests/flush-presenter.test.ts
+++ b/tests/flush-presenter.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  flushRetainQueueNotifyLevel,
+  formatFlushRetainQueueResult,
+} from "../extensions/flush-presenter.js";
+import type { FlushRetainQueueResult } from "../extensions/queue.js";
+
+function result(overrides: Partial<FlushRetainQueueResult> = {}): FlushRetainQueueResult {
+  return { sent: 1, remaining: 0, deadLettered: 0, malformed: 0, ...overrides };
+}
+
+describe("flush presenter", () => {
+  it("formats retain queue flush results", () => {
+    expect(formatFlushRetainQueueResult(result({ sent: 2, deadLettered: 1, remaining: 3 }))).toBe(
+      "Hindsight flushed 2; dead-lettered 1; remaining 3",
+    );
+  });
+
+  it("warns when a flush leaves queued or dead-lettered jobs", () => {
+    expect(flushRetainQueueNotifyLevel(result())).toBe("info");
+    expect(flushRetainQueueNotifyLevel(result({ remaining: 1 }))).toBe("warning");
+    expect(flushRetainQueueNotifyLevel(result({ deadLettered: 1 }))).toBe("warning");
+  });
+});

--- a/tests/setup-flow.test.ts
+++ b/tests/setup-flow.test.ts
@@ -37,6 +37,7 @@ describe("setup flow state", () => {
     expect(setupIntentFromInput("q")).toEqual({ type: "close" });
     expect(setupIntentFromInput("d")).toEqual({ type: "chooseDeployment" });
     expect(setupIntentFromInput("g")).toEqual({ type: "guidedSetup" });
+    expect(setupIntentFromInput("f")).toEqual({ type: "flushQueue" });
     expect(setupIntentFromInput("h")).toEqual({ type: "moveTab", delta: -1 });
     expect(setupIntentFromInput("l")).toEqual({ type: "moveTab", delta: 1 });
     expect(setupIntentFromInput("j")).toEqual({ type: "moveSelection", delta: 1 });
@@ -74,6 +75,10 @@ describe("setup flow state", () => {
     expect(applySetupIntent(tabs(), state, { type: "chooseDeployment" })).toMatchObject({
       kind: "action",
       action: "choose-deployment",
+    });
+    expect(applySetupIntent(tabs(), state, { type: "flushQueue" })).toMatchObject({
+      kind: "action",
+      action: "flush-queue",
     });
     expect(applySetupIntent(tabs(), state, { type: "close" })).toMatchObject({
       kind: "action",

--- a/tests/setup-tui.test.ts
+++ b/tests/setup-tui.test.ts
@@ -46,6 +46,8 @@ describe("setup TUI receipt facts", () => {
       () => undefined,
     );
 
-    expect(component.render(100).join("\n")).toContain("Extract durable project");
+    const rendered = component.render(100).join("\n");
+    expect(rendered).toContain("Extract durable project");
+    expect(rendered).toContain("f flush");
   });
 });


### PR DESCRIPTION
## Summary
- add `f` key action in `/hindsight` TUI to flush queued retain jobs
- share flush notification message/severity between command and TUI
- document TUI flush shortcut

## Verification
- npm run check
- npm run check:coverage
- npm run typecheck:tsc

Closes #120
