### PR TITLE
ci: tier checks by change impact

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,10 +27,12 @@
 ## Verification
 
 - [ ] `npm run check`
-- [ ] `npm run check:coverage`
-- [ ] `npm run typecheck:tsc`
+- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
+- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
+- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`)
+- [ ] package verification requested/passed (release/package changes or `ci:package`)
 - [ ] `npm run pack:verify` (release/package changes)
-- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes; document unavailable live proof)
+- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)
 
 ## Guidance sync
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,18 +3,148 @@ name: Check
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main, review/mvp]
+    tags:
+      - "v*.*.*"
+  schedule:
+    - cron: "41 2 * * *"
   workflow_dispatch:
+    inputs:
+      full:
+        description: Run full coverage/typecheck/package matrix
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 concurrency:
   group: check-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check:
-    name: check (${{ matrix.os }})
+  impact:
+    name: classify impact
+    runs-on: ubuntu-latest
+    outputs:
+      coverage: ${{ steps.classify.outputs.coverage }}
+      full_matrix: ${{ steps.classify.outputs.full_matrix }}
+      package_check: ${{ steps.classify.outputs.package_check }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          FULL_INPUT: ${{ inputs.full || 'true' }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          coverage=false
+          full_matrix=false
+          package_check=false
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$FULL_INPUT" = "false" ]; then
+            :
+          elif [ "$EVENT_NAME" != "pull_request" ]; then
+            coverage=true
+            full_matrix=true
+            package_check=true
+          elif [[ ",$LABELS," == *",ci:full,"* ]]; then
+            coverage=true
+            full_matrix=true
+            package_check=true
+          else
+            git fetch origin "$BASE_REF" --depth=1
+            changed=$(git diff --name-only "origin/$BASE_REF"...HEAD)
+            echo "Changed files:" >> "$GITHUB_STEP_SUMMARY"
+            printf '%s\n' "$changed" >> "$GITHUB_STEP_SUMMARY"
+
+            while IFS= read -r path; do
+              [ -z "$path" ] && continue
+              case "$path" in
+                extensions/*|tests/*|scripts/*|package.json|package-lock.json|tsconfig.json|vitest.config.ts)
+                  coverage=true
+                  ;;
+              esac
+              case "$path" in
+                extensions/client*|extensions/queue*|extensions/retain*|extensions/import*|extensions/memory-lifecycle*|extensions/memory-*operations.ts|extensions/bank*|extensions/config*|extensions/commands.ts|extensions/tools.ts|extensions/index.ts|scripts/smoke-*|scripts/verify-release.mjs|scripts/install-smoke.mjs|package.json|package-lock.json|.github/workflows/*)
+                  full_matrix=true
+                  ;;
+              esac
+              case "$path" in
+                package.json|package-lock.json|scripts/verify-release.mjs|scripts/install-smoke.mjs|.github/workflows/release.yml)
+                  package_check=true
+                  ;;
+              esac
+            done <<< "$changed"
+
+            if [[ ",$LABELS," == *",ci:coverage,"* ]]; then coverage=true; fi
+            if [[ ",$LABELS," == *",ci:package,"* ]]; then package_check=true; fi
+          fi
+
+          echo "coverage=$coverage" >> "$GITHUB_OUTPUT"
+          echo "full_matrix=$full_matrix" >> "$GITHUB_OUTPUT"
+          echo "package_check=$package_check" >> "$GITHUB_OUTPUT"
+          {
+            echo "coverage=$coverage"
+            echo "full_matrix=$full_matrix"
+            echo "package_check=$package_check"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  pr-fast:
+    name: fast PR check (ubuntu-latest)
+    runs-on: ubuntu-latest
+    needs: impact
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --engine-strict
+
+      - name: Run checks
+        run: npm run check
+
+  coverage:
+    name: coverage gate (ubuntu-latest)
+    runs-on: ubuntu-latest
+    needs: [impact, pr-fast]
+    if: needs.impact.outputs.coverage == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --engine-strict
+
+      - name: Run coverage gate
+        run: npm run check:coverage
+
+  full-matrix:
+    name: full matrix (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: [impact, pr-fast]
+    if: needs.impact.outputs.full_matrix == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -41,4 +171,45 @@ jobs:
         run: npm run typecheck:tsc
 
       - name: Verify package contents
+        if: needs.impact.outputs.package_check == 'true'
         run: npm pack --dry-run
+
+  package-check:
+    name: package verification (ubuntu-latest)
+    runs-on: ubuntu-latest
+    needs: [impact, pr-fast]
+    if: needs.impact.outputs.package_check == 'true' && needs.impact.outputs.full_matrix != 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --engine-strict
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+  tsc-fallback:
+    name: TypeScript compiler fallback (ubuntu-latest)
+    runs-on: ubuntu-latest
+    needs: [impact, pr-fast]
+    if: needs.impact.outputs.coverage == 'true' && needs.impact.outputs.full_matrix != 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --engine-strict
+
+      - name: Run TypeScript compiler fallback
+        run: npm run typecheck:tsc

--- a/.github/workflows/integration-hindsight.yml
+++ b/.github/workflows/integration-hindsight.yml
@@ -3,6 +3,7 @@ name: Hindsight Integration
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
@@ -12,8 +13,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  impact:
+    name: classify memory-path impact
+    runs-on: ubuntu-latest
+    outputs:
+      live_smoke: ${{ steps.classify.outputs.live_smoke }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+
+          live_smoke=false
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            live_smoke=true
+          elif [[ ",$LABELS," == *",ci:live-smoke,"* ]] || [[ ",$LABELS," == *",memory-path,"* ]]; then
+            live_smoke=true
+          else
+            git fetch origin "$BASE_REF" --depth=1
+            changed=$(git diff --name-only "origin/$BASE_REF"...HEAD)
+            echo "Changed files:" >> "$GITHUB_STEP_SUMMARY"
+            printf '%s\n' "$changed" >> "$GITHUB_STEP_SUMMARY"
+
+            while IFS= read -r path; do
+              [ -z "$path" ] && continue
+              case "$path" in
+                extensions/client*|extensions/recall*|extensions/retain*|extensions/queue*|extensions/import*|extensions/memory-lifecycle*|extensions/memory-*operations.ts|extensions/bank*|extensions/config*|extensions/smoke-*|scripts/smoke-*|scripts/install-smoke.mjs|scripts/verify-release.mjs|package.json|package-lock.json|.github/workflows/integration-hindsight.yml|.github/workflows/release.yml)
+                  live_smoke=true
+                  ;;
+              esac
+            done <<< "$changed"
+          fi
+
+          echo "live_smoke=$live_smoke" >> "$GITHUB_OUTPUT"
+          echo "live_smoke=$live_smoke" >> "$GITHUB_STEP_SUMMARY"
+
   live-smoke:
     runs-on: ubuntu-latest
+    needs: impact
+    if: needs.impact.outputs.live_smoke == 'true'
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+  schedule:
+    - cron: "23 4 * * *"
   workflow_dispatch:
     inputs:
       publish:
@@ -21,7 +23,12 @@ permissions:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    name: verify (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
 
@@ -45,13 +52,31 @@ jobs:
         run: npm run typecheck:tsc
 
       - name: Verify registry signatures
+        if: matrix.os == 'ubuntu-latest'
         run: npm run audit:signatures
 
       - name: Verify release metadata and package install
+        if: matrix.os == 'ubuntu-latest'
         run: npm run pack:verify
 
+  publish:
+    runs-on: ubuntu-latest
+    needs: verify
+    if: >-
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci --engine-strict
+
       - name: Publish package
-        if: >-
-          startsWith(github.ref, 'refs/tags/v') ||
-          (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
         run: npm publish --provenance --access public

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,13 +208,20 @@ Minimum expected coverage:
 - tool registration and schemas
 - recall injection formatting
 
-Before merging or considering a task done, run:
+Before merging or considering a task done, always run:
 
 ```bash
 npm run check
+```
+
+Also run coverage and compiler fallback for source, tests, critical paths, or full-CI work:
+
+```bash
 npm run check:coverage
 npm run typecheck:tsc
 ```
+
+GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix. Package/release changes and `ci:package` also run package verification. Manual `workflow_dispatch` can run the full matrix for any PR.
 
 If release or package dependencies changed, also run:
 
@@ -230,7 +237,7 @@ Preferred proof is a configured-server smoke test:
 npm run smoke:hindsight
 ```
 
-GitHub Actions has a `Hindsight Integration` workflow that runs on PRs, nightly schedule, and manual dispatch. It runs live smoke only when `HINDSIGHT_INTEGRATION_ENABLED=true`; then it uses `HINDSIGHT_BASE_URL` and optional `HINDSIGHT_API_KEY` secrets. Otherwise it skips cleanly. For memory-path PRs, do not treat an unconfigured skip as proof; either run the smoke test locally with credentials, confirm a configured workflow pass, or document why live proof is unavailable and what lower-level checks cover the risk.
+GitHub Actions has a `Hindsight Integration` workflow that runs for memory-path changes, `memory-path`/`ci:live-smoke` labels, nightly schedule, and manual dispatch. It runs live smoke only when `HINDSIGHT_INTEGRATION_ENABLED=true`; then it uses `HINDSIGHT_BASE_URL` and optional `HINDSIGHT_API_KEY` secrets. Otherwise it skips cleanly. For memory-path PRs, do not treat an unconfigured skip as proof; either run the smoke test locally with credentials, confirm a configured workflow pass, or document why live proof is unavailable and what lower-level checks cover the risk.
 
 ## Common mistakes to avoid
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,13 +76,20 @@ If a change intentionally reopens one of these invariants, document the contradi
 
 ## Tests and verification
 
-Run the relevant targeted tests while developing, then run the full checks before considering the work done:
+Run the relevant targeted tests while developing, then run the checks required by the change impact before considering the work done:
 
 ```bash
 npm run check
+```
+
+Run these for source, tests, critical paths, or full-CI work:
+
+```bash
 npm run check:coverage
 npm run typecheck:tsc
 ```
+
+GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix. Package/release changes and `ci:package` also run package verification. Manual `workflow_dispatch` can run the full matrix for any PR.
 
 For release-path or packaging changes, also run:
 
@@ -98,7 +105,7 @@ Preferred proof is a configured smoke test:
 npm run smoke:hindsight
 ```
 
-The GitHub `Hindsight Integration` workflow skips cleanly unless `HINDSIGHT_INTEGRATION_ENABLED=true` is configured. For memory-path PRs, do not treat an unconfigured skip as proof; either run the smoke test locally with credentials, confirm a configured workflow pass, or document why live proof is unavailable and what lower-level checks cover the risk.
+The GitHub `Hindsight Integration` workflow runs automatically for memory-path changes, `memory-path`/`ci:live-smoke` labels, nightly schedule, and manual dispatch. It still skips cleanly unless `HINDSIGHT_INTEGRATION_ENABLED=true` is configured. For memory-path PRs, do not treat an unconfigured skip as proof; either run the smoke test locally with credentials, confirm a configured workflow pass, or document why live proof is unavailable and what lower-level checks cover the risk.
 
 ## Commit messages
 
@@ -143,8 +150,9 @@ Before opening or marking a PR ready:
 - [ ] I updated README/docs when user-visible behavior changed.
 - [ ] I updated `AGENTS.md` and `CONTRIBUTING.md` together when source-of-truth order, workflow, verification, or definition-of-done guidance changed.
 - [ ] I ran `npm run check`.
-- [ ] I ran `npm run check:coverage` when touching critical paths.
-- [ ] I ran `npm run typecheck:tsc`.
+- [ ] I ran `npm run check:coverage` when touching source, tests, or critical paths.
+- [ ] I ran `npm run typecheck:tsc` when touching source or critical paths.
+- [ ] I requested or confirmed full matrix when touching runtime-sensitive paths, queue/import/memory paths, package/release code, workflows, or platform-sensitive behavior.
 - [ ] I ran `npm run audit:signatures` when touching release/package dependencies.
 - [ ] I ran `npm run smoke:hindsight` or confirmed a configured `Hindsight Integration` pass when memory-path behavior changed; if unavailable, I documented the limitation.
 


### PR DESCRIPTION
## Summary
- split Check workflow into fast PR default plus conditional coverage, package, and full-matrix jobs
- gate live Hindsight smoke by memory-path changes, labels, schedule, or manual dispatch
- keep release/nightly confidence with full matrix release verification and scheduled release checks
- document CI labels and verification expectations in PR template, AGENTS, and CONTRIBUTING

## Verification
- ruby YAML parse for .github/workflows/*.yml
- npm run check
- npm run check:coverage
- npm run typecheck:tsc

Closes #139
