### PR TITLE
feat(setup): review bank templates before apply

### DIFF
--- a/extensions/bank-template-editor.ts
+++ b/extensions/bank-template-editor.ts
@@ -1,6 +1,10 @@
-import { cloneBankTemplateManifest, type BankTemplateManifest } from "./bank-template-catalog.js";
+import {
+  cloneBankTemplateManifest,
+  type BankTemplateManifest,
+  type BankTemplateMentalModel,
+} from "./bank-template-catalog.js";
 
-export type BankTemplateEditorFieldId =
+export type BankTemplateBankFieldId =
   | "retain_mission"
   | "retain_extraction_mode"
   | "retain_custom_instructions"
@@ -11,6 +15,19 @@ export type BankTemplateEditorFieldId =
   | "disposition_literalism"
   | "disposition_empathy";
 
+export type BankTemplateMentalModelFieldName =
+  | "id"
+  | "name"
+  | "source_query"
+  | "tags"
+  | "max_tokens"
+  | "trigger.mode"
+  | "trigger.refresh_after_consolidation";
+
+export type BankTemplateEditorFieldId =
+  | BankTemplateBankFieldId
+  | `mental_models.${number}.${BankTemplateMentalModelFieldName}`;
+
 export interface BankTemplateEditorField {
   id: BankTemplateEditorFieldId;
   label: string;
@@ -20,7 +37,7 @@ export interface BankTemplateEditorField {
   advanced?: boolean;
 }
 
-const FIELD_LABELS: Record<BankTemplateEditorFieldId, string> = {
+const FIELD_LABELS: Record<BankTemplateBankFieldId, string> = {
   retain_mission: "Retain mission",
   retain_extraction_mode: "Retain extraction mode",
   retain_custom_instructions: "Custom retain instructions",
@@ -32,7 +49,7 @@ const FIELD_LABELS: Record<BankTemplateEditorFieldId, string> = {
   disposition_empathy: "Disposition empathy",
 };
 
-const FIELD_KINDS: Record<BankTemplateEditorFieldId, BankTemplateEditorField["kind"]> = {
+const FIELD_KINDS: Record<BankTemplateBankFieldId, BankTemplateEditorField["kind"]> = {
   retain_mission: "text",
   retain_extraction_mode: "select",
   retain_custom_instructions: "text",
@@ -44,7 +61,7 @@ const FIELD_KINDS: Record<BankTemplateEditorFieldId, BankTemplateEditorField["ki
   disposition_empathy: "integer",
 };
 
-const BASIC_FIELDS: readonly BankTemplateEditorFieldId[] = [
+const BASIC_FIELDS: readonly BankTemplateBankFieldId[] = [
   "retain_mission",
   "retain_extraction_mode",
   "retain_custom_instructions",
@@ -62,7 +79,7 @@ function stringValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
-function parseFieldValue(fieldId: BankTemplateEditorFieldId, value: string): unknown {
+function parseBankFieldValue(fieldId: BankTemplateBankFieldId, value: string): unknown {
   if (fieldId === "enable_observations") return value === "true";
   if (fieldId.startsWith("disposition_")) {
     const parsed = Number(value);
@@ -80,9 +97,7 @@ function parseFieldValue(fieldId: BankTemplateEditorFieldId, value: string): unk
   return value;
 }
 
-export function buildBankTemplateEditorFields(
-  manifest: BankTemplateManifest,
-): BankTemplateEditorField[] {
+function buildBankEditorFields(manifest: BankTemplateManifest): BankTemplateEditorField[] {
   const bank = manifest.bank ?? {};
   return BASIC_FIELDS.map((id) => ({
     id,
@@ -98,14 +113,163 @@ export function buildBankTemplateEditorFields(
   }));
 }
 
+function mentalModelEditorFields(manifest: BankTemplateManifest): BankTemplateEditorField[] {
+  return (manifest.mental_models ?? []).flatMap((model, index) => {
+    const label = model.name || model.id || `#${index + 1}`;
+    const trigger = model.trigger ?? {};
+    return [
+      {
+        id: `mental_models.${index}.id` as const,
+        label: `Mental model ${label} id`,
+        value: stringValue(model.id),
+        kind: "text" as const,
+      },
+      {
+        id: `mental_models.${index}.name` as const,
+        label: `Mental model ${label} name`,
+        value: stringValue(model.name),
+        kind: "text" as const,
+      },
+      {
+        id: `mental_models.${index}.source_query` as const,
+        label: `Mental model ${label} source query`,
+        value: stringValue(model.source_query),
+        kind: "text" as const,
+      },
+      {
+        id: `mental_models.${index}.tags` as const,
+        label: `Mental model ${label} tags`,
+        value: Array.isArray(model.tags) ? model.tags.join(", ") : stringValue(model.tags),
+        kind: "text" as const,
+        advanced: true,
+      },
+      {
+        id: `mental_models.${index}.max_tokens` as const,
+        label: `Mental model ${label} max tokens`,
+        value: stringValue(model.max_tokens),
+        kind: "integer" as const,
+      },
+      {
+        id: `mental_models.${index}.trigger.mode` as const,
+        label: `Mental model ${label} trigger mode`,
+        value: stringValue(trigger.mode),
+        kind: "select" as const,
+        choices: ["", "full", "incremental"],
+        advanced: true,
+      },
+      {
+        id: `mental_models.${index}.trigger.refresh_after_consolidation` as const,
+        label: `Mental model ${label} refresh after consolidation`,
+        value: stringValue(trigger.refresh_after_consolidation),
+        kind: "boolean" as const,
+        choices: ["", "true", "false"],
+        advanced: true,
+      },
+    ];
+  });
+}
+
+export function buildBankTemplateEditorFields(
+  manifest: BankTemplateManifest,
+): BankTemplateEditorField[] {
+  return [...buildBankEditorFields(manifest), ...mentalModelEditorFields(manifest)];
+}
+
+function parseMentalModelFieldValue(
+  fieldName: BankTemplateMentalModelFieldName,
+  value: string,
+): unknown {
+  if (fieldName === "tags") {
+    return value
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+  }
+  if (fieldName === "max_tokens") {
+    if (!value.trim()) return undefined;
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 256 || parsed > 8192) {
+      throw new Error("Mental model max tokens must be an integer from 256 to 8192.");
+    }
+    return parsed;
+  }
+  if (fieldName === "trigger.refresh_after_consolidation") {
+    if (!value) return undefined;
+    if (value !== "true" && value !== "false") {
+      throw new Error("Mental model refresh after consolidation must be true or false.");
+    }
+    return value === "true";
+  }
+  if (fieldName === "trigger.mode") {
+    if (!value) return undefined;
+    if (value !== "full" && value !== "incremental") {
+      throw new Error("Mental model trigger mode must be full or incremental.");
+    }
+    return value;
+  }
+  return value;
+}
+
+function parseMentalModelFieldId(
+  fieldId: BankTemplateEditorFieldId,
+): { index: number; fieldName: BankTemplateMentalModelFieldName } | undefined {
+  const match = /^mental_models\.(\d+)\.(.+)$/.exec(fieldId);
+  if (!match) return undefined;
+  return {
+    index: Number(match[1]),
+    fieldName: match[2] as BankTemplateMentalModelFieldName,
+  };
+}
+
+function isBankEditorFieldId(
+  fieldId: BankTemplateEditorFieldId,
+): fieldId is BankTemplateBankFieldId {
+  return !fieldId.startsWith("mental_models.");
+}
+
 export function updateBankTemplateField(
   manifest: BankTemplateManifest,
   fieldId: BankTemplateEditorFieldId,
   value: string,
 ): BankTemplateManifest {
   const next = cloneBankTemplateManifest(manifest);
+  const mentalField = parseMentalModelFieldId(fieldId);
+  if (mentalField) {
+    next.mental_models = [...(next.mental_models ?? [])];
+    const model = { ...next.mental_models[mentalField.index] } as BankTemplateMentalModel;
+    const parsed = parseMentalModelFieldValue(mentalField.fieldName, value);
+    if (mentalField.fieldName.startsWith("trigger.")) {
+      const triggerKey = mentalField.fieldName.slice("trigger.".length);
+      model.trigger = { ...model.trigger };
+      if (parsed === undefined || parsed === "") delete model.trigger[triggerKey];
+      else model.trigger[triggerKey] = parsed;
+      if (Object.keys(model.trigger).length === 0) delete model.trigger;
+    } else if (mentalField.fieldName === "id") {
+      if (parsed === undefined || parsed === "")
+        delete (model as Partial<BankTemplateMentalModel>).id;
+      else model.id = parsed as string;
+    } else if (mentalField.fieldName === "name") {
+      if (parsed === undefined || parsed === "")
+        delete (model as Partial<BankTemplateMentalModel>).name;
+      else model.name = parsed as string;
+    } else if (mentalField.fieldName === "source_query") {
+      if (parsed === undefined || parsed === "")
+        delete (model as Partial<BankTemplateMentalModel>).source_query;
+      else model.source_query = parsed as string;
+    } else if (mentalField.fieldName === "tags") {
+      if (parsed === undefined || (Array.isArray(parsed) && parsed.length === 0)) delete model.tags;
+      else model.tags = parsed as string[];
+    } else if (mentalField.fieldName === "max_tokens") {
+      if (parsed === undefined || parsed === "") delete model.max_tokens;
+      else model.max_tokens = parsed as number;
+    }
+    next.mental_models[mentalField.index] = model;
+    return next;
+  }
+
+  if (!isBankEditorFieldId(fieldId)) return next;
   next.bank = { ...next.bank };
-  const parsed = parseFieldValue(fieldId, value);
+  const parsed = parseBankFieldValue(fieldId, value);
   if (parsed === undefined || parsed === "") delete next.bank[fieldId];
   else next.bank[fieldId] = parsed;
   return next;
@@ -148,8 +312,30 @@ export function validateMentalModel(model: unknown, index = 0): string[] {
       errors.push(`Mental model ${label} max_tokens must be an integer from 256 to 8192.`);
     }
   }
-  if (model.tags !== undefined && !Array.isArray(model.tags)) {
+  if (
+    model.tags !== undefined &&
+    (!Array.isArray(model.tags) || model.tags.some((tag) => typeof tag !== "string"))
+  ) {
     errors.push(`Mental model ${label} tags must be an array of strings.`);
+  }
+  if (model.trigger !== undefined) {
+    if (!isRecord(model.trigger)) {
+      errors.push(`Mental model ${label} trigger must be an object.`);
+    } else {
+      if (
+        model.trigger.refresh_after_consolidation !== undefined &&
+        typeof model.trigger.refresh_after_consolidation !== "boolean"
+      ) {
+        errors.push(`Mental model ${label} trigger refresh_after_consolidation must be boolean.`);
+      }
+      if (
+        model.trigger.mode !== undefined &&
+        model.trigger.mode !== "full" &&
+        model.trigger.mode !== "incremental"
+      ) {
+        errors.push(`Mental model ${label} trigger mode must be full or incremental.`);
+      }
+    }
   }
   return errors;
 }

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -6,6 +6,13 @@ import {
   summarizeBankTemplateImportResult,
 } from "./bank-template-operations.js";
 import {
+  buildBankTemplateEditorFields,
+  mentalModelTagWarnings,
+  updateBankTemplateField,
+  validateBankTemplateManifestForEditing,
+  type BankTemplateEditorField,
+} from "./bank-template-editor.js";
+import {
   createMemoryOperations,
   type MemoryOperations,
   type MemoryOperationsDeps,
@@ -143,11 +150,69 @@ function templateChoiceFromLabel(label: string): BankTemplateProfileId | undefin
 
 function bankTemplateReview(manifest: BankTemplateManifest): string {
   const summary = summarizeBankTemplateManifest(manifest);
+  const warnings = mentalModelTagWarnings(manifest);
   return [
     `Bank overrides: ${summary.bankOverrideCount}`,
     `Mental models: ${summary.mentalModelCount}`,
     `Directives: ${summary.directiveCount}`,
+    ...(warnings.length ? ["Warnings:", ...warnings.map((warning) => `- ${warning}`)] : []),
   ].join("\n");
+}
+
+function templateFieldOption(field: BankTemplateEditorField): string {
+  const advanced = field.advanced ? " (advanced)" : "";
+  const value = field.value ? `: ${field.value}` : "";
+  return `${field.label}${advanced}${value}`;
+}
+
+function fieldFromOption(
+  fields: BankTemplateEditorField[],
+  option: string,
+): BankTemplateEditorField | undefined {
+  return fields.find((field) => templateFieldOption(field) === option);
+}
+
+function editedValueFallback(field: BankTemplateEditorField): string {
+  if (field.kind === "boolean" && field.value !== "true" && field.value !== "false") return "false";
+  return field.value;
+}
+
+export async function editTemplateManifestForSetup(args: {
+  ctx: ExtensionCommandContext;
+  label: string;
+  manifest: BankTemplateManifest;
+}): Promise<BankTemplateManifest | undefined> {
+  let manifest = cloneBankTemplateManifest(args.manifest);
+  while (true) {
+    const errors = validateBankTemplateManifestForEditing(manifest);
+    const body = [
+      `Template: ${args.label}`,
+      bankTemplateReview(manifest),
+      ...(errors.length ? ["", "Validation errors:", ...errors.map((error) => `- ${error}`)] : []),
+    ].join("\n");
+    const action = await args.ctx.ui.select(`Review or edit bank template\n${body}`, [
+      ...(errors.length === 0 ? ["Use template"] : []),
+      "Edit bank field",
+      "Cancel",
+    ]);
+    if (!action || action === "Cancel") return undefined;
+    if (action === "Use template") return manifest;
+
+    const fields = buildBankTemplateEditorFields(manifest);
+    const fieldOption = await args.ctx.ui.select(body, fields.map(templateFieldOption));
+    if (!fieldOption) continue;
+    const field = fieldFromOption(fields, fieldOption);
+    if (!field) continue;
+    const value = field.choices
+      ? await args.ctx.ui.select(`Set ${field.label}`, field.choices)
+      : await args.ctx.ui.input(`Set ${field.label}`, editedValueFallback(field));
+    if (value === undefined) continue;
+    try {
+      manifest = updateBankTemplateField(manifest, field.id, value);
+    } catch (error) {
+      args.ctx.ui.notify(error instanceof Error ? error.message : String(error), "warning");
+    }
+  }
 }
 
 async function selectTemplateManifest(args: {
@@ -218,15 +283,16 @@ async function maybeImportBankTemplate(args: {
       if (!continueWithoutCheck) continue;
     }
 
-    const reviewed = await args.ctx.ui.confirm(
-      `Review template for ${target.label}`,
-      `Template: ${selected.label}\n${bankTemplateReview(selected.manifest)}`,
-    );
-    if (!reviewed) continue;
+    const editedManifest = await editTemplateManifestForSetup({
+      ctx: args.ctx,
+      label: `${selected.label} for ${target.label}`,
+      manifest: selected.manifest,
+    });
+    if (!editedManifest) continue;
 
     const dryRun = await args.operations.importBankTemplate({
       bank: target.bank,
-      manifest: selected.manifest,
+      manifest: editedManifest,
       dryRun: true,
     });
     const dryRunSummary = summarizeBankTemplateImportResult(dryRun.result);
@@ -237,7 +303,7 @@ async function maybeImportBankTemplate(args: {
     if (!confirmed) continue;
     const applied = await args.operations.importBankTemplate({
       bank: target.bank,
-      manifest: selected.manifest,
+      manifest: editedManifest,
       dryRun: false,
     });
     args.ctx.ui.notify(

--- a/tests/bank-template-editor.test.ts
+++ b/tests/bank-template-editor.test.ts
@@ -106,6 +106,64 @@ describe("bank template editor", () => {
     ]);
   });
 
+  it("updates mental model fields while preserving other manifest data", () => {
+    const manifest = {
+      version: "1" as const,
+      directives: [{ name: "Keep", content: "Preserve me" }],
+      mental_models: [
+        {
+          id: "profile",
+          name: "Profile",
+          source_query: "What matters?",
+          max_tokens: 1024,
+          trigger: { mode: "full" },
+        },
+      ],
+    };
+
+    const updated = updateBankTemplateField(
+      manifest,
+      "mental_models.0.tags",
+      "profile:user, stable",
+    );
+    const withTrigger = updateBankTemplateField(
+      updated,
+      "mental_models.0.trigger.refresh_after_consolidation",
+      "true",
+    );
+
+    expect(withTrigger.directives).toEqual(manifest.directives);
+    expect(withTrigger.mental_models?.[0]).toEqual({
+      id: "profile",
+      name: "Profile",
+      source_query: "What matters?",
+      max_tokens: 1024,
+      tags: ["profile:user", "stable"],
+      trigger: { mode: "full", refresh_after_consolidation: true },
+    });
+  });
+
+  it("validates mental model trigger and tag element shape", () => {
+    expect(
+      validateBankTemplateManifestForEditing({
+        version: "1",
+        mental_models: [
+          {
+            id: "profile",
+            name: "Profile",
+            source_query: "What matters?",
+            tags: ["ok", 42] as never,
+            trigger: { mode: "fast", refresh_after_consolidation: "yes" },
+          },
+        ],
+      }),
+    ).toEqual([
+      "Mental model profile tags must be an array of strings.",
+      "Mental model profile trigger refresh_after_consolidation must be boolean.",
+      "Mental model profile trigger mode must be full or incremental.",
+    ]);
+  });
+
   it("warns when mental model tags constrain refresh source memories", () => {
     expect(
       mentalModelTagWarnings({

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -1,10 +1,11 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config-defaults.js";
 import {
   buildGuidedSetupPatch,
+  editTemplateManifestForSetup,
   enabledTemplateTargets,
   hasProjectHindsightConfig,
   setupProfileChoiceToMemoryProfile,
@@ -97,6 +98,128 @@ describe("guided setup", () => {
         bank: "global-luxus",
         defaultTemplateTarget: "user",
       },
+    ]);
+  });
+
+  it("edits a selected template before setup apply", async () => {
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("Edit bank field")
+      .mockResolvedValueOnce("Retain extraction mode: concise")
+      .mockResolvedValueOnce("verbose")
+      .mockResolvedValueOnce("Use template");
+    const ctx = {
+      ui: {
+        select,
+        input: vi.fn(),
+      },
+    } as never;
+
+    const result = await editTemplateManifestForSetup({
+      ctx,
+      label: "Coding Project",
+      manifest: {
+        version: "1",
+        bank: { retain_extraction_mode: "concise" },
+      },
+    });
+
+    expect(result?.bank?.retain_extraction_mode).toBe("verbose");
+    expect(select).toHaveBeenCalledWith(
+      expect.stringContaining("Review or edit bank template\nTemplate: Coding Project"),
+      ["Use template", "Edit bank field", "Cancel"],
+    );
+  });
+
+  it("edits mental model fields before setup apply", async () => {
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("Edit bank field")
+      .mockResolvedValueOnce("Mental model Project Context max tokens: 1024")
+      .mockResolvedValueOnce("Use template");
+    const input = vi.fn().mockResolvedValueOnce("2048");
+    const ctx = {
+      ui: {
+        select,
+        input,
+        notify: vi.fn(),
+      },
+    } as never;
+
+    const result = await editTemplateManifestForSetup({
+      ctx,
+      label: "Coding Project",
+      manifest: {
+        version: "1",
+        mental_models: [
+          {
+            id: "project-context",
+            name: "Project Context",
+            source_query: "What matters?",
+            max_tokens: 1024,
+          },
+        ],
+      },
+    });
+
+    expect(result?.mental_models?.[0]?.max_tokens).toBe(2048);
+  });
+
+  it("recovers from invalid setup editor field values", async () => {
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("Edit bank field")
+      .mockResolvedValueOnce("Disposition empathy (advanced)")
+      .mockResolvedValueOnce("Use template");
+    const notify = vi.fn();
+    const ctx = {
+      ui: {
+        select,
+        input: vi.fn().mockResolvedValueOnce("9"),
+        notify,
+      },
+    } as never;
+
+    const result = await editTemplateManifestForSetup({
+      ctx,
+      label: "Coding Project",
+      manifest: { version: "1", bank: {} },
+    });
+
+    expect(result?.bank).toEqual({});
+    expect(notify).toHaveBeenCalledWith(
+      "Disposition empathy must be an integer from 1 to 5.",
+      "warning",
+    );
+  });
+
+  it("requires template validation errors to be fixed before use", async () => {
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("Edit bank field")
+      .mockResolvedValueOnce("Retain mission")
+      .mockResolvedValueOnce("Cancel");
+    const input = vi.fn().mockResolvedValueOnce("Remember useful facts.");
+    const ctx = {
+      ui: {
+        select,
+        input,
+      },
+    } as never;
+
+    const result = await editTemplateManifestForSetup({
+      ctx,
+      label: "Bad Template",
+      manifest: {
+        version: "1",
+        mental_models: [{ id: "Bad ID", name: "", source_query: "" }],
+      },
+    });
+
+    expect(result).toBeUndefined();
+    expect(select).toHaveBeenNthCalledWith(1, expect.stringContaining("Validation errors:"), [
+      "Edit bank field",
+      "Cancel",
     ]);
   });
 


### PR DESCRIPTION
## Summary
- wire setup template review/edit loop before dry-run/apply
- include template summary, validation errors, and tag warnings in setup prompts
- add editable mental model fields for id/name/source query/tags/max tokens/trigger refresh mode
- validate trigger shape and recover from invalid field input without mutating the manifest

Refs #170.

## Review
- Pre-PR reviewer run: no blockers after fixes.

## Verification
- npm run check
- npm run typecheck:tsc
