### PR TITLE
feat(setup): add built-in bank templates and curated import metrics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,7 +85,7 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
     "storeLastRecallFailures": false,
     "lastRecallPath": ".pi/hindsight/last-recall.json",
     "topK": 8,
-    "timeoutMs": 10000,
+    "timeoutMs": 40000,
     "injectionPosition": "append"
   },
   "observations": {

--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -28,7 +28,7 @@ Tool equivalent:
 hindsight_import({ dryRun: true })
 ```
 
-Preview output includes document count, message count, content size, tags, update mode, target bank, checkpoint path, and manifest path.
+Preview output includes document count, raw message count, curated projection count, dropped non-error tool-result count, byte counts, update mode, target bank, checkpoint path, and manifest path. The curated projection metrics show likely import noise without replacing the raw structured source payload.
 
 ## Import commands
 
@@ -93,4 +93,4 @@ Then rerun the import. Use `--dry-run` first.
 
 ## Safety
 
-Imports retain structured raw conversation content, not summaries. Secret redaction still applies. Recalled memory blocks injected by this extension are filtered so they are not retained back into Hindsight.
+Imports retain structured raw conversation content, not summaries. Secret redaction still applies. Recalled memory blocks injected by this extension are filtered so they are not retained back into Hindsight. Import previews also compute curated projection metrics using the live retain filter so you can see how much tool-output noise future curated import modes could drop.

--- a/extensions/bank-template-catalog.ts
+++ b/extensions/bank-template-catalog.ts
@@ -1,0 +1,187 @@
+export type BankTemplateProfileId = "coding-project" | "assistant-personal" | "general-user";
+
+export type BankTemplateTarget = "project" | "user";
+
+export interface BankTemplateManifest {
+  version: "1";
+  bank?: Record<string, unknown>;
+  mental_models?: BankTemplateMentalModel[];
+  directives?: BankTemplateDirective[];
+}
+
+export interface BankTemplateMentalModel {
+  id: string;
+  name: string;
+  source_query: string;
+  tags?: string[];
+  max_tokens?: number;
+  trigger?: Record<string, unknown>;
+}
+
+export interface BankTemplateDirective {
+  name: string;
+  content: string;
+  priority?: number;
+  is_active?: boolean;
+  tags?: string[];
+}
+
+export interface BuiltInBankTemplate {
+  id: BankTemplateProfileId;
+  label: string;
+  target: BankTemplateTarget;
+  description: string;
+  importProfile: "coding" | "assistant" | "general";
+  manifest: BankTemplateManifest;
+}
+
+const refreshTrigger = { refresh_after_consolidation: true, mode: "full" } as const;
+
+export const BUILT_IN_BANK_TEMPLATES: readonly BuiltInBankTemplate[] = [
+  {
+    id: "coding-project",
+    label: "Coding / Project",
+    target: "project",
+    importProfile: "coding",
+    description:
+      "Repo-focused memory for architecture, decisions, conventions, and recurring issues.",
+    manifest: {
+      version: "1",
+      bank: {
+        retain_mission:
+          "Extract technical decisions and their rationale, architectural choices, coding patterns and conventions, project structure facts, library/tool preferences, and recurring issues. Ignore transient debugging output and boilerplate.",
+        reflect_mission:
+          "You are a senior coding assistant using project memory. Ground answers in documented architecture, decisions, conventions, recurring issues, and developer workflow preferences. Prefer precise, actionable engineering context over speculation.",
+        enable_observations: true,
+        observations_mission:
+          "Track stable project facts: tech stack, team conventions, architecture patterns, and how the codebase evolves over time.",
+      },
+      mental_models: [
+        {
+          id: "project-context",
+          name: "Project Context",
+          source_query:
+            "What is the project's tech stack, architecture, and key conventions? What are the main components and how do they fit together?",
+          max_tokens: 2048,
+          trigger: refreshTrigger,
+        },
+        {
+          id: "developer-preferences",
+          name: "Developer Preferences",
+          source_query:
+            "What are the developer's preferences for tools, libraries, coding style, and workflow? How do they like code to be written and reviewed?",
+          max_tokens: 1024,
+          trigger: refreshTrigger,
+        },
+      ],
+    },
+  },
+  {
+    id: "assistant-personal",
+    label: "Assistant / Personal",
+    target: "user",
+    importProfile: "assistant",
+    description:
+      "Personal assistant memory for routines, commitments, people, and recurring needs.",
+    manifest: {
+      version: "1",
+      bank: {
+        retain_mission:
+          "Extract the user's preferences, routines, scheduled events, commitments, people they mention, and any personal context they share. Track what they ask for repeatedly and what they care about.",
+        reflect_mission:
+          "You are a personal assistant using user memory. Ground help in the user's stable preferences, routines, commitments, relationships, and recurring needs. Be careful with privacy and distinguish durable facts from transient chat.",
+        enable_observations: true,
+        observations_mission:
+          "Track the user's stable preferences, recurring routines, important people and relationships, and how their priorities shift over time.",
+      },
+      mental_models: [
+        {
+          id: "user-profile",
+          name: "User Profile",
+          source_query:
+            "What do we know about this user? What are their preferences, routines, important people, and how do they like to be helped?",
+          max_tokens: 2048,
+          trigger: refreshTrigger,
+        },
+        {
+          id: "active-tasks",
+          name: "Active Tasks & Commitments",
+          source_query:
+            "What tasks, commitments, or follow-ups is the user currently tracking? What deadlines or promises have been made?",
+          max_tokens: 1024,
+          trigger: refreshTrigger,
+        },
+      ],
+    },
+  },
+  {
+    id: "general-user",
+    label: "General Conversation / User",
+    target: "user",
+    importProfile: "general",
+    description:
+      "General user memory for preferences, stated facts, recurring topics, and open threads.",
+    manifest: {
+      version: "1",
+      bank: {
+        retain_mission:
+          "Extract user preferences, stated facts about themselves, requests they've made, topics they care about, and any commitments or follow-ups. Ignore small talk and filler.",
+        reflect_mission:
+          "You are an assistant using user conversation memory. Ground answers in the user's stated preferences, background, communication style, recurring topics, commitments, and open follow-ups. Avoid over-interpreting small talk.",
+        enable_observations: true,
+        observations_mission:
+          "Track stable user preferences, communication style, recurring topics, and how the user's needs evolve over time.",
+      },
+      mental_models: [
+        {
+          id: "user-profile",
+          name: "User Profile",
+          source_query:
+            "What do we know about this user? What are their preferences, background, and how do they like to interact?",
+          max_tokens: 2048,
+          trigger: refreshTrigger,
+        },
+        {
+          id: "open-threads",
+          name: "Open Threads",
+          source_query:
+            "What topics, tasks, or follow-ups are still open or unresolved from past conversations?",
+          max_tokens: 1024,
+          trigger: refreshTrigger,
+        },
+      ],
+    },
+  },
+] as const;
+
+export function getBuiltInBankTemplate(id: BankTemplateProfileId): BuiltInBankTemplate {
+  const template = BUILT_IN_BANK_TEMPLATES.find((candidate) => candidate.id === id);
+  if (!template) throw new Error(`Unknown built-in bank template: ${id}`);
+  return template;
+}
+
+export function defaultBankTemplateForTarget(target: BankTemplateTarget): BuiltInBankTemplate {
+  return getBuiltInBankTemplate(target === "project" ? "coding-project" : "general-user");
+}
+
+export function isBankTemplateProfileId(value: string): value is BankTemplateProfileId {
+  return BUILT_IN_BANK_TEMPLATES.some((template) => template.id === value);
+}
+
+export function cloneBankTemplateManifest(manifest: BankTemplateManifest): BankTemplateManifest {
+  return JSON.parse(JSON.stringify(manifest)) as BankTemplateManifest;
+}
+
+export function summarizeBankTemplateManifest(manifest: BankTemplateManifest): {
+  version: string;
+  bankOverrideCount: number;
+  mentalModelCount: number;
+  directiveCount: number;
+} {
+  return {
+    version: manifest.version,
+    bankOverrideCount: manifest.bank ? Object.keys(manifest.bank).length : 0,
+    mentalModelCount: manifest.mental_models?.length ?? 0,
+    directiveCount: manifest.directives?.length ?? 0,
+  };
+}

--- a/extensions/bank-template-operations.ts
+++ b/extensions/bank-template-operations.ts
@@ -1,8 +1,9 @@
 import { resolveOperationBank } from "./bank-selection.js";
 import type { MemoryOperationsDeps } from "./memory-operation-types.js";
 import { isRecord } from "./client-rest.js";
+import type { BankTemplateManifest } from "./bank-template-catalog.js";
 
-export type BankTemplateManifest = Record<string, unknown>;
+export type { BankTemplateManifest } from "./bank-template-catalog.js";
 
 export function parseBankTemplateManifestJson(input: string): BankTemplateManifest {
   let parsed: unknown;
@@ -13,7 +14,8 @@ export function parseBankTemplateManifestJson(input: string): BankTemplateManife
     throw new Error(`Invalid bank template JSON: ${message}`);
   }
   if (!isRecord(parsed)) throw new Error("Invalid bank template JSON: manifest must be an object.");
-  return parsed;
+  if (parsed.version !== "1") throw new Error('Invalid bank template JSON: version must be "1".');
+  return parsed as unknown as BankTemplateManifest;
 }
 
 export function summarizeBankTemplateImportResult(result: unknown): string {

--- a/extensions/config-defaults.ts
+++ b/extensions/config-defaults.ts
@@ -26,7 +26,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
     storeLastRecallFailures: false,
     lastRecallPath: ".pi/hindsight/last-recall.json",
     topK: 8,
-    timeoutMs: 10_000,
+    timeoutMs: 40_000,
     injectionMode: "context",
     injectionPosition: "append",
     includeFactsInDebug: false,

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -10,9 +10,19 @@ import {
   type MemoryOperations,
   type MemoryOperationsDeps,
 } from "./memory-operation-service.js";
+import {
+  BUILT_IN_BANK_TEMPLATES,
+  cloneBankTemplateManifest,
+  defaultBankTemplateForTarget,
+  getBuiltInBankTemplate,
+  summarizeBankTemplateManifest,
+  type BankTemplateManifest,
+  type BankTemplateProfileId,
+  type BankTemplateTarget,
+} from "./bank-template-catalog.js";
 import type { MemoryProfile, ProjectConfigPatchInput } from "./config-writer.js";
 import type { SetupProfileChoice } from "./setup-tui-types.js";
-import type { ResolvedConfig } from "./types.js";
+import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
 
 export function hasProjectHindsightConfig(cwd: string): boolean {
   return (
@@ -55,73 +65,186 @@ async function askBankId(args: {
   return value.trim() || args.fallback;
 }
 
-function enabledTemplateTargets(args: {
+interface TemplateTarget {
+  label: string;
+  location: "Project" | "User";
+  bank: string;
+  defaultTemplateTarget: BankTemplateTarget;
+}
+
+export function enabledTemplateTargets(args: {
   setupProfile: SetupProfileChoice;
   projectBankId?: string;
   globalBankId?: string;
-}): Array<{ label: string; bank: string }> {
+}): TemplateTarget[] {
   return [
     ...(args.setupProfile !== "global-only" && args.projectBankId
-      ? [{ label: `project (${args.projectBankId})`, bank: args.projectBankId }]
+      ? [
+          {
+            label: `Project bank (${args.projectBankId})`,
+            location: "Project" as const,
+            bank: args.projectBankId,
+            defaultTemplateTarget: "project" as const,
+          },
+        ]
       : []),
     ...(args.setupProfile !== "project-only" && args.globalBankId
-      ? [{ label: `global (${args.globalBankId})`, bank: args.globalBankId }]
+      ? [
+          {
+            label: `User bank (${args.globalBankId})`,
+            location: "User" as const,
+            bank: args.globalBankId,
+            defaultTemplateTarget: "user" as const,
+          },
+        ]
       : []),
   ];
 }
 
+function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== "object" || !error) return false;
+  const fields = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    message?: unknown;
+  };
+  return (
+    fields.status === 404 ||
+    fields.statusCode === 404 ||
+    fields.code === 404 ||
+    fields.code === "404" ||
+    (typeof fields.message === "string" && /\b404\b|not found/i.test(fields.message))
+  );
+}
+
+async function bankExists(
+  client: HindsightLikeClient,
+  bankId: string,
+): Promise<boolean | undefined> {
+  if (!client.getBankProfile) return undefined;
+  try {
+    await client.getBankProfile(bankId);
+    return true;
+  } catch (error) {
+    if (isNotFoundError(error)) return false;
+    throw error;
+  }
+}
+
+function chooseBuiltInTemplateOption(target: TemplateTarget): string {
+  const fallback = defaultBankTemplateForTarget(target.defaultTemplateTarget).id;
+  return BUILT_IN_BANK_TEMPLATES.find((template) => template.id === fallback)?.label ?? fallback;
+}
+
+function templateChoiceFromLabel(label: string): BankTemplateProfileId | undefined {
+  return BUILT_IN_BANK_TEMPLATES.find((template) => template.label === label)?.id;
+}
+
+function bankTemplateReview(manifest: BankTemplateManifest): string {
+  const summary = summarizeBankTemplateManifest(manifest);
+  return [
+    `Bank overrides: ${summary.bankOverrideCount}`,
+    `Mental models: ${summary.mentalModelCount}`,
+    `Directives: ${summary.directiveCount}`,
+  ].join("\n");
+}
+
+async function selectTemplateManifest(args: {
+  ctx: ExtensionCommandContext;
+  target: TemplateTarget;
+}): Promise<{ label: string; manifest: BankTemplateManifest } | undefined> {
+  const defaultLabel = chooseBuiltInTemplateOption(args.target);
+  const options = [
+    "Skip",
+    defaultLabel,
+    ...BUILT_IN_BANK_TEMPLATES.map((template) => template.label).filter(
+      (label) => label !== defaultLabel,
+    ),
+    "Paste JSON manifest",
+  ];
+  const choice = await args.ctx.ui.select(`Choose template for ${args.target.label}`, options);
+  if (!choice || choice === "Skip") return undefined;
+  if (choice === "Paste JSON manifest") {
+    const rawManifest = await args.ctx.ui.input("Paste bank template JSON", '{"version":"1"}');
+    if (rawManifest === undefined) return undefined;
+    return { label: "Custom JSON", manifest: parseBankTemplateManifestJson(rawManifest) };
+  }
+  const templateId = templateChoiceFromLabel(choice);
+  if (!templateId) return undefined;
+  const template = getBuiltInBankTemplate(templateId);
+  return { label: template.label, manifest: cloneBankTemplateManifest(template.manifest) };
+}
+
 async function maybeImportBankTemplate(args: {
   ctx: ExtensionCommandContext;
+  deps: MemoryOperationsDeps;
   operations: MemoryOperations;
   setupProfile: SetupProfileChoice;
   projectBankId?: string;
   globalBankId?: string;
 }): Promise<void> {
-  const choice = await args.ctx.ui.select("Import Hindsight bank template JSON?", [
-    "Skip",
-    "Paste JSON manifest",
-  ]);
-  if (choice !== "Paste JSON manifest") return;
-
   const targets = enabledTemplateTargets(args);
   if (targets.length === 0) {
     args.ctx.ui.notify("No enabled bank target for template import.", "warning");
     return;
   }
-  const targetLabel =
-    targets.length === 1
-      ? targets[0]!.label
-      : await args.ctx.ui.select(
-          "Choose template import target bank",
-          targets.map((target) => target.label),
-        );
-  if (!targetLabel) return;
-  const target = targets.find((candidate) => candidate.label === targetLabel);
-  if (!target) return;
+  const configure = await args.ctx.ui.confirm(
+    "Configure Hindsight bank templates?",
+    targets.map((target) => `${target.location}: ${target.bank}`).join("\n"),
+  );
+  if (!configure) return;
 
-  const rawManifest = await args.ctx.ui.input("Paste bank template JSON", '{"version":"1"}');
-  if (rawManifest === undefined) return;
-  const manifest = parseBankTemplateManifestJson(rawManifest);
-  const dryRun = await args.operations.importBankTemplate({
-    bank: target.bank,
-    manifest,
-    dryRun: true,
-  });
-  const dryRunSummary = summarizeBankTemplateImportResult(dryRun.result);
-  const confirmed = await args.ctx.ui.confirm(
-    `Apply template to ${dryRun.bankId}?`,
-    `Dry run result:\n${dryRunSummary}`,
-  );
-  if (!confirmed) return;
-  const applied = await args.operations.importBankTemplate({
-    bank: target.bank,
-    manifest,
-    dryRun: false,
-  });
-  args.ctx.ui.notify(
-    `Imported bank template into ${applied.bankId}: ${summarizeBankTemplateImportResult(applied.result)}`,
-    "info",
-  );
+  const client = args.deps.getClient();
+  for (const target of targets) {
+    const selected = await selectTemplateManifest({ ctx: args.ctx, target });
+    if (!selected) continue;
+
+    const exists = await bankExists(client, target.bank);
+    if (exists) {
+      const updateExisting = await args.ctx.ui.confirm(
+        `Bank already exists: ${target.bank}`,
+        `Location: ${target.location}\nTemplate: ${selected.label}\n\nSetup preserves existing banks by default. Apply this template anyway?`,
+      );
+      if (!updateExisting) {
+        args.ctx.ui.notify(`Skipped existing bank ${target.bank}.`, "info");
+        continue;
+      }
+    } else if (exists === undefined) {
+      const continueWithoutCheck = await args.ctx.ui.confirm(
+        `Cannot check bank existence: ${target.bank}`,
+        "Hindsight client does not expose bank lookup. Continue with template dry-run?",
+      );
+      if (!continueWithoutCheck) continue;
+    }
+
+    const reviewed = await args.ctx.ui.confirm(
+      `Review template for ${target.label}`,
+      `Template: ${selected.label}\n${bankTemplateReview(selected.manifest)}`,
+    );
+    if (!reviewed) continue;
+
+    const dryRun = await args.operations.importBankTemplate({
+      bank: target.bank,
+      manifest: selected.manifest,
+      dryRun: true,
+    });
+    const dryRunSummary = summarizeBankTemplateImportResult(dryRun.result);
+    const confirmed = await args.ctx.ui.confirm(
+      `Apply template to ${dryRun.bankId}?`,
+      `Location: ${target.location}\nBank: ${dryRun.bankId}\nDry run result:\n${dryRunSummary}`,
+    );
+    if (!confirmed) continue;
+    const applied = await args.operations.importBankTemplate({
+      bank: target.bank,
+      manifest: selected.manifest,
+      dryRun: false,
+    });
+    args.ctx.ui.notify(
+      `Imported ${selected.label} template into ${applied.bankId}: ${summarizeBankTemplateImportResult(applied.result)}`,
+      "info",
+    );
+  }
 }
 
 export async function runGuidedSetup(args: {
@@ -183,6 +306,7 @@ export async function runGuidedSetup(args: {
 
   await maybeImportBankTemplate({
     ctx: args.ctx,
+    deps: args.deps,
     operations,
     setupProfile,
     ...(projectBankId !== undefined ? { projectBankId } : {}),

--- a/extensions/import-presentation.ts
+++ b/extensions/import-presentation.ts
@@ -4,6 +4,7 @@ export type ImportDocumentSummaryResult = {
     status: string;
     rawMessageCount?: number;
     messageCount?: number;
+    projectedMessageCount?: number;
     rawBytes?: number;
     projectedBytes?: number;
     droppedToolResultCount?: number;
@@ -41,7 +42,7 @@ export function importDocumentSummary(result: ImportDocumentSummaryResult): stri
     0,
   );
   const projectedMessages = result.documents.reduce(
-    (count, document) => count + (document.messageCount ?? 0),
+    (count, document) => count + (document.projectedMessageCount ?? document.messageCount ?? 0),
     0,
   );
   const droppedToolResults = result.documents.reduce(

--- a/extensions/import-presentation.ts
+++ b/extensions/import-presentation.ts
@@ -1,5 +1,15 @@
 export type ImportDocumentSummaryResult = {
-  documents: { updateMode: string; status: string }[];
+  documents: {
+    updateMode: string;
+    status: string;
+    rawMessageCount?: number;
+    messageCount?: number;
+    rawBytes?: number;
+    projectedBytes?: number;
+    droppedToolResultCount?: number;
+    droppedToolResultBytes?: number;
+    topDroppedTools?: Array<{ name: string; count: number; bytes: number }>;
+  }[];
   malformedLineCount?: number;
 };
 
@@ -26,7 +36,31 @@ export function importDocumentSummary(result: ImportDocumentSummaryResult): stri
   const malformed = result.malformedLineCount
     ? `; malformedLines=${result.malformedLineCount}`
     : "";
-  return `documents=${result.documents.length}; update=${modes || "n/a"}; status=${statuses || "n/a"}${malformed}`;
+  const rawMessages = result.documents.reduce(
+    (count, document) => count + (document.rawMessageCount ?? document.messageCount ?? 0),
+    0,
+  );
+  const projectedMessages = result.documents.reduce(
+    (count, document) => count + (document.messageCount ?? 0),
+    0,
+  );
+  const droppedToolResults = result.documents.reduce(
+    (count, document) => count + (document.droppedToolResultCount ?? 0),
+    0,
+  );
+  const rawBytes = result.documents.reduce(
+    (count, document) => count + (document.rawBytes ?? 0),
+    0,
+  );
+  const projectedBytes = result.documents.reduce(
+    (count, document) => count + (document.projectedBytes ?? 0),
+    0,
+  );
+  const quality =
+    rawMessages || droppedToolResults || rawBytes || projectedBytes
+      ? `; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; bytes=${projectedBytes}/${rawBytes}`
+      : "";
+  return `documents=${result.documents.length}; update=${modes || "n/a"}; status=${statuses || "n/a"}${malformed}${quality}`;
 }
 
 export function renderImportSessionMessage(

--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -27,6 +27,7 @@ export interface ImportDocumentPreview {
   leafId: string;
   messageCount: number;
   rawMessageCount?: number;
+  projectedMessageCount?: number;
   rawBytes?: number;
   projectedBytes?: number;
   droppedToolResultCount?: number;
@@ -163,9 +164,9 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
         ? { parentSessionFile: args.parsed.parentSessionFile }
         : {}),
       branchLeafId: leafId,
-      projection: "curated-v1",
-      rawMessageCount: branchMessages.length,
-      messages: projection.messages,
+      projection: "raw-with-curated-preview-v1",
+      projectedMessageCount: projection.messages.length,
+      messages: branchMessages.map((message) => message.data),
     },
     null,
     2,
@@ -191,8 +192,9 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
   const document: ImportDocumentPreview = {
     documentId,
     leafId,
-    messageCount: projection.messages.length,
+    messageCount: branchMessages.length,
     rawMessageCount: branchMessages.length,
+    projectedMessageCount: projection.messages.length,
     rawBytes: projection.rawBytes,
     projectedBytes: projection.projectedBytes,
     droppedToolResultCount: projection.droppedToolResultCount,
@@ -212,7 +214,7 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
     sourceFile: args.sessionFile,
     importedAt: new Date().toISOString(),
     contentHash,
-    messageCount: projection.messages.length,
+    messageCount: branchMessages.length,
     leafId,
     sessionId: args.sessionId,
     cwd: args.cwd,

--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -4,7 +4,7 @@ import { baseTags } from "./banking.js";
 import { redactSecrets } from "./sanitize.js";
 import { hashImportContent, type ImportManifestEntry } from "./import-manifest.js";
 import { createMemoryIdentity } from "./memory-identity.js";
-import { isInjectedHindsightMemory } from "./messages.js";
+import { isInjectedHindsightMemory, projectMessages } from "./messages.js";
 import { expandObservationScopes } from "./observation-scopes.js";
 import type { ImportBranch } from "./import-branches.js";
 import type { ParsedSession } from "./import-parser.js";
@@ -26,6 +26,12 @@ export interface ImportDocumentPreview {
   documentId: string;
   leafId: string;
   messageCount: number;
+  rawMessageCount?: number;
+  rawBytes?: number;
+  projectedBytes?: number;
+  droppedToolResultCount?: number;
+  droppedToolResultBytes?: number;
+  topDroppedTools?: Array<{ name: string; count: number; bytes: number }>;
   contentHash: string;
   contentBytes: number;
   tags: string[];
@@ -67,12 +73,83 @@ function resolvedParentSessionId(parsed: ParsedSession, cwd: string): string | u
   );
 }
 
+function byteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+function toolName(message: Record<string, unknown>): string {
+  const name = message.name ?? message.toolName ?? message.tool;
+  return typeof name === "string" && name.trim() ? name : "unknown";
+}
+
+function stableProjectionMessage(message: Record<string, unknown>): Record<string, unknown> {
+  const timestamp = message.timestamp;
+  const parsedTimestamp = typeof timestamp === "string" ? Date.parse(timestamp) : undefined;
+  return {
+    ...message,
+    timestamp:
+      typeof timestamp === "number"
+        ? timestamp
+        : typeof parsedTimestamp === "number" && Number.isFinite(parsedTimestamp)
+          ? parsedTimestamp
+          : 0,
+  };
+}
+
+function buildCuratedImportProjection(
+  messages: Array<{ data: Record<string, unknown> }>,
+  config: ResolvedConfig,
+): {
+  messages: Record<string, unknown>[];
+  rawBytes: number;
+  projectedBytes: number;
+  droppedToolResultCount: number;
+  droppedToolResultBytes: number;
+  topDroppedTools: Array<{ name: string; count: number; bytes: number }>;
+} {
+  const droppedTools = new Map<string, { count: number; bytes: number }>();
+  const projected = messages.flatMap((message) => {
+    const stableMessage = stableProjectionMessage(message.data);
+    const projectedMessage = projectMessages([stableMessage as never], config);
+    if (!projectedMessage.length && stableMessage.role === "toolResult") {
+      const name = toolName(stableMessage);
+      const bytes = byteLength(stableMessage);
+      const current = droppedTools.get(name) ?? { count: 0, bytes: 0 };
+      droppedTools.set(name, { count: current.count + 1, bytes: current.bytes + bytes });
+    }
+    return projectedMessage;
+  });
+  return {
+    messages: projected,
+    rawBytes: messages.reduce((total, message) => total + byteLength(message.data), 0),
+    projectedBytes: byteLength(projected),
+    droppedToolResultCount: [...droppedTools.values()].reduce(
+      (total, tool) => total + tool.count,
+      0,
+    ),
+    droppedToolResultBytes: [...droppedTools.values()].reduce(
+      (total, tool) => total + tool.bytes,
+      0,
+    ),
+    topDroppedTools: [...droppedTools]
+      .map(([name, value]) => ({ name, ...value }))
+      .sort(
+        (left, right) =>
+          right.bytes - left.bytes ||
+          right.count - left.count ||
+          left.name.localeCompare(right.name),
+      )
+      .slice(0, 5),
+  };
+}
+
 function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranchBuildResult {
   const leafId = args.branch.leafId;
   const parentSessionId = resolvedParentSessionId(args.parsed, args.cwd);
   const branchMessages = args.branch.messages.filter(
     (message) => !isInjectedHindsightMemory(message.data),
   );
+  const projection = buildCuratedImportProjection(branchMessages, args.config);
   const documentId = importDocumentId(args.sessionId, leafId);
   const updateMode = args.config.import.replaceExistingImportedDocs ? "replace" : "append";
   const contentRaw = JSON.stringify(
@@ -86,7 +163,9 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
         ? { parentSessionFile: args.parsed.parentSessionFile }
         : {}),
       branchLeafId: leafId,
-      messages: branchMessages.map((message) => message.data),
+      projection: "curated-v1",
+      rawMessageCount: branchMessages.length,
+      messages: projection.messages,
     },
     null,
     2,
@@ -112,7 +191,13 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
   const document: ImportDocumentPreview = {
     documentId,
     leafId,
-    messageCount: branchMessages.length,
+    messageCount: projection.messages.length,
+    rawMessageCount: branchMessages.length,
+    rawBytes: projection.rawBytes,
+    projectedBytes: projection.projectedBytes,
+    droppedToolResultCount: projection.droppedToolResultCount,
+    droppedToolResultBytes: projection.droppedToolResultBytes,
+    topDroppedTools: projection.topDroppedTools,
     contentHash,
     contentBytes: Buffer.byteLength(content, "utf8"),
     tags,
@@ -127,7 +212,7 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
     sourceFile: args.sessionFile,
     importedAt: new Date().toISOString(),
     contentHash,
-    messageCount: branchMessages.length,
+    messageCount: projection.messages.length,
     leafId,
     sessionId: args.sessionId,
     cwd: args.cwd,

--- a/extensions/setup-tui-types.ts
+++ b/extensions/setup-tui-types.ts
@@ -14,7 +14,12 @@ export type SetupStep = "config" | "profile" | "banks" | "template" | "review" |
 
 export type SetupProfileChoice = "project-only" | "project-global" | "global-only";
 
-export type SetupTemplateChoice = "none" | "paste-json";
+export type SetupTemplateChoice =
+  | "none"
+  | "coding-project"
+  | "assistant-personal"
+  | "general-user"
+  | "paste-json";
 
 export type SetupUiState = {
   step?: SetupStep;

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -1,3 +1,5 @@
+import type { BankTemplateManifest } from "./bank-template-catalog.js";
+
 export type Budget = "low" | "mid" | "high";
 export type UpdateMode = "append" | "replace";
 export type RetainUserContent = "text";
@@ -286,7 +288,7 @@ export interface HindsightLikeClient {
   deleteDocument?(bankId: string, documentId: string): Promise<unknown>;
   importBankTemplate?(
     bankId: string,
-    manifest: Record<string, unknown>,
+    manifest: BankTemplateManifest,
     options?: { dryRun?: boolean },
   ): Promise<unknown>;
   listMentalModels?(bankId: string, options?: ListMentalModelsOptions): Promise<unknown>;

--- a/tests/bank-template-catalog.test.ts
+++ b/tests/bank-template-catalog.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUILT_IN_BANK_TEMPLATES,
+  cloneBankTemplateManifest,
+  defaultBankTemplateForTarget,
+  getBuiltInBankTemplate,
+  isBankTemplateProfileId,
+  summarizeBankTemplateManifest,
+} from "../extensions/bank-template-catalog.js";
+
+describe("bank template catalog", () => {
+  it("defines stable built-in template ids", () => {
+    expect(BUILT_IN_BANK_TEMPLATES.map((template) => template.id)).toEqual([
+      "coding-project",
+      "assistant-personal",
+      "general-user",
+    ]);
+    expect(defaultBankTemplateForTarget("project").id).toBe("coding-project");
+    expect(defaultBankTemplateForTarget("user").id).toBe("general-user");
+  });
+
+  it("ships valid version 1 manifests with stable mental model ids", () => {
+    for (const template of BUILT_IN_BANK_TEMPLATES) {
+      expect(template.manifest.version).toBe("1");
+      expect(template.manifest.bank?.retain_mission).toEqual(expect.any(String));
+      expect(template.manifest.bank?.reflect_mission).toEqual(expect.any(String));
+      expect(template.manifest.bank?.enable_observations).toBe(true);
+      expect(template.manifest.bank?.observations_mission).toEqual(expect.any(String));
+      expect(template.manifest.mental_models).toHaveLength(2);
+      for (const model of template.manifest.mental_models ?? []) {
+        expect(model.id).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+        expect(model.name).toEqual(expect.any(String));
+        expect(model.source_query).toEqual(expect.any(String));
+        expect(model.max_tokens).toBeGreaterThanOrEqual(256);
+        expect(model.max_tokens).toBeLessThanOrEqual(8192);
+        expect(model.trigger).toMatchObject({
+          refresh_after_consolidation: true,
+          mode: "full",
+        });
+      }
+    }
+  });
+
+  it("gets, narrows, clones, and summarizes templates", () => {
+    expect(isBankTemplateProfileId("coding-project")).toBe(true);
+    expect(isBankTemplateProfileId("unknown")).toBe(false);
+    expect(() => getBuiltInBankTemplate("unknown" as never)).toThrow(
+      "Unknown built-in bank template",
+    );
+
+    const template = getBuiltInBankTemplate("coding-project");
+    const cloned = cloneBankTemplateManifest(template.manifest);
+    cloned.bank!.retain_mission = "Changed";
+
+    expect(template.manifest.bank?.retain_mission).not.toBe("Changed");
+    expect(summarizeBankTemplateManifest(template.manifest)).toEqual({
+      version: "1",
+      bankOverrideCount: 4,
+      mentalModelCount: 2,
+      directiveCount: 0,
+    });
+  });
+});

--- a/tests/bank-template-operations.test.ts
+++ b/tests/bank-template-operations.test.ts
@@ -36,6 +36,7 @@ describe("bank template operations", () => {
     expect(parseBankTemplateManifestJson('{"version":"1"}')).toEqual({ version: "1" });
     expect(() => parseBankTemplateManifestJson("not json")).toThrow("Invalid bank template JSON");
     expect(() => parseBankTemplateManifestJson("[]")).toThrow("manifest must be an object");
+    expect(() => parseBankTemplateManifestJson("{}")).toThrow('version must be "1"');
   });
 
   it("resolves bank aliases before dry-run import", async () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -345,7 +345,7 @@ describe("hindsight commands", () => {
     );
     expect(ctx.ui.notify).toHaveBeenCalledWith(
       expect.stringContaining(
-        "Import preview: current session; messages=1; documents=1; update=replace; status=pending; write=no",
+        "Import preview: current session; messages=1; documents=1; update=replace; status=pending; projected=1/1 messages; droppedToolResults=0",
       ),
       "info",
     );

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -259,7 +259,7 @@ describe("resolveConfig", () => {
     expect(config.recall.storeLastRecallFailures).toBe(false);
     expect(config.recall.lastRecallPath).toBe(".pi/hindsight/last-recall.json");
     expect(config.recall.topK).toBe(8);
-    expect(config.recall.timeoutMs).toBe(10_000);
+    expect(config.recall.timeoutMs).toBe(40_000);
     expect(config.recall.injectionPosition).toBe("append");
     expect(config.recall.queryTimestamp).toBeUndefined();
     expect(config.globalRetain.mode).toBe("explicit-only");

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config-defaults.js";
 import {
   buildGuidedSetupPatch,
+  enabledTemplateTargets,
   hasProjectHindsightConfig,
   setupProfileChoiceToMemoryProfile,
 } from "../extensions/guided-setup.js";
@@ -74,6 +75,29 @@ describe("guided setup", () => {
         config: DEFAULT_CONFIG,
       }),
     ).toEqual({ memoryProfile: "global-only", globalBankId: "global-luxus" });
+  });
+
+  it("builds template targets with concrete project and user bank locations", () => {
+    expect(
+      enabledTemplateTargets({
+        setupProfile: "project-global",
+        projectBankId: "project-bank",
+        globalBankId: "global-luxus",
+      }),
+    ).toEqual([
+      {
+        label: "Project bank (project-bank)",
+        location: "Project",
+        bank: "project-bank",
+        defaultTemplateTarget: "project",
+      },
+      {
+        label: "User bank (global-luxus)",
+        location: "User",
+        bank: "global-luxus",
+        defaultTemplateTarget: "user",
+      },
+    ]);
   });
 
   it("uses existing configured global bank ID when profile enables global memory", () => {

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -50,6 +50,58 @@ describe("Pi session import", () => {
     expect(parsed.messages[0]).toMatchObject({ id: "1", role: "user", content: "hi" });
   });
 
+  it("previews curated import metrics that drop non-error tool results", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-curated-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-curated", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "u1",
+          parentId: null,
+          message: { role: "user", content: "remember architecture" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "tool1",
+          parentId: "u1",
+          message: { role: "toolResult", name: "read", content: "huge successful file output" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "tool2",
+          parentId: "tool1",
+          message: { role: "toolResult", name: "bash", isError: true, content: "build failed" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "a1",
+          parentId: "tool2",
+          message: { role: "assistant", content: "decision recorded" },
+        }),
+      ].join("\n"),
+    );
+
+    const result = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      dryRun: true,
+      client: { retain: async () => undefined, recall: async () => [], reflect: async () => ({}) },
+    });
+
+    expect(result.documents[0]).toMatchObject({
+      rawMessageCount: 4,
+      messageCount: 3,
+      droppedToolResultCount: 1,
+      topDroppedTools: [{ name: "read", count: 1, bytes: expect.any(Number) }],
+      wouldWrite: false,
+    });
+  });
+
   it("retains current branch import with repo tags, provenance, deterministic branch document id, and replace mode", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-"));
     mkdirSync(join(dir, ".git"));

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -62,7 +62,7 @@ describe("Pi session import", () => {
           type: "message",
           id: "u1",
           parentId: null,
-          message: { role: "user", content: "remember architecture" },
+          message: { role: "user", content: "remember architecture", timestamp: 1 },
         }),
         JSON.stringify({
           type: "message",
@@ -78,9 +78,19 @@ describe("Pi session import", () => {
         }),
         JSON.stringify({
           type: "message",
-          id: "a1",
+          id: "tool3",
           parentId: "tool2",
-          message: { role: "assistant", content: "decision recorded" },
+          message: { role: "toolResult", content: "other successful output" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "a1",
+          parentId: "tool3",
+          message: {
+            role: "assistant",
+            content: "decision recorded",
+            timestamp: "2026-01-02T03:04:05.000Z",
+          },
         }),
       ].join("\n"),
     );
@@ -94,10 +104,14 @@ describe("Pi session import", () => {
     });
 
     expect(result.documents[0]).toMatchObject({
-      rawMessageCount: 4,
-      messageCount: 3,
-      droppedToolResultCount: 1,
-      topDroppedTools: [{ name: "read", count: 1, bytes: expect.any(Number) }],
+      rawMessageCount: 5,
+      messageCount: 5,
+      projectedMessageCount: 3,
+      droppedToolResultCount: 2,
+      topDroppedTools: expect.arrayContaining([
+        { name: "read", count: 1, bytes: expect.any(Number) },
+        { name: "unknown", count: 1, bytes: expect.any(Number) },
+      ]),
       wouldWrite: false,
     });
   });


### PR DESCRIPTION
## Summary
- increase default recall timeout to 40s
- add shared built-in bank template catalog for coding/project, assistant/personal, and general/user profiles
- make guided setup apply built-in or custom templates with dry-run confirmation and existing-bank preservation by default
- add curated historical import projection metrics that drop non-error tool results and show raw/projected counts

Refs #168.
Refs #169.
Refs #173.

## Verification
- npm run check
