### PR TITLE
feat(tui): make mental models read-only

### DIFF
--- a/docs/core-vs-companion-adapters.md
+++ b/docs/core-vs-companion-adapters.md
@@ -66,7 +66,7 @@ If most answers are yes, it can be core. If any answer depends on a non-Pi frame
 
 | Request                                                                   | Location        | Reason                                                              |
 | ------------------------------------------------------------------------- | --------------- | ------------------------------------------------------------------- |
-| Add `/hindsight` action to refresh a mental model                         | Core            | Pi TUI exposes Hindsight mental-model API directly.                 |
+| Add `/hindsight` read-only mental model list/detail view                  | Core            | Pi can inspect Hindsight mental models without cloning web UI.      |
 | Add operation-service seam for creating Hindsight bank templates          | Core            | Bank templates are Hindsight-native and framework-neutral.          |
 | Import Markdown, text, or JSON seed files into a selected bank            | Core if generic | Simple content import helps Pi projects without framework coupling. |
 | Add LiteLLM middleware that injects recalled memory into chat completions | Companion       | Middleware shape belongs to LiteLLM, not Pi.                        |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,7 +46,7 @@ Current keyboard controls:
 - `Enter`: edit selected setting
 - `r`: remove the selected setting's active override
 - `f`: flush queued retain jobs
-- `m`: open the mental model library
+- `m`: open the read-only mental model list/detail view
 - `d`: deployment setup
 - `g`: rerun guided setup
 

--- a/docs/hindsight-core-functions.md
+++ b/docs/hindsight-core-functions.md
@@ -110,7 +110,7 @@ Good mental model examples:
 - “What recurring workflow habits matter?”
 - “What does this project consider good design?”
 
-Mental models are not raw recall. They are reusable synthesized answers. In Pi Hindsight they are explicit advanced resources: users should create, refresh, inspect, or delete them intentionally through operations/TUI/tool surfaces. The extension must not auto-create mental models from routine sessions or refresh them in the background unless a future issue designs that policy. Starter suggestions are documented in [`starter-mental-model-suggestions.md`](starter-mental-model-suggestions.md).
+Mental models are not raw recall. They are reusable synthesized answers. In Pi Hindsight they are explicit advanced resources. Pi's `/hindsight` TUI shows a read-only list/detail view and hands off create, edit, refresh, and delete to the Hindsight web interface. The extension must not auto-create mental models from routine sessions or refresh them in the background unless a future issue designs that policy. Starter suggestions are documented in [`starter-mental-model-suggestions.md`](starter-mental-model-suggestions.md).
 
 Creating a mental model preserves a source query. Hindsight runs that query through reflect and stores the generated content. Refresh reruns the stored source query against newer memory.
 

--- a/docs/starter-mental-model-suggestions.md
+++ b/docs/starter-mental-model-suggestions.md
@@ -59,15 +59,13 @@ Avoid starter mental models for:
 
 ## Future TUI behavior
 
-A future TUI slice can show starter suggestions as a picker inside the mental model library:
+A future TUI slice should not try to recreate Hindsight's full mental model editor. If starter suggestions become interactive in Pi, prefer one of these lighter options:
 
-1. Choose bank: project or global.
-2. Choose `Create from starter suggestion`.
-3. Preview name, source query, tags, and target bank.
-4. Confirm creation.
-5. Submit through the existing mental model creation operation.
+1. Show suggestions as read-only copy with a Hindsight web interface handoff.
+2. Offer a preview-only dry run of name, source query, tags, and target bank.
+3. Defer actual create/edit/refresh/delete to the Hindsight web interface unless a later issue explicitly reopens Pi-side editing.
 
-The picker should allow editing the name, query, and tags before create. It should not hide the source query behind friendly labels.
+Pi should not hide source queries behind friendly labels.
 
 ## Bank template guidance
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -10,7 +10,7 @@ For a generated reference of registered tools, commands, and editable config fie
 /hindsight
 ```
 
-Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Press `m` to open the mental model library for explicit view, refresh, or exact-ID deletion.
+Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Press `m` to open the read-only mental model list/detail view; use the Hindsight web interface for create, edit, refresh, or delete.
 
 ## Setup and config
 

--- a/extensions/mental-model-presenter.ts
+++ b/extensions/mental-model-presenter.ts
@@ -67,7 +67,11 @@ export function mentalModelOption(model: MentalModelSummary): string {
   return `${model.name} (${model.id})${tags}${stale}`;
 }
 
-export function renderMentalModel(model: MentalModelSummary): string {
+export function mentalModelWebInterfaceHint(baseUrl: string): string {
+  return `Pi mental model view is read-only. Use the Hindsight web interface for create, edit, refresh, or delete: ${baseUrl}`;
+}
+
+export function renderMentalModel(model: MentalModelSummary, webHint?: string): string {
   const lines = [
     `Mental model ${model.name} (${model.id})`,
     `Bank: ${model.bankId ?? "unknown"}`,
@@ -76,11 +80,12 @@ export function renderMentalModel(model: MentalModelSummary): string {
     `Stale: ${model.isStale === undefined || model.isStale === null ? "unknown" : model.isStale ? "yes" : "no"}`,
   ];
   if (model.sourceQuery) lines.push(`Source query: ${model.sourceQuery}`);
+  if (webHint) lines.push("", webHint);
   if (model.content) lines.push("", model.content);
   return lines.join("\n");
 }
 
-export function renderMentalModelHistory(value: unknown): string {
+export function renderMentalModelHistory(value: unknown, webHint?: string): string {
   if (!isRecord(value) || !Array.isArray(value.items) || value.items.length === 0) {
     return "Mental model history: none";
   }
@@ -93,6 +98,7 @@ export function renderMentalModelHistory(value: unknown): string {
     const status = stringValue(item.status);
     lines.push(`- ${id} at ${createdAt}${status ? ` status=${status}` : ""}`);
   }
+  if (webHint) lines.push("", webHint);
   return lines.length > 1 ? lines.join("\n") : "Mental model history: none";
 }
 

--- a/extensions/setup-tui-mental-models.ts
+++ b/extensions/setup-tui-mental-models.ts
@@ -4,22 +4,15 @@ import {
   mentalModelFromUnknown,
   mentalModelListFromUnknown,
   mentalModelOption,
+  mentalModelWebInterfaceHint,
   renderMentalModel,
   renderMentalModelHistory,
-  renderMentalModelOperationResult,
 } from "./mental-model-presenter.js";
 import { CANCEL } from "./setup-tui-types.js";
 
 function bankOptions(deps: MemoryOperationsDeps): string[] {
   const config = deps.getConfig();
   return config.banks.global.enabled ? ["Project", "Global", CANCEL] : ["Project", CANCEL];
-}
-
-function parseTags(value: string | undefined): string[] {
-  return (value ?? "")
-    .split(",")
-    .map((tag) => tag.trim())
-    .filter(Boolean);
 }
 
 function bankForChoice(choice: string | undefined): "project" | "global" | undefined {
@@ -37,43 +30,7 @@ export async function handleMentalModels(
   if (!bank) return;
 
   const operations = createMemoryOperations(deps);
-  const mode = await ctx.ui.select("Mental model action", [
-    "Create from reflect query",
-    "Browse existing",
-    CANCEL,
-  ]);
-  if (mode === "Create from reflect query") {
-    const name = ((await ctx.ui.input("Mental model name", "")) ?? "").trim();
-    if (!name) {
-      ctx.ui.notify("Mental model create cancelled; name is required.", "warning");
-      return;
-    }
-    const sourceQuery = ((await ctx.ui.input("Reflect source query", "")) ?? "").trim();
-    if (!sourceQuery) {
-      ctx.ui.notify("Mental model create cancelled; source query is required.", "warning");
-      return;
-    }
-    const tags = parseTags(await ctx.ui.input("Tags, comma-separated", ""));
-    const preview = [`Name: ${name}`, `Bank: ${bankChoice}`, `Source query: ${sourceQuery}`];
-    if (tags.length) preview.push(`Tags: ${tags.join(", ")}`);
-    const confirm = await ctx.ui.select(`Create mental model?\n${preview.join("\n")}`, [
-      "Create",
-      CANCEL,
-    ]);
-    if (confirm !== "Create") return;
-    const created = await operations.promoteReflectQueryToMentalModel({
-      bank,
-      name,
-      sourceQuery,
-      ...(tags.length ? { tags } : {}),
-    });
-    ctx.ui.notify(
-      `Hindsight mental model create queued for ${name}; ${renderMentalModelOperationResult(created.result)}`,
-      "info",
-    );
-    return;
-  }
-  if (mode !== "Browse existing") return;
+  const webHint = mentalModelWebInterfaceHint(deps.getConfig().hindsight.baseUrl);
 
   const listed = await operations.listMentalModels({
     bank,
@@ -81,7 +38,7 @@ export async function handleMentalModels(
   });
   const models = mentalModelListFromUnknown(listed.result);
   if (models.length === 0) {
-    ctx.ui.notify(`No ${bankChoice?.toLowerCase()} mental models found.`, "info");
+    ctx.ui.notify(`No ${bankChoice?.toLowerCase()} mental models found.\n${webHint}`, "info");
     return;
   }
 
@@ -92,49 +49,28 @@ export async function handleMentalModels(
   if (!model) return;
 
   const action = await ctx.ui.select(`Mental model ${model.name} (${model.id})`, [
-    "View",
-    "History",
-    "Refresh",
-    "Delete",
+    "View read-only summary",
+    "History summary",
+    "Web interface hint",
     CANCEL,
   ]);
   if (!action || action === CANCEL) return;
 
-  if (action === "View") {
+  if (action === "View read-only summary") {
     const full = await operations.getMentalModel({
       bank,
       mentalModelId: model.id,
       options: { detail: "full" },
     });
-    ctx.ui.notify(renderMentalModel(mentalModelFromUnknown(full.result) ?? model), "info");
+    ctx.ui.notify(renderMentalModel(mentalModelFromUnknown(full.result) ?? model, webHint), "info");
     return;
   }
 
-  if (action === "History") {
+  if (action === "History summary") {
     const history = await operations.getMentalModelHistory({ bank, mentalModelId: model.id });
-    ctx.ui.notify(renderMentalModelHistory(history.result), "info");
+    ctx.ui.notify(renderMentalModelHistory(history.result, webHint), "info");
     return;
   }
 
-  if (action === "Refresh") {
-    const refreshed = await operations.refreshMentalModel({ bank, mentalModelId: model.id });
-    ctx.ui.notify(
-      `Hindsight mental model refresh queued for ${model.id}; ${renderMentalModelOperationResult(refreshed.result)}`,
-      "info",
-    );
-    return;
-  }
-
-  if (action === "Delete") {
-    const confirmation = await ctx.ui.input(
-      `Type exact mental model ID to delete ${model.name}`,
-      "",
-    );
-    if (confirmation !== model.id) {
-      ctx.ui.notify("Mental model delete cancelled; exact ID did not match.", "warning");
-      return;
-    }
-    await operations.deleteMentalModel({ bank, mentalModelId: model.id });
-    ctx.ui.notify(`Deleted Hindsight mental model ${model.id}.`, "warning");
-  }
+  if (action === "Web interface hint") ctx.ui.notify(webHint, "info");
 }

--- a/extensions/setup-tui-render.ts
+++ b/extensions/setup-tui-render.ts
@@ -194,7 +194,7 @@ export function createSetupComponent(
         boxed(
           theme.fg(
             "dim",
-            ` h/l or </> tabs · j/k move · enter edit · r reset · f flush · m models · a advanced ${state.showAdvanced ? "on" : "off"} · d deployment · g guided · q close `,
+            ` h/l or </> tabs · j/k move · enter edit · r reset · f flush · m models read-only · a advanced ${state.showAdvanced ? "on" : "off"} · d deployment · g guided · q close `,
           ),
           width,
           theme,

--- a/tests/setup-tui-mental-models.test.ts
+++ b/tests/setup-tui-mental-models.test.ts
@@ -61,7 +61,7 @@ describe("setup TUI mental models", () => {
         return { ...listResponse.items[0], bank_id: bank, content: "remembered architecture" };
       },
     });
-    const ui = ctx(["Project", "Browse existing", "Project model (model-1) tags=project", "View"]);
+    const ui = ctx(["Project", "Project model (model-1) tags=project", "View read-only summary"]);
 
     await handleMentalModels(ui.ctx as never, deps(client));
 
@@ -70,38 +70,22 @@ describe("setup TUI mental models", () => {
       { method: "get", bank: "project-bank", id: "model-1" },
     ]);
     expect(ui.notifications[0]?.message).toContain("remembered architecture");
+    expect(ui.notifications[0]?.message).toContain("read-only");
   });
 
-  it("creates a mental model from a reflect query with preview", async () => {
-    const calls: Array<{ method: string; bank: string; request: unknown }> = [];
+  it("shows web interface hint without exposing create actions", async () => {
     const client = clientWith({
-      createMentalModel: async (bank, request) => {
-        calls.push({ method: "create", bank, request });
-        return { operation_id: "op-create", status: "queued" };
-      },
+      listMentalModels: async () => listResponse,
     });
-    const ui = ctx(
-      ["Project", "Create from reflect query", "Create"],
-      ["Project patterns", "What project patterns recur?", "project, patterns"],
-    );
+    const ui = ctx(["Project", "Project model (model-1) tags=project", "Web interface hint"]);
 
     await handleMentalModels(ui.ctx as never, deps(client));
 
-    expect(calls).toEqual([
-      {
-        method: "create",
-        bank: "project-bank",
-        request: {
-          name: "Project patterns",
-          sourceQuery: "What project patterns recur?",
-          tags: ["project", "patterns"],
-        },
-      },
-    ]);
-    expect(ui.notifications[0]?.message).toContain("op-create");
+    expect(ui.notifications[0]?.message).toContain("read-only");
+    expect(ui.notifications[0]?.message).toContain("http://localhost:8888");
   });
 
-  it("refreshes, shows history, and requires typed exact id for delete", async () => {
+  it("shows history without exposing refresh or delete actions", async () => {
     const calls: Array<{ method: string; bank: string; id?: string }> = [];
     const config = {
       ...DEFAULT_CONFIG,
@@ -115,47 +99,20 @@ describe("setup TUI mental models", () => {
         calls.push({ method: "list", bank });
         return listResponse;
       },
-      refreshMentalModel: async (bank, id) => {
-        calls.push({ method: "refresh", bank, id });
-        return { operation_id: "op-1", status: "queued" };
-      },
       getMentalModelHistory: async (bank, id) => {
         calls.push({ method: "history", bank, id });
         return { items: [{ id: "v1", created_at: "2026-05-04T01:00:00Z" }] };
       },
-      deleteMentalModel: async (bank, id) => {
-        calls.push({ method: "delete", bank, id });
-        return {};
-      },
     });
 
-    await handleMentalModels(
-      ctx(["Global", "Browse existing", "Project model (model-1) tags=project", "Refresh"])
-        .ctx as never,
-      deps(client, config),
-    );
-    await handleMentalModels(
-      ctx(["Global", "Browse existing", "Project model (model-1) tags=project", "History"])
-        .ctx as never,
-      deps(client, config),
-    );
-    const wrongDelete = ctx(
-      ["Global", "Browse existing", "Project model (model-1) tags=project", "Delete"],
-      ["wrong"],
-    );
-    await handleMentalModels(wrongDelete.ctx as never, deps(client, config));
-    const exactDelete = ctx(
-      ["Global", "Browse existing", "Project model (model-1) tags=project", "Delete"],
-      ["model-1"],
-    );
-    await handleMentalModels(exactDelete.ctx as never, deps(client, config));
+    const ui = ctx(["Global", "Project model (model-1) tags=project", "History summary"]);
+    await handleMentalModels(ui.ctx as never, deps(client, config));
 
-    expect(exactDelete.prompts[0]?.fallback).toBe("");
-    expect(calls).toContainEqual({ method: "refresh", bank: "global-bank", id: "model-1" });
-    expect(calls).toContainEqual({ method: "history", bank: "global-bank", id: "model-1" });
-    expect(calls.filter((call) => call.method === "delete")).toEqual([
-      { method: "delete", bank: "global-bank", id: "model-1" },
+    expect(calls).toEqual([
+      { method: "list", bank: "global-bank" },
+      { method: "history", bank: "global-bank", id: "model-1" },
     ]);
-    expect(wrongDelete.notifications[0]?.message).toContain("exact ID did not match");
+    expect(ui.notifications[0]?.message).toContain("Mental model history");
+    expect(ui.notifications[0]?.message).toContain("read-only");
   });
 });

--- a/tests/setup-tui.test.ts
+++ b/tests/setup-tui.test.ts
@@ -49,6 +49,6 @@ describe("setup TUI receipt facts", () => {
     const rendered = component.render(100).join("\n");
     expect(rendered).toContain("Extract durable project");
     expect(rendered).toContain("f flush");
-    expect(rendered).toContain("m models");
+    expect(rendered).toContain("m models read-only");
   });
 });


### PR DESCRIPTION
## Summary
- make `/hindsight` mental model TUI read-only
- keep list, detail, and history summary views
- remove create, refresh, and delete as primary TUI actions
- add web interface handoff copy for full mental model management
- update docs and tests for read-only behavior

## Verification
- npm test -- setup-tui-mental-models mental-model-presenter setup-tui
- npm run check
- npm run typecheck:tsc

Closes #162
