### PR TITLE
feat(routing): explain route dry runs

### DIFF
--- a/extensions/memory-router.ts
+++ b/extensions/memory-router.ts
@@ -1,3 +1,5 @@
+import { baseTags, deriveProjectBankId } from "./banking.js";
+import { stableSessionId } from "./session.js";
 import type { ResolvedConfig } from "./types.js";
 
 export type MemoryRoute = "project" | "global" | "both" | "skip";
@@ -7,6 +9,9 @@ export interface MemoryRouteInput {
   content: string;
   context?: string;
   config: ResolvedConfig;
+  cwd?: string;
+  projectBankId?: string;
+  sessionFile?: string;
 }
 
 export interface MemoryRouteClassification {
@@ -25,10 +30,19 @@ export interface MemoryRouterAdapter {
   }): MemoryRouteClassification;
 }
 
+export interface MemoryRouteTargetPreview {
+  bankRole: "project" | "global";
+  bankId: string;
+  tags: string[];
+  willWrite: boolean;
+}
+
 export interface MemoryRouteDecision extends MemoryRouteClassification {
   reason: string;
   mode: ResolvedConfig["globalRetain"]["mode"];
   writes: string[];
+  targets: MemoryRouteTargetPreview[];
+  safetyNotes: string[];
   projectMission: string;
   globalMission: string;
 }
@@ -54,6 +68,11 @@ const SKIP_PATTERNS: Array<[RegExp, string]> = [
   [/\/var\/folders\//i, "temporary file path"],
   [/\btemporary\b/i, "temporary detail"],
   [/\bscreenshot\b/i, "screenshot artifact"],
+];
+
+const SECRET_PATTERNS: Array<[RegExp, string]> = [
+  [/\b(bearer|api[_-]?key|token|cookie|secret|password)\b/i, "secret-like content"],
+  [/https?:\/\/[^\s]*\b(private|internal|token|key)\b[^\s]*/i, "private URL"],
 ];
 
 function matchSignals(text: string, patterns: Array<[RegExp, string]>): string[] {
@@ -144,6 +163,72 @@ function missionSummary(mission: string | undefined, fallback: string): string {
   return mission.length > 120 ? `${mission.slice(0, 117)}...` : mission;
 }
 
+function previewTags(args: { cwd?: string; sessionFile?: string }): string[] {
+  if (!args.cwd) return [];
+  return baseTags(args.cwd, stableSessionId(args.sessionFile, args.cwd));
+}
+
+function routeTargets(args: {
+  route: MemoryRoute;
+  config: ResolvedConfig;
+  writes: string[];
+  cwd?: string;
+  projectBankId?: string;
+  sessionFile?: string;
+}): MemoryRouteTargetPreview[] {
+  const targets: MemoryRouteTargetPreview[] = [];
+  if (args.route === "project" || args.route === "both") {
+    const bankId =
+      args.projectBankId ??
+      args.config.banks.project.bankId ??
+      (args.cwd ? deriveProjectBankId(args.cwd, args.config) : undefined);
+    if (bankId) {
+      targets.push({
+        bankRole: "project",
+        bankId,
+        tags: previewTags({
+          ...(args.cwd ? { cwd: args.cwd } : {}),
+          ...(args.sessionFile ? { sessionFile: args.sessionFile } : {}),
+        }),
+        willWrite: args.writes.includes("project"),
+      });
+    }
+  }
+  if (args.route === "global" || args.route === "both") {
+    const bankId = args.config.banks.global.enabled ? args.config.banks.global.bankId : undefined;
+    if (bankId) {
+      targets.push({
+        bankRole: "global",
+        bankId,
+        tags: previewTags({
+          ...(args.cwd ? { cwd: args.cwd } : {}),
+          ...(args.sessionFile ? { sessionFile: args.sessionFile } : {}),
+        }),
+        willWrite: args.writes.includes("global"),
+      });
+    }
+  }
+  return targets;
+}
+
+function safetyNotes(args: {
+  text: string;
+  route: MemoryRoute;
+  mode: ResolvedConfig["globalRetain"]["mode"];
+}) {
+  const notes: string[] = [];
+  const secretMatches = matchSignals(args.text, SECRET_PATTERNS);
+  if (secretMatches.length) notes.push(`review/redact before retain: ${secretMatches.join(", ")}`);
+  if (args.mode === "explicit-only")
+    notes.push("dry-run only; no automatic writes in explicit-only mode");
+  if (args.route === "global" || args.route === "both") {
+    notes.push("global memory candidate; keep only durable cross-project facts");
+  }
+  if (args.route === "skip")
+    notes.push("skip candidate; do not retain transient or unsafe content");
+  return notes;
+}
+
 export function routeMemoryCandidate(
   args: MemoryRouteInput,
   adapter: MemoryRouterAdapter = createMissionAwareMemoryRouter(),
@@ -162,7 +247,7 @@ export function routeMemoryCandidate(
     projectMission,
     globalMission,
   });
-  const writes =
+  const candidateWrites =
     args.config.globalRetain.mode === "router"
       ? classification.route === "both"
         ? ["project", "global"]
@@ -170,6 +255,12 @@ export function routeMemoryCandidate(
           ? []
           : [classification.route]
       : [];
+  const writes = candidateWrites.filter((target) =>
+    target === "project"
+      ? args.config.banks.project.enabled
+      : args.config.banks.global.enabled && Boolean(args.config.banks.global.bankId),
+  );
+  const text = `${args.content}\n${args.context ?? ""}`;
   const reason =
     args.config.globalRetain.mode === "explicit-only"
       ? `dry-run only: globalRetain.mode=explicit-only; suggested=${classification.route}; signals=${classification.matchedSignals.join(", ") || "none"}`
@@ -180,6 +271,19 @@ export function routeMemoryCandidate(
     reason,
     mode: args.config.globalRetain.mode,
     writes,
+    targets: routeTargets({
+      route: classification.route,
+      config: args.config,
+      writes,
+      ...(args.cwd ? { cwd: args.cwd } : {}),
+      ...(args.projectBankId ? { projectBankId: args.projectBankId } : {}),
+      ...(args.sessionFile ? { sessionFile: args.sessionFile } : {}),
+    }),
+    safetyNotes: safetyNotes({
+      text,
+      route: classification.route,
+      mode: args.config.globalRetain.mode,
+    }),
     projectMission,
     globalMission,
   };

--- a/extensions/memory-routing-operations.ts
+++ b/extensions/memory-routing-operations.ts
@@ -3,11 +3,14 @@ import { routeMemoryCandidate } from "./memory-router.js";
 
 export function createRoutingOperations(deps: MemoryOperationsDeps) {
   return {
-    routeMemory(args: { content: string; context?: string }) {
+    routeMemory(args: { content: string; context?: string; cwd?: string; sessionFile?: string }) {
       return routeMemoryCandidate({
         content: args.content,
         ...(args.context ? { context: args.context } : {}),
         config: deps.getConfig(),
+        projectBankId: deps.getProjectBankId(),
+        ...(args.cwd ? { cwd: args.cwd } : {}),
+        ...(args.sessionFile ? { sessionFile: args.sessionFile } : {}),
       });
     },
   };

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -5,6 +5,7 @@ import { maintenanceCommandOperations } from "./command-maintenance.js";
 import { sessionCommandOperations } from "./command-session.js";
 import type { MemoryOperationsDeps } from "./memory-operation-service.js";
 import { createMemoryOperations } from "./memory-operation-service.js";
+import { getSessionFile } from "./session.js";
 import { runHindsightSetupTui } from "./setup-tui.js";
 import {
   configureToolResponse,
@@ -162,9 +163,12 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       }),
       async execute(_id, params, _signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
+        const sessionFile = getSessionFile(ctx);
         const result = operations.routeMemory({
           content: params.content,
           ...(params.context ? { context: params.context } : {}),
+          cwd: ctx.cwd,
+          ...(sessionFile ? { sessionFile } : {}),
         });
         return routeMemoryToolResponse(result);
       },

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -26,11 +26,26 @@ export function retainToolResponse(result: RetainToolResult): ToolTextResponse<R
 export function routeMemoryToolResponse(
   result: RouteMemoryToolResult,
 ): ToolTextResponse<RouteMemoryToolResult> {
+  const targetText = result.targets.length
+    ? result.targets
+        .map(
+          (target) =>
+            `${target.bankRole}:${target.bankId} tags=${target.tags.join(",") || "none"} ${target.willWrite ? "will-write" : "preview-only"}`,
+        )
+        .join("; ")
+    : "none";
+  const writeText = result.writes.length ? result.writes.join(",") : "none";
+  const safetyText = result.safetyNotes.length ? result.safetyNotes.join("; ") : "none";
   return {
     content: [
       {
         type: "text",
-        text: `Route ${result.route} confidence=${result.confidence}; ${result.reason}`,
+        text: [
+          `Route ${result.route} confidence=${result.confidence}; ${result.reason}`,
+          `Targets: ${targetText}`,
+          `Writes now: ${writeText}`,
+          `Safety: ${safetyText}`,
+        ].join("\n"),
       },
     ],
     details: result,

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -423,6 +423,9 @@ describe("extension hooks", () => {
     );
 
     expect(result.details).toMatchObject({ route: "global", mode: "explicit-only", writes: [] });
+    expect(result.details.targets).toEqual([]);
+    expect(result.content[0].text).toContain("Targets: none");
+    expect(result.content[0].text).toContain("Writes now: none");
     expect(mocked.client.retain).not.toHaveBeenCalled();
   });
 

--- a/tests/memory-router.test.ts
+++ b/tests/memory-router.test.ts
@@ -62,7 +62,13 @@ describe("memory router", () => {
   it("defaults to explicit-only dry-run with no writes", () => {
     const decision = routeMemoryCandidate({
       content: "Kai prefers terse replies across projects",
-      config: DEFAULT_CONFIG,
+      config: {
+        ...DEFAULT_CONFIG,
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          global: { ...DEFAULT_CONFIG.banks.global, enabled: true, bankId: "global-bank" },
+        },
+      },
     });
 
     expect(decision).toMatchObject({
@@ -72,6 +78,20 @@ describe("memory router", () => {
       signals: ["global"],
     });
     expect(decision.reason).toContain("dry-run only");
+    expect(decision.targets).toEqual([
+      {
+        bankRole: "global",
+        bankId: "global-bank",
+        tags: [],
+        willWrite: false,
+      },
+    ]);
+    expect(decision.safetyNotes).toEqual(
+      expect.arrayContaining([
+        "dry-run only; no automatic writes in explicit-only mode",
+        "global memory candidate; keep only durable cross-project facts",
+      ]),
+    );
     expect(decision.matchedSignals).toEqual(
       expect.arrayContaining(["preference", "cross-project workflow/style"]),
     );
@@ -80,11 +100,48 @@ describe("memory router", () => {
   it("can describe router writes when router mode is enabled", () => {
     const decision = routeMemoryCandidate({
       content: "Kai prefers terse replies for this repo config workflow",
-      config: { ...DEFAULT_CONFIG, globalRetain: { mode: "router" } },
+      config: {
+        ...DEFAULT_CONFIG,
+        globalRetain: { mode: "router" },
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { ...DEFAULT_CONFIG.banks.project, bankId: "project-bank" },
+          global: { ...DEFAULT_CONFIG.banks.global, enabled: true, bankId: "global-bank" },
+        },
+      },
     });
 
     expect(decision.route).toBe("both");
     expect(decision.writes).toEqual(["project", "global"]);
+    expect(decision.targets).toEqual([
+      {
+        bankRole: "project",
+        bankId: "project-bank",
+        tags: [],
+        willWrite: true,
+      },
+      {
+        bankRole: "global",
+        bankId: "global-bank",
+        tags: [],
+        willWrite: true,
+      },
+    ]);
+  });
+
+  it("adds safety notes for secret-like content", () => {
+    const decision = routeMemoryCandidate({
+      content: "Temporary note contained bearer token abc123 from a private URL",
+      config: DEFAULT_CONFIG,
+    });
+
+    expect(decision.route).toBe("skip");
+    expect(decision.safetyNotes).toEqual(
+      expect.arrayContaining([
+        "review/redact before retain: secret-like content",
+        "skip candidate; do not retain transient or unsafe content",
+      ]),
+    );
   });
 
   it("uses mission terms as routing signals", () => {


### PR DESCRIPTION
## Summary
- preserve existing route decision fields while adding target previews and safety notes
- show bank role/id, actual retain tag preview when cwd/session are available, and write/no-write status
- make write status account for disabled/unconfigured banks
- expand route dry-run tool output and tests

## Verification
- npm test -- memory-router extension-hooks
- npm run check
- npm run typecheck:tsc

Closes #154
