### PR TITLE
feat(core): expose mental model api seam

### DIFF
--- a/docs/hindsight-core-functions.md
+++ b/docs/hindsight-core-functions.md
@@ -110,7 +110,9 @@ Good mental model examples:
 - “What recurring workflow habits matter?”
 - “What does this project consider good design?”
 
-Mental models are not raw recall. They are reusable synthesized answers.
+Mental models are not raw recall. They are reusable synthesized answers. In Pi Hindsight they are explicit advanced resources: users should create, refresh, inspect, or delete them intentionally through operations/TUI/tool surfaces. The extension must not auto-create mental models from routine sessions or refresh them in the background unless a future issue designs that policy.
+
+Creating a mental model preserves a source query. Hindsight runs that query through reflect and stores the generated content. Refresh reruns the stored source query against newer memory.
 
 ```text
 Observations  = facts learned from repetition

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -1,4 +1,10 @@
-import type { ResolvedConfig } from "./types.js";
+import type {
+  CreateMentalModelRequest,
+  GetMentalModelOptions,
+  ListMentalModelsOptions,
+  ResolvedConfig,
+  UpdateMentalModelRequest,
+} from "./types.js";
 
 export interface HindsightRestTransport {
   request(path: string, init?: RequestInit): Promise<unknown>;
@@ -83,6 +89,70 @@ export function reflectRequestBody(
   };
 }
 
+function appendQuery(path: string, params: URLSearchParams): string {
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
 export function encodeBankPath(bankId: string, suffix: string): string {
   return `/v1/default/banks/${encodeURIComponent(bankId)}${suffix}`;
+}
+
+export function mentalModelCollectionPath(
+  bankId: string,
+  options: ListMentalModelsOptions = {},
+): string {
+  const params = new URLSearchParams();
+  for (const tag of options.tags ?? []) params.append("tags", tag);
+  if (options.tagsMatch) params.set("tags_match", options.tagsMatch);
+  if (options.detail) params.set("detail", options.detail);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  return appendQuery(encodeBankPath(bankId, "/mental-models"), params);
+}
+
+export function mentalModelItemPath(
+  bankId: string,
+  mentalModelId: string,
+  options: GetMentalModelOptions = {},
+): string {
+  const params = new URLSearchParams();
+  if (options.detail) params.set("detail", options.detail);
+  return appendQuery(
+    `${encodeBankPath(bankId, "/mental-models")}/${encodeURIComponent(mentalModelId)}`,
+    params,
+  );
+}
+
+export function mentalModelHistoryPath(bankId: string, mentalModelId: string): string {
+  return `${mentalModelItemPath(bankId, mentalModelId)}/history`;
+}
+
+export function mentalModelRefreshPath(bankId: string, mentalModelId: string): string {
+  return `${mentalModelItemPath(bankId, mentalModelId)}/refresh`;
+}
+
+export function createMentalModelRequestBody(
+  request: CreateMentalModelRequest,
+): Record<string, unknown> {
+  return {
+    ...(request.id !== undefined ? { id: request.id } : {}),
+    name: request.name,
+    source_query: request.sourceQuery,
+    ...(request.tags ? { tags: request.tags } : {}),
+    ...(request.maxTokens !== undefined ? { max_tokens: request.maxTokens } : {}),
+    ...(request.trigger ? { trigger: request.trigger } : {}),
+  };
+}
+
+export function updateMentalModelRequestBody(
+  request: UpdateMentalModelRequest,
+): Record<string, unknown> {
+  return {
+    ...(request.name !== undefined ? { name: request.name } : {}),
+    ...(request.sourceQuery !== undefined ? { source_query: request.sourceQuery } : {}),
+    ...(request.tags !== undefined ? { tags: request.tags } : {}),
+    ...(request.maxTokens !== undefined ? { max_tokens: request.maxTokens } : {}),
+    ...(request.trigger !== undefined ? { trigger: request.trigger } : {}),
+  };
 }

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -5,8 +5,14 @@ import {
   assertHealthResponse,
   assertReflectResponse,
   createHindsightRestTransport,
+  createMentalModelRequestBody,
   encodeBankPath,
+  mentalModelCollectionPath,
+  mentalModelHistoryPath,
+  mentalModelItemPath,
+  mentalModelRefreshPath,
   reflectRequestBody,
+  updateMentalModelRequestBody,
 } from "./client-rest.js";
 import { withTimeout } from "./timeout.js";
 
@@ -100,6 +106,42 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
             body: JSON.stringify(manifest),
           },
         ),
+      ),
+    listMentalModels: (bankId, options) =>
+      withTimeout("hindsight listMentalModels", timeoutMs, (signal) =>
+        rest.request(mentalModelCollectionPath(bankId, options), { signal }),
+      ),
+    getMentalModel: (bankId, mentalModelId, options) =>
+      withTimeout("hindsight getMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelItemPath(bankId, mentalModelId, options), { signal }),
+      ),
+    createMentalModel: (bankId, request) =>
+      withTimeout("hindsight createMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelCollectionPath(bankId), {
+          method: "POST",
+          signal,
+          body: JSON.stringify(createMentalModelRequestBody(request)),
+        }),
+      ),
+    updateMentalModel: (bankId, mentalModelId, request) =>
+      withTimeout("hindsight updateMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelItemPath(bankId, mentalModelId), {
+          method: "PATCH",
+          signal,
+          body: JSON.stringify(updateMentalModelRequestBody(request)),
+        }),
+      ),
+    deleteMentalModel: (bankId, mentalModelId) =>
+      withTimeout("hindsight deleteMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelItemPath(bankId, mentalModelId), { method: "DELETE", signal }),
+      ),
+    getMentalModelHistory: (bankId, mentalModelId) =>
+      withTimeout("hindsight getMentalModelHistory", timeoutMs, (signal) =>
+        rest.request(mentalModelHistoryPath(bankId, mentalModelId), { signal }),
+      ),
+    refreshMentalModel: (bankId, mentalModelId) =>
+      withTimeout("hindsight refreshMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelRefreshPath(bankId, mentalModelId), { method: "POST", signal }),
       ),
   };
 }

--- a/extensions/memory-mental-model-operations.ts
+++ b/extensions/memory-mental-model-operations.ts
@@ -1,0 +1,88 @@
+import { resolveOperationBank } from "./bank-selection.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+import type {
+  CreateMentalModelRequest,
+  GetMentalModelOptions,
+  ListMentalModelsOptions,
+  UpdateMentalModelRequest,
+} from "./types.js";
+
+function resolveBank(deps: MemoryOperationsDeps, requestedBank: string | undefined): string {
+  return resolveOperationBank({
+    requestedBank,
+    config: deps.getConfig(),
+    projectBankId: deps.getProjectBankId(),
+  });
+}
+
+function unavailable(name: string): Error {
+  return new Error(`Hindsight mental model ${name} is unavailable in this client`);
+}
+
+export function createMentalModelOperations(deps: MemoryOperationsDeps) {
+  return {
+    async listMentalModels(args: { bank?: string; options?: ListMentalModelsOptions } = {}) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.listMentalModels) throw unavailable("list");
+      const result = await client.listMentalModels(bankId, args.options);
+      return { bankId, result };
+    },
+
+    async getMentalModel(args: {
+      bank?: string;
+      mentalModelId: string;
+      options?: GetMentalModelOptions;
+    }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getMentalModel) throw unavailable("get");
+      const result = await client.getMentalModel(bankId, args.mentalModelId, args.options);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+
+    async createMentalModel(args: { bank?: string; request: CreateMentalModelRequest }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.createMentalModel) throw unavailable("create");
+      const result = await client.createMentalModel(bankId, args.request);
+      return { bankId, result };
+    },
+
+    async updateMentalModel(args: {
+      bank?: string;
+      mentalModelId: string;
+      request: UpdateMentalModelRequest;
+    }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.updateMentalModel) throw unavailable("update");
+      const result = await client.updateMentalModel(bankId, args.mentalModelId, args.request);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+
+    async deleteMentalModel(args: { bank?: string; mentalModelId: string }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.deleteMentalModel) throw unavailable("delete");
+      const result = await client.deleteMentalModel(bankId, args.mentalModelId);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+
+    async getMentalModelHistory(args: { bank?: string; mentalModelId: string }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getMentalModelHistory) throw unavailable("history");
+      const result = await client.getMentalModelHistory(bankId, args.mentalModelId);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+
+    async refreshMentalModel(args: { bank?: string; mentalModelId: string }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.refreshMentalModel) throw unavailable("refresh");
+      const result = await client.refreshMentalModel(bankId, args.mentalModelId);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+  };
+}

--- a/extensions/memory-operation-service.ts
+++ b/extensions/memory-operation-service.ts
@@ -3,6 +3,7 @@ import { importMemoryProjectSessions, importMemorySession } from "./import-opera
 import { createBankTemplateOperations } from "./bank-template-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
 import { createDocumentOperations } from "./memory-document-operations.js";
+import { createMentalModelOperations } from "./memory-mental-model-operations.js";
 import { createRecallOperations } from "./memory-recall-operations.js";
 import { createRetainOperations } from "./memory-retain-operations.js";
 import { createRoutingOperations } from "./memory-routing-operations.js";
@@ -44,6 +45,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createRoutingOperations(deps),
     ...createConfigOperations(deps),
     ...createBankTemplateOperations(deps),
+    ...createMentalModelOperations(deps),
     ...createImportOperations(deps),
     ...createSessionOperations(),
   };

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -4,6 +4,8 @@ export type RetainUserContent = "text";
 export type RetainAssistantContent = "text" | "toolCall" | "thinking";
 export type RetainToolResultContent = "error" | "summary" | "content";
 export type TagsMatch = "any" | "all" | "any_strict" | "all_strict";
+export type MentalModelDetail = "metadata" | "content" | "full";
+export type MentalModelTagsMatch = "any" | "all" | "exact";
 export type StatusStyle = "off" | "text" | "emoji" | "nerdfont";
 export type StatusDetail = "minimal" | "project" | "activity" | "verbose";
 export type RecallRole = "user" | "assistant" | "tool" | "system";
@@ -169,6 +171,48 @@ export interface HindsightCapabilities {
   probeDocumentId?: string;
 }
 
+export interface MentalModelTrigger {
+  mode?: "full" | "delta";
+  refresh_after_consolidation?: boolean;
+  fact_types?: Array<"world" | "experience" | "observation"> | null;
+  exclude_mental_models?: boolean;
+  exclude_mental_model_ids?: string[] | null;
+  tags_match?: TagsMatch | null;
+  tag_groups?: unknown[] | null;
+  include_chunks?: boolean | null;
+  recall_max_tokens?: number | null;
+  recall_chunks_max_tokens?: number | null;
+}
+
+export interface CreateMentalModelRequest {
+  id?: string | null;
+  name: string;
+  sourceQuery: string;
+  tags?: string[];
+  maxTokens?: number;
+  trigger?: MentalModelTrigger;
+}
+
+export interface UpdateMentalModelRequest {
+  name?: string | null;
+  sourceQuery?: string | null;
+  tags?: string[] | null;
+  maxTokens?: number | null;
+  trigger?: MentalModelTrigger | null;
+}
+
+export interface ListMentalModelsOptions {
+  tags?: string[];
+  tagsMatch?: MentalModelTagsMatch;
+  detail?: MentalModelDetail;
+  limit?: number;
+  offset?: number;
+}
+
+export interface GetMentalModelOptions {
+  detail?: MentalModelDetail;
+}
+
 export interface HindsightLikeClient {
   retain(
     bankId: string,
@@ -243,4 +287,19 @@ export interface HindsightLikeClient {
     manifest: Record<string, unknown>,
     options?: { dryRun?: boolean },
   ): Promise<unknown>;
+  listMentalModels?(bankId: string, options?: ListMentalModelsOptions): Promise<unknown>;
+  getMentalModel?(
+    bankId: string,
+    mentalModelId: string,
+    options?: GetMentalModelOptions,
+  ): Promise<unknown>;
+  createMentalModel?(bankId: string, request: CreateMentalModelRequest): Promise<unknown>;
+  updateMentalModel?(
+    bankId: string,
+    mentalModelId: string,
+    request: UpdateMentalModelRequest,
+  ): Promise<unknown>;
+  deleteMentalModel?(bankId: string, mentalModelId: string): Promise<unknown>;
+  getMentalModelHistory?(bankId: string, mentalModelId: string): Promise<unknown>;
+  refreshMentalModel?(bankId: string, mentalModelId: string): Promise<unknown>;
 }

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -63,6 +63,53 @@ describe("Hindsight client adapter integration", () => {
         sendJson(res, 200, { dry_run: true, config_applied: true });
         return;
       }
+      if (
+        req.method === "GET" &&
+        req.url ===
+          "/v1/default/banks/test-bank/mental-models?tags=source%3Api&tags_match=all&detail=metadata&limit=10&offset=2"
+      ) {
+        sendJson(res, 200, { items: [{ id: "model-1", name: "Model" }] });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1?detail=full"
+      ) {
+        sendJson(res, 200, { id: "model-1", name: "Model", content: "full" });
+        return;
+      }
+      if (req.method === "POST" && req.url === "/v1/default/banks/test-bank/mental-models") {
+        sendJson(res, 202, { operation_id: "create-op", status: "queued" });
+        return;
+      }
+      if (
+        req.method === "PATCH" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1"
+      ) {
+        sendJson(res, 200, { id: "model-1", name: "Updated" });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1/history"
+      ) {
+        sendJson(res, 200, { items: [{ id: "v1" }] });
+        return;
+      }
+      if (
+        req.method === "POST" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1/refresh"
+      ) {
+        sendJson(res, 202, { operation_id: "refresh-op", status: "queued" });
+        return;
+      }
+      if (
+        req.method === "DELETE" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1"
+      ) {
+        sendJson(res, 200, { deleted: true });
+        return;
+      }
       sendJson(res, 404, { detail: `unexpected ${req.method} ${req.url}` });
     });
 
@@ -117,10 +164,38 @@ describe("Hindsight client adapter integration", () => {
       { version: "1", bank: { retain_mission: "Retain useful facts." } },
       { dryRun: true },
     );
+    const models = await client.listMentalModels?.("test-bank", {
+      tags: ["source:pi"],
+      tagsMatch: "all",
+      detail: "metadata",
+      limit: 10,
+      offset: 2,
+    });
+    const model = await client.getMentalModel?.("test-bank", "model-1", { detail: "full" });
+    const createdModel = await client.createMentalModel?.("test-bank", {
+      name: "Model",
+      sourceQuery: "What should recur?",
+      tags: ["source:pi"],
+      maxTokens: 256,
+    });
+    const updatedModel = await client.updateMentalModel?.("test-bank", "model-1", {
+      sourceQuery: "Updated query",
+      tags: null,
+    });
+    const history = await client.getMentalModelHistory?.("test-bank", "model-1");
+    const refreshed = await client.refreshMentalModel?.("test-bank", "model-1");
+    const deleted = await client.deleteMentalModel?.("test-bank", "model-1");
 
     expect(recall).toEqual({ results: [{ text: "remembered fact" }] });
     expect(reflection).toEqual({ text: "reflection" });
     expect(templateDryRun).toEqual({ dry_run: true, config_applied: true });
+    expect(models).toEqual({ items: [{ id: "model-1", name: "Model" }] });
+    expect(model).toEqual({ id: "model-1", name: "Model", content: "full" });
+    expect(createdModel).toEqual({ operation_id: "create-op", status: "queued" });
+    expect(updatedModel).toEqual({ id: "model-1", name: "Updated" });
+    expect(history).toEqual({ items: [{ id: "v1" }] });
+    expect(refreshed).toEqual({ operation_id: "refresh-op", status: "queued" });
+    expect(deleted).toEqual({ deleted: true });
 
     expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
       "GET /v1/default/banks/test-bank/profile",
@@ -130,6 +205,13 @@ describe("Hindsight client adapter integration", () => {
       "POST /v1/default/banks/test-bank/memories/recall",
       "POST /v1/default/banks/test-bank/reflect",
       "POST /v1/default/banks/test-bank/import?dry_run=true",
+      "GET /v1/default/banks/test-bank/mental-models?tags=source%3Api&tags_match=all&detail=metadata&limit=10&offset=2",
+      "GET /v1/default/banks/test-bank/mental-models/model-1?detail=full",
+      "POST /v1/default/banks/test-bank/mental-models",
+      "PATCH /v1/default/banks/test-bank/mental-models/model-1",
+      "GET /v1/default/banks/test-bank/mental-models/model-1/history",
+      "POST /v1/default/banks/test-bank/mental-models/model-1/refresh",
+      "DELETE /v1/default/banks/test-bank/mental-models/model-1",
     ]);
 
     expect(requests[2]?.body).toMatchObject({
@@ -177,5 +259,12 @@ describe("Hindsight client adapter integration", () => {
       version: "1",
       bank: { retain_mission: "Retain useful facts." },
     });
+    expect(requests[9]?.body).toEqual({
+      name: "Model",
+      source_query: "What should recur?",
+      tags: ["source:pi"],
+      max_tokens: 256,
+    });
+    expect(requests[10]?.body).toEqual({ source_query: "Updated query", tags: null });
   });
 });

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it } from "vitest";
 import {
   assertHealthResponse,
   assertReflectResponse,
+  createMentalModelRequestBody,
   encodeBankPath,
+  mentalModelCollectionPath,
+  mentalModelHistoryPath,
+  mentalModelItemPath,
+  mentalModelRefreshPath,
   reflectRequestBody,
+  updateMentalModelRequestBody,
 } from "../extensions/client-rest.js";
 
 describe("Hindsight REST transport helpers", () => {
@@ -28,6 +34,75 @@ describe("Hindsight REST transport helpers", () => {
 
   it("encodes bank ids in REST paths", () => {
     expect(encodeBankPath("bank/id", "/reflect")).toBe("/v1/default/banks/bank%2Fid/reflect");
+  });
+
+  it("maps mental model paths and query options to Hindsight REST shape", () => {
+    expect(
+      mentalModelCollectionPath("bank/id", {
+        tags: ["project", "stable"],
+        tagsMatch: "all",
+        detail: "metadata",
+        limit: 10,
+        offset: 5,
+      }),
+    ).toBe(
+      "/v1/default/banks/bank%2Fid/mental-models?tags=project&tags=stable&tags_match=all&detail=metadata&limit=10&offset=5",
+    );
+    expect(mentalModelItemPath("bank/id", "model/id", { detail: "full" })).toBe(
+      "/v1/default/banks/bank%2Fid/mental-models/model%2Fid?detail=full",
+    );
+    expect(mentalModelHistoryPath("bank/id", "model/id")).toBe(
+      "/v1/default/banks/bank%2Fid/mental-models/model%2Fid/history",
+    );
+    expect(mentalModelRefreshPath("bank/id", "model/id")).toBe(
+      "/v1/default/banks/bank%2Fid/mental-models/model%2Fid/refresh",
+    );
+  });
+
+  it("maps mental model request bodies to OpenAPI field names", () => {
+    expect(
+      createMentalModelRequestBody({
+        id: "team-style",
+        name: "Team Style",
+        sourceQuery: "How does the team prefer to work?",
+        tags: ["team"],
+        maxTokens: 2048,
+        trigger: {
+          mode: "delta",
+          refresh_after_consolidation: false,
+          fact_types: ["world", "observation"],
+          exclude_mental_models: true,
+          exclude_mental_model_ids: ["old-model"],
+          tags_match: "all_strict",
+          tag_groups: [{ and: ["project", "stable"] }],
+          include_chunks: false,
+          recall_max_tokens: 1024,
+          recall_chunks_max_tokens: 256,
+        },
+      }),
+    ).toEqual({
+      id: "team-style",
+      name: "Team Style",
+      source_query: "How does the team prefer to work?",
+      tags: ["team"],
+      max_tokens: 2048,
+      trigger: {
+        mode: "delta",
+        refresh_after_consolidation: false,
+        fact_types: ["world", "observation"],
+        exclude_mental_models: true,
+        exclude_mental_model_ids: ["old-model"],
+        tags_match: "all_strict",
+        tag_groups: [{ and: ["project", "stable"] }],
+        include_chunks: false,
+        recall_max_tokens: 1024,
+        recall_chunks_max_tokens: 256,
+      },
+    });
+    expect(updateMentalModelRequestBody({ sourceQuery: "New query", tags: null })).toEqual({
+      source_query: "New query",
+      tags: null,
+    });
   });
 
   it("asserts REST fallback response shapes", () => {

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -179,6 +179,18 @@ describe("memory operations", () => {
           calls.push({ method: "delete", bank });
           return {};
         },
+        listMentalModels: async (bank) => {
+          calls.push({ method: "listMentalModels", bank });
+          return { items: [] };
+        },
+        createMentalModel: async (bank) => {
+          calls.push({ method: "createMentalModel", bank });
+          return { operation_id: "op" };
+        },
+        refreshMentalModel: async (bank) => {
+          calls.push({ method: "refreshMentalModel", bank });
+          return { operation_id: "op", status: "queued" };
+        },
       }),
       getConfig: () => config,
       getProjectBankId: () => "project-bank",
@@ -194,6 +206,12 @@ describe("memory operations", () => {
     });
     await operations.reflect(cwd, "query", undefined, "project");
     await operations.deleteDocument({ bank: "global", documentId: "doc" });
+    await operations.listMentalModels({ bank: "global" });
+    await operations.createMentalModel({
+      bank: "project",
+      request: { name: "Project model", sourceQuery: "What matters?" },
+    });
+    await operations.refreshMentalModel({ bank: "global", mentalModelId: "model" });
 
     expect(calls).toEqual(
       expect.arrayContaining([
@@ -201,6 +219,9 @@ describe("memory operations", () => {
         { method: "retain", bank: "global-luxus" },
         { method: "reflect", bank: "project-bank" },
         { method: "delete", bank: "global-luxus" },
+        { method: "listMentalModels", bank: "global-luxus" },
+        { method: "createMentalModel", bank: "project-bank" },
+        { method: "refreshMentalModel", bank: "global-luxus" },
       ]),
     );
   });


### PR DESCRIPTION
## Summary
- add typed Hindsight mental model client methods for list/get/create/update/delete/history/refresh
- map mental model REST paths and OpenAPI request body field names
- add operation-service seams with project/global bank alias resolution
- document mental models as explicit advanced resources, not automatic background behavior

## Verification
- npm run check
- npm run typecheck:tsc
- npm run smoke:hindsight

Closes #123
