### PR TITLE
feat(import): add gateway transcript import

### DIFF
--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -9,8 +9,9 @@ The extension supports:
 - current Pi session
 - explicit JSONL session file
 - all repo-scoped JSONL sessions in the current session directory
+- explicit gateway/chat transcript JSONL files for user memory
 
-Imports write deterministic document IDs and update an import manifest summarized in `/hindsight`.
+Pi session imports write deterministic document IDs and update an import manifest summarized in `/hindsight`. Gateway transcript imports use a separate explicit tool path and do not share the repo-session import flow.
 
 ## Preview first
 
@@ -22,13 +23,16 @@ Preview imports before writing memory:
 /hindsight:import-project-sessions --dry-run
 ```
 
-Tool equivalent:
+Tool equivalents:
 
 ```text
 hindsight_import({ dryRun: true })
+hindsight_import_gateway({ sourceFile: "/path/to/gateway.jsonl", dryRun: true })
 ```
 
-Preview output includes document count, import mode, raw message count, curated projection count, dropped non-error tool-result count, kept tool-error count, estimated chunk count, byte counts, update mode, target bank, checkpoint path, and manifest path. Curated projection metrics show likely import noise without replacing the raw structured source payload.
+Pi session preview output includes document count, import mode, raw message count, curated projection count, dropped non-error tool-result count, kept tool-error count, estimated chunk count, byte counts, update mode, target bank, checkpoint path, and manifest path. Curated projection metrics show likely import noise without replacing the raw structured source payload.
+
+Gateway preview output includes kept event count, retained user-turn count, dropped event count/type totals, malformed-line count, target user bank, content hash, and byte count.
 
 ## Import commands
 
@@ -46,6 +50,26 @@ Preview output includes document count, import mode, raw message count, curated 
 Use `--all-leaves` only when you explicitly want every fork leaf. The default imports only the current branch.
 
 Non-dry-run import commands announce the start and require confirmation because they write memory and update local checkpoint/manifest files.
+
+## Gateway transcript import
+
+Gateway import is explicit and separate from Pi session import:
+
+```text
+hindsight_import_gateway({ sourceFile: "/path/to/gateway.jsonl", dryRun: true })
+```
+
+By default it targets the configured user bank. Pass `bank` only when intentionally importing into a different bank.
+
+Accepted event type keys are `type`, `event`, `event_type`, and `kind`. High-signal events retained as source material are:
+
+- `user_message`
+- `assistant_reply`
+- `process_end`
+
+Streaming/UI/process noise such as `message_update` and `extension_ui_request` is dropped by default and counted in dry-run metrics. Gateway provenance is preserved with tags/metadata when present: `channel`, `channel_id`, `session_id`, `sessionId`, `conversation_id`, `conversationId`, and `thread_id`. Raw provenance values stay in metadata; tag values are normalized.
+
+If no high-signal events are found, gateway import skips writing instead of creating an empty memory document.
 
 ## Project session discovery
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -98,6 +98,16 @@ Import a historical Pi session JSONL file into Hindsight with deterministic docu
 | `dryRun`      | boolean | no       | Preview import without writing.                          |
 | `allLeaves`   | boolean | no       | Import or preview all branch leaves.                     |
 
+### `hindsight_import_gateway`
+
+Import a gateway/chat transcript JSONL file into the configured user memory bank. Explicit separate path from Pi session import.
+
+| Parameter    | Type    | Required | Description                                         |
+| ------------ | ------- | -------- | --------------------------------------------------- |
+| `sourceFile` | string  | yes      | Gateway transcript JSONL path.                      |
+| `bank`       | string  | no       | Optional bank id. Defaults to configured user bank. |
+| `dryRun`     | boolean | no       | Preview import without writing.                     |
+
 ### `hindsight_reflect`
 
 Ask Hindsight to synthesize an answer from memory. Use explicitly, not for default recall.

--- a/extensions/import-gateway-transcript.ts
+++ b/extensions/import-gateway-transcript.ts
@@ -1,0 +1,216 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { createHash } from "node:crypto";
+import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
+import { deliverImportRetain } from "./import-delivery.js";
+import { ImportRetainQueuedError } from "./import-retain.js";
+import { redactSecrets } from "./sanitize.js";
+
+const KEPT_GATEWAY_EVENTS = new Set(["user_message", "assistant_reply", "process_end"]);
+
+export interface GatewayTranscriptEvent {
+  type: string;
+  timestamp?: string;
+  content?: unknown;
+  channel?: string;
+  sessionId?: string;
+  conversationId?: string;
+  data: Record<string, unknown>;
+}
+
+export interface GatewayTranscriptImportResult {
+  sourceFile: string;
+  documentId: string;
+  retained: boolean;
+  skipped: boolean;
+  skipReason?: string;
+  dryRun: boolean;
+  bankId: string;
+  keptEventCount: number;
+  droppedEventCount: number;
+  malformedLineCount: number;
+  retainedTurnCount: number;
+  droppedEventTypes: Array<{ type: string; count: number }>;
+  contentHash: string;
+  contentBytes: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return undefined;
+}
+
+function eventType(record: Record<string, unknown>): string | undefined {
+  return stringField(record, ["type", "event", "event_type", "kind"]);
+}
+
+function normalizeGatewayEvent(
+  record: Record<string, unknown>,
+): GatewayTranscriptEvent | undefined {
+  const type = eventType(record);
+  if (!type) return undefined;
+  const content = record.content ?? record.text ?? record.message ?? record.output;
+  const timestamp = stringField(record, ["timestamp", "created_at", "time"]);
+  const channel = stringField(record, ["channel", "channel_id"]);
+  const sessionId = stringField(record, ["session_id", "sessionId"]);
+  const conversationId = stringField(record, ["conversation_id", "conversationId", "thread_id"]);
+  return {
+    type,
+    ...(timestamp ? { timestamp } : {}),
+    ...(content !== undefined ? { content } : {}),
+    ...(channel ? { channel } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(conversationId ? { conversationId } : {}),
+    data: record,
+  };
+}
+
+export function parseGatewayTranscriptJsonl(text: string): {
+  kept: GatewayTranscriptEvent[];
+  droppedEventTypes: Array<{ type: string; count: number }>;
+  droppedEventCount: number;
+  malformedLineCount: number;
+} {
+  const kept: GatewayTranscriptEvent[] = [];
+  const dropped = new Map<string, number>();
+  let malformedLineCount = 0;
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      malformedLineCount += 1;
+      continue;
+    }
+    if (!isRecord(parsed)) {
+      malformedLineCount += 1;
+      continue;
+    }
+    const event = normalizeGatewayEvent(parsed);
+    if (!event) {
+      malformedLineCount += 1;
+      continue;
+    }
+    if (KEPT_GATEWAY_EVENTS.has(event.type)) kept.push(event);
+    else dropped.set(event.type, (dropped.get(event.type) ?? 0) + 1);
+  }
+  return {
+    kept,
+    droppedEventTypes: [...dropped]
+      .map(([type, count]) => ({ type, count }))
+      .sort((left, right) => right.count - left.count || left.type.localeCompare(right.type)),
+    droppedEventCount: [...dropped.values()].reduce((total, count) => total + count, 0),
+    malformedLineCount,
+  };
+}
+
+function firstDefined(
+  events: GatewayTranscriptEvent[],
+  key: "channel" | "sessionId" | "conversationId",
+): string | undefined {
+  return events.find((event) => event[key])?.[key];
+}
+
+function tagValue(value: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, "-")
+      .slice(0, 80) || "unknown"
+  );
+}
+
+function documentId(sourceFile: string, kept: GatewayTranscriptEvent[]): string {
+  const basis = JSON.stringify({ sourceFile, first: kept[0]?.data, last: kept.at(-1)?.data });
+  return `pi-gateway-import:${createHash("sha256").update(basis).digest("hex").slice(0, 16)}`;
+}
+
+export async function importGatewayTranscript(args: {
+  sourceFile: string;
+  cwd: string;
+  bankId: string;
+  client: HindsightLikeClient;
+  config: ResolvedConfig;
+  dryRun?: boolean;
+}): Promise<GatewayTranscriptImportResult> {
+  const parsed = parseGatewayTranscriptJsonl(await readFile(args.sourceFile, "utf8"));
+  const docId = documentId(args.sourceFile, parsed.kept);
+  const channel = firstDefined(parsed.kept, "channel");
+  const sessionId = firstDefined(parsed.kept, "sessionId");
+  const conversationId = firstDefined(parsed.kept, "conversationId");
+  const contentRaw = JSON.stringify(
+    {
+      source: "gateway-transcript-import",
+      sourceFile: args.sourceFile,
+      channel,
+      sessionId,
+      conversationId,
+      events: parsed.kept.map((event) => event.data),
+      droppedEventCount: parsed.droppedEventCount,
+      droppedEventTypes: parsed.droppedEventTypes,
+    },
+    null,
+    2,
+  );
+  const content = args.config.retain.redactSecrets ? redactSecrets(contentRaw) : contentRaw;
+  const contentHash = createHash("sha256").update(content).digest("hex");
+  const result: GatewayTranscriptImportResult = {
+    sourceFile: args.sourceFile,
+    documentId: docId,
+    retained: false,
+    skipped: parsed.kept.length === 0,
+    ...(parsed.kept.length === 0 ? { skipReason: "No high-signal gateway events found." } : {}),
+    dryRun: Boolean(args.dryRun),
+    bankId: args.bankId,
+    keptEventCount: parsed.kept.length,
+    droppedEventCount: parsed.droppedEventCount,
+    malformedLineCount: parsed.malformedLineCount,
+    retainedTurnCount: parsed.kept.filter((event) => event.type === "user_message").length,
+    droppedEventTypes: parsed.droppedEventTypes,
+    contentHash,
+    contentBytes: Buffer.byteLength(content, "utf8"),
+  };
+  if (args.dryRun || parsed.kept.length === 0) return result;
+  const delivery = await deliverImportRetain({
+    cwd: args.cwd,
+    config: args.config,
+    client: args.client,
+    bankId: args.bankId,
+    content,
+    context: `Gateway transcript import from ${basename(args.sourceFile)}`,
+    documentId: docId,
+    updateMode: "replace",
+    tags: [
+      "source:gateway",
+      "import:gateway",
+      "imported:true",
+      ...(channel ? [`channel:${tagValue(channel)}`] : []),
+      ...(sessionId ? [`session:${tagValue(sessionId)}`] : []),
+      ...(conversationId ? [`conversation:${tagValue(conversationId)}`] : []),
+      `document:${docId}`,
+    ],
+    metadata: {
+      source_file: args.sourceFile,
+      source: "gateway-transcript",
+      ...(channel ? { channel } : {}),
+      ...(sessionId ? { session_id: sessionId } : {}),
+      ...(conversationId ? { conversation_id: conversationId } : {}),
+      content_hash: contentHash,
+    },
+  });
+  if (!delivery.delivered) {
+    throw new ImportRetainQueuedError(
+      `Gateway transcript import queued as ${delivery.queueJobId}; ${delivery.remaining} retain job${delivery.remaining === 1 ? "" : "s"} pending`,
+    );
+  }
+  return { ...result, retained: true };
+}

--- a/extensions/import-operations.ts
+++ b/extensions/import-operations.ts
@@ -1,4 +1,5 @@
 import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
+import { importGatewayTranscript } from "./import-gateway-transcript.js";
 import { importPiSession, importProjectSessions } from "./import-sessions.js";
 import { resolveOperationBank } from "./bank-selection.js";
 
@@ -33,6 +34,30 @@ export async function importMemorySession(
     ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
   });
   return { bankId, ...result };
+}
+
+export async function importMemoryGatewayTranscript(
+  args: {
+    sourceFile: string;
+    cwd: string;
+    bank?: string;
+    dryRun?: boolean;
+  },
+  deps: ImportOperationDeps,
+) {
+  const bankId = resolveOperationBank({
+    requestedBank: args.bank ?? "global",
+    config: deps.getConfig(),
+    projectBankId: deps.getProjectBankId(),
+  });
+  return importGatewayTranscript({
+    sourceFile: args.sourceFile,
+    cwd: args.cwd,
+    bankId,
+    client: deps.getClient(),
+    config: deps.getConfig(),
+    ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+  });
 }
 
 export async function importMemoryProjectSessions(

--- a/extensions/memory-operation-service.ts
+++ b/extensions/memory-operation-service.ts
@@ -1,5 +1,9 @@
 import type { MemoryOperationsDeps } from "./memory-operation-types.js";
-import { importMemoryProjectSessions, importMemorySession } from "./import-operations.js";
+import {
+  importMemoryGatewayTranscript,
+  importMemoryProjectSessions,
+  importMemorySession,
+} from "./import-operations.js";
 import { createBankTemplateOperations } from "./bank-template-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
 import { createDocumentOperations } from "./memory-document-operations.js";
@@ -22,6 +26,15 @@ function createImportOperations(deps: MemoryOperationsDeps) {
       includeBranches?: ResolvedConfig["import"]["includeBranches"];
     }) {
       return importMemorySession(args, deps);
+    },
+
+    async importGatewayTranscript(args: {
+      sourceFile: string;
+      cwd: string;
+      bank?: string;
+      dryRun?: boolean;
+    }) {
+      return importMemoryGatewayTranscript(args, deps);
     },
 
     async importProjectSessions(args: {

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -11,6 +11,7 @@ import {
   configureToolResponse,
   deleteDocumentToolResponse,
   exportBankTemplateToolResponse,
+  gatewayImportToolResponse,
   importToolResponse,
   retainReceiptListToolResponse,
   retainToolResponse,
@@ -277,6 +278,29 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
             : {}),
         });
         return importToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_import_gateway",
+      label: "Hindsight Import Gateway Transcript",
+      description:
+        "Import a gateway/chat transcript JSONL file into the configured user memory bank. Explicit separate path from Pi session import.",
+      parameters: Type.Object({
+        sourceFile: Type.String({ description: "Gateway transcript JSONL path." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to configured user bank." }),
+        ),
+        dryRun: Type.Optional(Type.Boolean({ description: "Preview import without writing." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.importGatewayTranscript({
+          sourceFile: params.sourceFile,
+          cwd: ctx.cwd,
+          ...(params.bank ? { bank: params.bank } : {}),
+          ...(params.dryRun !== undefined ? { dryRun: params.dryRun } : {}),
+        });
+        return gatewayImportToolResponse(result);
       },
     }),
     defineCatalogTool({

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -10,6 +10,9 @@ export type RouteMemoryToolResult = ReturnType<MemoryOperations["routeMemory"]>;
 export type DeleteDocumentToolResult = Awaited<ReturnType<MemoryOperations["deleteDocument"]>>;
 export type ConfigureToolResult = Awaited<ReturnType<MemoryOperations["configure"]>>;
 export type ImportToolResult = Awaited<ReturnType<MemoryOperations["importSession"]>>;
+export type GatewayImportToolResult = Awaited<
+  ReturnType<MemoryOperations["importGatewayTranscript"]>
+>;
 export type ExportBankTemplateToolResult = Awaited<
   ReturnType<MemoryOperations["exportBankTemplate"]>
 >;
@@ -81,6 +84,20 @@ export function configureToolResponse(
     ],
     details: { path: result.path, projectBankId: result.projectBankId },
   };
+}
+
+export function gatewayImportToolResponse(
+  result: GatewayImportToolResult,
+): ToolTextResponse<GatewayImportToolResult> {
+  const dropped = result.droppedEventTypes.length
+    ? result.droppedEventTypes.map((event) => `${event.type}:${event.count}`).join(", ")
+    : "none";
+  const text = result.skipped
+    ? `Gateway import skipped: ${result.skipReason}; dropped=${result.droppedEventCount} (${dropped}); malformed=${result.malformedLineCount}.`
+    : result.dryRun
+      ? `Gateway import preview: kept=${result.keptEventCount}; turns=${result.retainedTurnCount}; dropped=${result.droppedEventCount} (${dropped}); malformed=${result.malformedLineCount}; bank=${result.bankId}; document=${result.documentId}.`
+      : `Imported gateway transcript into ${result.bankId} as ${result.documentId}; kept=${result.keptEventCount}; dropped=${result.droppedEventCount}.`;
+  return { content: [{ type: "text", text }], details: result };
 }
 
 export function importToolResponse(result: ImportToolResult): ToolTextResponse<ImportToolResult> {

--- a/tests/import-gateway-transcript.test.ts
+++ b/tests/import-gateway-transcript.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+import {
+  importGatewayTranscript,
+  parseGatewayTranscriptJsonl,
+} from "../extensions/import-gateway-transcript.js";
+import { importMemoryGatewayTranscript } from "../extensions/import-operations.js";
+
+describe("gateway transcript import", () => {
+  it("parses high-signal gateway transcript events and drops stream noise", () => {
+    const parsed = parseGatewayTranscriptJsonl(
+      [
+        JSON.stringify({ type: "user_message", content: "hi", channel: "telegram" }),
+        JSON.stringify({ type: "message_update", content: "partial" }),
+        JSON.stringify({ event: "assistant_reply", content: "hello" }),
+        JSON.stringify({ kind: "process_end", output: "done" }),
+        JSON.stringify({ type: "extension_ui_request", content: "noise" }),
+        "{bad",
+      ].join("\n"),
+    );
+
+    expect(parsed.kept.map((event) => event.type)).toEqual([
+      "user_message",
+      "assistant_reply",
+      "process_end",
+    ]);
+    expect(parsed.droppedEventCount).toBe(2);
+    expect(parsed.droppedEventTypes).toEqual([
+      { type: "extension_ui_request", count: 1 },
+      { type: "message_update", count: 1 },
+    ]);
+    expect(parsed.malformedLineCount).toBe(1);
+  });
+
+  it("dry-runs gateway transcript import with user-memory provenance metrics", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-gateway-"));
+    mkdirSync(join(dir, ".git"));
+    const sourceFile = join(dir, "gateway.jsonl");
+    writeFileSync(
+      sourceFile,
+      [
+        JSON.stringify({
+          type: "user_message",
+          content: "prefer concise replies",
+          channel: "telegram",
+          session_id: "s1",
+          conversation_id: "c1",
+        }),
+        JSON.stringify({ type: "message_update", content: "streaming" }),
+        JSON.stringify({ type: "assistant_reply", content: "Noted.", channel: "telegram" }),
+        JSON.stringify({ type: "process_end", output: "ok" }),
+      ].join("\n"),
+    );
+
+    const result = await importGatewayTranscript({
+      sourceFile,
+      cwd: dir,
+      bankId: "user-bank",
+      config: DEFAULT_CONFIG,
+      dryRun: true,
+      client: { retain: async () => undefined, recall: async () => [], reflect: async () => ({}) },
+    });
+
+    expect(result).toMatchObject({
+      bankId: "user-bank",
+      retained: false,
+      dryRun: true,
+      keptEventCount: 3,
+      droppedEventCount: 1,
+      retainedTurnCount: 1,
+      malformedLineCount: 0,
+      contentHash: expect.any(String),
+      contentBytes: expect.any(Number),
+    });
+    expect(result.documentId).toMatch(/^pi-gateway-import:/);
+  });
+
+  it("skips noise-only gateway transcript without writing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-gateway-empty-"));
+    mkdirSync(join(dir, ".git"));
+    const sourceFile = join(dir, "gateway.jsonl");
+    writeFileSync(
+      sourceFile,
+      [
+        JSON.stringify({ type: "message_update", content: "stream" }),
+        JSON.stringify({ type: "extension_ui_request", content: "ui" }),
+      ].join("\n"),
+    );
+    const calls: unknown[][] = [];
+
+    const result = await importGatewayTranscript({
+      sourceFile,
+      cwd: dir,
+      bankId: "user-bank",
+      config: DEFAULT_CONFIG,
+      client: {
+        retain: async (...args: unknown[]) => {
+          calls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(result).toMatchObject({
+      retained: false,
+      skipped: true,
+      skipReason: "No high-signal gateway events found.",
+      keptEventCount: 0,
+      droppedEventCount: 2,
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("imports gateway transcript using replace mode and gateway tags", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-gateway-retain-"));
+    mkdirSync(join(dir, ".git"));
+    const sourceFile = join(dir, "gateway.jsonl");
+    writeFileSync(
+      sourceFile,
+      [
+        JSON.stringify({ type: "user_message", content: "remember tone", channel: "sms" }),
+        JSON.stringify({ type: "assistant_reply", content: "Stored." }),
+      ].join("\n"),
+    );
+    const calls: unknown[][] = [];
+
+    const result = await importGatewayTranscript({
+      sourceFile,
+      cwd: dir,
+      bankId: "user-bank",
+      config: DEFAULT_CONFIG,
+      client: {
+        retain: async (...args: unknown[]) => {
+          calls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(result.retained).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toBe("user-bank");
+    expect(calls[0]?.[2]).toMatchObject({
+      documentId: result.documentId,
+      updateMode: "replace",
+      tags: expect.arrayContaining(["source:gateway", "import:gateway", "channel:sms"]),
+      metadata: expect.objectContaining({ source: "gateway-transcript", channel: "sms" }),
+    });
+  });
+
+  it("defaults operation imports to configured user bank", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-gateway-operation-"));
+    mkdirSync(join(dir, ".git"));
+    const sourceFile = join(dir, "gateway.jsonl");
+    writeFileSync(sourceFile, JSON.stringify({ type: "user_message", content: "save user pref" }));
+
+    const result = await importMemoryGatewayTranscript(
+      { sourceFile, cwd: dir, dryRun: true },
+      {
+        getClient: () => ({
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        }),
+        getProjectBankId: () => "project-bank",
+        getConfig: () => ({
+          ...DEFAULT_CONFIG,
+          banks: {
+            ...DEFAULT_CONFIG.banks,
+            user: { enabled: true, bankId: "configured-user-bank" },
+            global: { enabled: true, bankId: "configured-user-bank" },
+          },
+        }),
+      },
+    );
+
+    expect(result.bankId).toBe("configured-user-bank");
+    expect(result.keptEventCount).toBe(1);
+  });
+});

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -30,6 +30,7 @@ describe("operation catalog", () => {
       "hindsight_configure",
       "hindsight_export_bank_template",
       "hindsight_import",
+      "hindsight_import_gateway",
       "hindsight_reflect",
     ]);
 


### PR DESCRIPTION
## Summary
- add explicit `hindsight_import_gateway` tool for gateway/chat transcript JSONL imports
- parse high-signal gateway events (`user_message`, `assistant_reply`, `process_end`) and drop streaming/UI noise with dry-run metrics
- default gateway imports to configured user bank while allowing explicit bank override
- preserve channel/session/conversation provenance in normalized tags and raw metadata
- skip noise-only transcripts and report queued delivery accurately
- document parser contract and gateway import behavior

Refs #175.

## Review
- Pre-PR reviewer run: no blockers after fixes.

## Verification
- npm run check
- npm run typecheck:tsc
