### PR TITLE
feat(template): add setup template editor model

### DIFF
--- a/extensions/bank-template-editor.ts
+++ b/extensions/bank-template-editor.ts
@@ -1,0 +1,210 @@
+import { cloneBankTemplateManifest, type BankTemplateManifest } from "./bank-template-catalog.js";
+
+export type BankTemplateEditorFieldId =
+  | "retain_mission"
+  | "retain_extraction_mode"
+  | "retain_custom_instructions"
+  | "enable_observations"
+  | "observations_mission"
+  | "reflect_mission"
+  | "disposition_skepticism"
+  | "disposition_literalism"
+  | "disposition_empathy";
+
+export interface BankTemplateEditorField {
+  id: BankTemplateEditorFieldId;
+  label: string;
+  value: string;
+  kind: "text" | "select" | "boolean" | "integer";
+  choices?: string[];
+  advanced?: boolean;
+}
+
+const FIELD_LABELS: Record<BankTemplateEditorFieldId, string> = {
+  retain_mission: "Retain mission",
+  retain_extraction_mode: "Retain extraction mode",
+  retain_custom_instructions: "Custom retain instructions",
+  enable_observations: "Enable observations",
+  observations_mission: "Observations mission",
+  reflect_mission: "Reflect mission",
+  disposition_skepticism: "Disposition skepticism",
+  disposition_literalism: "Disposition literalism",
+  disposition_empathy: "Disposition empathy",
+};
+
+const FIELD_KINDS: Record<BankTemplateEditorFieldId, BankTemplateEditorField["kind"]> = {
+  retain_mission: "text",
+  retain_extraction_mode: "select",
+  retain_custom_instructions: "text",
+  enable_observations: "boolean",
+  observations_mission: "text",
+  reflect_mission: "text",
+  disposition_skepticism: "integer",
+  disposition_literalism: "integer",
+  disposition_empathy: "integer",
+};
+
+const BASIC_FIELDS: readonly BankTemplateEditorFieldId[] = [
+  "retain_mission",
+  "retain_extraction_mode",
+  "retain_custom_instructions",
+  "enable_observations",
+  "observations_mission",
+  "reflect_mission",
+  "disposition_skepticism",
+  "disposition_literalism",
+  "disposition_empathy",
+];
+
+function stringValue(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function parseFieldValue(fieldId: BankTemplateEditorFieldId, value: string): unknown {
+  if (fieldId === "enable_observations") return value === "true";
+  if (fieldId.startsWith("disposition_")) {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 5) {
+      throw new Error(`${FIELD_LABELS[fieldId]} must be an integer from 1 to 5.`);
+    }
+    return parsed;
+  }
+  if (fieldId === "retain_extraction_mode") {
+    if (!["", "concise", "verbose", "custom", "chunks"].includes(value)) {
+      throw new Error("Retain extraction mode must be concise, verbose, custom, or chunks.");
+    }
+    return value || undefined;
+  }
+  return value;
+}
+
+export function buildBankTemplateEditorFields(
+  manifest: BankTemplateManifest,
+): BankTemplateEditorField[] {
+  const bank = manifest.bank ?? {};
+  return BASIC_FIELDS.map((id) => ({
+    id,
+    label: FIELD_LABELS[id],
+    value: stringValue(bank[id]),
+    kind: FIELD_KINDS[id],
+    ...(id === "retain_extraction_mode"
+      ? { choices: ["", "concise", "verbose", "custom", "chunks"] }
+      : {}),
+    ...(id === "retain_custom_instructions" || id.startsWith("disposition_")
+      ? { advanced: true }
+      : {}),
+  }));
+}
+
+export function updateBankTemplateField(
+  manifest: BankTemplateManifest,
+  fieldId: BankTemplateEditorFieldId,
+  value: string,
+): BankTemplateManifest {
+  const next = cloneBankTemplateManifest(manifest);
+  next.bank = { ...next.bank };
+  const parsed = parseFieldValue(fieldId, value);
+  if (parsed === undefined || parsed === "") delete next.bank[fieldId];
+  else next.bank[fieldId] = parsed;
+  return next;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function mentalModelLabel(model: Record<string, unknown>, index: number): string {
+  return stringField(model.id) || `#${index + 1}`;
+}
+
+export function validateMentalModel(model: unknown, index = 0): string[] {
+  const errors: string[] = [];
+  if (!isRecord(model)) return [`Mental model #${index + 1} must be an object.`];
+  const id = stringField(model.id);
+  const label = mentalModelLabel(model, index);
+  if (!id || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id)) {
+    errors.push(
+      `Mental model id ${JSON.stringify(model.id)} must be lowercase alphanumeric with hyphens.`,
+    );
+  }
+  const name = stringField(model.name);
+  if (!name?.trim()) errors.push(`Mental model ${label} name is required.`);
+  const sourceQuery = stringField(model.source_query);
+  if (!sourceQuery?.trim()) errors.push(`Mental model ${label} source query is required.`);
+  if (model.max_tokens !== undefined) {
+    const maxTokens = model.max_tokens;
+    if (
+      typeof maxTokens !== "number" ||
+      !Number.isInteger(maxTokens) ||
+      maxTokens < 256 ||
+      maxTokens > 8192
+    ) {
+      errors.push(`Mental model ${label} max_tokens must be an integer from 256 to 8192.`);
+    }
+  }
+  if (model.tags !== undefined && !Array.isArray(model.tags)) {
+    errors.push(`Mental model ${label} tags must be an array of strings.`);
+  }
+  return errors;
+}
+
+function validateDirectives(manifest: BankTemplateManifest): string[] {
+  if (manifest.directives === undefined) return [];
+  if (!Array.isArray(manifest.directives)) return ["directives must be an array."];
+  return manifest.directives.flatMap((directive, index) => {
+    if (!isRecord(directive)) return [`Directive #${index + 1} must be an object.`];
+    const label = stringField(directive.name) || `#${index + 1}`;
+    const errors: string[] = [];
+    if (!stringField(directive.name)?.trim()) errors.push(`Directive ${label} name is required.`);
+    if (!stringField(directive.content)?.trim()) {
+      errors.push(`Directive ${label} content is required.`);
+    }
+    if (directive.priority !== undefined && !Number.isInteger(directive.priority)) {
+      errors.push(`Directive ${label} priority must be an integer.`);
+    }
+    if (directive.is_active !== undefined && typeof directive.is_active !== "boolean") {
+      errors.push(`Directive ${label} is_active must be boolean.`);
+    }
+    if (directive.tags !== undefined && !Array.isArray(directive.tags)) {
+      errors.push(`Directive ${label} tags must be an array of strings.`);
+    }
+    return errors;
+  });
+}
+
+export function validateBankTemplateManifestForEditing(manifest: BankTemplateManifest): string[] {
+  const errors: string[] = [];
+  if (manifest.bank !== undefined && !isRecord(manifest.bank))
+    errors.push("bank must be an object.");
+  if (manifest.mental_models !== undefined && !Array.isArray(manifest.mental_models)) {
+    errors.push("mental_models must be an array.");
+  }
+  if (Array.isArray(manifest.mental_models)) {
+    const seen = new Set<string>();
+    manifest.mental_models.forEach((model, index) => {
+      errors.push(...validateMentalModel(model, index));
+      if (isRecord(model) && typeof model.id === "string") {
+        if (seen.has(model.id)) errors.push(`Duplicate mental model id: ${model.id}.`);
+        seen.add(model.id);
+      }
+    });
+  }
+  errors.push(...validateDirectives(manifest));
+  return errors;
+}
+
+export function mentalModelTagWarnings(manifest: BankTemplateManifest): string[] {
+  if (!Array.isArray(manifest.mental_models)) return [];
+  return manifest.mental_models
+    .filter((model) => isRecord(model) && Array.isArray(model.tags) && model.tags.length)
+    .map((model) => {
+      const tags = (model.tags as string[]).join(", ");
+      return `Mental model ${String(model.id)} has tags (${tags}); refresh only reads memories with compatible tags.`;
+    });
+}

--- a/extensions/bank-template-operations.ts
+++ b/extensions/bank-template-operations.ts
@@ -2,6 +2,7 @@ import { resolveOperationBank } from "./bank-selection.js";
 import type { MemoryOperationsDeps } from "./memory-operation-types.js";
 import { isRecord } from "./client-rest.js";
 import type { BankTemplateManifest } from "./bank-template-catalog.js";
+import { validateBankTemplateManifestForEditing } from "./bank-template-editor.js";
 
 export type { BankTemplateManifest } from "./bank-template-catalog.js";
 
@@ -15,7 +16,10 @@ export function parseBankTemplateManifestJson(input: string): BankTemplateManife
   }
   if (!isRecord(parsed)) throw new Error("Invalid bank template JSON: manifest must be an object.");
   if (parsed.version !== "1") throw new Error('Invalid bank template JSON: version must be "1".');
-  return parsed as unknown as BankTemplateManifest;
+  const manifest = parsed as unknown as BankTemplateManifest;
+  const errors = validateBankTemplateManifestForEditing(manifest);
+  if (errors.length) throw new Error(`Invalid bank template JSON: ${errors.join(" ")}`);
+  return manifest;
 }
 
 export function summarizeBankTemplateManifestValue(manifest: unknown): string {

--- a/tests/bank-template-editor.test.ts
+++ b/tests/bank-template-editor.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { getBuiltInBankTemplate } from "../extensions/bank-template-catalog.js";
+import {
+  buildBankTemplateEditorFields,
+  mentalModelTagWarnings,
+  updateBankTemplateField,
+  validateBankTemplateManifestForEditing,
+} from "../extensions/bank-template-editor.js";
+
+describe("bank template editor", () => {
+  it("builds reusable editor fields from a template manifest", () => {
+    const manifest = getBuiltInBankTemplate("coding-project").manifest;
+
+    expect(buildBankTemplateEditorFields(manifest)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "retain_mission",
+          label: "Retain mission",
+          kind: "text",
+          value: expect.stringContaining("technical decisions"),
+        }),
+        expect.objectContaining({
+          id: "enable_observations",
+          kind: "boolean",
+          value: "true",
+        }),
+        expect.objectContaining({
+          id: "retain_extraction_mode",
+          kind: "select",
+          choices: ["", "concise", "verbose", "custom", "chunks"],
+        }),
+      ]),
+    );
+  });
+
+  it("updates bank fields without mutating the original manifest", () => {
+    const manifest = getBuiltInBankTemplate("coding-project").manifest;
+
+    const updated = updateBankTemplateField(manifest, "disposition_skepticism", "4");
+
+    expect(manifest.bank?.disposition_skepticism).toBeUndefined();
+    expect(updated.bank?.disposition_skepticism).toBe(4);
+    expect(updateBankTemplateField(updated, "retain_extraction_mode", "").bank).not.toHaveProperty(
+      "retain_extraction_mode",
+    );
+  });
+
+  it("validates bank fields and mental model shape", () => {
+    const manifest = {
+      version: "1" as const,
+      mental_models: [
+        { id: "Bad ID", name: "", source_query: "", max_tokens: 32 },
+        { id: "good-id", name: "Good", source_query: "What matters?", max_tokens: 2048 },
+      ],
+    };
+
+    expect(() => updateBankTemplateField(manifest, "disposition_empathy", "8")).toThrow(
+      "Disposition empathy must be an integer from 1 to 5",
+    );
+    expect(validateBankTemplateManifestForEditing(manifest)).toEqual([
+      'Mental model id "Bad ID" must be lowercase alphanumeric with hyphens.',
+      "Mental model Bad ID name is required.",
+      "Mental model Bad ID source query is required.",
+      "Mental model Bad ID max_tokens must be an integer from 256 to 8192.",
+    ]);
+  });
+
+  it("returns validation errors for malformed custom manifest shapes", () => {
+    expect(
+      validateBankTemplateManifestForEditing({
+        version: "1",
+        bank: [] as never,
+        mental_models: {} as never,
+        directives: {} as never,
+      }),
+    ).toEqual([
+      "bank must be an object.",
+      "mental_models must be an array.",
+      "directives must be an array.",
+    ]);
+
+    expect(
+      validateBankTemplateManifestForEditing({
+        version: "1",
+        mental_models: [
+          {} as never,
+          "nope" as never,
+          { id: "dup", name: "One", source_query: "Q" },
+          { id: "dup", name: "Two", source_query: "Q" },
+        ],
+        directives: [
+          {} as never,
+          { name: "rule", content: "Be safe", priority: 1.5, is_active: "yes" as never },
+        ],
+      }),
+    ).toEqual([
+      "Mental model id undefined must be lowercase alphanumeric with hyphens.",
+      "Mental model #1 name is required.",
+      "Mental model #1 source query is required.",
+      "Mental model #2 must be an object.",
+      "Duplicate mental model id: dup.",
+      "Directive #1 name is required.",
+      "Directive #1 content is required.",
+      "Directive rule priority must be an integer.",
+      "Directive rule is_active must be boolean.",
+    ]);
+  });
+
+  it("warns when mental model tags constrain refresh source memories", () => {
+    expect(
+      mentalModelTagWarnings({
+        version: "1",
+        mental_models: [
+          {
+            id: "user-profile",
+            name: "User Profile",
+            source_query: "What does user prefer?",
+            tags: ["profile:user"],
+          },
+        ],
+      }),
+    ).toEqual([
+      "Mental model user-profile has tags (profile:user); refresh only reads memories with compatible tags.",
+    ]);
+  });
+});

--- a/tests/bank-template-operations.test.ts
+++ b/tests/bank-template-operations.test.ts
@@ -45,6 +45,17 @@ describe("bank template operations", () => {
     expect(() => parseBankTemplateManifestJson("not json")).toThrow("Invalid bank template JSON");
     expect(() => parseBankTemplateManifestJson("[]")).toThrow("manifest must be an object");
     expect(() => parseBankTemplateManifestJson("{}")).toThrow('version must be "1"');
+    expect(() =>
+      parseBankTemplateManifestJson(
+        JSON.stringify({
+          version: "1",
+          mental_models: [
+            { id: "dup", name: "A", source_query: "Q" },
+            { id: "dup", name: "B", source_query: "Q" },
+          ],
+        }),
+      ),
+    ).toThrow("Duplicate mental model id: dup");
   });
 
   it("resolves bank aliases before dry-run import", async () => {


### PR DESCRIPTION
## Summary
- add reusable bank template editor field model for setup-time manifest review/edit
- validate mental model IDs, max token ranges, malformed manifest shapes, duplicate model IDs, and directive basics
- wire validation into custom JSON parsing so malformed pasted templates fail before dry-run/apply

Refs #170.

## Review
- Pre-PR reviewer run: no blockers after fixes.

## Verification
- npm run check
- npm run typecheck:tsc
