### PR TITLE
feat(setup): offer profile-aware historical import

### DIFF
--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -34,6 +34,10 @@ Pi session preview output includes document count, import mode, raw message coun
 
 Gateway preview output includes kept event count, retained user-turn count, dropped event count/type totals, malformed-line count, target user bank, content hash, and byte count.
 
+## Guided setup import prompt
+
+Guided setup offers historical import after config/template setup. It always previews first. Project/coding setup offers repo-scoped Pi session import; user/assistant setup offers gateway transcript import. You can skip and run the tools later.
+
 ## Import commands
 
 ```text

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -27,6 +27,7 @@ import {
   type BankTemplateProfileId,
   type BankTemplateTarget,
 } from "./bank-template-catalog.js";
+import { importDocumentSummary } from "./import-presentation.js";
 import type { MemoryProfile, ProjectConfigPatchInput } from "./config-writer.js";
 import type { SetupProfileChoice } from "./setup-tui-types.js";
 import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
@@ -218,7 +219,9 @@ export async function editTemplateManifestForSetup(args: {
 async function selectTemplateManifest(args: {
   ctx: ExtensionCommandContext;
   target: TemplateTarget;
-}): Promise<{ label: string; manifest: BankTemplateManifest } | undefined> {
+}): Promise<
+  { label: string; manifest: BankTemplateManifest; profileId?: BankTemplateProfileId } | undefined
+> {
   const defaultLabel = chooseBuiltInTemplateOption(args.target);
   const options = [
     "Skip",
@@ -238,7 +241,11 @@ async function selectTemplateManifest(args: {
   const templateId = templateChoiceFromLabel(choice);
   if (!templateId) return undefined;
   const template = getBuiltInBankTemplate(templateId);
-  return { label: template.label, manifest: cloneBankTemplateManifest(template.manifest) };
+  return {
+    label: template.label,
+    manifest: cloneBankTemplateManifest(template.manifest),
+    profileId: template.id,
+  };
 }
 
 async function maybeImportBankTemplate(args: {
@@ -248,18 +255,19 @@ async function maybeImportBankTemplate(args: {
   setupProfile: SetupProfileChoice;
   projectBankId?: string;
   globalBankId?: string;
-}): Promise<void> {
+}): Promise<Set<BankTemplateProfileId>> {
   const targets = enabledTemplateTargets(args);
   if (targets.length === 0) {
     args.ctx.ui.notify("No enabled bank target for template import.", "warning");
-    return;
+    return new Set();
   }
   const configure = await args.ctx.ui.confirm(
     "Configure Hindsight bank templates?",
     targets.map((target) => `${target.location}: ${target.bank}`).join("\n"),
   );
-  if (!configure) return;
+  if (!configure) return new Set();
 
+  const appliedProfiles = new Set<BankTemplateProfileId>();
   const client = args.deps.getClient();
   for (const target of targets) {
     const selected = await selectTemplateManifest({ ctx: args.ctx, target });
@@ -310,7 +318,117 @@ async function maybeImportBankTemplate(args: {
       `Imported ${selected.label} template into ${applied.bankId}: ${summarizeBankTemplateImportResult(applied.result)}`,
       "info",
     );
+    if (selected.profileId) appliedProfiles.add(selected.profileId);
   }
+  return appliedProfiles;
+}
+
+export function importChoicesForSetup(args: {
+  setupProfile: SetupProfileChoice;
+  appliedProfiles: Set<BankTemplateProfileId>;
+  projectBankId?: string;
+  globalBankId?: string;
+}): string[] {
+  const choices = ["Skip import"];
+  const profileHints = args.appliedProfiles;
+  const canProject = args.setupProfile !== "global-only" && Boolean(args.projectBankId);
+  const canGateway = args.setupProfile !== "project-only" && Boolean(args.globalBankId);
+  const wantsProject = profileHints.has("coding-project") || (!profileHints.size && canProject);
+  const wantsGateway =
+    profileHints.has("assistant-personal") ||
+    profileHints.has("general-user") ||
+    (!profileHints.size && canGateway);
+  if (canProject && wantsProject) choices.push("Preview repo Pi sessions");
+  if (canGateway && wantsGateway) choices.push("Preview gateway transcript");
+  if (canProject && !choices.includes("Preview repo Pi sessions")) {
+    choices.push("Preview repo Pi sessions");
+  }
+  if (canGateway && !choices.includes("Preview gateway transcript")) {
+    choices.push("Preview gateway transcript");
+  }
+  return choices;
+}
+
+export async function maybeOfferHistoricalImportForSetup(args: {
+  ctx: ExtensionCommandContext;
+  operations: MemoryOperations;
+  setupProfile: SetupProfileChoice;
+  appliedProfiles?: Set<BankTemplateProfileId>;
+  cwd: string;
+  projectBankId?: string;
+  globalBankId?: string;
+}): Promise<void> {
+  const proceed = await args.ctx.ui.confirm(
+    "Preview historical import now?",
+    "Imports always dry-run first. Project profiles use repo Pi sessions; user profiles can import gateway/chat transcripts.",
+  );
+  if (!proceed) return;
+  const choice = await args.ctx.ui.select(
+    "Choose import source",
+    importChoicesForSetup({
+      setupProfile: args.setupProfile,
+      appliedProfiles: args.appliedProfiles ?? new Set(),
+      ...(args.projectBankId ? { projectBankId: args.projectBankId } : {}),
+      ...(args.globalBankId ? { globalBankId: args.globalBankId } : {}),
+    }),
+  );
+  if (!choice || choice === "Skip import") return;
+
+  if (choice === "Preview repo Pi sessions") {
+    const currentSessionFile = args.ctx.sessionManager?.getSessionFile?.();
+    const dryRun = await args.operations.importProjectSessions({
+      cwd: args.cwd,
+      ...(currentSessionFile ? { currentSessionFile } : {}),
+      ...(args.projectBankId ? { bank: args.projectBankId } : {}),
+      dryRun: true,
+    });
+    const summary = importDocumentSummary({
+      documents: dryRun.imported.flatMap((result) => result.documents),
+      malformedLineCount: dryRun.malformedLineCount,
+    });
+    const confirmed = await args.ctx.ui.confirm(
+      `Import repo Pi sessions into ${dryRun.bankId}?`,
+      `Dry run: sessions=${dryRun.sessionFiles.length}; documents=${dryRun.documentCount}; messages=${dryRun.messageCount}; ${summary}`,
+    );
+    if (!confirmed) return;
+    const result = await args.operations.importProjectSessions({
+      cwd: args.cwd,
+      ...(currentSessionFile ? { currentSessionFile } : {}),
+      ...(args.projectBankId ? { bank: args.projectBankId } : {}),
+      dryRun: false,
+    });
+    args.ctx.ui.notify(
+      `Imported repo Pi sessions into ${result.bankId}: sessions=${result.sessionFiles.length}; documents=${result.documentCount}; messages=${result.messageCount}`,
+      "info",
+    );
+    return;
+  }
+
+  const sourceFile = await args.ctx.ui.input("Gateway transcript JSONL path", "");
+  if (!sourceFile?.trim()) return;
+  const dryRun = await args.operations.importGatewayTranscript({
+    sourceFile: sourceFile.trim(),
+    cwd: args.cwd,
+    ...(args.globalBankId ? { bank: args.globalBankId } : {}),
+    dryRun: true,
+  });
+  const confirmed = await args.ctx.ui.confirm(
+    `Import gateway transcript into ${dryRun.bankId}?`,
+    `Dry run: kept=${dryRun.keptEventCount}; turns=${dryRun.retainedTurnCount}; dropped=${dryRun.droppedEventCount}; malformed=${dryRun.malformedLineCount}; document=${dryRun.documentId}`,
+  );
+  if (!confirmed) return;
+  const result = await args.operations.importGatewayTranscript({
+    sourceFile: sourceFile.trim(),
+    cwd: args.cwd,
+    ...(args.globalBankId ? { bank: args.globalBankId } : {}),
+    dryRun: false,
+  });
+  args.ctx.ui.notify(
+    result.skipped
+      ? `Gateway import skipped: ${result.skipReason}`
+      : `Imported gateway transcript into ${result.bankId} as ${result.documentId}`,
+    "info",
+  );
 }
 
 export async function runGuidedSetup(args: {
@@ -370,11 +488,21 @@ export async function runGuidedSetup(args: {
   const result = await operations.configure(args.cwd, patch);
   args.ctx.ui.notify(`Wrote ${result.path}`, "info");
 
-  await maybeImportBankTemplate({
+  const appliedProfiles = await maybeImportBankTemplate({
     ctx: args.ctx,
     deps: args.deps,
     operations,
     setupProfile,
+    ...(projectBankId !== undefined ? { projectBankId } : {}),
+    ...(globalBankId !== undefined ? { globalBankId } : {}),
+  });
+
+  await maybeOfferHistoricalImportForSetup({
+    ctx: args.ctx,
+    operations,
+    setupProfile,
+    appliedProfiles,
+    cwd: args.cwd,
     ...(projectBankId !== undefined ? { projectBankId } : {}),
     ...(globalBankId !== undefined ? { globalBankId } : {}),
   });

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -8,6 +8,8 @@ import {
   editTemplateManifestForSetup,
   enabledTemplateTargets,
   hasProjectHindsightConfig,
+  importChoicesForSetup,
+  maybeOfferHistoricalImportForSetup,
   setupProfileChoiceToMemoryProfile,
 } from "../extensions/guided-setup.js";
 
@@ -221,6 +223,112 @@ describe("guided setup", () => {
       "Edit bank field",
       "Cancel",
     ]);
+  });
+
+  it("limits setup import choices to configured setup banks", () => {
+    expect(
+      importChoicesForSetup({
+        setupProfile: "global-only",
+        appliedProfiles: new Set(["coding-project"]),
+        globalBankId: "user-bank",
+      }),
+    ).toEqual(["Skip import", "Preview gateway transcript"]);
+    expect(
+      importChoicesForSetup({
+        setupProfile: "project-only",
+        appliedProfiles: new Set(["assistant-personal"]),
+        projectBankId: "project-bank",
+      }),
+    ).toEqual(["Skip import", "Preview repo Pi sessions"]);
+    expect(
+      importChoicesForSetup({
+        setupProfile: "project-global",
+        appliedProfiles: new Set(["assistant-personal"]),
+        projectBankId: "project-bank",
+        globalBankId: "user-bank",
+      }),
+    ).toEqual(["Skip import", "Preview gateway transcript", "Preview repo Pi sessions"]);
+  });
+
+  it("previews repo session import after project setup before writing", async () => {
+    const ctx = {
+      cwd: "/repo",
+      sessionManager: { getSessionFile: () => "/sessions/current.jsonl" },
+      ui: {
+        confirm: vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false),
+        select: vi.fn().mockResolvedValueOnce("Preview repo Pi sessions"),
+        input: vi.fn(),
+        notify: vi.fn(),
+      },
+    } as never;
+    const importProjectSessions = vi.fn().mockResolvedValueOnce({
+      bankId: "project-bank",
+      sessionFiles: ["/sessions/current.jsonl"],
+      imported: [{ documents: [{ updateMode: "replace", status: "pending", messageCount: 2 }] }],
+      malformedLineCount: 0,
+      documentCount: 1,
+      messageCount: 2,
+    });
+    const operations = {
+      importProjectSessions,
+      importGatewayTranscript: vi.fn(),
+    } as never;
+
+    await maybeOfferHistoricalImportForSetup({
+      ctx,
+      operations,
+      setupProfile: "project-only",
+      cwd: "/repo",
+      projectBankId: "project-bank",
+    });
+
+    expect(importProjectSessions).toHaveBeenCalledWith({
+      cwd: "/repo",
+      currentSessionFile: "/sessions/current.jsonl",
+      bank: "project-bank",
+      dryRun: true,
+    });
+    expect(importProjectSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it("previews gateway import after user setup before writing", async () => {
+    const ctx = {
+      ui: {
+        confirm: vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false),
+        select: vi.fn().mockResolvedValueOnce("Preview gateway transcript"),
+        input: vi.fn().mockResolvedValueOnce("/tmp/gateway.jsonl"),
+        notify: vi.fn(),
+      },
+    } as never;
+    const importGatewayTranscript = vi.fn().mockResolvedValueOnce({
+      bankId: "user-bank",
+      keptEventCount: 3,
+      retainedTurnCount: 1,
+      droppedEventCount: 2,
+      malformedLineCount: 0,
+      documentId: "doc",
+    });
+    const operations = {
+      importProjectSessions: vi.fn(),
+      importGatewayTranscript,
+    } as never;
+
+    await maybeOfferHistoricalImportForSetup({
+      ctx,
+      operations,
+      setupProfile: "global-only",
+      appliedProfiles: new Set(["assistant-personal"]),
+      cwd: "/repo",
+      globalBankId: "user-bank",
+    });
+
+    expect(importGatewayTranscript).toHaveBeenCalledWith({
+      sourceFile: "/tmp/gateway.jsonl",
+      cwd: "/repo",
+      bank: "user-bank",
+      dryRun: true,
+    });
+    expect(importGatewayTranscript).toHaveBeenCalledTimes(1);
   });
 
   it("uses existing configured global bank ID when profile enables global memory", () => {


### PR DESCRIPTION
## Summary
- offer historical import at the end of guided setup
- infer source ordering from applied bank template profiles while gating choices by setup bank/profile
- preview repo Pi session imports for project/coding setup and gateway transcript imports for user/assistant setup
- keep all setup-triggered imports dry-run-first with explicit apply confirmation
- document the guided setup import prompt

Refs #176.

## Review
- Pre-PR reviewer run: blocker found, fixed, final reviewer reports no blockers.

## Verification
- npm test -- tests/guided-setup.test.ts
- npm run check
- npm run typecheck:tsc
