### PR TITLE
feat(bank-settings): add config reset tools

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ Pi Hindsight distinguishes local Pi behavior from bank-owned Hindsight settings.
 - `Location: Project` or `Location: User` describes the Pi memory route.
 - `Bank: <bank-id>` names the concrete Hindsight bank that owns missions, config overrides, mental models, and directives.
 
-Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config.
+Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config. Use `hindsight_get_bank_config` to inspect resolved bank config and override counts. Use `hindsight_reset_bank_config` only when you intentionally want to clear bank config overrides and fall back to Hindsight defaults/template state.
 
 ## Setup TUI
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -79,6 +79,22 @@ Write project Hindsight config (.pi/hindsight.json), including project bank over
 | `enabled`          | boolean | no       | Enable or disable Hindsight extension.                           |
 | `queuePath`        | string  | no       | Retain queue path. Defaults to .pi/hindsight/retain-queue.jsonl. |
 
+### `hindsight_get_bank_config`
+
+Read resolved Hindsight bank config and override counts for a selected bank.
+
+| Parameter | Type   | Required | Description                                 |
+| --------- | ------ | -------- | ------------------------------------------- |
+| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_reset_bank_config`
+
+Reset Hindsight bank config overrides for a selected bank.
+
+| Parameter | Type   | Required | Description                                 |
+| --------- | ------ | -------- | ------------------------------------------- |
+| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+
 ### `hindsight_export_bank_template`
 
 Export a portable Hindsight bank template manifest for reuse in another project or bank.

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -77,7 +77,11 @@ Required tools:
 Additional tools:
 
 - `hindsight_configure`
+- `hindsight_get_bank_config`
+- `hindsight_reset_bank_config`
+- `hindsight_export_bank_template`
 - `hindsight_import`
+- `hindsight_import_gateway`
 - `hindsight_retain_global`
 - `hindsight_route_memory`
 - `hindsight_retain_receipts`

--- a/extensions/bank-config-operations.ts
+++ b/extensions/bank-config-operations.ts
@@ -1,0 +1,36 @@
+import { resolveOperationBank } from "./bank-selection.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+
+function unavailable(name: string): Error {
+  return new Error(`Hindsight client does not support bank config ${name}.`);
+}
+
+export function createBankConfigOperations(deps: MemoryOperationsDeps) {
+  return {
+    async getBankConfig(args: { bank?: string } = {}) {
+      const client = deps.getClient();
+      if (!client.getBankConfig) throw unavailable("read");
+      const bankId = resolveOperationBank({
+        requestedBank: args.bank,
+        config: deps.getConfig(),
+        projectBankId: deps.getProjectBankId(),
+      });
+      const result = await client.getBankConfig(bankId);
+      return { bankId, result };
+    },
+
+    async resetBankConfig(args: { bank?: string } = {}) {
+      const client = deps.getClient();
+      if (!client.resetBankConfig) throw unavailable("reset");
+      const bankId = resolveOperationBank({
+        requestedBank: args.bank,
+        config: deps.getConfig(),
+        projectBankId: deps.getProjectBankId(),
+      });
+      const before = client.getBankConfig ? await client.getBankConfig(bankId) : undefined;
+      const result = await client.resetBankConfig(bankId);
+      const after = client.getBankConfig ? await client.getBankConfig(bankId) : undefined;
+      return { bankId, before, result, after };
+    },
+  };
+}

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -101,6 +101,10 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
           body: JSON.stringify(updateBankConfigRequestBody(updates)),
         }),
       ),
+    resetBankConfig: (bankId) =>
+      withTimeout("hindsight resetBankConfig", timeoutMs, (signal) =>
+        rest.request(bankConfigPath(bankId), { method: "DELETE", signal }),
+      ),
     health: () =>
       withTimeout("hindsight health", timeoutMs, async (signal) =>
         assertHealthResponse(await rest.request("/health", { signal })),

--- a/extensions/memory-operation-service.ts
+++ b/extensions/memory-operation-service.ts
@@ -4,6 +4,7 @@ import {
   importMemoryProjectSessions,
   importMemorySession,
 } from "./import-operations.js";
+import { createBankConfigOperations } from "./bank-config-operations.js";
 import { createBankTemplateOperations } from "./bank-template-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
 import { createDocumentOperations } from "./memory-document-operations.js";
@@ -57,6 +58,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createDocumentOperations(deps),
     ...createRoutingOperations(deps),
     ...createConfigOperations(deps),
+    ...createBankConfigOperations(deps),
     ...createBankTemplateOperations(deps),
     ...createMentalModelOperations(deps),
     ...createImportOperations(deps),

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -12,7 +12,9 @@ import {
   deleteDocumentToolResponse,
   exportBankTemplateToolResponse,
   gatewayImportToolResponse,
+  getBankConfigToolResponse,
   importToolResponse,
+  resetBankConfigToolResponse,
   retainReceiptListToolResponse,
   retainToolResponse,
   routeMemoryToolResponse,
@@ -226,6 +228,36 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         useCwd(ctx.cwd);
         const result = await operations.configure(ctx.cwd, params);
         return configureToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_bank_config",
+      label: "Hindsight Get Bank Config",
+      description: "Read resolved Hindsight bank config and override counts for a selected bank.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getBankConfig(params.bank ? { bank: params.bank } : {});
+        return getBankConfigToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_reset_bank_config",
+      label: "Hindsight Reset Bank Config",
+      description: "Reset Hindsight bank config overrides for a selected bank.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.resetBankConfig(params.bank ? { bank: params.bank } : {});
+        return resetBankConfigToolResponse(result);
       },
     }),
     defineCatalogTool({

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -1,4 +1,7 @@
-import { exportedBankTemplateSummaryLines } from "./bank-settings-presenter.js";
+import {
+  bankConfigOverrideSummaryLines,
+  exportedBankTemplateSummaryLines,
+} from "./bank-settings-presenter.js";
 import type { MemoryOperations } from "./memory-operation-service.js";
 
 type ToolTextResponse<Details> = {
@@ -17,6 +20,8 @@ export type GatewayImportToolResult = Awaited<
 export type ExportBankTemplateToolResult = Awaited<
   ReturnType<MemoryOperations["exportBankTemplate"]>
 >;
+export type GetBankConfigToolResult = Awaited<ReturnType<MemoryOperations["getBankConfig"]>>;
+export type ResetBankConfigToolResult = Awaited<ReturnType<MemoryOperations["resetBankConfig"]>>;
 export type RetainReceiptListResult = Awaited<ReturnType<MemoryOperations["listRetainReceipts"]>>;
 
 export function retainToolResponse(result: RetainToolResult): ToolTextResponse<RetainToolResult> {
@@ -107,6 +112,48 @@ export function importToolResponse(result: ImportToolResult): ToolTextResponse<I
     ? `Import preview: ${result.messageCount} messages would write ${result.documents.length} ${documentLabel} to ${result.bankId}. First document: ${result.documentId}. Manifest unchanged: ${result.manifestPath}.`
     : `Imported ${result.messageCount} messages into ${result.bankId} as ${result.documentId}. Manifest: ${result.manifestPath}.`;
   return { content: [{ type: "text", text }], details: result };
+}
+
+export function getBankConfigToolResponse(
+  result: GetBankConfigToolResult,
+): ToolTextResponse<GetBankConfigToolResult> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Read bank config for ${result.bankId}.`,
+          bankConfigOverrideSummaryLines(result.result).join("; "),
+          JSON.stringify(result.result, null, 2),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function resetBankConfigToolResponse(
+  result: ResetBankConfigToolResult,
+): ToolTextResponse<ResetBankConfigToolResult> {
+  const before = result.before
+    ? bankConfigOverrideSummaryLines(result.before).join("; ")
+    : "unavailable";
+  const after = result.after
+    ? bankConfigOverrideSummaryLines(result.after).join("; ")
+    : "unavailable";
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Reset bank config overrides for ${result.bankId}.`,
+          `Before: ${before}`,
+          `After: ${after}`,
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
 }
 
 export function exportBankTemplateToolResponse(

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -293,6 +293,7 @@ export interface HindsightLikeClient {
   getBankStats?(bankId: string): Promise<unknown>;
   getBankConfig?(bankId: string): Promise<unknown>;
   updateBankConfig?(bankId: string, updates: Record<string, unknown>): Promise<unknown>;
+  resetBankConfig?(bankId: string): Promise<unknown>;
   health?(): Promise<unknown>;
   deleteDocument?(bankId: string, documentId: string): Promise<unknown>;
   importBankTemplate?(

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -75,6 +75,10 @@ describe("Hindsight client adapter integration", () => {
         sendJson(res, 200, { updated: true });
         return;
       }
+      if (req.method === "DELETE" && req.url === "/v1/default/banks/test-bank/config") {
+        sendJson(res, 200, { reset: true });
+        return;
+      }
       if (
         req.method === "GET" &&
         req.url ===
@@ -181,6 +185,7 @@ describe("Hindsight client adapter integration", () => {
     const bankConfigUpdate = await client.updateBankConfig?.("test-bank", {
       retain_custom_instructions: "Write to db",
     });
+    const bankConfigReset = await client.resetBankConfig?.("test-bank");
     const models = await client.listMentalModels?.("test-bank", {
       tags: ["source:pi"],
       tagsMatch: "all",
@@ -209,6 +214,7 @@ describe("Hindsight client adapter integration", () => {
     expect(exportedTemplate).toEqual({ version: "1", bank: { retain_mission: "Exported" } });
     expect(bankConfig).toEqual({ config: { retain_custom_instructions: "Read from db" } });
     expect(bankConfigUpdate).toEqual({ updated: true });
+    expect(bankConfigReset).toEqual({ reset: true });
     expect(models).toEqual({ items: [{ id: "model-1", name: "Model" }] });
     expect(model).toEqual({ id: "model-1", name: "Model", content: "full" });
     expect(createdModel).toEqual({ operation_id: "create-op", status: "queued" });
@@ -228,6 +234,7 @@ describe("Hindsight client adapter integration", () => {
       "GET /v1/default/banks/test-bank/export",
       "GET /v1/default/banks/test-bank/config",
       "PATCH /v1/default/banks/test-bank/config",
+      "DELETE /v1/default/banks/test-bank/config",
       "GET /v1/default/banks/test-bank/mental-models?tags=source%3Api&tags_match=all&detail=metadata&limit=10&offset=2",
       "GET /v1/default/banks/test-bank/mental-models/model-1?detail=full",
       "POST /v1/default/banks/test-bank/mental-models",
@@ -285,12 +292,12 @@ describe("Hindsight client adapter integration", () => {
     expect(requests[9]?.body).toEqual({
       updates: { retain_custom_instructions: "Write to db" },
     });
-    expect(requests[12]?.body).toEqual({
+    expect(requests[13]?.body).toEqual({
       name: "Model",
       source_query: "What should recur?",
       tags: ["source:pi"],
       max_tokens: 256,
     });
-    expect(requests[13]?.body).toEqual({ source_query: "Updated query", tags: null });
+    expect(requests[14]?.body).toEqual({ source_query: "Updated query", tags: null });
   });
 });

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -155,6 +155,25 @@ describe("memory operations", () => {
     ]);
   });
 
+  it("reports unavailable bank config APIs", async () => {
+    const operations = createMemoryOperations({
+      getClient: () => ({
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+      }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    await expect(operations.getBankConfig({ bank: "project" })).rejects.toThrow(
+      "Hindsight client does not support bank config read.",
+    );
+    await expect(operations.resetBankConfig({ bank: "project" })).rejects.toThrow(
+      "Hindsight client does not support bank config reset.",
+    );
+  });
+
   it("resolves project/global bank aliases for explicit operations", async () => {
     const calls: Array<{ method: string; bank: string; request?: unknown }> = [];
     const config = {
@@ -178,6 +197,14 @@ describe("memory operations", () => {
         deleteDocument: async (bank) => {
           calls.push({ method: "delete", bank });
           return {};
+        },
+        getBankConfig: async (bank) => {
+          calls.push({ method: "getBankConfig", bank });
+          return { config: {}, overrides: {} };
+        },
+        resetBankConfig: async (bank) => {
+          calls.push({ method: "resetBankConfig", bank });
+          return { ok: true };
         },
         listMentalModels: async (bank) => {
           calls.push({ method: "listMentalModels", bank });
@@ -206,6 +233,8 @@ describe("memory operations", () => {
     });
     await operations.reflect(cwd, "query", undefined, "project");
     await operations.deleteDocument({ bank: "global", documentId: "doc" });
+    await operations.getBankConfig({ bank: "global" });
+    await operations.resetBankConfig({ bank: "global" });
     await operations.listMentalModels({ bank: "global" });
     await operations.createMentalModel({
       bank: "project",
@@ -240,6 +269,9 @@ describe("memory operations", () => {
         { method: "retain", bank: "global-luxus" },
         { method: "reflect", bank: "project-bank" },
         { method: "delete", bank: "global-luxus" },
+        { method: "getBankConfig", bank: "global-luxus" },
+        { method: "resetBankConfig", bank: "global-luxus" },
+        { method: "getBankConfig", bank: "global-luxus" },
         { method: "listMentalModels", bank: "global-luxus" },
         {
           method: "createMentalModel",

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -8,6 +8,8 @@ function client(): HindsightLikeClient {
     retain: async () => undefined,
     recall: async () => [],
     reflect: async () => ({}),
+    getBankConfig: async () => ({ config: {}, overrides: {} }),
+    resetBankConfig: async () => ({ ok: true }),
     exportBankTemplate: async () => ({ version: "1" }),
   };
 }
@@ -28,6 +30,8 @@ describe("operation catalog", () => {
       "hindsight_route_memory",
       "hindsight_delete_document",
       "hindsight_configure",
+      "hindsight_get_bank_config",
+      "hindsight_reset_bank_config",
       "hindsight_export_bank_template",
       "hindsight_import",
       "hindsight_import_gateway",


### PR DESCRIPTION
## Summary
- add bank config get/reset operation layer with shared bank alias resolution
- expose `hindsight_get_bank_config` and `hindsight_reset_bank_config` tools
- add client adapter support for `DELETE /v1/default/banks/{bank}/config`
- present resolved config/override counts before and after reset using the shared bank settings presenter
- document bank-owned config inspection/reset behavior and regenerate surface reference

Refs #190.

## Review
- Pre-PR reviewer found fallback wording and unavailable API test gaps; fixed.
- Final reviewer: no blockers.

## Verification
- npm test -- tests/memory-operations.test.ts tests/operation-catalog.test.ts tests/client-integration.test.ts tests/bank-settings-presenter.test.ts
- npm run check
- npm run typecheck:tsc
