### PR TITLE
feat(bank-settings): add location presenter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,15 @@ Project config SecretRef shape:
 
 When a profile enables user memory without an existing bank ID, setup writes `pi-global` as the default user bank ID for compatibility. Override it with `PI_HINDSIGHT_USER_BANK_ID`, `.pi/hindsight.json` `banks.user.bankId`, or the setup TUI if you prefer a different shared bank. Legacy `PI_HINDSIGHT_GLOBAL_BANK_ID` and `banks.global` configs are migrated/supported during transition.
 
+## Bank settings display
+
+Pi Hindsight distinguishes local Pi behavior from bank-owned Hindsight settings. Setup and status surfaces show both:
+
+- `Location: Project` or `Location: User` describes the Pi memory route.
+- `Bank: <bank-id>` names the concrete Hindsight bank that owns missions, config overrides, mental models, and directives.
+
+Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config.
+
 ## Setup TUI
 
 Run:

--- a/extensions/bank-settings-presenter.ts
+++ b/extensions/bank-settings-presenter.ts
@@ -1,0 +1,72 @@
+import {
+  summarizeBankTemplateManifest,
+  type BankTemplateManifest,
+} from "./bank-template-catalog.js";
+import { isRecord } from "./client-rest.js";
+
+export type BankSettingsLocation = "Project" | "User";
+
+export interface BankSettingsTarget {
+  location: BankSettingsLocation;
+  bankId: string;
+}
+
+export interface BankSettingsTargetDisplay {
+  location: BankSettingsLocation;
+  bankId: string;
+  locationLabel: string;
+  bankLabel: string;
+  optionLabel: string;
+  reviewLine: string;
+}
+
+export function bankSettingsTargetDisplay(target: BankSettingsTarget): BankSettingsTargetDisplay {
+  return {
+    location: target.location,
+    bankId: target.bankId,
+    locationLabel: `Location: ${target.location}`,
+    bankLabel: `Bank: ${target.bankId}`,
+    optionLabel: `${target.location} bank (${target.bankId})`,
+    reviewLine: `${target.location} → Bank: ${target.bankId}`,
+  };
+}
+
+export function bankSettingsTargetLines(target: BankSettingsTarget): string[] {
+  const display = bankSettingsTargetDisplay(target);
+  return [display.locationLabel, display.bankLabel];
+}
+
+export function bankTemplateSummaryLines(manifest: BankTemplateManifest): string[] {
+  const summary = summarizeBankTemplateManifest(manifest);
+  return [
+    `Bank overrides: ${summary.bankOverrideCount}`,
+    `Mental models: ${summary.mentalModelCount}`,
+    `Directives: ${summary.directiveCount}`,
+  ];
+}
+
+function objectCount(value: unknown): number {
+  return isRecord(value) ? Object.keys(value).length : 0;
+}
+
+function arrayCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+export function exportedBankTemplateSummaryLines(manifest: unknown): string[] {
+  if (!isRecord(manifest)) return ["Bank overrides: 0", "Mental models: 0", "Directives: 0"];
+  return [
+    `Bank overrides: ${objectCount(manifest.bank)}`,
+    `Mental models: ${arrayCount(manifest.mental_models)}`,
+    `Directives: ${arrayCount(manifest.directives)}`,
+  ];
+}
+
+export function bankConfigOverrideSummaryLines(response: unknown): string[] {
+  if (!isRecord(response)) return ["Bank overrides: unavailable"];
+  const overrides = isRecord(response.overrides) ? response.overrides : undefined;
+  const config = isRecord(response.config) ? response.config : undefined;
+  const overrideCount = objectCount(overrides);
+  const resolvedCount = objectCount(config);
+  return [`Bank overrides: ${overrideCount}`, `Resolved config fields: ${resolvedCount}`];
+}

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -13,6 +13,11 @@ import {
   type BankTemplateEditorField,
 } from "./bank-template-editor.js";
 import {
+  bankSettingsTargetDisplay,
+  bankSettingsTargetLines,
+  bankTemplateSummaryLines,
+} from "./bank-settings-presenter.js";
+import {
   createMemoryOperations,
   type MemoryOperations,
   type MemoryOperationsDeps,
@@ -22,7 +27,6 @@ import {
   cloneBankTemplateManifest,
   defaultBankTemplateForTarget,
   getBuiltInBankTemplate,
-  summarizeBankTemplateManifest,
   type BankTemplateManifest,
   type BankTemplateMentalModel,
   type BankTemplateProfileId,
@@ -98,7 +102,8 @@ export function enabledTemplateTargets(args: {
     ...(args.setupProfile !== "global-only" && args.projectBankId
       ? [
           {
-            label: `Project bank (${args.projectBankId})`,
+            label: bankSettingsTargetDisplay({ location: "Project", bankId: args.projectBankId })
+              .optionLabel,
             location: "Project" as const,
             bank: args.projectBankId,
             defaultTemplateTarget: "project" as const,
@@ -108,7 +113,8 @@ export function enabledTemplateTargets(args: {
     ...(args.setupProfile !== "project-only" && args.globalBankId
       ? [
           {
-            label: `User bank (${args.globalBankId})`,
+            label: bankSettingsTargetDisplay({ location: "User", bankId: args.globalBankId })
+              .optionLabel,
             location: "User" as const,
             bank: args.globalBankId,
             defaultTemplateTarget: "user" as const,
@@ -159,12 +165,9 @@ function templateChoiceFromLabel(label: string): BankTemplateProfileId | undefin
 }
 
 function bankTemplateReview(manifest: BankTemplateManifest): string {
-  const summary = summarizeBankTemplateManifest(manifest);
   const warnings = mentalModelTagWarnings(manifest);
   return [
-    `Bank overrides: ${summary.bankOverrideCount}`,
-    `Mental models: ${summary.mentalModelCount}`,
-    `Directives: ${summary.directiveCount}`,
+    ...bankTemplateSummaryLines(manifest),
     ...(warnings.length ? ["Warnings:", ...warnings.map((warning) => `- ${warning}`)] : []),
   ].join("\n");
 }
@@ -272,7 +275,11 @@ async function maybeImportBankTemplate(args: {
   }
   const configure = await args.ctx.ui.confirm(
     "Configure Hindsight bank templates?",
-    targets.map((target) => `${target.location}: ${target.bank}`).join("\n"),
+    targets
+      .flatMap((target) =>
+        bankSettingsTargetLines({ location: target.location, bankId: target.bank }),
+      )
+      .join("\n"),
   );
   if (!configure) return [];
 
@@ -286,7 +293,12 @@ async function maybeImportBankTemplate(args: {
     if (exists) {
       const updateExisting = await args.ctx.ui.confirm(
         `Bank already exists: ${target.bank}`,
-        `Location: ${target.location}\nTemplate: ${selected.label}\n\nSetup preserves existing banks by default. Apply this template anyway?`,
+        [
+          ...bankSettingsTargetLines({ location: target.location, bankId: target.bank }),
+          `Template: ${selected.label}`,
+          "",
+          "Setup preserves existing banks by default. Apply this template anyway?",
+        ].join("\n"),
       );
       if (!updateExisting) {
         args.ctx.ui.notify(`Skipped existing bank ${target.bank}.`, "info");

--- a/extensions/status-health.ts
+++ b/extensions/status-health.ts
@@ -1,9 +1,17 @@
+import {
+  bankConfigOverrideSummaryLines,
+  bankSettingsTargetDisplay,
+} from "./bank-settings-presenter.js";
 import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
 import { redactError } from "./sanitize.js";
 
 export type StatusHealthFacts = Array<[string, string]>;
 
-type BankRoute = { label: "Project bank" | "User bank"; bankId: string };
+type BankRoute = {
+  label: "Project bank" | "User bank";
+  location: "Project" | "User";
+  bankId: string;
+};
 const STATUS_HEALTH_TIMEOUT_MS = 1_500;
 
 async function withStatusTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
@@ -38,10 +46,16 @@ function dateField(value: unknown, key: string): string | undefined {
 function bankRoutes(config: ResolvedConfig, projectBankId: string): BankRoute[] {
   return [
     ...(config.banks.project.enabled
-      ? [{ label: "Project bank" as const, bankId: projectBankId }]
+      ? [{ label: "Project bank" as const, location: "Project" as const, bankId: projectBankId }]
       : []),
     ...(config.banks.user.enabled && config.banks.user.bankId
-      ? [{ label: "User bank" as const, bankId: config.banks.user.bankId }]
+      ? [
+          {
+            label: "User bank" as const,
+            location: "User" as const,
+            bankId: config.banks.user.bankId,
+          },
+        ]
       : []),
   ];
 }
@@ -103,7 +117,8 @@ async function bankFact(client: HindsightLikeClient, route: BankRoute): Promise<
       : undefined;
     const name =
       isRecord(profile) && typeof profile.name === "string" ? profile.name : route.bankId;
-    const facts: StatusHealthFacts = [[route.label, `reachable · ${name}`]];
+    const target = bankSettingsTargetDisplay({ location: route.location, bankId: route.bankId });
+    const facts: StatusHealthFacts = [[route.label, `reachable · ${name} · ${target.reviewLine}`]];
     if (client.getBankConfig) {
       try {
         const config = await withStatusTimeout(
@@ -111,6 +126,8 @@ async function bankFact(client: HindsightLikeClient, route: BankRoute): Promise<
           `${route.label} config`,
         );
         const summary = formatMissionConfig(config);
+        const overrideSummary = bankConfigOverrideSummaryLines(config).join(" · ");
+        facts.push([`${route.label} config`, overrideSummary]);
         if (summary) facts.push([`${route.label} missions`, `db · ${summary}`]);
       } catch (error) {
         facts.push([`${route.label} missions`, `unavailable · ${redactError(error)}`]);

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -1,3 +1,4 @@
+import { exportedBankTemplateSummaryLines } from "./bank-settings-presenter.js";
 import type { MemoryOperations } from "./memory-operation-service.js";
 
 type ToolTextResponse<Details> = {
@@ -108,37 +109,17 @@ export function importToolResponse(result: ImportToolResult): ToolTextResponse<I
   return { content: [{ type: "text", text }], details: result };
 }
 
-function manifestCounts(manifest: unknown): {
-  bankOverrideCount: number;
-  mentalModelCount: number;
-  directiveCount: number;
-} {
-  if (typeof manifest !== "object" || !manifest || Array.isArray(manifest)) {
-    return { bankOverrideCount: 0, mentalModelCount: 0, directiveCount: 0 };
-  }
-  const record = manifest as Record<string, unknown>;
-  const bank = record.bank;
-  return {
-    bankOverrideCount:
-      typeof bank === "object" && bank !== null && !Array.isArray(bank)
-        ? Object.keys(bank).length
-        : 0,
-    mentalModelCount: Array.isArray(record.mental_models) ? record.mental_models.length : 0,
-    directiveCount: Array.isArray(record.directives) ? record.directives.length : 0,
-  };
-}
-
 export function exportBankTemplateToolResponse(
   result: ExportBankTemplateToolResult,
 ): ToolTextResponse<ExportBankTemplateToolResult> {
-  const counts = manifestCounts(result.manifest);
+  const summary = exportedBankTemplateSummaryLines(result.manifest).join("; ");
   return {
     content: [
       {
         type: "text",
         text: [
           `Exported bank template from ${result.bankId}.`,
-          `Bank overrides: ${counts.bankOverrideCount}; mental models: ${counts.mentalModelCount}; directives: ${counts.directiveCount}`,
+          summary,
           JSON.stringify(result.manifest, null, 2),
         ].join("\n"),
       },

--- a/tests/bank-settings-presenter.test.ts
+++ b/tests/bank-settings-presenter.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  bankConfigOverrideSummaryLines,
+  bankSettingsTargetDisplay,
+  bankSettingsTargetLines,
+  bankTemplateSummaryLines,
+  exportedBankTemplateSummaryLines,
+} from "../extensions/bank-settings-presenter.js";
+
+describe("bank settings presenter", () => {
+  it("shows concrete location and bank IDs", () => {
+    expect(bankSettingsTargetDisplay({ location: "Project", bankId: "project-bank" })).toEqual({
+      location: "Project",
+      bankId: "project-bank",
+      locationLabel: "Location: Project",
+      bankLabel: "Bank: project-bank",
+      optionLabel: "Project bank (project-bank)",
+      reviewLine: "Project → Bank: project-bank",
+    });
+    expect(bankSettingsTargetLines({ location: "User", bankId: "user-bank" })).toEqual([
+      "Location: User",
+      "Bank: user-bank",
+    ]);
+  });
+
+  it("summarizes template-owned bank settings", () => {
+    expect(
+      bankTemplateSummaryLines({
+        version: "1",
+        bank: { retain_mission: "Remember project decisions", enable_observations: true },
+        mental_models: [
+          { id: "project-context", name: "Project Context", source_query: "What matters?" },
+        ],
+        directives: [{ name: "rule", content: "Prefer source facts." }],
+      }),
+    ).toEqual(["Bank overrides: 2", "Mental models: 1", "Directives: 1"]);
+  });
+
+  it("summarizes exported manifests and resolved config responses", () => {
+    expect(
+      exportedBankTemplateSummaryLines({
+        bank: { retain_mission: "x" },
+        mental_models: [{ id: "m" }],
+        directives: [{ name: "d" }, { name: "e" }],
+      }),
+    ).toEqual(["Bank overrides: 1", "Mental models: 1", "Directives: 2"]);
+    expect(
+      bankConfigOverrideSummaryLines({
+        config: { retain_mission: "resolved", reflect_mission: "resolved" },
+        overrides: { retain_mission: "override" },
+      }),
+    ).toEqual(["Bank overrides: 1", "Resolved config fields: 2"]);
+  });
+});

--- a/tests/status-health.test.ts
+++ b/tests/status-health.test.ts
@@ -46,8 +46,10 @@ describe("status health", () => {
     expect(facts).toEqual(
       expect.arrayContaining([
         ["Server", "reachable"],
-        ["Project bank", "reachable · project-bank name"],
-        ["User bank", "reachable · global-bank name"],
+        ["Project bank", "reachable · project-bank name · Project → Bank: project-bank"],
+        ["User bank", "reachable · global-bank name · User → Bank: global-bank"],
+        ["Project bank config", "Bank overrides: 1 · Resolved config fields: 2"],
+        ["User bank config", "Bank overrides: 1 · Resolved config fields: 2"],
         ["Project bank missions", "db · retain Override retain from db · reflect Reflect from db"],
         ["Project bank stats", "memories 3 · docs 2 · observations 1 · pending 4 · failed 0"],
       ]),


### PR DESCRIPTION
## Summary
- add shared bank settings presenter for Location + concrete Bank vocabulary
- reuse presenter in guided setup target labels, template prompts, and review summaries
- add config override/resolved-field summaries to status health facts
- reuse exported-template summary lines in export tool output
- document bank-owned settings display vocabulary

Refs #188.

## Review
- Pre-PR reviewer found inconsistent setup prompt wording and missing user config assertion; fixed.
- Final reviewer: no blockers.

## Verification
- npm test -- tests/bank-settings-presenter.test.ts tests/guided-setup.test.ts tests/status-health.test.ts tests/operation-catalog.test.ts
- npm run check
- npm run typecheck:tsc
