### PR TITLE
feat(import): chunk curated sessions by turns

### DIFF
--- a/extensions/config-defaults.ts
+++ b/extensions/config-defaults.ts
@@ -94,6 +94,8 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
   },
   import: {
     mode: "curated",
+    turnsPerDocument: 12,
+    maxDocumentBytes: 80_000,
     includeBranches: "current-only",
     replaceExistingImportedDocs: true,
     manifestPath: ".pi/hindsight/import-manifest.json",

--- a/extensions/config-normalize.ts
+++ b/extensions/config-normalize.ts
@@ -303,6 +303,14 @@ export function normalizeConfig(
         ["curated", "raw", "forensic"],
         DEFAULT_CONFIG.import.mode,
       ),
+      turnsPerDocument: positiveInt(
+        config.import?.turnsPerDocument,
+        DEFAULT_CONFIG.import.turnsPerDocument,
+      ),
+      maxDocumentBytes: positiveInt(
+        config.import?.maxDocumentBytes,
+        DEFAULT_CONFIG.import.maxDocumentBytes,
+      ),
       includeBranches: enumValue(
         config.import?.includeBranches,
         ["current-only", "all-leaves"],

--- a/extensions/import-checkpoint.ts
+++ b/extensions/import-checkpoint.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
-import type { UpdateMode } from "./types.js";
+import type { ImportMode, UpdateMode } from "./types.js";
 
 export type ImportDocumentStatus = "pending" | "queued" | "completed" | "failed" | "skipped";
 
@@ -9,6 +9,11 @@ export interface ImportCheckpointDocument {
   leafId: string;
   contentHash: string;
   messageCount: number;
+  importMode?: ImportMode;
+  projectionVersion?: string;
+  importProfile?: string;
+  chunkIndex?: number;
+  messageRange?: { start: number; end: number };
   status: ImportDocumentStatus;
   updatedAt: string;
   error?: string;
@@ -22,6 +27,8 @@ export interface ImportCheckpoint {
   sessionId: string;
   cwd: string;
   includeBranches: "current-only" | "all-leaves";
+  importMode?: ImportMode;
+  importProfile?: string;
   updateMode: UpdateMode;
   startedAt: string;
   updatedAt: string;
@@ -43,6 +50,7 @@ export function importRunId(args: {
   bankId: string;
   sessionId: string;
   includeBranches: "current-only" | "all-leaves";
+  importMode?: ImportMode;
   updateMode: UpdateMode;
 }): string {
   return [
@@ -50,6 +58,7 @@ export function importRunId(args: {
     args.bankId,
     args.sessionId,
     args.includeBranches,
+    args.importMode ?? "legacy",
     args.updateMode,
     args.sourceFile,
   ]
@@ -127,6 +136,7 @@ export function createImportCheckpoint(args: {
   sessionId: string;
   cwd: string;
   includeBranches: "current-only" | "all-leaves";
+  importMode?: ImportMode;
   updateMode: UpdateMode;
   now: string;
 }): ImportCheckpoint {
@@ -138,6 +148,7 @@ export function createImportCheckpoint(args: {
     sessionId: args.sessionId,
     cwd: args.cwd,
     includeBranches: args.includeBranches,
+    ...(args.importMode ? { importMode: args.importMode } : {}),
     updateMode: args.updateMode,
     startedAt: args.now,
     updatedAt: args.now,

--- a/extensions/import-execution.ts
+++ b/extensions/import-execution.ts
@@ -19,6 +19,11 @@ export interface ImportSessionDocumentResult {
   documentId: string;
   leafId: string;
   messageCount: number;
+  importMode?: "curated" | "raw" | "forensic";
+  projectionVersion?: string;
+  importProfile?: string;
+  chunkIndex?: number;
+  messageRange?: { start: number; end: number };
   contentHash: string;
   contentBytes: number;
   tags: string[];
@@ -69,6 +74,7 @@ export async function executeImportPlan(args: {
           sessionId,
           cwd,
           includeBranches,
+          importMode: importConfig.import.mode,
           updateMode,
           now,
         });
@@ -86,72 +92,113 @@ export async function executeImportPlan(args: {
       leaves,
       branch,
     };
-    const preview = previewImportBranch(common);
-    const previous = checkpoint.documents[preview.document.documentId];
-    const canSkip =
-      !args.dryRun &&
-      importConfig.import.resume &&
-      previous?.status === "completed" &&
-      previous.contentHash === preview.document.contentHash;
-    if (args.dryRun || canSkip) {
-      results.push({
-        ...preview,
-        document: {
-          ...preview.document,
-          wouldWrite: false,
-          status: canSkip ? ("skipped" as const) : preview.document.status,
-        },
-      });
-      continue;
-    }
+    const previews = previewImportBranch(common);
+    for (const preview of previews) {
+      const previous = checkpoint.documents[preview.document.documentId];
+      const canSkip =
+        !args.dryRun &&
+        importConfig.import.resume &&
+        previous?.status === "completed" &&
+        previous.contentHash === preview.document.contentHash;
+      if (args.dryRun || canSkip) {
+        results.push({
+          ...preview,
+          document: {
+            ...preview.document,
+            wouldWrite: false,
+            status: canSkip ? ("skipped" as const) : preview.document.status,
+          },
+        });
+        continue;
+      }
 
-    checkpoint.documents[preview.document.documentId] = {
-      documentId: preview.document.documentId,
-      leafId: preview.document.leafId,
-      contentHash: preview.document.contentHash,
-      messageCount: preview.document.messageCount,
-      status: "pending",
-      updatedAt: new Date().toISOString(),
-    };
-    await writeImportCheckpoint(checkpointPath, checkpoint);
-
-    try {
-      const retained = await retainImportBranch({ ...common, client: args.client });
-      const completedAt = new Date().toISOString();
-      checkpoint.documents[retained.document.documentId] = {
-        documentId: retained.document.documentId,
-        leafId: retained.document.leafId,
-        contentHash: retained.document.contentHash,
-        messageCount: retained.document.messageCount,
-        status: "completed",
-        updatedAt: completedAt,
-      };
-      checkpoint.updatedAt = completedAt;
-      await writeImportCheckpoint(checkpointPath, checkpoint);
-      results.push({
-        ...retained,
-        document: { ...retained.document, status: "completed" as const },
-      });
-    } catch (error) {
-      const failedAt = new Date().toISOString();
-      const message = redactError(error);
-      const status = isImportRetainQueuedError(error) ? "queued" : "failed";
       checkpoint.documents[preview.document.documentId] = {
         documentId: preview.document.documentId,
         leafId: preview.document.leafId,
         contentHash: preview.document.contentHash,
         messageCount: preview.document.messageCount,
-        status,
-        updatedAt: failedAt,
-        error: message,
+        ...(preview.document.importMode ? { importMode: preview.document.importMode } : {}),
+        ...(preview.document.projectionVersion
+          ? { projectionVersion: preview.document.projectionVersion }
+          : {}),
+        ...(preview.document.importProfile
+          ? { importProfile: preview.document.importProfile }
+          : {}),
+        ...(preview.document.chunkIndex !== undefined
+          ? { chunkIndex: preview.document.chunkIndex }
+          : {}),
+        ...(preview.document.messageRange ? { messageRange: preview.document.messageRange } : {}),
+        status: "pending",
+        updatedAt: new Date().toISOString(),
       };
-      checkpoint.updatedAt = failedAt;
       await writeImportCheckpoint(checkpointPath, checkpoint);
-      results.push({
-        ...preview,
-        document: { ...preview.document, status, error: message },
-      });
-      throw error;
+
+      try {
+        const retained = await retainImportBranch({
+          ...common,
+          client: args.client,
+          documentId: preview.document.documentId,
+        });
+        const completedAt = new Date().toISOString();
+        checkpoint.documents[retained.document.documentId] = {
+          documentId: retained.document.documentId,
+          leafId: retained.document.leafId,
+          contentHash: retained.document.contentHash,
+          messageCount: retained.document.messageCount,
+          ...(retained.document.importMode ? { importMode: retained.document.importMode } : {}),
+          ...(retained.document.projectionVersion
+            ? { projectionVersion: retained.document.projectionVersion }
+            : {}),
+          ...(retained.document.importProfile
+            ? { importProfile: retained.document.importProfile }
+            : {}),
+          ...(retained.document.chunkIndex !== undefined
+            ? { chunkIndex: retained.document.chunkIndex }
+            : {}),
+          ...(retained.document.messageRange
+            ? { messageRange: retained.document.messageRange }
+            : {}),
+          status: "completed",
+          updatedAt: completedAt,
+        };
+        checkpoint.updatedAt = completedAt;
+        await writeImportCheckpoint(checkpointPath, checkpoint);
+        results.push({
+          ...retained,
+          document: { ...retained.document, status: "completed" as const },
+        });
+      } catch (error) {
+        const failedAt = new Date().toISOString();
+        const message = redactError(error);
+        const status = isImportRetainQueuedError(error) ? "queued" : "failed";
+        checkpoint.documents[preview.document.documentId] = {
+          documentId: preview.document.documentId,
+          leafId: preview.document.leafId,
+          contentHash: preview.document.contentHash,
+          messageCount: preview.document.messageCount,
+          ...(preview.document.importMode ? { importMode: preview.document.importMode } : {}),
+          ...(preview.document.projectionVersion
+            ? { projectionVersion: preview.document.projectionVersion }
+            : {}),
+          ...(preview.document.importProfile
+            ? { importProfile: preview.document.importProfile }
+            : {}),
+          ...(preview.document.chunkIndex !== undefined
+            ? { chunkIndex: preview.document.chunkIndex }
+            : {}),
+          ...(preview.document.messageRange ? { messageRange: preview.document.messageRange } : {}),
+          status,
+          updatedAt: failedAt,
+          error: message,
+        };
+        checkpoint.updatedAt = failedAt;
+        await writeImportCheckpoint(checkpointPath, checkpoint);
+        results.push({
+          ...preview,
+          document: { ...preview.document, status, error: message },
+        });
+        throw error;
+      }
     }
   }
 

--- a/extensions/import-manifest.ts
+++ b/extensions/import-manifest.ts
@@ -15,6 +15,10 @@ export interface ImportManifestEntry {
   cwd: string;
   includeBranches: "current-only" | "all-leaves";
   importMode?: ImportMode;
+  projectionVersion?: string;
+  importProfile?: string;
+  chunkIndex?: number;
+  messageRange?: { start: number; end: number };
   updateMode: UpdateMode;
 }
 

--- a/extensions/import-plan.ts
+++ b/extensions/import-plan.ts
@@ -52,6 +52,7 @@ export function buildImportPlan(args: {
     bankId: args.bankId,
     sessionId,
     includeBranches,
+    importMode: args.config.import.mode,
     updateMode,
   });
   return {

--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -38,6 +38,10 @@ export interface ImportDocumentPreview {
   estimatedDocumentCount?: number;
   estimatedChunkCount?: number;
   importMode?: ResolvedConfig["import"]["mode"];
+  projectionVersion?: string;
+  importProfile?: string;
+  chunkIndex?: number;
+  messageRange?: { start: number; end: number };
   contentHash: string;
   contentBytes: number;
   tags: string[];
@@ -165,7 +169,86 @@ function buildCuratedImportProjection(
   };
 }
 
-function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranchBuildResult {
+const CURATED_PROJECTION_VERSION = "curated-turns-v1";
+
+interface ImportChunk {
+  index: number;
+  messages: Array<{ message: ImportBranch["messages"][number]; originalIndex: number }>;
+  start: number;
+  end: number;
+}
+
+function chunkCuratedMessages(
+  messages: ImportBranch["messages"],
+  config: ResolvedConfig,
+): ImportChunk[] {
+  const indexed = messages.map((message, originalIndex) => ({ message, originalIndex }));
+  const turns: ImportChunk[] = [];
+  let current: ImportChunk["messages"] = [];
+  for (const entry of indexed) {
+    if (entry.message.data.role === "user" && current.length) {
+      turns.push({
+        index: turns.length,
+        messages: current,
+        start: current[0]!.originalIndex,
+        end: current.at(-1)!.originalIndex,
+      });
+      current = [];
+    }
+    current.push(entry);
+  }
+  if (current.length)
+    turns.push({
+      index: turns.length,
+      messages: current,
+      start: current[0]!.originalIndex,
+      end: current.at(-1)!.originalIndex,
+    });
+  const chunks: ImportChunk[] = [];
+  let chunk: ImportChunk["messages"] = [];
+  let turnCount = 0;
+  const flush = () => {
+    if (!chunk.length) return;
+    chunks.push({
+      index: chunks.length,
+      messages: chunk,
+      start: chunk[0]!.originalIndex,
+      end: chunk.at(-1)!.originalIndex,
+    });
+    chunk = [];
+    turnCount = 0;
+  };
+  for (const turn of turns) {
+    const nextMessages = [...chunk, ...turn.messages];
+    const wouldOverflowTurns = turnCount >= config.import.turnsPerDocument;
+    const wouldOverflowBytes =
+      chunk.length > 0 &&
+      byteLength(nextMessages.map((entry) => entry.message.data)) > config.import.maxDocumentBytes;
+    if (wouldOverflowTurns || wouldOverflowBytes) flush();
+    chunk.push(...turn.messages);
+    turnCount += 1;
+  }
+  flush();
+  return chunks.length ? chunks : [{ index: 0, messages: [], start: 0, end: 0 }];
+}
+
+function curatedImportProfile(config: ResolvedConfig): string {
+  return `turns-${config.import.turnsPerDocument}-bytes-${config.import.maxDocumentBytes}`;
+}
+
+function importChunkDocumentId(args: {
+  sessionId: string;
+  leafId: string;
+  mode: ResolvedConfig["import"]["mode"];
+  profile?: string;
+  chunk?: ImportChunk;
+}): string {
+  if (args.mode !== "curated" || !args.chunk || !args.profile)
+    return importDocumentId(args.sessionId, args.leafId);
+  return `${importDocumentId(args.sessionId, args.leafId)}:${args.profile}:${CURATED_PROJECTION_VERSION}:chunk-${args.chunk.index}-${args.chunk.start}-${args.chunk.end}`;
+}
+
+function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranchBuildResult[] {
   const leafId = args.branch.leafId;
   const parentSessionId = resolvedParentSessionId(args.parsed, args.cwd);
   const mode = args.config.import.mode;
@@ -173,64 +256,18 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
     mode === "forensic"
       ? args.branch.messages
       : args.branch.messages.filter((message) => !isInjectedHindsightMemory(message.data));
-  const projection =
+  const chunks =
     mode === "curated"
-      ? buildCuratedImportProjection(branchMessages, args.config)
-      : {
-          messages: branchMessages.map((message) => stableProjectionMessage(message.data)),
-          rawBytes: branchMessages.reduce((total, message) => total + byteLength(message.data), 0),
-          projectedBytes: byteLength(branchMessages.map((message) => message.data)),
-          droppedToolResultCount: 0,
-          droppedToolResultBytes: 0,
-          topDroppedTools: [],
-          keptToolErrorCount: branchMessages.filter(
-            (message) => message.data.role === "toolResult" && message.data.isError === true,
-          ).length,
-          keptToolErrorBytes: branchMessages
-            .filter(
-              (message) => message.data.role === "toolResult" && message.data.isError === true,
-            )
-            .reduce((total, message) => total + byteLength(message.data), 0),
-          estimatedChunkCount: Math.max(
-            1,
-            Math.ceil(byteLength(branchMessages.map((message) => message.data)) / 8_000),
-          ),
-        };
-  const documentId = importDocumentId(args.sessionId, leafId);
+      ? chunkCuratedMessages(branchMessages, args.config)
+      : [
+          {
+            index: 0,
+            messages: branchMessages.map((message, originalIndex) => ({ message, originalIndex })),
+            start: 0,
+            end: Math.max(0, branchMessages.length - 1),
+          },
+        ];
   const updateMode = args.config.import.replaceExistingImportedDocs ? "replace" : "append";
-  const contentRaw = JSON.stringify(
-    {
-      source: "pi-session-import",
-      sessionFile: args.sessionFile,
-      cwd: args.parsed.cwd,
-      sessionId: args.sessionId,
-      ...(parentSessionId ? { parentSessionId } : {}),
-      ...(args.parsed.parentSessionFile
-        ? { parentSessionFile: args.parsed.parentSessionFile }
-        : {}),
-      branchLeafId: leafId,
-      projection:
-        mode === "curated"
-          ? "raw-with-curated-preview-v1"
-          : mode === "forensic"
-            ? "forensic-raw-v1"
-            : "raw-v1",
-      projectedMessageCount: projection.messages.length,
-      messages: branchMessages.map((message) => message.data),
-    },
-    null,
-    2,
-  );
-  const content = args.config.retain.redactSecrets ? redactSecrets(contentRaw) : contentRaw;
-  const contentHash = hashImportContent(content);
-  const tags = [
-    ...baseTags(args.cwd, args.sessionId, leafId),
-    "import:historical",
-    "imported:true",
-    `document:${documentId}`,
-  ];
-  if (parentSessionId) tags.push(`parent:${parentSessionId}`);
-  if (args.leaves.length > 1) tags.push("forked:true");
   const identity = createMemoryIdentity(args.cwd, args.config, args.sessionFile);
   const observationScopes = args.config.observations.enabled
     ? expandObservationScopes(args.config.observations.scopes, {
@@ -239,60 +276,145 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
         projectBankId: args.bankId,
       })
     : [];
-  const document: ImportDocumentPreview = {
-    documentId,
-    leafId,
-    messageCount: branchMessages.length,
-    rawMessageCount: branchMessages.length,
-    projectedMessageCount: projection.messages.length,
-    rawBytes: projection.rawBytes,
-    projectedBytes: projection.projectedBytes,
-    droppedToolResultCount: projection.droppedToolResultCount,
-    droppedToolResultBytes: projection.droppedToolResultBytes,
-    topDroppedTools: projection.topDroppedTools,
-    keptToolErrorCount: projection.keptToolErrorCount,
-    keptToolErrorBytes: projection.keptToolErrorBytes,
-    estimatedDocumentCount: 1,
-    estimatedChunkCount: projection.estimatedChunkCount,
-    importMode: mode,
-    contentHash,
-    contentBytes: Buffer.byteLength(content, "utf8"),
-    tags,
-    updateMode,
-    bankId: args.bankId,
-    wouldWrite: true,
-    status: "pending" as const,
-  };
-  const manifestEntry: ImportManifestEntry = {
-    documentId,
-    bankId: args.bankId,
-    sourceFile: args.sessionFile,
-    importedAt: new Date().toISOString(),
-    contentHash,
-    messageCount: branchMessages.length,
-    leafId,
-    sessionId: args.sessionId,
-    cwd: args.cwd,
-    includeBranches: args.config.import.includeBranches,
-    importMode: mode,
-    updateMode,
-  };
-  return {
-    document,
-    manifestEntry,
-    content,
-    context: `Historical Pi session import from ${args.sessionFile}, branch ${leafId}`,
-    observationScopes,
-  };
+
+  return chunks.map((chunk) => {
+    const chunkMessages = chunk.messages.map((entry) => entry.message);
+    const projection =
+      mode === "curated"
+        ? buildCuratedImportProjection(chunkMessages, args.config)
+        : {
+            messages: chunkMessages.map((message) => stableProjectionMessage(message.data)),
+            rawBytes: chunkMessages.reduce((total, message) => total + byteLength(message.data), 0),
+            projectedBytes: byteLength(chunkMessages.map((message) => message.data)),
+            droppedToolResultCount: 0,
+            droppedToolResultBytes: 0,
+            topDroppedTools: [],
+            keptToolErrorCount: chunkMessages.filter(
+              (message) => message.data.role === "toolResult" && message.data.isError === true,
+            ).length,
+            keptToolErrorBytes: chunkMessages
+              .filter(
+                (message) => message.data.role === "toolResult" && message.data.isError === true,
+              )
+              .reduce((total, message) => total + byteLength(message.data), 0),
+            estimatedChunkCount: Math.max(
+              1,
+              Math.ceil(byteLength(chunkMessages.map((message) => message.data)) / 8_000),
+            ),
+          };
+    const importProfile = mode === "curated" ? curatedImportProfile(args.config) : undefined;
+    const documentId = importChunkDocumentId({
+      sessionId: args.sessionId,
+      leafId,
+      mode,
+      ...(importProfile ? { profile: importProfile } : {}),
+      chunk,
+    });
+    const projectionVersion = mode === "curated" ? CURATED_PROJECTION_VERSION : undefined;
+    const messageRange = { start: chunk.start, end: chunk.end };
+    const contentRaw = JSON.stringify(
+      {
+        source: "pi-session-import",
+        sessionFile: args.sessionFile,
+        cwd: args.parsed.cwd,
+        sessionId: args.sessionId,
+        ...(parentSessionId ? { parentSessionId } : {}),
+        ...(args.parsed.parentSessionFile
+          ? { parentSessionFile: args.parsed.parentSessionFile }
+          : {}),
+        branchLeafId: leafId,
+        projection:
+          mode === "curated"
+            ? projectionVersion
+            : mode === "forensic"
+              ? "forensic-raw-v1"
+              : "raw-v1",
+        ...(mode === "curated" ? { chunkIndex: chunk.index, messageRange } : {}),
+        projectedMessageCount: projection.messages.length,
+        messages: chunkMessages.map((message) => message.data),
+      },
+      null,
+      2,
+    );
+    const content = args.config.retain.redactSecrets ? redactSecrets(contentRaw) : contentRaw;
+    const contentHash = hashImportContent(content);
+    const tags = [
+      ...baseTags(args.cwd, args.sessionId, leafId),
+      "import:historical",
+      "imported:true",
+      `document:${documentId}`,
+    ];
+    if (parentSessionId) tags.push(`parent:${parentSessionId}`);
+    if (args.leaves.length > 1) tags.push("forked:true");
+    const document: ImportDocumentPreview = {
+      documentId,
+      leafId,
+      messageCount: chunkMessages.length,
+      rawMessageCount: chunkMessages.length,
+      projectedMessageCount: projection.messages.length,
+      rawBytes: projection.rawBytes,
+      projectedBytes: projection.projectedBytes,
+      droppedToolResultCount: projection.droppedToolResultCount,
+      droppedToolResultBytes: projection.droppedToolResultBytes,
+      topDroppedTools: projection.topDroppedTools,
+      keptToolErrorCount: projection.keptToolErrorCount,
+      keptToolErrorBytes: projection.keptToolErrorBytes,
+      estimatedDocumentCount: chunks.length,
+      estimatedChunkCount: projection.estimatedChunkCount,
+      importMode: mode,
+      ...(projectionVersion ? { projectionVersion } : {}),
+      ...(importProfile ? { importProfile } : {}),
+      ...(mode === "curated" ? { chunkIndex: chunk.index, messageRange } : {}),
+      contentHash,
+      contentBytes: Buffer.byteLength(content, "utf8"),
+      tags,
+      updateMode,
+      bankId: args.bankId,
+      wouldWrite: true,
+      status: "pending" as const,
+    };
+    const manifestEntry: ImportManifestEntry = {
+      documentId,
+      bankId: args.bankId,
+      sourceFile: args.sessionFile,
+      importedAt: new Date().toISOString(),
+      contentHash,
+      messageCount: chunkMessages.length,
+      leafId,
+      sessionId: args.sessionId,
+      cwd: args.cwd,
+      includeBranches: args.config.import.includeBranches,
+      importMode: mode,
+      ...(projectionVersion ? { projectionVersion } : {}),
+      ...(importProfile ? { importProfile } : {}),
+      ...(mode === "curated" ? { chunkIndex: chunk.index, messageRange } : {}),
+      updateMode,
+    };
+    return {
+      document,
+      manifestEntry,
+      content,
+      context: `Historical Pi session import from ${args.sessionFile}, branch ${leafId}, chunk ${chunk.index}`,
+      observationScopes,
+    };
+  });
 }
 
-export function previewImportBranch(args: Omit<ImportRetainArgs, "client">): ImportRetainResult {
-  const built = buildImportBranch(args);
-  return { document: { ...built.document, wouldWrite: false }, manifestEntry: built.manifestEntry };
+export function previewImportBranch(args: Omit<ImportRetainArgs, "client">): ImportRetainResult[] {
+  return buildImportBranch(args).map((built) => ({
+    document: { ...built.document, wouldWrite: false },
+    manifestEntry: built.manifestEntry,
+  }));
 }
 
-export async function retainImportBranch(args: ImportRetainArgs): Promise<ImportRetainResult> {
-  const built = buildImportBranch(args);
+export async function retainImportBranch(
+  args: ImportRetainArgs & { documentId: string },
+): Promise<ImportRetainResult> {
+  const built = buildImportBranch(args).find(
+    (candidate) => candidate.document.documentId === args.documentId,
+  );
+  if (!built)
+    throw new Error(`Import document ${args.documentId} no longer exists in import plan.`);
   const parentSessionId = resolvedParentSessionId(args.parsed, args.cwd);
   const retainResult = await deliverImportRetain({
     cwd: args.cwd,
@@ -315,6 +437,20 @@ export async function retainImportBranch(args: ImportRetainArgs): Promise<Import
         : {}),
       branch_leaf_id: built.document.leafId,
       import_mode: args.config.import.mode,
+      ...(built.document.projectionVersion
+        ? { projection_version: built.document.projectionVersion }
+        : {}),
+      ...(built.document.importProfile ? { import_profile: built.document.importProfile } : {}),
+      ...(built.document.chunkIndex !== undefined
+        ? { chunk_index: String(built.document.chunkIndex) }
+        : {}),
+      ...(built.document.messageRange
+        ? {
+            message_range_start: String(built.document.messageRange.start),
+            message_range_end: String(built.document.messageRange.end),
+          }
+        : {}),
+      content_hash: built.document.contentHash,
       include_branches: args.config.import.includeBranches,
       ...(args.parsed.sessionTimestamp ? { session_timestamp: args.parsed.sessionTimestamp } : {}),
     },

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -100,6 +100,8 @@ export interface ResolvedConfig {
   };
   import: {
     mode: ImportMode;
+    turnsPerDocument: number;
+    maxDocumentBytes: number;
     includeBranches: "current-only" | "all-leaves";
     replaceExistingImportedDocs: boolean;
     manifestPath: string;

--- a/tests/best-practices.test.ts
+++ b/tests/best-practices.test.ts
@@ -182,7 +182,9 @@ describe("Hindsight best-practice invariants", () => {
       dryRun: true,
     });
 
-    expect(first.documentId).toBe("pi-import:session-import:leaf:leaf");
+    expect(first.documentId).toBe(
+      "pi-import:session-import:leaf:leaf:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
+    );
     expect(second.documentId).toBe(first.documentId);
     expect(first.documents[0]).toMatchObject({
       documentId: first.documentId,

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -121,6 +121,101 @@ describe("Pi session import", () => {
     });
   });
 
+  it("chunks curated import documents by user turns with deterministic IDs and checkpoint metadata", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-chunks-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-chunks", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "u1",
+          parentId: null,
+          message: { role: "user", content: "one" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "a1",
+          parentId: "u1",
+          message: { role: "assistant", content: "answer one" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "u2",
+          parentId: "a1",
+          message: { role: "user", content: "two" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "a2",
+          parentId: "u2",
+          message: { role: "assistant", content: "answer two" },
+        }),
+      ].join("\n"),
+    );
+    const calls: unknown[][] = [];
+    const config = {
+      ...DEFAULT_CONFIG,
+      import: { ...DEFAULT_CONFIG.import, turnsPerDocument: 1, maxDocumentBytes: 100_000 },
+    };
+
+    const result = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config,
+      client: {
+        retain: async (...args: unknown[]) => {
+          calls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+    const checkpoint = await readImportCheckpoint(result.checkpointPath);
+    const manifest = await readImportManifest(result.manifestPath);
+
+    expect(result.documents).toHaveLength(2);
+    expect(result.documents.map((document) => document.documentId)).toEqual([
+      "pi-import:session-chunks:leaf:a2:turns-1-bytes-100000:curated-turns-v1:chunk-0-0-1",
+      "pi-import:session-chunks:leaf:a2:turns-1-bytes-100000:curated-turns-v1:chunk-1-2-3",
+    ]);
+    expect(result.documents[0]).toMatchObject({
+      messageCount: 2,
+      importMode: "curated",
+      projectionVersion: "curated-turns-v1",
+      importProfile: "turns-1-bytes-100000",
+      chunkIndex: 0,
+      messageRange: { start: 0, end: 1 },
+      estimatedDocumentCount: 2,
+    });
+    expect(Object.values(checkpoint?.documents ?? {})).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          documentId:
+            "pi-import:session-chunks:leaf:a2:turns-1-bytes-100000:curated-turns-v1:chunk-1-2-3",
+          importMode: "curated",
+          projectionVersion: "curated-turns-v1",
+          importProfile: "turns-1-bytes-100000",
+          chunkIndex: 1,
+          messageRange: { start: 2, end: 3 },
+        }),
+      ]),
+    );
+    expect(
+      manifest.imports[
+        "pi-import:session-chunks:leaf:a2:turns-1-bytes-100000:curated-turns-v1:chunk-0-0-1"
+      ],
+    ).toMatchObject({
+      importMode: "curated",
+      projectionVersion: "curated-turns-v1",
+      chunkIndex: 0,
+      messageRange: { start: 0, end: 1 },
+    });
+    expect(calls).toHaveLength(2);
+  });
+
   it("supports raw and forensic import modes as explicit escape hatches", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-mode-"));
     mkdirSync(join(dir, ".git"));
@@ -260,10 +355,13 @@ describe("Pi session import", () => {
     });
     expect(result.messageCount).toBe(2);
     expect(result.malformedLineCount).toBe(1);
-    expect(result.documentId).toBe("pi-import:session-1:leaf:current");
+    expect(result.documentId).toBe(
+      "pi-import:session-1:leaf:current:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
+    );
     expect(result.documents).toEqual([
       expect.objectContaining({
-        documentId: "pi-import:session-1:leaf:current",
+        documentId:
+          "pi-import:session-1:leaf:current:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
         leafId: "current",
         messageCount: 2,
         contentHash: expect.any(String),
@@ -368,7 +466,7 @@ describe("Pi session import", () => {
 
     expect(calls.map((call) => (call[2] as { documentId: string }).documentId)).toEqual([
       "existing-doc",
-      "pi-import:session-backlog:leaf:root",
+      "pi-import:session-backlog:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0",
     ]);
     expect(await readRetainQueue(queuePath)).toEqual([]);
     expect(result.documents[0]?.status).toBe("completed");
@@ -409,10 +507,20 @@ describe("Pi session import", () => {
     const checkpoint = await readImportCheckpoint(
       join(dir, ".pi/hindsight/import-checkpoint.json"),
     );
-    expect(checkpoint?.documents["pi-import:session-queued:leaf:root"]?.status).toBe("queued");
-    expect(checkpoint?.documents["pi-import:session-queued:leaf:root"]?.error).toContain("queued");
+    expect(
+      checkpoint?.documents[
+        "pi-import:session-queued:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0"
+      ]?.status,
+    ).toBe("queued");
+    expect(
+      checkpoint?.documents[
+        "pi-import:session-queued:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0"
+      ]?.error,
+    ).toContain("queued");
     const queue = await readRetainQueue(resolveQueuePath(dir, DEFAULT_CONFIG.retain.queuePath));
-    expect(queue.map((job) => job.documentId)).toEqual(["pi-import:session-queued:leaf:root"]);
+    expect(queue.map((job) => job.documentId)).toEqual([
+      "pi-import:session-queued:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0",
+    ]);
   });
 
   it("imports all leaves only when includeBranches is all-leaves", async () => {
@@ -461,13 +569,13 @@ describe("Pi session import", () => {
     });
     expect(result.documents).toEqual([
       expect.objectContaining({
-        documentId: "pi-import:session-2:leaf:a",
+        documentId: "pi-import:session-2:leaf:a:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
         leafId: "a",
         messageCount: 2,
         contentHash: expect.any(String),
       }),
       expect.objectContaining({
-        documentId: "pi-import:session-2:leaf:b",
+        documentId: "pi-import:session-2:leaf:b:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
         leafId: "b",
         messageCount: 2,
         contentHash: expect.any(String),
@@ -475,8 +583,8 @@ describe("Pi session import", () => {
     ]);
     expect(calls).toHaveLength(2);
     expect(calls.map((call) => (call[2] as { documentId: string }).documentId)).toEqual([
-      "pi-import:session-2:leaf:a",
-      "pi-import:session-2:leaf:b",
+      "pi-import:session-2:leaf:a:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
+      "pi-import:session-2:leaf:b:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
     ]);
   });
 
@@ -663,7 +771,8 @@ describe("Pi session import", () => {
     await expect(readImportCheckpoint(result.checkpointPath)).resolves.toBeUndefined();
     expect(result.documents).toEqual([
       expect.objectContaining({
-        documentId: "pi-import:session-preview:leaf:a",
+        documentId:
+          "pi-import:session-preview:leaf:a:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
         leafId: "a",
         messageCount: 2,
         contentBytes: expect.any(Number),
@@ -681,7 +790,8 @@ describe("Pi session import", () => {
         wouldWrite: false,
       }),
       expect.objectContaining({
-        documentId: "pi-import:session-preview:leaf:b",
+        documentId:
+          "pi-import:session-preview:leaf:b:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
         leafId: "b",
         messageCount: 2,
         wouldWrite: false,
@@ -781,8 +891,16 @@ describe("Pi session import", () => {
     const checkpoint = await readImportCheckpoint(
       join(dir, ".pi/hindsight/import-checkpoint.json"),
     );
-    expect(checkpoint?.documents["pi-import:session-resume:leaf:a"]?.status).toBe("completed");
-    expect(checkpoint?.documents["pi-import:session-resume:leaf:b"]?.status).toBe("queued");
+    expect(
+      checkpoint?.documents[
+        "pi-import:session-resume:leaf:a:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1"
+      ]?.status,
+    ).toBe("completed");
+    expect(
+      checkpoint?.documents[
+        "pi-import:session-resume:leaf:b:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1"
+      ]?.status,
+    ).toBe("queued");
 
     const secondCalls: unknown[][] = [];
     const result = await importPiSession({
@@ -801,22 +919,28 @@ describe("Pi session import", () => {
 
     expect(secondCalls).toHaveLength(1);
     const retainedOptions = secondCalls[0]?.[2] as { documentId: string };
-    expect(retainedOptions.documentId).toBe("pi-import:session-resume:leaf:b");
+    expect(retainedOptions.documentId).toBe(
+      "pi-import:session-resume:leaf:b:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
+    );
     expect(result.documents.map((document) => [document.leafId, document.status])).toEqual([
       ["a", "skipped"],
       ["b", "completed"],
     ]);
     const resumedCheckpoint = await readImportCheckpoint(result.checkpointPath);
-    expect(resumedCheckpoint?.documents["pi-import:session-resume:leaf:a"]?.status).toBe(
-      "completed",
-    );
-    expect(resumedCheckpoint?.documents["pi-import:session-resume:leaf:b"]?.status).toBe(
-      "completed",
-    );
+    expect(
+      resumedCheckpoint?.documents[
+        "pi-import:session-resume:leaf:a:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1"
+      ]?.status,
+    ).toBe("completed");
+    expect(
+      resumedCheckpoint?.documents[
+        "pi-import:session-resume:leaf:b:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1"
+      ]?.status,
+    ).toBe("completed");
     const manifest = await readImportManifest(result.manifestPath);
     expect(Object.keys(manifest.imports).sort()).toEqual([
-      "pi-import:session-resume:leaf:a",
-      "pi-import:session-resume:leaf:b",
+      "pi-import:session-resume:leaf:a:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
+      "pi-import:session-resume:leaf:b:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
     ]);
   });
 
@@ -903,7 +1027,9 @@ describe("Pi session import", () => {
         },
       });
 
-      expect(result.documents[0]?.documentId).toBe("pi-import:session-normalized:leaf:root");
+      expect(result.documents[0]?.documentId).toBe(
+        "pi-import:session-normalized:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0",
+      );
     },
   );
 
@@ -1117,7 +1243,9 @@ describe("Pi session import", () => {
 
     expect(secondCalls).toHaveLength(1);
     const retainedOptions = secondCalls[0]?.[2] as { documentId: string };
-    expect(retainedOptions.documentId).toBe("pi-import:second:leaf:1");
+    expect(retainedOptions.documentId).toBe(
+      "pi-import:second:leaf:1:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0",
+    );
     expect(result.imported.map((item) => [item.sessionFile, item.documents[0]?.status])).toEqual([
       [first, "skipped"],
       [second, "completed"],


### PR DESCRIPTION
## Summary
- chunk curated historical imports by deterministic user-turn documents
- include import profile, projection version, chunk index, and message range in curated document IDs
- persist chunk/profile metadata in preview results, checkpoints, manifests, and Hindsight retain metadata
- preserve raw/forensic legacy document IDs and payload shape
- add chunking/resume regression coverage

Refs #174.

## Review
- Pre-PR reviewer run: no blockers after fixes.

## Verification
- npm run check
- npm run typecheck:tsc
