### PR TITLE
feat(operations): promote reflect query to mental model

### DIFF
--- a/extensions/memory-mental-model-operations.ts
+++ b/extensions/memory-mental-model-operations.ts
@@ -49,6 +49,31 @@ export function createMentalModelOperations(deps: MemoryOperationsDeps) {
       return { bankId, result };
     },
 
+    async promoteReflectQueryToMentalModel(args: {
+      bank: "project" | "global";
+      name: string;
+      sourceQuery: string;
+      id?: string | null;
+      tags?: string[];
+      maxTokens?: number;
+    }) {
+      const name = args.name.trim();
+      const sourceQuery = args.sourceQuery.trim();
+      if (!name) throw new Error("Mental model name is required");
+      if (!sourceQuery) throw new Error("Mental model source query is required");
+      const bankId = resolveBank(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.createMentalModel) throw unavailable("create");
+      const result = await client.createMentalModel(bankId, {
+        ...(args.id !== undefined ? { id: args.id } : {}),
+        name,
+        sourceQuery,
+        ...(args.tags ? { tags: args.tags } : {}),
+        ...(args.maxTokens !== undefined ? { maxTokens: args.maxTokens } : {}),
+      });
+      return { bankId, result };
+    },
+
     async updateMentalModel(args: {
       bank?: string;
       mentalModelId: string;

--- a/extensions/setup-tui-mental-models.ts
+++ b/extensions/setup-tui-mental-models.ts
@@ -15,7 +15,14 @@ function bankOptions(deps: MemoryOperationsDeps): string[] {
   return config.banks.global.enabled ? ["Project", "Global", CANCEL] : ["Project", CANCEL];
 }
 
-function bankForChoice(choice: string | undefined): string | undefined {
+function parseTags(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+}
+
+function bankForChoice(choice: string | undefined): "project" | "global" | undefined {
   if (choice === "Project") return "project";
   if (choice === "Global") return "global";
   return undefined;
@@ -30,6 +37,44 @@ export async function handleMentalModels(
   if (!bank) return;
 
   const operations = createMemoryOperations(deps);
+  const mode = await ctx.ui.select("Mental model action", [
+    "Create from reflect query",
+    "Browse existing",
+    CANCEL,
+  ]);
+  if (mode === "Create from reflect query") {
+    const name = ((await ctx.ui.input("Mental model name", "")) ?? "").trim();
+    if (!name) {
+      ctx.ui.notify("Mental model create cancelled; name is required.", "warning");
+      return;
+    }
+    const sourceQuery = ((await ctx.ui.input("Reflect source query", "")) ?? "").trim();
+    if (!sourceQuery) {
+      ctx.ui.notify("Mental model create cancelled; source query is required.", "warning");
+      return;
+    }
+    const tags = parseTags(await ctx.ui.input("Tags, comma-separated", ""));
+    const preview = [`Name: ${name}`, `Bank: ${bankChoice}`, `Source query: ${sourceQuery}`];
+    if (tags.length) preview.push(`Tags: ${tags.join(", ")}`);
+    const confirm = await ctx.ui.select(`Create mental model?\n${preview.join("\n")}`, [
+      "Create",
+      CANCEL,
+    ]);
+    if (confirm !== "Create") return;
+    const created = await operations.promoteReflectQueryToMentalModel({
+      bank,
+      name,
+      sourceQuery,
+      ...(tags.length ? { tags } : {}),
+    });
+    ctx.ui.notify(
+      `Hindsight mental model create queued for ${name}; ${renderMentalModelOperationResult(created.result)}`,
+      "info",
+    );
+    return;
+  }
+  if (mode !== "Browse existing") return;
+
   const listed = await operations.listMentalModels({
     bank,
     options: { detail: "metadata", limit: 100 },

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -156,7 +156,7 @@ describe("memory operations", () => {
   });
 
   it("resolves project/global bank aliases for explicit operations", async () => {
-    const calls: Array<{ method: string; bank: string }> = [];
+    const calls: Array<{ method: string; bank: string; request?: unknown }> = [];
     const config = {
       ...DEFAULT_CONFIG,
       banks: { ...DEFAULT_CONFIG.banks, global: { enabled: true, bankId: "global-luxus" } },
@@ -183,8 +183,8 @@ describe("memory operations", () => {
           calls.push({ method: "listMentalModels", bank });
           return { items: [] };
         },
-        createMentalModel: async (bank) => {
-          calls.push({ method: "createMentalModel", bank });
+        createMentalModel: async (bank, request) => {
+          calls.push({ method: "createMentalModel", bank, request });
           return { operation_id: "op" };
         },
         refreshMentalModel: async (bank) => {
@@ -212,6 +212,27 @@ describe("memory operations", () => {
       request: { name: "Project model", sourceQuery: "What matters?" },
     });
     await operations.refreshMentalModel({ bank: "global", mentalModelId: "model" });
+    await operations.promoteReflectQueryToMentalModel({
+      bank: "global",
+      name: "Project patterns",
+      sourceQuery: "What patterns recur?",
+      tags: ["project", "patterns"],
+    });
+
+    await expect(
+      operations.promoteReflectQueryToMentalModel({
+        bank: "project",
+        name: "   ",
+        sourceQuery: "What patterns recur?",
+      }),
+    ).rejects.toThrow("Mental model name is required");
+    await expect(
+      operations.promoteReflectQueryToMentalModel({
+        bank: "project",
+        name: "Project patterns",
+        sourceQuery: "   ",
+      }),
+    ).rejects.toThrow("Mental model source query is required");
 
     expect(calls).toEqual(
       expect.arrayContaining([
@@ -220,8 +241,21 @@ describe("memory operations", () => {
         { method: "reflect", bank: "project-bank" },
         { method: "delete", bank: "global-luxus" },
         { method: "listMentalModels", bank: "global-luxus" },
-        { method: "createMentalModel", bank: "project-bank" },
+        {
+          method: "createMentalModel",
+          bank: "project-bank",
+          request: { name: "Project model", sourceQuery: "What matters?" },
+        },
         { method: "refreshMentalModel", bank: "global-luxus" },
+        {
+          method: "createMentalModel",
+          bank: "global-luxus",
+          request: {
+            name: "Project patterns",
+            sourceQuery: "What patterns recur?",
+            tags: ["project", "patterns"],
+          },
+        },
       ]),
     );
   });

--- a/tests/setup-tui-mental-models.test.ts
+++ b/tests/setup-tui-mental-models.test.ts
@@ -61,7 +61,7 @@ describe("setup TUI mental models", () => {
         return { ...listResponse.items[0], bank_id: bank, content: "remembered architecture" };
       },
     });
-    const ui = ctx(["Project", "Project model (model-1) tags=project", "View"]);
+    const ui = ctx(["Project", "Browse existing", "Project model (model-1) tags=project", "View"]);
 
     await handleMentalModels(ui.ctx as never, deps(client));
 
@@ -70,6 +70,35 @@ describe("setup TUI mental models", () => {
       { method: "get", bank: "project-bank", id: "model-1" },
     ]);
     expect(ui.notifications[0]?.message).toContain("remembered architecture");
+  });
+
+  it("creates a mental model from a reflect query with preview", async () => {
+    const calls: Array<{ method: string; bank: string; request: unknown }> = [];
+    const client = clientWith({
+      createMentalModel: async (bank, request) => {
+        calls.push({ method: "create", bank, request });
+        return { operation_id: "op-create", status: "queued" };
+      },
+    });
+    const ui = ctx(
+      ["Project", "Create from reflect query", "Create"],
+      ["Project patterns", "What project patterns recur?", "project, patterns"],
+    );
+
+    await handleMentalModels(ui.ctx as never, deps(client));
+
+    expect(calls).toEqual([
+      {
+        method: "create",
+        bank: "project-bank",
+        request: {
+          name: "Project patterns",
+          sourceQuery: "What project patterns recur?",
+          tags: ["project", "patterns"],
+        },
+      },
+    ]);
+    expect(ui.notifications[0]?.message).toContain("op-create");
   });
 
   it("refreshes, shows history, and requires typed exact id for delete", async () => {
@@ -101,20 +130,22 @@ describe("setup TUI mental models", () => {
     });
 
     await handleMentalModels(
-      ctx(["Global", "Project model (model-1) tags=project", "Refresh"]).ctx as never,
+      ctx(["Global", "Browse existing", "Project model (model-1) tags=project", "Refresh"])
+        .ctx as never,
       deps(client, config),
     );
     await handleMentalModels(
-      ctx(["Global", "Project model (model-1) tags=project", "History"]).ctx as never,
+      ctx(["Global", "Browse existing", "Project model (model-1) tags=project", "History"])
+        .ctx as never,
       deps(client, config),
     );
     const wrongDelete = ctx(
-      ["Global", "Project model (model-1) tags=project", "Delete"],
+      ["Global", "Browse existing", "Project model (model-1) tags=project", "Delete"],
       ["wrong"],
     );
     await handleMentalModels(wrongDelete.ctx as never, deps(client, config));
     const exactDelete = ctx(
-      ["Global", "Project model (model-1) tags=project", "Delete"],
+      ["Global", "Browse existing", "Project model (model-1) tags=project", "Delete"],
       ["model-1"],
     );
     await handleMentalModels(exactDelete.ctx as never, deps(client, config));


### PR DESCRIPTION
## Summary
- add operation intent to promote a reflect source query into a Hindsight mental model
- require explicit project/global bank alias and non-empty model name/source query
- add TUI create flow with name/query/tags and preview before create
- cover bank alias, request shape, validation, and TUI create path in tests

## Verification
- npm run check
- npm run typecheck:tsc

Replaces closed stacked PR #150 after base branch deletion.

Closes #131
