### PR TITLE
feat(import): offer post-import mental model refresh

### DIFF
--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -36,7 +36,7 @@ Gateway preview output includes kept event count, retained user-turn count, drop
 
 ## Guided setup import prompt
 
-Guided setup offers historical import after config/template setup. It always previews first. Project/coding setup offers repo-scoped Pi session import; user/assistant setup offers gateway transcript import. You can skip and run the tools later.
+Guided setup offers historical import after config/template setup. It always previews first. Project/coding setup offers repo-scoped Pi session import; user/assistant setup offers gateway transcript import. After a successful setup import, Pi can explicitly refresh the target mental models from the selected bank template and shows returned operation IDs/status. You can skip import or refresh and run the tools later.
 
 ## Import commands
 

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -24,6 +24,7 @@ import {
   getBuiltInBankTemplate,
   summarizeBankTemplateManifest,
   type BankTemplateManifest,
+  type BankTemplateMentalModel,
   type BankTemplateProfileId,
   type BankTemplateTarget,
 } from "./bank-template-catalog.js";
@@ -78,6 +79,14 @@ interface TemplateTarget {
   location: "Project" | "User";
   bank: string;
   defaultTemplateTarget: BankTemplateTarget;
+}
+
+interface AppliedTemplateTarget {
+  bank: string;
+  location: "Project" | "User";
+  label: string;
+  profileId?: BankTemplateProfileId;
+  mentalModels: BankTemplateMentalModel[];
 }
 
 export function enabledTemplateTargets(args: {
@@ -255,19 +264,19 @@ async function maybeImportBankTemplate(args: {
   setupProfile: SetupProfileChoice;
   projectBankId?: string;
   globalBankId?: string;
-}): Promise<Set<BankTemplateProfileId>> {
+}): Promise<AppliedTemplateTarget[]> {
   const targets = enabledTemplateTargets(args);
   if (targets.length === 0) {
     args.ctx.ui.notify("No enabled bank target for template import.", "warning");
-    return new Set();
+    return [];
   }
   const configure = await args.ctx.ui.confirm(
     "Configure Hindsight bank templates?",
     targets.map((target) => `${target.location}: ${target.bank}`).join("\n"),
   );
-  if (!configure) return new Set();
+  if (!configure) return [];
 
-  const appliedProfiles = new Set<BankTemplateProfileId>();
+  const appliedTemplates: AppliedTemplateTarget[] = [];
   const client = args.deps.getClient();
   for (const target of targets) {
     const selected = await selectTemplateManifest({ ctx: args.ctx, target });
@@ -318,9 +327,15 @@ async function maybeImportBankTemplate(args: {
       `Imported ${selected.label} template into ${applied.bankId}: ${summarizeBankTemplateImportResult(applied.result)}`,
       "info",
     );
-    if (selected.profileId) appliedProfiles.add(selected.profileId);
+    appliedTemplates.push({
+      bank: applied.bankId,
+      location: target.location,
+      label: selected.label,
+      ...(selected.profileId ? { profileId: selected.profileId } : {}),
+      mentalModels: editedManifest.mental_models ?? [],
+    });
   }
-  return appliedProfiles;
+  return appliedTemplates;
 }
 
 export function importChoicesForSetup(args: {
@@ -349,11 +364,74 @@ export function importChoicesForSetup(args: {
   return choices;
 }
 
+function operationSummary(result: unknown): string {
+  if (typeof result !== "object" || !result) return "operation accepted";
+  const fields = result as {
+    operation_id?: unknown;
+    operationId?: unknown;
+    id?: unknown;
+    status?: unknown;
+  };
+  const id = [fields.operation_id, fields.operationId, fields.id].find(
+    (value): value is string => typeof value === "string" && Boolean(value.trim()),
+  );
+  const status =
+    typeof fields.status === "string" && fields.status.trim() ? fields.status.trim() : undefined;
+  return [id?.trim(), status].filter(Boolean).join(" / ") || "operation accepted";
+}
+
+async function maybeOfferMentalModelRefreshForSetup(args: {
+  ctx: ExtensionCommandContext;
+  operations: MemoryOperations;
+  bankId: string;
+  location: "Project" | "User";
+  appliedTemplates?: AppliedTemplateTarget[];
+}): Promise<void> {
+  const mentalModels = (args.appliedTemplates ?? [])
+    .filter((template) => template.bank === args.bankId && template.location === args.location)
+    .flatMap((template) => template.mentalModels);
+  if (mentalModels.length === 0) return;
+  const warnings = mentalModels.flatMap((model) =>
+    model.tags?.length
+      ? [`${model.name} uses tags [${model.tags.join(", ")}]; refresh only sees matching memories.`]
+      : [],
+  );
+  const confirmed = await args.ctx.ui.confirm(
+    `Refresh ${mentalModels.length} mental model${mentalModels.length === 1 ? "" : "s"} for ${args.location} bank ${args.bankId}?`,
+    [
+      "Source import is complete. Refresh is explicit and does not replace retained source material.",
+      "Target mental models:",
+      ...mentalModels.map((model) => `- ${model.name} (${model.id})`),
+      ...(warnings.length ? ["Warnings:", ...warnings.map((warning) => `- ${warning}`)] : []),
+    ].join("\n"),
+  );
+  if (!confirmed) return;
+  const refreshed: string[] = [];
+  const failed: string[] = [];
+  for (const model of mentalModels) {
+    try {
+      const result = await args.operations.refreshMentalModel({
+        bank: args.bankId,
+        mentalModelId: model.id,
+      });
+      refreshed.push(`${model.name}: ${operationSummary(result.result)}`);
+    } catch (error) {
+      failed.push(`${model.name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  if (refreshed.length) {
+    args.ctx.ui.notify(`Queued mental model refresh:\n${refreshed.join("\n")}`, "info");
+  }
+  if (failed.length) {
+    args.ctx.ui.notify(`Mental model refresh failed:\n${failed.join("\n")}`, "warning");
+  }
+}
+
 export async function maybeOfferHistoricalImportForSetup(args: {
   ctx: ExtensionCommandContext;
   operations: MemoryOperations;
   setupProfile: SetupProfileChoice;
-  appliedProfiles?: Set<BankTemplateProfileId>;
+  appliedTemplates?: AppliedTemplateTarget[];
   cwd: string;
   projectBankId?: string;
   globalBankId?: string;
@@ -363,11 +441,16 @@ export async function maybeOfferHistoricalImportForSetup(args: {
     "Imports always dry-run first. Project profiles use repo Pi sessions; user profiles can import gateway/chat transcripts.",
   );
   if (!proceed) return;
+  const appliedProfiles = new Set(
+    (args.appliedTemplates ?? [])
+      .map((template) => template.profileId)
+      .filter((profileId): profileId is BankTemplateProfileId => Boolean(profileId)),
+  );
   const choice = await args.ctx.ui.select(
     "Choose import source",
     importChoicesForSetup({
       setupProfile: args.setupProfile,
-      appliedProfiles: args.appliedProfiles ?? new Set(),
+      appliedProfiles,
       ...(args.projectBankId ? { projectBankId: args.projectBankId } : {}),
       ...(args.globalBankId ? { globalBankId: args.globalBankId } : {}),
     }),
@@ -401,6 +484,13 @@ export async function maybeOfferHistoricalImportForSetup(args: {
       `Imported repo Pi sessions into ${result.bankId}: sessions=${result.sessionFiles.length}; documents=${result.documentCount}; messages=${result.messageCount}`,
       "info",
     );
+    await maybeOfferMentalModelRefreshForSetup({
+      ctx: args.ctx,
+      operations: args.operations,
+      bankId: result.bankId,
+      location: "Project",
+      ...(args.appliedTemplates ? { appliedTemplates: args.appliedTemplates } : {}),
+    });
     return;
   }
 
@@ -429,6 +519,15 @@ export async function maybeOfferHistoricalImportForSetup(args: {
       : `Imported gateway transcript into ${result.bankId} as ${result.documentId}`,
     "info",
   );
+  if (!result.skipped) {
+    await maybeOfferMentalModelRefreshForSetup({
+      ctx: args.ctx,
+      operations: args.operations,
+      bankId: result.bankId,
+      location: "User",
+      ...(args.appliedTemplates ? { appliedTemplates: args.appliedTemplates } : {}),
+    });
+  }
 }
 
 export async function runGuidedSetup(args: {
@@ -488,7 +587,7 @@ export async function runGuidedSetup(args: {
   const result = await operations.configure(args.cwd, patch);
   args.ctx.ui.notify(`Wrote ${result.path}`, "info");
 
-  const appliedProfiles = await maybeImportBankTemplate({
+  const appliedTemplates = await maybeImportBankTemplate({
     ctx: args.ctx,
     deps: args.deps,
     operations,
@@ -501,7 +600,7 @@ export async function runGuidedSetup(args: {
     ctx: args.ctx,
     operations,
     setupProfile,
-    appliedProfiles,
+    appliedTemplates,
     cwd: args.cwd,
     ...(projectBankId !== undefined ? { projectBankId } : {}),
     ...(globalBankId !== undefined ? { globalBankId } : {}),

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -317,7 +317,15 @@ describe("guided setup", () => {
       ctx,
       operations,
       setupProfile: "global-only",
-      appliedProfiles: new Set(["assistant-personal"]),
+      appliedTemplates: [
+        {
+          bank: "user-bank",
+          location: "User",
+          label: "Assistant / Personal",
+          profileId: "assistant-personal",
+          mentalModels: [],
+        },
+      ],
       cwd: "/repo",
       globalBankId: "user-bank",
     });
@@ -329,6 +337,276 @@ describe("guided setup", () => {
       dryRun: true,
     });
     expect(importGatewayTranscript).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers mental model refresh after successful setup import", async () => {
+    const confirm = vi
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    const notify = vi.fn();
+    const ctx = {
+      ui: {
+        confirm,
+        select: vi.fn().mockResolvedValueOnce("Preview gateway transcript"),
+        input: vi.fn().mockResolvedValueOnce("/tmp/gateway.jsonl"),
+        notify,
+      },
+    } as never;
+    const importGatewayTranscript = vi
+      .fn()
+      .mockResolvedValueOnce({
+        bankId: "user-bank",
+        keptEventCount: 3,
+        retainedTurnCount: 1,
+        droppedEventCount: 2,
+        malformedLineCount: 0,
+        documentId: "doc",
+      })
+      .mockResolvedValueOnce({
+        bankId: "user-bank",
+        skipped: false,
+        documentId: "doc",
+      });
+    const refreshMentalModel = vi.fn().mockResolvedValueOnce({
+      bankId: "user-bank",
+      mentalModelId: "user-profile",
+      result: { operation_id: "op-123", status: "queued" },
+    });
+    const operations = {
+      importProjectSessions: vi.fn(),
+      importGatewayTranscript,
+      refreshMentalModel,
+    } as never;
+
+    await maybeOfferHistoricalImportForSetup({
+      ctx,
+      operations,
+      setupProfile: "global-only",
+      appliedTemplates: [
+        {
+          bank: "user-bank",
+          location: "User",
+          label: "Assistant / Personal",
+          profileId: "assistant-personal",
+          mentalModels: [
+            {
+              id: "user-profile",
+              name: "User Profile",
+              source_query: "What do we know?",
+              tags: ["profile"],
+            },
+          ],
+        },
+      ],
+      cwd: "/repo",
+      globalBankId: "user-bank",
+    });
+
+    expect(refreshMentalModel).toHaveBeenCalledWith({
+      bank: "user-bank",
+      mentalModelId: "user-profile",
+    });
+    expect(confirm).toHaveBeenNthCalledWith(
+      3,
+      "Refresh 1 mental model for User bank user-bank?",
+      expect.stringContaining(
+        "User Profile uses tags [profile]; refresh only sees matching memories.",
+      ),
+    );
+    expect(notify).toHaveBeenCalledWith(
+      "Queued mental model refresh:\nUser Profile: op-123 / queued",
+      "info",
+    );
+  });
+
+  it("skips mental model refresh when user declines", async () => {
+    const confirm = vi
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const ctx = {
+      ui: {
+        confirm,
+        select: vi.fn().mockResolvedValueOnce("Preview gateway transcript"),
+        input: vi.fn().mockResolvedValueOnce("/tmp/gateway.jsonl"),
+        notify: vi.fn(),
+      },
+    } as never;
+    const importGatewayTranscript = vi
+      .fn()
+      .mockResolvedValueOnce({
+        bankId: "user-bank",
+        keptEventCount: 1,
+        retainedTurnCount: 1,
+        droppedEventCount: 0,
+        malformedLineCount: 0,
+        documentId: "doc",
+      })
+      .mockResolvedValueOnce({ bankId: "user-bank", skipped: false, documentId: "doc" });
+    const refreshMentalModel = vi.fn();
+
+    await maybeOfferHistoricalImportForSetup({
+      ctx,
+      operations: {
+        importProjectSessions: vi.fn(),
+        importGatewayTranscript,
+        refreshMentalModel,
+      } as never,
+      setupProfile: "global-only",
+      appliedTemplates: [
+        {
+          bank: "user-bank",
+          location: "User",
+          label: "Assistant / Personal",
+          profileId: "assistant-personal",
+          mentalModels: [{ id: "user-profile", name: "User Profile", source_query: "q" }],
+        },
+      ],
+      cwd: "/repo",
+      globalBankId: "user-bank",
+    });
+
+    expect(refreshMentalModel).not.toHaveBeenCalled();
+  });
+
+  it("continues mental model refresh when one model fails", async () => {
+    const notify = vi.fn();
+    const ctx = {
+      ui: {
+        confirm: vi
+          .fn()
+          .mockResolvedValueOnce(true)
+          .mockResolvedValueOnce(true)
+          .mockResolvedValueOnce(true),
+        select: vi.fn().mockResolvedValueOnce("Preview gateway transcript"),
+        input: vi.fn().mockResolvedValueOnce("/tmp/gateway.jsonl"),
+        notify,
+      },
+    } as never;
+    const refreshMentalModel = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("refresh failed"))
+      .mockResolvedValueOnce({ result: { operation_id: "op-2", status: "queued" } });
+
+    await maybeOfferHistoricalImportForSetup({
+      ctx,
+      operations: {
+        importProjectSessions: vi.fn(),
+        importGatewayTranscript: vi
+          .fn()
+          .mockResolvedValueOnce({
+            bankId: "user-bank",
+            keptEventCount: 2,
+            retainedTurnCount: 1,
+            droppedEventCount: 0,
+            malformedLineCount: 0,
+            documentId: "doc",
+          })
+          .mockResolvedValueOnce({ bankId: "user-bank", skipped: false, documentId: "doc" }),
+        refreshMentalModel,
+      } as never,
+      setupProfile: "global-only",
+      appliedTemplates: [
+        {
+          bank: "user-bank",
+          location: "User",
+          label: "Assistant / Personal",
+          profileId: "assistant-personal",
+          mentalModels: [
+            { id: "first", name: "First", source_query: "q" },
+            { id: "second", name: "Second", source_query: "q" },
+          ],
+        },
+      ],
+      cwd: "/repo",
+      globalBankId: "user-bank",
+    });
+
+    expect(refreshMentalModel).toHaveBeenCalledTimes(2);
+    expect(notify).toHaveBeenCalledWith(
+      "Queued mental model refresh:\nSecond: op-2 / queued",
+      "info",
+    );
+    expect(notify).toHaveBeenCalledWith(
+      "Mental model refresh failed:\nFirst: refresh failed",
+      "warning",
+    );
+  });
+
+  it("refreshes only mental models for the imported setup location", async () => {
+    const confirm = vi
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    const ctx = {
+      sessionManager: { getSessionFile: () => "/sessions/current.jsonl" },
+      ui: {
+        confirm,
+        select: vi.fn().mockResolvedValueOnce("Preview repo Pi sessions"),
+        input: vi.fn(),
+        notify: vi.fn(),
+      },
+    } as never;
+    const importProjectSessions = vi
+      .fn()
+      .mockResolvedValueOnce({
+        bankId: "shared-bank",
+        sessionFiles: ["/sessions/current.jsonl"],
+        imported: [{ documents: [] }],
+        malformedLineCount: 0,
+        documentCount: 1,
+        messageCount: 2,
+      })
+      .mockResolvedValueOnce({
+        bankId: "shared-bank",
+        sessionFiles: ["/sessions/current.jsonl"],
+        documentCount: 1,
+        messageCount: 2,
+      });
+    const refreshMentalModel = vi.fn().mockResolvedValue({
+      bankId: "shared-bank",
+      result: { operation_id: "op-project" },
+    });
+    const operations = {
+      importProjectSessions,
+      importGatewayTranscript: vi.fn(),
+      refreshMentalModel,
+    } as never;
+
+    await maybeOfferHistoricalImportForSetup({
+      ctx,
+      operations,
+      setupProfile: "project-global",
+      appliedTemplates: [
+        {
+          bank: "shared-bank",
+          location: "Project",
+          label: "Coding / Project",
+          profileId: "coding-project",
+          mentalModels: [{ id: "project-context", name: "Project Context", source_query: "q" }],
+        },
+        {
+          bank: "shared-bank",
+          location: "User",
+          label: "Assistant / Personal",
+          profileId: "assistant-personal",
+          mentalModels: [{ id: "user-profile", name: "User Profile", source_query: "q" }],
+        },
+      ],
+      cwd: "/repo",
+      projectBankId: "shared-bank",
+      globalBankId: "shared-bank",
+    });
+
+    expect(refreshMentalModel).toHaveBeenCalledTimes(1);
+    expect(refreshMentalModel).toHaveBeenCalledWith({
+      bank: "shared-bank",
+      mentalModelId: "project-context",
+    });
   });
 
   it("uses existing configured global bank ID when profile enables global memory", () => {


### PR DESCRIPTION
## Summary
- after setup-triggered historical import, offer explicit mental model refresh for target models from the applied bank template
- keep refresh separate from source import and require user confirmation
- filter refresh targets by both bank ID and setup location to avoid shared-bank cross-refreshes
- show returned operation IDs and status values
- isolate per-model refresh failures while still showing queued successes
- document post-import refresh behavior

Refs #186.

## Review
- Pre-PR reviewer found shared-bank/status/test gaps; fixed.
- Final reviewer: no blockers.

## Verification
- npm test -- tests/guided-setup.test.ts
- npm run check
- npm run typecheck:tsc
