### PR TITLE
feat(template): export bank manifests

### DIFF
--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -79,6 +79,14 @@ Write project Hindsight config (.pi/hindsight.json), including project bank over
 | `enabled`          | boolean | no       | Enable or disable Hindsight extension.                           |
 | `queuePath`        | string  | no       | Retain queue path. Defaults to .pi/hindsight/retain-queue.jsonl. |
 
+### `hindsight_export_bank_template`
+
+Export a portable Hindsight bank template manifest for reuse in another project or bank.
+
+| Parameter | Type   | Required | Description                                 |
+| --------- | ------ | -------- | ------------------------------------------- |
+| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+
 ### `hindsight_import`
 
 Import a historical Pi session JSONL file into Hindsight with deterministic document ID.

--- a/extensions/bank-template-operations.ts
+++ b/extensions/bank-template-operations.ts
@@ -18,6 +18,19 @@ export function parseBankTemplateManifestJson(input: string): BankTemplateManife
   return parsed as unknown as BankTemplateManifest;
 }
 
+export function summarizeBankTemplateManifestValue(manifest: unknown): string {
+  if (!isRecord(manifest)) return JSON.stringify(manifest, null, 2);
+  const bank = isRecord(manifest.bank) ? manifest.bank : undefined;
+  const mentalModels = Array.isArray(manifest.mental_models) ? manifest.mental_models : [];
+  const directives = Array.isArray(manifest.directives) ? manifest.directives : [];
+  return [
+    `version: ${JSON.stringify(manifest.version ?? "unknown")}`,
+    `bank_overrides: ${bank ? Object.keys(bank).length : 0}`,
+    `mental_models: ${mentalModels.length}`,
+    `directives: ${directives.length}`,
+  ].join("\n");
+}
+
 export function summarizeBankTemplateImportResult(result: unknown): string {
   if (!isRecord(result)) return JSON.stringify(result, null, 2);
   const preferred = [
@@ -37,6 +50,19 @@ export function summarizeBankTemplateImportResult(result: unknown): string {
 
 export function createBankTemplateOperations(deps: MemoryOperationsDeps) {
   return {
+    async exportBankTemplate(args: { bank?: string }) {
+      const client = deps.getClient();
+      if (!client.exportBankTemplate)
+        throw new Error("Hindsight client does not support bank template export.");
+      const bankId = resolveOperationBank({
+        requestedBank: args.bank,
+        config: deps.getConfig(),
+        projectBankId: deps.getProjectBankId(),
+      });
+      const manifest = await client.exportBankTemplate(bankId);
+      return { bankId, manifest };
+    },
+
     async importBankTemplate(args: {
       bank?: string;
       manifest: BankTemplateManifest;

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -102,6 +102,14 @@ export function bankConfigPath(bankId: string): string {
   return encodeBankPath(bankId, "/config");
 }
 
+export function bankTemplateImportPath(bankId: string, options: { dryRun?: boolean } = {}): string {
+  return `${encodeBankPath(bankId, "/import")}${options.dryRun ? "?dry_run=true" : ""}`;
+}
+
+export function bankTemplateExportPath(bankId: string): string {
+  return encodeBankPath(bankId, "/export");
+}
+
 export function updateBankConfigRequestBody(
   updates: Record<string, unknown>,
 ): Record<string, unknown> {

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -5,6 +5,8 @@ import {
   assertHealthResponse,
   assertReflectResponse,
   bankConfigPath,
+  bankTemplateExportPath,
+  bankTemplateImportPath,
   createHindsightRestTransport,
   createMentalModelRequestBody,
   encodeBankPath,
@@ -110,16 +112,25 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
           signal,
         }),
       ),
+    // The installed high-level SDK does not export bank-template helpers. Its generated
+    // import helper also exposes no typed body because the server endpoint accepts raw JSON.
+    // Keep a narrow REST shim for template import/export until the public SDK wraps them.
     importBankTemplate: (bankId, manifest, options) =>
       withTimeout("hindsight importBankTemplate", timeoutMs, (signal) =>
-        rest.request(
-          `${encodeBankPath(bankId, "/import")}${options?.dryRun ? "?dry_run=true" : ""}`,
-          {
-            method: "POST",
+        rest.request(bankTemplateImportPath(bankId, options), {
+          method: "POST",
+          signal,
+          body: JSON.stringify(manifest),
+        }),
+      ),
+    exportBankTemplate: (bankId) =>
+      withTimeout(
+        "hindsight exportBankTemplate",
+        timeoutMs,
+        async (signal) =>
+          (await rest.request(bankTemplateExportPath(bankId), {
             signal,
-            body: JSON.stringify(manifest),
-          },
-        ),
+          })) as import("./bank-template-catalog.js").BankTemplateManifest,
       ),
     listMentalModels: (bankId, options) =>
       withTimeout("hindsight listMentalModels", timeoutMs, (signal) =>

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -10,6 +10,7 @@ import { runHindsightSetupTui } from "./setup-tui.js";
 import {
   configureToolResponse,
   deleteDocumentToolResponse,
+  exportBankTemplateToolResponse,
   importToolResponse,
   retainReceiptListToolResponse,
   retainToolResponse,
@@ -224,6 +225,24 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         useCwd(ctx.cwd);
         const result = await operations.configure(ctx.cwd, params);
         return configureToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_export_bank_template",
+      label: "Hindsight Export Bank Template",
+      description:
+        "Export a portable Hindsight bank template manifest for reuse in another project or bank.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.exportBankTemplate(
+          params.bank ? { bank: params.bank } : {},
+        );
+        return exportBankTemplateToolResponse(result);
       },
     }),
     defineCatalogTool({

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -10,6 +10,9 @@ export type RouteMemoryToolResult = ReturnType<MemoryOperations["routeMemory"]>;
 export type DeleteDocumentToolResult = Awaited<ReturnType<MemoryOperations["deleteDocument"]>>;
 export type ConfigureToolResult = Awaited<ReturnType<MemoryOperations["configure"]>>;
 export type ImportToolResult = Awaited<ReturnType<MemoryOperations["importSession"]>>;
+export type ExportBankTemplateToolResult = Awaited<
+  ReturnType<MemoryOperations["exportBankTemplate"]>
+>;
 export type RetainReceiptListResult = Awaited<ReturnType<MemoryOperations["listRetainReceipts"]>>;
 
 export function retainToolResponse(result: RetainToolResult): ToolTextResponse<RetainToolResult> {
@@ -86,6 +89,45 @@ export function importToolResponse(result: ImportToolResult): ToolTextResponse<I
     ? `Import preview: ${result.messageCount} messages would write ${result.documents.length} ${documentLabel} to ${result.bankId}. First document: ${result.documentId}. Manifest unchanged: ${result.manifestPath}.`
     : `Imported ${result.messageCount} messages into ${result.bankId} as ${result.documentId}. Manifest: ${result.manifestPath}.`;
   return { content: [{ type: "text", text }], details: result };
+}
+
+function manifestCounts(manifest: unknown): {
+  bankOverrideCount: number;
+  mentalModelCount: number;
+  directiveCount: number;
+} {
+  if (typeof manifest !== "object" || !manifest || Array.isArray(manifest)) {
+    return { bankOverrideCount: 0, mentalModelCount: 0, directiveCount: 0 };
+  }
+  const record = manifest as Record<string, unknown>;
+  const bank = record.bank;
+  return {
+    bankOverrideCount:
+      typeof bank === "object" && bank !== null && !Array.isArray(bank)
+        ? Object.keys(bank).length
+        : 0,
+    mentalModelCount: Array.isArray(record.mental_models) ? record.mental_models.length : 0,
+    directiveCount: Array.isArray(record.directives) ? record.directives.length : 0,
+  };
+}
+
+export function exportBankTemplateToolResponse(
+  result: ExportBankTemplateToolResult,
+): ToolTextResponse<ExportBankTemplateToolResult> {
+  const counts = manifestCounts(result.manifest);
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Exported bank template from ${result.bankId}.`,
+          `Bank overrides: ${counts.bankOverrideCount}; mental models: ${counts.mentalModelCount}; directives: ${counts.directiveCount}`,
+          JSON.stringify(result.manifest, null, 2),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
 }
 
 export function retainReceiptListToolResponse(

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -291,6 +291,7 @@ export interface HindsightLikeClient {
     manifest: BankTemplateManifest,
     options?: { dryRun?: boolean },
   ): Promise<unknown>;
+  exportBankTemplate?(bankId: string): Promise<BankTemplateManifest>;
   listMentalModels?(bankId: string, options?: ListMentalModelsOptions): Promise<unknown>;
   getMentalModel?(
     bankId: string,

--- a/tests/bank-template-operations.test.ts
+++ b/tests/bank-template-operations.test.ts
@@ -3,12 +3,18 @@ import {
   createBankTemplateOperations,
   parseBankTemplateManifestJson,
   summarizeBankTemplateImportResult,
+  summarizeBankTemplateManifestValue,
 } from "../extensions/bank-template-operations.js";
 import { DEFAULT_CONFIG } from "../extensions/config-defaults.js";
 import type { MemoryOperationsDeps } from "../extensions/memory-operation-types.js";
 
 function deps() {
   const importBankTemplate = vi.fn(async () => ({ dry_run: true, config_applied: true }));
+  const exportBankTemplate = vi.fn(async () => ({
+    version: "1" as const,
+    bank: { retain_mission: "Remember useful facts" },
+    mental_models: [{ id: "profile", name: "Profile", source_query: "What matters?" }],
+  }));
   const config = {
     ...DEFAULT_CONFIG,
     banks: {
@@ -18,12 +24,14 @@ function deps() {
   };
   return {
     importBankTemplate,
+    exportBankTemplate,
     deps: {
       getClient: () => ({
         retain: vi.fn(),
         recall: vi.fn(),
         reflect: vi.fn(),
         importBankTemplate,
+        exportBankTemplate,
       }),
       getConfig: () => config,
       getProjectBankId: () => "project-bank",
@@ -58,7 +66,22 @@ describe("bank template operations", () => {
     );
   });
 
-  it("formats dry-run summaries", () => {
+  it("exports bank templates through resolved bank aliases", async () => {
+    const fixture = deps();
+    const operations = createBankTemplateOperations(fixture.deps);
+
+    await expect(operations.exportBankTemplate({ bank: "global" })).resolves.toEqual({
+      bankId: "global-luxus",
+      manifest: {
+        version: "1",
+        bank: { retain_mission: "Remember useful facts" },
+        mental_models: [{ id: "profile", name: "Profile", source_query: "What matters?" }],
+      },
+    });
+    expect(fixture.exportBankTemplate).toHaveBeenCalledWith("global-luxus");
+  });
+
+  it("formats dry-run and manifest summaries", () => {
     expect(
       summarizeBankTemplateImportResult({
         dry_run: true,
@@ -68,5 +91,13 @@ describe("bank template operations", () => {
       }),
     ).toContain("mental_models_created: 2");
     expect(summarizeBankTemplateImportResult("ok")).toBe('"ok"');
+    expect(
+      summarizeBankTemplateManifestValue({
+        version: "1",
+        bank: { retain_mission: "Retain" },
+        mental_models: [{}],
+        directives: [{ name: "Rule" }],
+      }),
+    ).toContain("mental_models: 1");
   });
 });

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -63,6 +63,10 @@ describe("Hindsight client adapter integration", () => {
         sendJson(res, 200, { dry_run: true, config_applied: true });
         return;
       }
+      if (req.method === "GET" && req.url === "/v1/default/banks/test-bank/export") {
+        sendJson(res, 200, { version: "1", bank: { retain_mission: "Exported" } });
+        return;
+      }
       if (req.method === "GET" && req.url === "/v1/default/banks/test-bank/config") {
         sendJson(res, 200, { config: { retain_custom_instructions: "Read from db" } });
         return;
@@ -172,6 +176,7 @@ describe("Hindsight client adapter integration", () => {
       { version: "1", bank: { retain_mission: "Retain useful facts." } },
       { dryRun: true },
     );
+    const exportedTemplate = await client.exportBankTemplate?.("test-bank");
     const bankConfig = await client.getBankConfig?.("test-bank");
     const bankConfigUpdate = await client.updateBankConfig?.("test-bank", {
       retain_custom_instructions: "Write to db",
@@ -201,6 +206,7 @@ describe("Hindsight client adapter integration", () => {
     expect(recall).toEqual({ results: [{ text: "remembered fact" }] });
     expect(reflection).toEqual({ text: "reflection" });
     expect(templateDryRun).toEqual({ dry_run: true, config_applied: true });
+    expect(exportedTemplate).toEqual({ version: "1", bank: { retain_mission: "Exported" } });
     expect(bankConfig).toEqual({ config: { retain_custom_instructions: "Read from db" } });
     expect(bankConfigUpdate).toEqual({ updated: true });
     expect(models).toEqual({ items: [{ id: "model-1", name: "Model" }] });
@@ -219,6 +225,7 @@ describe("Hindsight client adapter integration", () => {
       "POST /v1/default/banks/test-bank/memories/recall",
       "POST /v1/default/banks/test-bank/reflect",
       "POST /v1/default/banks/test-bank/import?dry_run=true",
+      "GET /v1/default/banks/test-bank/export",
       "GET /v1/default/banks/test-bank/config",
       "PATCH /v1/default/banks/test-bank/config",
       "GET /v1/default/banks/test-bank/mental-models?tags=source%3Api&tags_match=all&detail=metadata&limit=10&offset=2",
@@ -275,15 +282,15 @@ describe("Hindsight client adapter integration", () => {
       version: "1",
       bank: { retain_mission: "Retain useful facts." },
     });
-    expect(requests[8]?.body).toEqual({
+    expect(requests[9]?.body).toEqual({
       updates: { retain_custom_instructions: "Write to db" },
     });
-    expect(requests[11]?.body).toEqual({
+    expect(requests[12]?.body).toEqual({
       name: "Model",
       source_query: "What should recur?",
       tags: ["source:pi"],
       max_tokens: 256,
     });
-    expect(requests[12]?.body).toEqual({ source_query: "Updated query", tags: null });
+    expect(requests[13]?.body).toEqual({ source_query: "Updated query", tags: null });
   });
 });

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -3,6 +3,8 @@ import {
   assertHealthResponse,
   assertReflectResponse,
   bankConfigPath,
+  bankTemplateExportPath,
+  bankTemplateImportPath,
   createMentalModelRequestBody,
   encodeBankPath,
   mentalModelCollectionPath,
@@ -37,6 +39,10 @@ describe("Hindsight REST transport helpers", () => {
   it("encodes bank ids in REST paths", () => {
     expect(encodeBankPath("bank/id", "/reflect")).toBe("/v1/default/banks/bank%2Fid/reflect");
     expect(bankConfigPath("bank/id")).toBe("/v1/default/banks/bank%2Fid/config");
+    expect(bankTemplateImportPath("bank/id", { dryRun: true })).toBe(
+      "/v1/default/banks/bank%2Fid/import?dry_run=true",
+    );
+    expect(bankTemplateExportPath("bank/id")).toBe("/v1/default/banks/bank%2Fid/export");
     expect(
       updateBankConfigRequestBody({ retain_custom_instructions: "Extract carefully" }),
     ).toEqual({

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -8,6 +8,7 @@ function client(): HindsightLikeClient {
     retain: async () => undefined,
     recall: async () => [],
     reflect: async () => ({}),
+    exportBankTemplate: async () => ({ version: "1" }),
   };
 }
 
@@ -27,6 +28,7 @@ describe("operation catalog", () => {
       "hindsight_route_memory",
       "hindsight_delete_document",
       "hindsight_configure",
+      "hindsight_export_bank_template",
       "hindsight_import",
       "hindsight_reflect",
     ]);


### PR DESCRIPTION
## Summary
- add bank-template export REST helpers and client/operation support
- expose `hindsight_export_bank_template` tool with manifest summary + JSON output
- update generated surface reference and tests

Refs #171.

## Review
- Pre-PR reviewer run: no blockers after fixes.

## Verification
- npm run check
- npm run typecheck:tsc
