### PR TITLE
refactor(routing): extract typed strategy seam

### DIFF
--- a/extensions/memory-router.ts
+++ b/extensions/memory-router.ts
@@ -1,51 +1,31 @@
 import { baseTags, deriveProjectBankId } from "./banking.js";
 import { stableSessionId } from "./session.js";
+import type {
+  MemoryRoute,
+  MemoryRouteClassification,
+  MemoryRouteDecision,
+  MemoryRouterAdapter,
+  MemoryRouteSignal,
+  MemoryRouteTargetPreview,
+  RoutingBankRole,
+  RoutingCandidate,
+  RoutingStrategy,
+  RoutingStrategyInput,
+} from "./routing-strategy.js";
 import type { ResolvedConfig } from "./types.js";
 
-export type MemoryRoute = "project" | "global" | "both" | "skip";
-export type MemoryRouteSignal = "global" | "project" | "skip";
-
-export interface MemoryRouteInput {
-  content: string;
-  context?: string;
-  config: ResolvedConfig;
-  cwd?: string;
-  projectBankId?: string;
-  sessionFile?: string;
-}
-
-export interface MemoryRouteClassification {
-  route: MemoryRoute;
-  confidence: number;
-  signals: MemoryRouteSignal[];
-  matchedSignals: string[];
-}
-
-export interface MemoryRouterAdapter {
-  classify(args: {
-    content: string;
-    context?: string;
-    projectMission?: string;
-    globalMission?: string;
-  }): MemoryRouteClassification;
-}
-
-export interface MemoryRouteTargetPreview {
-  bankRole: "project" | "global";
-  bankId: string;
-  tags: string[];
-  willWrite: boolean;
-}
-
-export interface MemoryRouteDecision extends MemoryRouteClassification {
-  reason: string;
-  mode: ResolvedConfig["globalRetain"]["mode"];
-  writes: string[];
-  targets: MemoryRouteTargetPreview[];
-  safetyNotes: string[];
-  projectMission: string;
-  globalMission: string;
-}
+export type {
+  MemoryRoute,
+  MemoryRouteClassification,
+  MemoryRouteDecision,
+  MemoryRouterAdapter,
+  MemoryRouteSignal,
+  MemoryRouteTargetPreview,
+  RoutingBankRole,
+  RoutingCandidate as MemoryRouteInput,
+  RoutingStrategy,
+  RoutingStrategyInput,
+} from "./routing-strategy.js";
 
 const GLOBAL_PATTERNS: Array<[RegExp, string]> = [
   [/\b(prefer|prefers|preference|likes|wants|always|never)\b/i, "preference"],
@@ -135,18 +115,18 @@ function missionMatches(text: string, mission: string | undefined, label: string
   return matched.length ? [`${label} mission:${matched.slice(0, 3).join("/")}`] : [];
 }
 
-export function createMissionAwareMemoryRouter(): MemoryRouterAdapter {
+export function createMissionAwareMemoryRouter(): RoutingStrategy {
   return {
     classify(args) {
       const text = `${args.content}\n${args.context ?? ""}`;
       return classifyFromSignals({
         globalMatches: [
           ...matchSignals(text, GLOBAL_PATTERNS),
-          ...missionMatches(text, args.globalMission, "global"),
+          ...missionMatches(text, args.missions.global, "global"),
         ],
         projectMatches: [
           ...matchSignals(text, PROJECT_PATTERNS),
-          ...missionMatches(text, args.projectMission, "project"),
+          ...missionMatches(text, args.missions.project, "project"),
         ],
         skipMatches: matchSignals(text, SKIP_PATTERNS),
       });
@@ -154,7 +134,7 @@ export function createMissionAwareMemoryRouter(): MemoryRouterAdapter {
   };
 }
 
-export function createHeuristicMemoryRouter(): MemoryRouterAdapter {
+export function createHeuristicMemoryRouter(): RoutingStrategy {
   return createMissionAwareMemoryRouter();
 }
 
@@ -230,8 +210,8 @@ function safetyNotes(args: {
 }
 
 export function routeMemoryCandidate(
-  args: MemoryRouteInput,
-  adapter: MemoryRouterAdapter = createMissionAwareMemoryRouter(),
+  args: RoutingCandidate,
+  strategy: RoutingStrategy = createMissionAwareMemoryRouter(),
 ): MemoryRouteDecision {
   const projectMission = missionSummary(
     args.config.banks.project.retainMission,
@@ -241,19 +221,23 @@ export function routeMemoryCandidate(
     args.config.banks.global.retainMission,
     "built-in global retain mission",
   );
-  const classification = adapter.classify({
+  const strategyInput: RoutingStrategyInput = {
     content: args.content,
     ...(args.context ? { context: args.context } : {}),
-    projectMission,
-    globalMission,
-  });
-  const candidateWrites =
+    config: args.config,
+    missions: { project: projectMission, global: globalMission },
+    ...(args.cwd ? { cwd: args.cwd } : {}),
+    ...(args.projectBankId ? { projectBankId: args.projectBankId } : {}),
+    ...(args.sessionFile ? { sessionFile: args.sessionFile } : {}),
+  };
+  const classification = strategy.classify(strategyInput);
+  const candidateWrites: RoutingBankRole[] =
     args.config.globalRetain.mode === "router"
       ? classification.route === "both"
         ? ["project", "global"]
         : classification.route === "skip"
           ? []
-          : [classification.route]
+          : [classification.route as RoutingBankRole]
       : [];
   const writes = candidateWrites.filter((target) =>
     target === "project"

--- a/extensions/routing-strategy.ts
+++ b/extensions/routing-strategy.ts
@@ -1,0 +1,57 @@
+import type { ResolvedConfig } from "./types.js";
+
+export type MemoryRoute = "project" | "global" | "both" | "skip";
+export type MemoryRouteSignal = "global" | "project" | "skip";
+export type RoutingBankRole = "project" | "global";
+
+export interface RoutingCandidate {
+  content: string;
+  context?: string;
+  config: ResolvedConfig;
+  cwd?: string;
+  projectBankId?: string;
+  sessionFile?: string;
+}
+
+export interface RoutingStrategyInput {
+  content: string;
+  context?: string;
+  config: ResolvedConfig;
+  missions: {
+    project: string;
+    global: string;
+  };
+  cwd?: string;
+  projectBankId?: string;
+  sessionFile?: string;
+}
+
+export interface MemoryRouteClassification {
+  route: MemoryRoute;
+  confidence: number;
+  signals: MemoryRouteSignal[];
+  matchedSignals: string[];
+}
+
+export interface RoutingStrategy {
+  classify(args: RoutingStrategyInput): MemoryRouteClassification;
+}
+
+export type MemoryRouterAdapter = RoutingStrategy;
+
+export interface MemoryRouteTargetPreview {
+  bankRole: RoutingBankRole;
+  bankId: string;
+  tags: string[];
+  willWrite: boolean;
+}
+
+export interface MemoryRouteDecision extends MemoryRouteClassification {
+  reason: string;
+  mode: ResolvedConfig["globalRetain"]["mode"];
+  writes: RoutingBankRole[];
+  targets: MemoryRouteTargetPreview[];
+  safetyNotes: string[];
+  projectMission: string;
+  globalMission: string;
+}

--- a/tests/memory-router.test.ts
+++ b/tests/memory-router.test.ts
@@ -6,7 +6,7 @@ import {
   routeMemoryCandidate,
   type MemoryRoute,
   type MemoryRouteSignal,
-  type MemoryRouterAdapter,
+  type RoutingStrategy,
 } from "../extensions/memory-router.js";
 
 interface RouterEvalFixture {
@@ -209,9 +209,9 @@ describe("memory router", () => {
     );
   });
 
-  it("passes mission context through the router adapter seam", () => {
+  it("passes normalized config and mission context through the routing strategy seam", () => {
     const calls: unknown[] = [];
-    const adapter: MemoryRouterAdapter = {
+    const adapter: RoutingStrategy = {
       classify(args) {
         calls.push(args);
         return {
@@ -239,8 +239,9 @@ describe("memory router", () => {
     );
 
     expect(calls[0]).toMatchObject({
-      projectMission: "Project retain mission",
-      globalMission: "Global retain mission",
+      content: "remember this",
+      config: expect.objectContaining({ globalRetain: { mode: "explicit-only" } }),
+      missions: { project: "Project retain mission", global: "Global retain mission" },
     });
     expect(decision.projectMission).toBe("Project retain mission");
     expect(decision.globalMission).toBe("Global retain mission");


### PR DESCRIPTION
## Summary
- extract a focused typed routing strategy module
- add normalized routing candidate/input and decision types
- keep the existing mission-aware heuristic as the default strategy
- update strategy injection test to assert config and mission context flow

## Verification
- npm test -- memory-router
- npm run check
- npm run typecheck:tsc

Closes #156
