### PR TITLE
feat(tui): add mental model library

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,7 @@ Current keyboard controls:
 - `Enter`: edit selected setting
 - `r`: remove the selected setting's active override
 - `f`: flush queued retain jobs
+- `m`: open the mental model library
 - `d`: deployment setup
 - `g`: rerun guided setup
 

--- a/docs/hindsight-core-functions.md
+++ b/docs/hindsight-core-functions.md
@@ -110,7 +110,9 @@ Good mental model examples:
 - “What recurring workflow habits matter?”
 - “What does this project consider good design?”
 
-Mental models are not raw recall. They are reusable synthesized answers.
+Mental models are not raw recall. They are reusable synthesized answers. In Pi Hindsight they are explicit advanced resources: users should create, refresh, inspect, or delete them intentionally through operations/TUI/tool surfaces. The extension must not auto-create mental models from routine sessions or refresh them in the background unless a future issue designs that policy.
+
+Creating a mental model preserves a source query. Hindsight runs that query through reflect and stores the generated content. Refresh reruns the stored source query against newer memory.
 
 ```text
 Observations  = facts learned from repetition

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -10,7 +10,7 @@ For a generated reference of registered tools, commands, and editable config fie
 /hindsight
 ```
 
-Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI.
+Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Press `m` to open the mental model library for explicit view, refresh, or exact-ID deletion.
 
 ## Setup and config
 

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -1,4 +1,10 @@
-import type { ResolvedConfig } from "./types.js";
+import type {
+  CreateMentalModelRequest,
+  GetMentalModelOptions,
+  ListMentalModelsOptions,
+  ResolvedConfig,
+  UpdateMentalModelRequest,
+} from "./types.js";
 
 export interface HindsightRestTransport {
   request(path: string, init?: RequestInit): Promise<unknown>;
@@ -83,6 +89,70 @@ export function reflectRequestBody(
   };
 }
 
+function appendQuery(path: string, params: URLSearchParams): string {
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
 export function encodeBankPath(bankId: string, suffix: string): string {
   return `/v1/default/banks/${encodeURIComponent(bankId)}${suffix}`;
+}
+
+export function mentalModelCollectionPath(
+  bankId: string,
+  options: ListMentalModelsOptions = {},
+): string {
+  const params = new URLSearchParams();
+  for (const tag of options.tags ?? []) params.append("tags", tag);
+  if (options.tagsMatch) params.set("tags_match", options.tagsMatch);
+  if (options.detail) params.set("detail", options.detail);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  return appendQuery(encodeBankPath(bankId, "/mental-models"), params);
+}
+
+export function mentalModelItemPath(
+  bankId: string,
+  mentalModelId: string,
+  options: GetMentalModelOptions = {},
+): string {
+  const params = new URLSearchParams();
+  if (options.detail) params.set("detail", options.detail);
+  return appendQuery(
+    `${encodeBankPath(bankId, "/mental-models")}/${encodeURIComponent(mentalModelId)}`,
+    params,
+  );
+}
+
+export function mentalModelHistoryPath(bankId: string, mentalModelId: string): string {
+  return `${mentalModelItemPath(bankId, mentalModelId)}/history`;
+}
+
+export function mentalModelRefreshPath(bankId: string, mentalModelId: string): string {
+  return `${mentalModelItemPath(bankId, mentalModelId)}/refresh`;
+}
+
+export function createMentalModelRequestBody(
+  request: CreateMentalModelRequest,
+): Record<string, unknown> {
+  return {
+    ...(request.id !== undefined ? { id: request.id } : {}),
+    name: request.name,
+    source_query: request.sourceQuery,
+    ...(request.tags ? { tags: request.tags } : {}),
+    ...(request.maxTokens !== undefined ? { max_tokens: request.maxTokens } : {}),
+    ...(request.trigger ? { trigger: request.trigger } : {}),
+  };
+}
+
+export function updateMentalModelRequestBody(
+  request: UpdateMentalModelRequest,
+): Record<string, unknown> {
+  return {
+    ...(request.name !== undefined ? { name: request.name } : {}),
+    ...(request.sourceQuery !== undefined ? { source_query: request.sourceQuery } : {}),
+    ...(request.tags !== undefined ? { tags: request.tags } : {}),
+    ...(request.maxTokens !== undefined ? { max_tokens: request.maxTokens } : {}),
+    ...(request.trigger !== undefined ? { trigger: request.trigger } : {}),
+  };
 }

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -5,8 +5,14 @@ import {
   assertHealthResponse,
   assertReflectResponse,
   createHindsightRestTransport,
+  createMentalModelRequestBody,
   encodeBankPath,
+  mentalModelCollectionPath,
+  mentalModelHistoryPath,
+  mentalModelItemPath,
+  mentalModelRefreshPath,
   reflectRequestBody,
+  updateMentalModelRequestBody,
 } from "./client-rest.js";
 import { withTimeout } from "./timeout.js";
 
@@ -100,6 +106,42 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
             body: JSON.stringify(manifest),
           },
         ),
+      ),
+    listMentalModels: (bankId, options) =>
+      withTimeout("hindsight listMentalModels", timeoutMs, (signal) =>
+        rest.request(mentalModelCollectionPath(bankId, options), { signal }),
+      ),
+    getMentalModel: (bankId, mentalModelId, options) =>
+      withTimeout("hindsight getMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelItemPath(bankId, mentalModelId, options), { signal }),
+      ),
+    createMentalModel: (bankId, request) =>
+      withTimeout("hindsight createMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelCollectionPath(bankId), {
+          method: "POST",
+          signal,
+          body: JSON.stringify(createMentalModelRequestBody(request)),
+        }),
+      ),
+    updateMentalModel: (bankId, mentalModelId, request) =>
+      withTimeout("hindsight updateMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelItemPath(bankId, mentalModelId), {
+          method: "PATCH",
+          signal,
+          body: JSON.stringify(updateMentalModelRequestBody(request)),
+        }),
+      ),
+    deleteMentalModel: (bankId, mentalModelId) =>
+      withTimeout("hindsight deleteMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelItemPath(bankId, mentalModelId), { method: "DELETE", signal }),
+      ),
+    getMentalModelHistory: (bankId, mentalModelId) =>
+      withTimeout("hindsight getMentalModelHistory", timeoutMs, (signal) =>
+        rest.request(mentalModelHistoryPath(bankId, mentalModelId), { signal }),
+      ),
+    refreshMentalModel: (bankId, mentalModelId) =>
+      withTimeout("hindsight refreshMentalModel", timeoutMs, (signal) =>
+        rest.request(mentalModelRefreshPath(bankId, mentalModelId), { method: "POST", signal }),
       ),
   };
 }

--- a/extensions/memory-mental-model-operations.ts
+++ b/extensions/memory-mental-model-operations.ts
@@ -1,0 +1,88 @@
+import { resolveOperationBank } from "./bank-selection.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+import type {
+  CreateMentalModelRequest,
+  GetMentalModelOptions,
+  ListMentalModelsOptions,
+  UpdateMentalModelRequest,
+} from "./types.js";
+
+function resolveBank(deps: MemoryOperationsDeps, requestedBank: string | undefined): string {
+  return resolveOperationBank({
+    requestedBank,
+    config: deps.getConfig(),
+    projectBankId: deps.getProjectBankId(),
+  });
+}
+
+function unavailable(name: string): Error {
+  return new Error(`Hindsight mental model ${name} is unavailable in this client`);
+}
+
+export function createMentalModelOperations(deps: MemoryOperationsDeps) {
+  return {
+    async listMentalModels(args: { bank?: string; options?: ListMentalModelsOptions } = {}) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.listMentalModels) throw unavailable("list");
+      const result = await client.listMentalModels(bankId, args.options);
+      return { bankId, result };
+    },
+
+    async getMentalModel(args: {
+      bank?: string;
+      mentalModelId: string;
+      options?: GetMentalModelOptions;
+    }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getMentalModel) throw unavailable("get");
+      const result = await client.getMentalModel(bankId, args.mentalModelId, args.options);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+
+    async createMentalModel(args: { bank?: string; request: CreateMentalModelRequest }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.createMentalModel) throw unavailable("create");
+      const result = await client.createMentalModel(bankId, args.request);
+      return { bankId, result };
+    },
+
+    async updateMentalModel(args: {
+      bank?: string;
+      mentalModelId: string;
+      request: UpdateMentalModelRequest;
+    }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.updateMentalModel) throw unavailable("update");
+      const result = await client.updateMentalModel(bankId, args.mentalModelId, args.request);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+
+    async deleteMentalModel(args: { bank?: string; mentalModelId: string }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.deleteMentalModel) throw unavailable("delete");
+      const result = await client.deleteMentalModel(bankId, args.mentalModelId);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+
+    async getMentalModelHistory(args: { bank?: string; mentalModelId: string }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getMentalModelHistory) throw unavailable("history");
+      const result = await client.getMentalModelHistory(bankId, args.mentalModelId);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+
+    async refreshMentalModel(args: { bank?: string; mentalModelId: string }) {
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.refreshMentalModel) throw unavailable("refresh");
+      const result = await client.refreshMentalModel(bankId, args.mentalModelId);
+      return { bankId, mentalModelId: args.mentalModelId, result };
+    },
+  };
+}

--- a/extensions/memory-operation-service.ts
+++ b/extensions/memory-operation-service.ts
@@ -3,6 +3,7 @@ import { importMemoryProjectSessions, importMemorySession } from "./import-opera
 import { createBankTemplateOperations } from "./bank-template-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
 import { createDocumentOperations } from "./memory-document-operations.js";
+import { createMentalModelOperations } from "./memory-mental-model-operations.js";
 import { createRecallOperations } from "./memory-recall-operations.js";
 import { createRetainOperations } from "./memory-retain-operations.js";
 import { createRoutingOperations } from "./memory-routing-operations.js";
@@ -44,6 +45,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createRoutingOperations(deps),
     ...createConfigOperations(deps),
     ...createBankTemplateOperations(deps),
+    ...createMentalModelOperations(deps),
     ...createImportOperations(deps),
     ...createSessionOperations(),
   };

--- a/extensions/mental-model-presenter.ts
+++ b/extensions/mental-model-presenter.ts
@@ -1,0 +1,105 @@
+import { isRecord } from "./client-rest.js";
+
+export interface MentalModelSummary {
+  id: string;
+  name: string;
+  bankId?: string;
+  sourceQuery?: string | null;
+  content?: string | null;
+  tags: string[];
+  lastRefreshedAt?: string | null;
+  createdAt?: string | null;
+  isStale?: boolean | null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function nullableString(value: unknown): string | null | undefined {
+  return value === null ? null : stringValue(value);
+}
+
+function booleanValue(value: unknown): boolean | null | undefined {
+  if (value === null) return null;
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function tagsValue(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((tag): tag is string => typeof tag === "string") : [];
+}
+
+export function mentalModelFromUnknown(value: unknown): MentalModelSummary | undefined {
+  if (!isRecord(value)) return undefined;
+  const id = stringValue(value.id);
+  const name = stringValue(value.name);
+  if (!id || !name) return undefined;
+  const bankId = stringValue(value.bank_id);
+  const sourceQuery = nullableString(value.source_query);
+  const content = nullableString(value.content);
+  const lastRefreshedAt = nullableString(value.last_refreshed_at);
+  const createdAt = nullableString(value.created_at);
+  const isStale = booleanValue(value.is_stale);
+  return {
+    id,
+    name,
+    ...(bankId !== undefined ? { bankId } : {}),
+    ...(sourceQuery !== undefined ? { sourceQuery } : {}),
+    ...(content !== undefined ? { content } : {}),
+    tags: tagsValue(value.tags),
+    ...(lastRefreshedAt !== undefined ? { lastRefreshedAt } : {}),
+    ...(createdAt !== undefined ? { createdAt } : {}),
+    ...(isStale !== undefined ? { isStale } : {}),
+  };
+}
+
+export function mentalModelListFromUnknown(value: unknown): MentalModelSummary[] {
+  if (!isRecord(value) || !Array.isArray(value.items)) return [];
+  return value.items.flatMap((item) => {
+    const model = mentalModelFromUnknown(item);
+    return model ? [model] : [];
+  });
+}
+
+export function mentalModelOption(model: MentalModelSummary): string {
+  const tags = model.tags.length ? ` tags=${model.tags.join(",")}` : "";
+  const stale = model.isStale ? " stale" : "";
+  return `${model.name} (${model.id})${tags}${stale}`;
+}
+
+export function renderMentalModel(model: MentalModelSummary): string {
+  const lines = [
+    `Mental model ${model.name} (${model.id})`,
+    `Bank: ${model.bankId ?? "unknown"}`,
+    `Tags: ${model.tags.join(",") || "none"}`,
+    `Last refresh: ${model.lastRefreshedAt ?? "never"}`,
+    `Stale: ${model.isStale === undefined || model.isStale === null ? "unknown" : model.isStale ? "yes" : "no"}`,
+  ];
+  if (model.sourceQuery) lines.push(`Source query: ${model.sourceQuery}`);
+  if (model.content) lines.push("", model.content);
+  return lines.join("\n");
+}
+
+export function renderMentalModelHistory(value: unknown): string {
+  if (!isRecord(value) || !Array.isArray(value.items) || value.items.length === 0) {
+    return "Mental model history: none";
+  }
+  const lines = ["Mental model history"];
+  for (const item of value.items.slice(0, 5)) {
+    if (!isRecord(item)) continue;
+    const id = stringValue(item.id) ?? stringValue(item.version_id) ?? "unknown";
+    const createdAt =
+      stringValue(item.created_at) ?? stringValue(item.refreshed_at) ?? "unknown time";
+    const status = stringValue(item.status);
+    lines.push(`- ${id} at ${createdAt}${status ? ` status=${status}` : ""}`);
+  }
+  return lines.length > 1 ? lines.join("\n") : "Mental model history: none";
+}
+
+export function renderMentalModelOperationResult(value: unknown): string {
+  if (!isRecord(value)) return JSON.stringify(value);
+  const operationId = stringValue(value.operation_id);
+  const status = stringValue(value.status);
+  if (operationId) return `operation=${operationId}${status ? ` status=${status}` : ""}`;
+  return JSON.stringify(value);
+}

--- a/extensions/setup-flow.ts
+++ b/extensions/setup-flow.ts
@@ -13,6 +13,7 @@ export type SetupIntent =
   | { type: "chooseDeployment" }
   | { type: "guidedSetup" }
   | { type: "flushQueue" }
+  | { type: "mentalModels" }
   | { type: "toggleAdvanced" }
   | { type: "moveTab"; delta: number }
   | { type: "moveSelection"; delta: number }
@@ -104,6 +105,7 @@ export function setupIntentFromInput(data: string): SetupIntent | undefined {
   if (data === "d") return { type: "chooseDeployment" };
   if (data === "g") return { type: "guidedSetup" };
   if (data === "f") return { type: "flushQueue" };
+  if (data === "m") return { type: "mentalModels" };
   if (matchesKey(data, Key.left) || data === "h" || data === "<") {
     return { type: "moveTab", delta: -1 };
   }
@@ -128,6 +130,7 @@ export function applySetupIntent(
   if (intent.type === "chooseDeployment") return withAction("choose-deployment", normalized);
   if (intent.type === "guidedSetup") return withAction("guided-setup", normalized);
   if (intent.type === "flushQueue") return withAction("flush-queue", normalized);
+  if (intent.type === "mentalModels") return withAction("mental-models", normalized);
   if (intent.type === "toggleAdvanced") return withAction("toggle-advanced", normalized);
   if (intent.type === "finish") return withAction("done", { ...normalized, step: "done" });
   if (intent.type === "startGuidedSetup") return withState({ ...normalized, step: "profile" });

--- a/extensions/setup-tui-mental-models.ts
+++ b/extensions/setup-tui-mental-models.ts
@@ -1,0 +1,95 @@
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { createMemoryOperations, type MemoryOperationsDeps } from "./memory-operation-service.js";
+import {
+  mentalModelFromUnknown,
+  mentalModelListFromUnknown,
+  mentalModelOption,
+  renderMentalModel,
+  renderMentalModelHistory,
+  renderMentalModelOperationResult,
+} from "./mental-model-presenter.js";
+import { CANCEL } from "./setup-tui-types.js";
+
+function bankOptions(deps: MemoryOperationsDeps): string[] {
+  const config = deps.getConfig();
+  return config.banks.global.enabled ? ["Project", "Global", CANCEL] : ["Project", CANCEL];
+}
+
+function bankForChoice(choice: string | undefined): string | undefined {
+  if (choice === "Project") return "project";
+  if (choice === "Global") return "global";
+  return undefined;
+}
+
+export async function handleMentalModels(
+  ctx: ExtensionCommandContext,
+  deps: MemoryOperationsDeps,
+): Promise<void> {
+  const bankChoice = await ctx.ui.select("Mental model bank", bankOptions(deps));
+  const bank = bankForChoice(bankChoice);
+  if (!bank) return;
+
+  const operations = createMemoryOperations(deps);
+  const listed = await operations.listMentalModels({
+    bank,
+    options: { detail: "metadata", limit: 100 },
+  });
+  const models = mentalModelListFromUnknown(listed.result);
+  if (models.length === 0) {
+    ctx.ui.notify(`No ${bankChoice?.toLowerCase()} mental models found.`, "info");
+    return;
+  }
+
+  const options = models.map(mentalModelOption).concat(CANCEL);
+  const selected = await ctx.ui.select("Mental models", options);
+  if (!selected || selected === CANCEL) return;
+  const model = models[options.indexOf(selected)];
+  if (!model) return;
+
+  const action = await ctx.ui.select(`Mental model ${model.name} (${model.id})`, [
+    "View",
+    "History",
+    "Refresh",
+    "Delete",
+    CANCEL,
+  ]);
+  if (!action || action === CANCEL) return;
+
+  if (action === "View") {
+    const full = await operations.getMentalModel({
+      bank,
+      mentalModelId: model.id,
+      options: { detail: "full" },
+    });
+    ctx.ui.notify(renderMentalModel(mentalModelFromUnknown(full.result) ?? model), "info");
+    return;
+  }
+
+  if (action === "History") {
+    const history = await operations.getMentalModelHistory({ bank, mentalModelId: model.id });
+    ctx.ui.notify(renderMentalModelHistory(history.result), "info");
+    return;
+  }
+
+  if (action === "Refresh") {
+    const refreshed = await operations.refreshMentalModel({ bank, mentalModelId: model.id });
+    ctx.ui.notify(
+      `Hindsight mental model refresh queued for ${model.id}; ${renderMentalModelOperationResult(refreshed.result)}`,
+      "info",
+    );
+    return;
+  }
+
+  if (action === "Delete") {
+    const confirmation = await ctx.ui.input(
+      `Type exact mental model ID to delete ${model.name}`,
+      "",
+    );
+    if (confirmation !== model.id) {
+      ctx.ui.notify("Mental model delete cancelled; exact ID did not match.", "warning");
+      return;
+    }
+    await operations.deleteMentalModel({ bank, mentalModelId: model.id });
+    ctx.ui.notify(`Deleted Hindsight mental model ${model.id}.`, "warning");
+  }
+}

--- a/extensions/setup-tui-render.ts
+++ b/extensions/setup-tui-render.ts
@@ -194,7 +194,7 @@ export function createSetupComponent(
         boxed(
           theme.fg(
             "dim",
-            ` h/l or </> tabs · j/k move · enter edit · r reset · f flush · a advanced ${state.showAdvanced ? "on" : "off"} · d deployment · g guided · q close `,
+            ` h/l or </> tabs · j/k move · enter edit · r reset · f flush · m models · a advanced ${state.showAdvanced ? "on" : "off"} · d deployment · g guided · q close `,
           ),
           width,
           theme,

--- a/extensions/setup-tui-types.ts
+++ b/extensions/setup-tui-types.ts
@@ -6,6 +6,7 @@ export type SetupActionId =
   | "choose-deployment"
   | "guided-setup"
   | "flush-queue"
+  | "mental-models"
   | "toggle-advanced"
   | "done";
 

--- a/extensions/setup-tui.ts
+++ b/extensions/setup-tui.ts
@@ -4,6 +4,7 @@ import { createMemoryOperations, type MemoryOperationsDeps } from "./memory-oper
 import { flushRetainQueueNotifyLevel, formatFlushRetainQueueResult } from "./flush-presenter.js";
 import { hasProjectHindsightConfig, runGuidedSetup } from "./guided-setup.js";
 import { buildSetupTabs } from "./setup-tui-facts.js";
+import { handleMentalModels } from "./setup-tui-mental-models.js";
 import { createSetupComponent } from "./setup-tui-render.js";
 import { handleDeployment, handleFieldEdit, handleResetFieldAction } from "./setup-tui-actions.js";
 import type { SetupActionId, SetupUiState, ThemeLike } from "./setup-tui-types.js";
@@ -73,7 +74,8 @@ export async function runHindsightSetupTui(
       else if (action === "flush-queue") {
         const result = await createMemoryOperations(deps).flush(ctx.cwd);
         ctx.ui.notify(formatFlushRetainQueueResult(result), flushRetainQueueNotifyLevel(result));
-      } else if (action === "toggle-advanced") {
+      } else if (action === "mental-models") await handleMentalModels(ctx, deps);
+      else if (action === "toggle-advanced") {
         state.showAdvanced = !state.showAdvanced;
         state.selectedByTab = {};
       } else if (action.startsWith("reset:")) {

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -4,6 +4,8 @@ export type RetainUserContent = "text";
 export type RetainAssistantContent = "text" | "toolCall" | "thinking";
 export type RetainToolResultContent = "error" | "summary" | "content";
 export type TagsMatch = "any" | "all" | "any_strict" | "all_strict";
+export type MentalModelDetail = "metadata" | "content" | "full";
+export type MentalModelTagsMatch = "any" | "all" | "exact";
 export type StatusStyle = "off" | "text" | "emoji" | "nerdfont";
 export type StatusDetail = "minimal" | "project" | "activity" | "verbose";
 export type RecallRole = "user" | "assistant" | "tool" | "system";
@@ -169,6 +171,48 @@ export interface HindsightCapabilities {
   probeDocumentId?: string;
 }
 
+export interface MentalModelTrigger {
+  mode?: "full" | "delta";
+  refresh_after_consolidation?: boolean;
+  fact_types?: Array<"world" | "experience" | "observation"> | null;
+  exclude_mental_models?: boolean;
+  exclude_mental_model_ids?: string[] | null;
+  tags_match?: TagsMatch | null;
+  tag_groups?: unknown[] | null;
+  include_chunks?: boolean | null;
+  recall_max_tokens?: number | null;
+  recall_chunks_max_tokens?: number | null;
+}
+
+export interface CreateMentalModelRequest {
+  id?: string | null;
+  name: string;
+  sourceQuery: string;
+  tags?: string[];
+  maxTokens?: number;
+  trigger?: MentalModelTrigger;
+}
+
+export interface UpdateMentalModelRequest {
+  name?: string | null;
+  sourceQuery?: string | null;
+  tags?: string[] | null;
+  maxTokens?: number | null;
+  trigger?: MentalModelTrigger | null;
+}
+
+export interface ListMentalModelsOptions {
+  tags?: string[];
+  tagsMatch?: MentalModelTagsMatch;
+  detail?: MentalModelDetail;
+  limit?: number;
+  offset?: number;
+}
+
+export interface GetMentalModelOptions {
+  detail?: MentalModelDetail;
+}
+
 export interface HindsightLikeClient {
   retain(
     bankId: string,
@@ -243,4 +287,19 @@ export interface HindsightLikeClient {
     manifest: Record<string, unknown>,
     options?: { dryRun?: boolean },
   ): Promise<unknown>;
+  listMentalModels?(bankId: string, options?: ListMentalModelsOptions): Promise<unknown>;
+  getMentalModel?(
+    bankId: string,
+    mentalModelId: string,
+    options?: GetMentalModelOptions,
+  ): Promise<unknown>;
+  createMentalModel?(bankId: string, request: CreateMentalModelRequest): Promise<unknown>;
+  updateMentalModel?(
+    bankId: string,
+    mentalModelId: string,
+    request: UpdateMentalModelRequest,
+  ): Promise<unknown>;
+  deleteMentalModel?(bankId: string, mentalModelId: string): Promise<unknown>;
+  getMentalModelHistory?(bankId: string, mentalModelId: string): Promise<unknown>;
+  refreshMentalModel?(bankId: string, mentalModelId: string): Promise<unknown>;
 }

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -63,6 +63,53 @@ describe("Hindsight client adapter integration", () => {
         sendJson(res, 200, { dry_run: true, config_applied: true });
         return;
       }
+      if (
+        req.method === "GET" &&
+        req.url ===
+          "/v1/default/banks/test-bank/mental-models?tags=source%3Api&tags_match=all&detail=metadata&limit=10&offset=2"
+      ) {
+        sendJson(res, 200, { items: [{ id: "model-1", name: "Model" }] });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1?detail=full"
+      ) {
+        sendJson(res, 200, { id: "model-1", name: "Model", content: "full" });
+        return;
+      }
+      if (req.method === "POST" && req.url === "/v1/default/banks/test-bank/mental-models") {
+        sendJson(res, 202, { operation_id: "create-op", status: "queued" });
+        return;
+      }
+      if (
+        req.method === "PATCH" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1"
+      ) {
+        sendJson(res, 200, { id: "model-1", name: "Updated" });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1/history"
+      ) {
+        sendJson(res, 200, { items: [{ id: "v1" }] });
+        return;
+      }
+      if (
+        req.method === "POST" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1/refresh"
+      ) {
+        sendJson(res, 202, { operation_id: "refresh-op", status: "queued" });
+        return;
+      }
+      if (
+        req.method === "DELETE" &&
+        req.url === "/v1/default/banks/test-bank/mental-models/model-1"
+      ) {
+        sendJson(res, 200, { deleted: true });
+        return;
+      }
       sendJson(res, 404, { detail: `unexpected ${req.method} ${req.url}` });
     });
 
@@ -117,10 +164,38 @@ describe("Hindsight client adapter integration", () => {
       { version: "1", bank: { retain_mission: "Retain useful facts." } },
       { dryRun: true },
     );
+    const models = await client.listMentalModels?.("test-bank", {
+      tags: ["source:pi"],
+      tagsMatch: "all",
+      detail: "metadata",
+      limit: 10,
+      offset: 2,
+    });
+    const model = await client.getMentalModel?.("test-bank", "model-1", { detail: "full" });
+    const createdModel = await client.createMentalModel?.("test-bank", {
+      name: "Model",
+      sourceQuery: "What should recur?",
+      tags: ["source:pi"],
+      maxTokens: 256,
+    });
+    const updatedModel = await client.updateMentalModel?.("test-bank", "model-1", {
+      sourceQuery: "Updated query",
+      tags: null,
+    });
+    const history = await client.getMentalModelHistory?.("test-bank", "model-1");
+    const refreshed = await client.refreshMentalModel?.("test-bank", "model-1");
+    const deleted = await client.deleteMentalModel?.("test-bank", "model-1");
 
     expect(recall).toEqual({ results: [{ text: "remembered fact" }] });
     expect(reflection).toEqual({ text: "reflection" });
     expect(templateDryRun).toEqual({ dry_run: true, config_applied: true });
+    expect(models).toEqual({ items: [{ id: "model-1", name: "Model" }] });
+    expect(model).toEqual({ id: "model-1", name: "Model", content: "full" });
+    expect(createdModel).toEqual({ operation_id: "create-op", status: "queued" });
+    expect(updatedModel).toEqual({ id: "model-1", name: "Updated" });
+    expect(history).toEqual({ items: [{ id: "v1" }] });
+    expect(refreshed).toEqual({ operation_id: "refresh-op", status: "queued" });
+    expect(deleted).toEqual({ deleted: true });
 
     expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
       "GET /v1/default/banks/test-bank/profile",
@@ -130,6 +205,13 @@ describe("Hindsight client adapter integration", () => {
       "POST /v1/default/banks/test-bank/memories/recall",
       "POST /v1/default/banks/test-bank/reflect",
       "POST /v1/default/banks/test-bank/import?dry_run=true",
+      "GET /v1/default/banks/test-bank/mental-models?tags=source%3Api&tags_match=all&detail=metadata&limit=10&offset=2",
+      "GET /v1/default/banks/test-bank/mental-models/model-1?detail=full",
+      "POST /v1/default/banks/test-bank/mental-models",
+      "PATCH /v1/default/banks/test-bank/mental-models/model-1",
+      "GET /v1/default/banks/test-bank/mental-models/model-1/history",
+      "POST /v1/default/banks/test-bank/mental-models/model-1/refresh",
+      "DELETE /v1/default/banks/test-bank/mental-models/model-1",
     ]);
 
     expect(requests[2]?.body).toMatchObject({
@@ -177,5 +259,12 @@ describe("Hindsight client adapter integration", () => {
       version: "1",
       bank: { retain_mission: "Retain useful facts." },
     });
+    expect(requests[9]?.body).toEqual({
+      name: "Model",
+      source_query: "What should recur?",
+      tags: ["source:pi"],
+      max_tokens: 256,
+    });
+    expect(requests[10]?.body).toEqual({ source_query: "Updated query", tags: null });
   });
 });

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -2,8 +2,14 @@ import { describe, expect, it } from "vitest";
 import {
   assertHealthResponse,
   assertReflectResponse,
+  createMentalModelRequestBody,
   encodeBankPath,
+  mentalModelCollectionPath,
+  mentalModelHistoryPath,
+  mentalModelItemPath,
+  mentalModelRefreshPath,
   reflectRequestBody,
+  updateMentalModelRequestBody,
 } from "../extensions/client-rest.js";
 
 describe("Hindsight REST transport helpers", () => {
@@ -28,6 +34,75 @@ describe("Hindsight REST transport helpers", () => {
 
   it("encodes bank ids in REST paths", () => {
     expect(encodeBankPath("bank/id", "/reflect")).toBe("/v1/default/banks/bank%2Fid/reflect");
+  });
+
+  it("maps mental model paths and query options to Hindsight REST shape", () => {
+    expect(
+      mentalModelCollectionPath("bank/id", {
+        tags: ["project", "stable"],
+        tagsMatch: "all",
+        detail: "metadata",
+        limit: 10,
+        offset: 5,
+      }),
+    ).toBe(
+      "/v1/default/banks/bank%2Fid/mental-models?tags=project&tags=stable&tags_match=all&detail=metadata&limit=10&offset=5",
+    );
+    expect(mentalModelItemPath("bank/id", "model/id", { detail: "full" })).toBe(
+      "/v1/default/banks/bank%2Fid/mental-models/model%2Fid?detail=full",
+    );
+    expect(mentalModelHistoryPath("bank/id", "model/id")).toBe(
+      "/v1/default/banks/bank%2Fid/mental-models/model%2Fid/history",
+    );
+    expect(mentalModelRefreshPath("bank/id", "model/id")).toBe(
+      "/v1/default/banks/bank%2Fid/mental-models/model%2Fid/refresh",
+    );
+  });
+
+  it("maps mental model request bodies to OpenAPI field names", () => {
+    expect(
+      createMentalModelRequestBody({
+        id: "team-style",
+        name: "Team Style",
+        sourceQuery: "How does the team prefer to work?",
+        tags: ["team"],
+        maxTokens: 2048,
+        trigger: {
+          mode: "delta",
+          refresh_after_consolidation: false,
+          fact_types: ["world", "observation"],
+          exclude_mental_models: true,
+          exclude_mental_model_ids: ["old-model"],
+          tags_match: "all_strict",
+          tag_groups: [{ and: ["project", "stable"] }],
+          include_chunks: false,
+          recall_max_tokens: 1024,
+          recall_chunks_max_tokens: 256,
+        },
+      }),
+    ).toEqual({
+      id: "team-style",
+      name: "Team Style",
+      source_query: "How does the team prefer to work?",
+      tags: ["team"],
+      max_tokens: 2048,
+      trigger: {
+        mode: "delta",
+        refresh_after_consolidation: false,
+        fact_types: ["world", "observation"],
+        exclude_mental_models: true,
+        exclude_mental_model_ids: ["old-model"],
+        tags_match: "all_strict",
+        tag_groups: [{ and: ["project", "stable"] }],
+        include_chunks: false,
+        recall_max_tokens: 1024,
+        recall_chunks_max_tokens: 256,
+      },
+    });
+    expect(updateMentalModelRequestBody({ sourceQuery: "New query", tags: null })).toEqual({
+      source_query: "New query",
+      tags: null,
+    });
   });
 
   it("asserts REST fallback response shapes", () => {

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -179,6 +179,18 @@ describe("memory operations", () => {
           calls.push({ method: "delete", bank });
           return {};
         },
+        listMentalModels: async (bank) => {
+          calls.push({ method: "listMentalModels", bank });
+          return { items: [] };
+        },
+        createMentalModel: async (bank) => {
+          calls.push({ method: "createMentalModel", bank });
+          return { operation_id: "op" };
+        },
+        refreshMentalModel: async (bank) => {
+          calls.push({ method: "refreshMentalModel", bank });
+          return { operation_id: "op", status: "queued" };
+        },
       }),
       getConfig: () => config,
       getProjectBankId: () => "project-bank",
@@ -194,6 +206,12 @@ describe("memory operations", () => {
     });
     await operations.reflect(cwd, "query", undefined, "project");
     await operations.deleteDocument({ bank: "global", documentId: "doc" });
+    await operations.listMentalModels({ bank: "global" });
+    await operations.createMentalModel({
+      bank: "project",
+      request: { name: "Project model", sourceQuery: "What matters?" },
+    });
+    await operations.refreshMentalModel({ bank: "global", mentalModelId: "model" });
 
     expect(calls).toEqual(
       expect.arrayContaining([
@@ -201,6 +219,9 @@ describe("memory operations", () => {
         { method: "retain", bank: "global-luxus" },
         { method: "reflect", bank: "project-bank" },
         { method: "delete", bank: "global-luxus" },
+        { method: "listMentalModels", bank: "global-luxus" },
+        { method: "createMentalModel", bank: "project-bank" },
+        { method: "refreshMentalModel", bank: "global-luxus" },
       ]),
     );
   });

--- a/tests/mental-model-presenter.test.ts
+++ b/tests/mental-model-presenter.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  mentalModelListFromUnknown,
+  mentalModelOption,
+  renderMentalModel,
+  renderMentalModelHistory,
+  renderMentalModelOperationResult,
+} from "../extensions/mental-model-presenter.js";
+
+describe("mental model presenter", () => {
+  it("normalizes list responses and renders selectable labels", () => {
+    const models = mentalModelListFromUnknown({
+      items: [
+        {
+          id: "project-architecture",
+          bank_id: "project-bank",
+          name: "Project architecture",
+          source_query: "What is the architecture?",
+          tags: ["project", "architecture"],
+          last_refreshed_at: "2026-05-04T01:00:00Z",
+          is_stale: true,
+        },
+        { id: 123, name: "bad" },
+      ],
+    });
+
+    expect(models).toHaveLength(1);
+    expect(mentalModelOption(models[0]!)).toBe(
+      "Project architecture (project-architecture) tags=project,architecture stale",
+    );
+    expect(renderMentalModel(models[0]!)).toContain("Source query: What is the architecture?");
+  });
+
+  it("renders history and async operation results", () => {
+    expect(
+      renderMentalModelHistory({
+        items: [{ id: "version-1", created_at: "2026-05-04T01:00:00Z", status: "ready" }],
+      }),
+    ).toContain("version-1 at 2026-05-04T01:00:00Z status=ready");
+    expect(renderMentalModelOperationResult({ operation_id: "op-1", status: "queued" })).toBe(
+      "operation=op-1 status=queued",
+    );
+  });
+});

--- a/tests/setup-flow.test.ts
+++ b/tests/setup-flow.test.ts
@@ -38,6 +38,7 @@ describe("setup flow state", () => {
     expect(setupIntentFromInput("d")).toEqual({ type: "chooseDeployment" });
     expect(setupIntentFromInput("g")).toEqual({ type: "guidedSetup" });
     expect(setupIntentFromInput("f")).toEqual({ type: "flushQueue" });
+    expect(setupIntentFromInput("m")).toEqual({ type: "mentalModels" });
     expect(setupIntentFromInput("h")).toEqual({ type: "moveTab", delta: -1 });
     expect(setupIntentFromInput("l")).toEqual({ type: "moveTab", delta: 1 });
     expect(setupIntentFromInput("j")).toEqual({ type: "moveSelection", delta: 1 });
@@ -79,6 +80,10 @@ describe("setup flow state", () => {
     expect(applySetupIntent(tabs(), state, { type: "flushQueue" })).toMatchObject({
       kind: "action",
       action: "flush-queue",
+    });
+    expect(applySetupIntent(tabs(), state, { type: "mentalModels" })).toMatchObject({
+      kind: "action",
+      action: "mental-models",
     });
     expect(applySetupIntent(tabs(), state, { type: "close" })).toMatchObject({
       kind: "action",

--- a/tests/setup-tui-mental-models.test.ts
+++ b/tests/setup-tui-mental-models.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { handleMentalModels } from "../extensions/setup-tui-mental-models.js";
+import { DEFAULT_CONFIG } from "../extensions/config-defaults.js";
+import type { HindsightLikeClient, ResolvedConfig } from "../extensions/types.js";
+import type { MemoryOperationsDeps } from "../extensions/memory-operation-service.js";
+
+function clientWith(overrides: Partial<HindsightLikeClient>): HindsightLikeClient {
+  return {
+    retain: async () => undefined,
+    recall: async () => "",
+    reflect: async () => "",
+    ...overrides,
+  };
+}
+
+function deps(
+  client: HindsightLikeClient,
+  config: ResolvedConfig = DEFAULT_CONFIG,
+): MemoryOperationsDeps {
+  return {
+    getConfig: () => config,
+    getProjectBankId: () => "project-bank",
+    getClient: () => client,
+  };
+}
+
+function ctx(selects: string[], inputs: string[] = []) {
+  const notifications: Array<{ message: string; level: string }> = [];
+  const prompts: Array<{ prompt: string; fallback?: string }> = [];
+  return {
+    ctx: {
+      cwd: "/repo",
+      ui: {
+        select: async () => selects.shift(),
+        input: async (prompt: string, fallback?: string) => {
+          prompts.push(fallback === undefined ? { prompt } : { prompt, fallback });
+          return inputs.shift();
+        },
+        notify: (message: string, level: string) => notifications.push({ message, level }),
+      },
+    },
+    notifications,
+    prompts,
+  };
+}
+
+const listResponse = {
+  items: [{ id: "model-1", name: "Project model", tags: ["project"], is_stale: false }],
+};
+
+describe("setup TUI mental models", () => {
+  it("views model content through project bank alias", async () => {
+    const calls: Array<{ method: string; bank: string; id?: string }> = [];
+    const client = clientWith({
+      listMentalModels: async (bank) => {
+        calls.push({ method: "list", bank });
+        return listResponse;
+      },
+      getMentalModel: async (bank, id) => {
+        calls.push({ method: "get", bank, id });
+        return { ...listResponse.items[0], bank_id: bank, content: "remembered architecture" };
+      },
+    });
+    const ui = ctx(["Project", "Project model (model-1) tags=project", "View"]);
+
+    await handleMentalModels(ui.ctx as never, deps(client));
+
+    expect(calls).toEqual([
+      { method: "list", bank: "project-bank" },
+      { method: "get", bank: "project-bank", id: "model-1" },
+    ]);
+    expect(ui.notifications[0]?.message).toContain("remembered architecture");
+  });
+
+  it("refreshes, shows history, and requires typed exact id for delete", async () => {
+    const calls: Array<{ method: string; bank: string; id?: string }> = [];
+    const config = {
+      ...DEFAULT_CONFIG,
+      banks: {
+        ...DEFAULT_CONFIG.banks,
+        global: { ...DEFAULT_CONFIG.banks.global, enabled: true, bankId: "global-bank" },
+      },
+    };
+    const client = clientWith({
+      listMentalModels: async (bank) => {
+        calls.push({ method: "list", bank });
+        return listResponse;
+      },
+      refreshMentalModel: async (bank, id) => {
+        calls.push({ method: "refresh", bank, id });
+        return { operation_id: "op-1", status: "queued" };
+      },
+      getMentalModelHistory: async (bank, id) => {
+        calls.push({ method: "history", bank, id });
+        return { items: [{ id: "v1", created_at: "2026-05-04T01:00:00Z" }] };
+      },
+      deleteMentalModel: async (bank, id) => {
+        calls.push({ method: "delete", bank, id });
+        return {};
+      },
+    });
+
+    await handleMentalModels(
+      ctx(["Global", "Project model (model-1) tags=project", "Refresh"]).ctx as never,
+      deps(client, config),
+    );
+    await handleMentalModels(
+      ctx(["Global", "Project model (model-1) tags=project", "History"]).ctx as never,
+      deps(client, config),
+    );
+    const wrongDelete = ctx(
+      ["Global", "Project model (model-1) tags=project", "Delete"],
+      ["wrong"],
+    );
+    await handleMentalModels(wrongDelete.ctx as never, deps(client, config));
+    const exactDelete = ctx(
+      ["Global", "Project model (model-1) tags=project", "Delete"],
+      ["model-1"],
+    );
+    await handleMentalModels(exactDelete.ctx as never, deps(client, config));
+
+    expect(exactDelete.prompts[0]?.fallback).toBe("");
+    expect(calls).toContainEqual({ method: "refresh", bank: "global-bank", id: "model-1" });
+    expect(calls).toContainEqual({ method: "history", bank: "global-bank", id: "model-1" });
+    expect(calls.filter((call) => call.method === "delete")).toEqual([
+      { method: "delete", bank: "global-bank", id: "model-1" },
+    ]);
+    expect(wrongDelete.notifications[0]?.message).toContain("exact ID did not match");
+  });
+});

--- a/tests/setup-tui.test.ts
+++ b/tests/setup-tui.test.ts
@@ -49,5 +49,6 @@ describe("setup TUI receipt facts", () => {
     const rendered = component.render(100).join("\n");
     expect(rendered).toContain("Extract durable project");
     expect(rendered).toContain("f flush");
+    expect(rendered).toContain("m models");
   });
 });


### PR DESCRIPTION
## Summary
- add `m` key in `/hindsight` TUI for mental model library
- list project/global mental models through operation-service seams
- support view, history, explicit refresh, and delete with typed exact-ID confirmation
- add presenter and TUI handler tests

## Verification
- npm run check
- npm run typecheck:tsc

Stacked on #148.

Closes #130
