### PR TITLE
feat(bank-templates): add schema fetch tool

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ Pi Hindsight distinguishes local Pi behavior from bank-owned Hindsight settings.
 - `Location: Project` or `Location: User` describes the Pi memory route.
 - `Bank: <bank-id>` names the concrete Hindsight bank that owns missions, config overrides, mental models, and directives.
 
-Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config. Use `hindsight_get_bank_config` to inspect resolved bank config and override counts. Use `hindsight_reset_bank_config` only when you intentionally want to clear bank config overrides and fall back to Hindsight defaults/template state.
+Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config. Use `hindsight_get_bank_config` to inspect resolved bank config and override counts. Use `hindsight_reset_bank_config` only when you intentionally want to clear bank config overrides and fall back to Hindsight defaults/template state. Use `hindsight_get_bank_template_schema` to fetch the server JSON Schema for portable bank template manifests.
 
 ## Setup TUI
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -95,6 +95,13 @@ Reset Hindsight bank config overrides for a selected bank.
 | --------- | ------ | -------- | ------------------------------------------- |
 | `bank`    | string | no       | Optional bank id. Defaults to project bank. |
 
+### `hindsight_get_bank_template_schema`
+
+Fetch the Hindsight bank-template JSON Schema used to validate portable manifests.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+
 ### `hindsight_export_bank_template`
 
 Export a portable Hindsight bank template manifest for reuse in another project or bank.

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -79,6 +79,7 @@ Additional tools:
 - `hindsight_configure`
 - `hindsight_get_bank_config`
 - `hindsight_reset_bank_config`
+- `hindsight_get_bank_template_schema`
 - `hindsight_export_bank_template`
 - `hindsight_import`
 - `hindsight_import_gateway`

--- a/extensions/bank-template-operations.ts
+++ b/extensions/bank-template-operations.ts
@@ -54,6 +54,15 @@ export function summarizeBankTemplateImportResult(result: unknown): string {
 
 export function createBankTemplateOperations(deps: MemoryOperationsDeps) {
   return {
+    async getBankTemplateSchema() {
+      const client = deps.getClient();
+      if (!client.getBankTemplateSchema) {
+        throw new Error("Hindsight client does not support bank template schema fetch.");
+      }
+      const schema = await client.getBankTemplateSchema();
+      return { schema };
+    },
+
     async exportBankTemplate(args: { bank?: string }) {
       const client = deps.getClient();
       if (!client.exportBankTemplate)

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -110,6 +110,10 @@ export function bankTemplateExportPath(bankId: string): string {
   return encodeBankPath(bankId, "/export");
 }
 
+export function bankTemplateSchemaPath(): string {
+  return "/v1/bank-template-schema";
+}
+
 export function updateBankConfigRequestBody(
   updates: Record<string, unknown>,
 ): Record<string, unknown> {

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -7,6 +7,7 @@ import {
   bankConfigPath,
   bankTemplateExportPath,
   bankTemplateImportPath,
+  bankTemplateSchemaPath,
   createHindsightRestTransport,
   createMentalModelRequestBody,
   encodeBankPath,
@@ -118,7 +119,7 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
       ),
     // The installed high-level SDK does not export bank-template helpers. Its generated
     // import helper also exposes no typed body because the server endpoint accepts raw JSON.
-    // Keep a narrow REST shim for template import/export until the public SDK wraps them.
+    // Keep a narrow REST shim for template import/export/schema until the public SDK wraps them.
     importBankTemplate: (bankId, manifest, options) =>
       withTimeout("hindsight importBankTemplate", timeoutMs, (signal) =>
         rest.request(bankTemplateImportPath(bankId, options), {
@@ -135,6 +136,10 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
           (await rest.request(bankTemplateExportPath(bankId), {
             signal,
           })) as import("./bank-template-catalog.js").BankTemplateManifest,
+      ),
+    getBankTemplateSchema: () =>
+      withTimeout("hindsight getBankTemplateSchema", timeoutMs, (signal) =>
+        rest.request(bankTemplateSchemaPath(), { signal }),
       ),
     listMentalModels: (bankId, options) =>
       withTimeout("hindsight listMentalModels", timeoutMs, (signal) =>

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -13,6 +13,7 @@ import {
   exportBankTemplateToolResponse,
   gatewayImportToolResponse,
   getBankConfigToolResponse,
+  getBankTemplateSchemaToolResponse,
   importToolResponse,
   resetBankConfigToolResponse,
   retainReceiptListToolResponse,
@@ -258,6 +259,18 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         useCwd(ctx.cwd);
         const result = await operations.resetBankConfig(params.bank ? { bank: params.bank } : {});
         return resetBankConfigToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_bank_template_schema",
+      label: "Hindsight Get Bank Template Schema",
+      description:
+        "Fetch the Hindsight bank-template JSON Schema used to validate portable manifests.",
+      parameters: Type.Object({}),
+      async execute(_id, _params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getBankTemplateSchema();
+        return getBankTemplateSchemaToolResponse(result);
       },
     }),
     defineCatalogTool({

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -17,6 +17,9 @@ export type ImportToolResult = Awaited<ReturnType<MemoryOperations["importSessio
 export type GatewayImportToolResult = Awaited<
   ReturnType<MemoryOperations["importGatewayTranscript"]>
 >;
+export type GetBankTemplateSchemaToolResult = Awaited<
+  ReturnType<MemoryOperations["getBankTemplateSchema"]>
+>;
 export type ExportBankTemplateToolResult = Awaited<
   ReturnType<MemoryOperations["exportBankTemplate"]>
 >;
@@ -112,6 +115,37 @@ export function importToolResponse(result: ImportToolResult): ToolTextResponse<I
     ? `Import preview: ${result.messageCount} messages would write ${result.documents.length} ${documentLabel} to ${result.bankId}. First document: ${result.documentId}. Manifest unchanged: ${result.manifestPath}.`
     : `Imported ${result.messageCount} messages into ${result.bankId} as ${result.documentId}. Manifest: ${result.manifestPath}.`;
   return { content: [{ type: "text", text }], details: result };
+}
+
+function schemaSummary(schema: unknown): string {
+  if (typeof schema !== "object" || !schema || Array.isArray(schema))
+    return "Schema fields: unavailable";
+  const record = schema as Record<string, unknown>;
+  const title = typeof record.title === "string" ? record.title : "Bank template schema";
+  const properties = record.properties;
+  const propertyCount =
+    typeof properties === "object" && properties && !Array.isArray(properties)
+      ? Object.keys(properties).length
+      : 0;
+  return `${title}; top-level fields: ${propertyCount}`;
+}
+
+export function getBankTemplateSchemaToolResponse(
+  result: GetBankTemplateSchemaToolResult,
+): ToolTextResponse<GetBankTemplateSchemaToolResult> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          "Fetched Hindsight bank template JSON Schema.",
+          schemaSummary(result.schema),
+          JSON.stringify(result.schema, null, 2),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
 }
 
 export function getBankConfigToolResponse(

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -302,6 +302,7 @@ export interface HindsightLikeClient {
     options?: { dryRun?: boolean },
   ): Promise<unknown>;
   exportBankTemplate?(bankId: string): Promise<BankTemplateManifest>;
+  getBankTemplateSchema?(): Promise<unknown>;
   listMentalModels?(bankId: string, options?: ListMentalModelsOptions): Promise<unknown>;
   getMentalModel?(
     bankId: string,

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -67,6 +67,10 @@ describe("Hindsight client adapter integration", () => {
         sendJson(res, 200, { version: "1", bank: { retain_mission: "Exported" } });
         return;
       }
+      if (req.method === "GET" && req.url === "/v1/bank-template-schema") {
+        sendJson(res, 200, { title: "BankTemplateManifest", properties: { version: {} } });
+        return;
+      }
       if (req.method === "GET" && req.url === "/v1/default/banks/test-bank/config") {
         sendJson(res, 200, { config: { retain_custom_instructions: "Read from db" } });
         return;
@@ -181,6 +185,7 @@ describe("Hindsight client adapter integration", () => {
       { dryRun: true },
     );
     const exportedTemplate = await client.exportBankTemplate?.("test-bank");
+    const bankTemplateSchema = await client.getBankTemplateSchema?.();
     const bankConfig = await client.getBankConfig?.("test-bank");
     const bankConfigUpdate = await client.updateBankConfig?.("test-bank", {
       retain_custom_instructions: "Write to db",
@@ -212,6 +217,10 @@ describe("Hindsight client adapter integration", () => {
     expect(reflection).toEqual({ text: "reflection" });
     expect(templateDryRun).toEqual({ dry_run: true, config_applied: true });
     expect(exportedTemplate).toEqual({ version: "1", bank: { retain_mission: "Exported" } });
+    expect(bankTemplateSchema).toEqual({
+      title: "BankTemplateManifest",
+      properties: { version: {} },
+    });
     expect(bankConfig).toEqual({ config: { retain_custom_instructions: "Read from db" } });
     expect(bankConfigUpdate).toEqual({ updated: true });
     expect(bankConfigReset).toEqual({ reset: true });
@@ -232,6 +241,7 @@ describe("Hindsight client adapter integration", () => {
       "POST /v1/default/banks/test-bank/reflect",
       "POST /v1/default/banks/test-bank/import?dry_run=true",
       "GET /v1/default/banks/test-bank/export",
+      "GET /v1/bank-template-schema",
       "GET /v1/default/banks/test-bank/config",
       "PATCH /v1/default/banks/test-bank/config",
       "DELETE /v1/default/banks/test-bank/config",
@@ -289,15 +299,15 @@ describe("Hindsight client adapter integration", () => {
       version: "1",
       bank: { retain_mission: "Retain useful facts." },
     });
-    expect(requests[9]?.body).toEqual({
+    expect(requests[10]?.body).toEqual({
       updates: { retain_custom_instructions: "Write to db" },
     });
-    expect(requests[13]?.body).toEqual({
+    expect(requests[14]?.body).toEqual({
       name: "Model",
       source_query: "What should recur?",
       tags: ["source:pi"],
       max_tokens: 256,
     });
-    expect(requests[14]?.body).toEqual({ source_query: "Updated query", tags: null });
+    expect(requests[15]?.body).toEqual({ source_query: "Updated query", tags: null });
   });
 });

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -5,6 +5,7 @@ import {
   bankConfigPath,
   bankTemplateExportPath,
   bankTemplateImportPath,
+  bankTemplateSchemaPath,
   createMentalModelRequestBody,
   encodeBankPath,
   mentalModelCollectionPath,
@@ -43,6 +44,7 @@ describe("Hindsight REST transport helpers", () => {
       "/v1/default/banks/bank%2Fid/import?dry_run=true",
     );
     expect(bankTemplateExportPath("bank/id")).toBe("/v1/default/banks/bank%2Fid/export");
+    expect(bankTemplateSchemaPath()).toBe("/v1/bank-template-schema");
     expect(
       updateBankConfigRequestBody({ retain_custom_instructions: "Extract carefully" }),
     ).toEqual({

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -172,6 +172,9 @@ describe("memory operations", () => {
     await expect(operations.resetBankConfig({ bank: "project" })).rejects.toThrow(
       "Hindsight client does not support bank config reset.",
     );
+    await expect(operations.getBankTemplateSchema()).rejects.toThrow(
+      "Hindsight client does not support bank template schema fetch.",
+    );
   });
 
   it("resolves project/global bank aliases for explicit operations", async () => {
@@ -206,6 +209,10 @@ describe("memory operations", () => {
           calls.push({ method: "resetBankConfig", bank });
           return { ok: true };
         },
+        getBankTemplateSchema: async () => {
+          calls.push({ method: "getBankTemplateSchema", bank: "none" });
+          return { title: "BankTemplateManifest" };
+        },
         listMentalModels: async (bank) => {
           calls.push({ method: "listMentalModels", bank });
           return { items: [] };
@@ -235,6 +242,7 @@ describe("memory operations", () => {
     await operations.deleteDocument({ bank: "global", documentId: "doc" });
     await operations.getBankConfig({ bank: "global" });
     await operations.resetBankConfig({ bank: "global" });
+    await operations.getBankTemplateSchema();
     await operations.listMentalModels({ bank: "global" });
     await operations.createMentalModel({
       bank: "project",
@@ -272,6 +280,7 @@ describe("memory operations", () => {
         { method: "getBankConfig", bank: "global-luxus" },
         { method: "resetBankConfig", bank: "global-luxus" },
         { method: "getBankConfig", bank: "global-luxus" },
+        { method: "getBankTemplateSchema", bank: "none" },
         { method: "listMentalModels", bank: "global-luxus" },
         {
           method: "createMentalModel",

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -10,6 +10,7 @@ function client(): HindsightLikeClient {
     reflect: async () => ({}),
     getBankConfig: async () => ({ config: {}, overrides: {} }),
     resetBankConfig: async () => ({ ok: true }),
+    getBankTemplateSchema: async () => ({ title: "BankTemplateManifest", properties: {} }),
     exportBankTemplate: async () => ({ version: "1" }),
   };
 }
@@ -32,6 +33,7 @@ describe("operation catalog", () => {
       "hindsight_configure",
       "hindsight_get_bank_config",
       "hindsight_reset_bank_config",
+      "hindsight_get_bank_template_schema",
       "hindsight_export_bank_template",
       "hindsight_import",
       "hindsight_import_gateway",

--- a/tests/tool-presenters.test.ts
+++ b/tests/tool-presenters.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { getBankTemplateSchemaToolResponse } from "../extensions/tool-presenters.js";
+
+describe("tool presenters", () => {
+  it("presents bank template schema summary and raw JSON", () => {
+    const result = {
+      schema: {
+        title: "BankTemplateManifest",
+        properties: {
+          version: { type: "string" },
+          bank: { type: "object" },
+        },
+      },
+    };
+
+    const response = getBankTemplateSchemaToolResponse(result);
+
+    expect(response.details).toBe(result);
+    expect(response.content[0]?.text).toContain("Fetched Hindsight bank template JSON Schema.");
+    expect(response.content[0]?.text).toContain("BankTemplateManifest; top-level fields: 2");
+    expect(response.content[0]?.text).toContain('"version"');
+  });
+});


### PR DESCRIPTION
## Summary
- add `hindsight_get_bank_template_schema` tool
- add client/operation support for `GET /v1/bank-template-schema` through the existing narrow bank-template REST shim
- present schema title/top-level field count plus raw formatted JSON
- regenerate surface reference and update docs

Refs #192.

## Review
- Pre-PR reviewer found presenter-test and REST-rationale wording gaps; fixed.
- Final reviewer: no blockers.

## Verification
- npm test -- tests/client-rest.test.ts tests/client-integration.test.ts tests/memory-operations.test.ts tests/operation-catalog.test.ts tests/tool-presenters.test.ts
- npm run check
- npm run typecheck:tsc
- precommit hook
