### PR TITLE
feat(bank-settings): add directive tools

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ Pi Hindsight distinguishes local Pi behavior from bank-owned Hindsight settings.
 - `Location: Project` or `Location: User` describes the Pi memory route.
 - `Bank: <bank-id>` names the concrete Hindsight bank that owns missions, config overrides, mental models, and directives.
 
-Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config. Use `hindsight_get_bank_config` to inspect resolved bank config and override counts. Use `hindsight_reset_bank_config` only when you intentionally want to clear bank config overrides and fall back to Hindsight defaults/template state. Use `hindsight_get_bank_template_schema` to fetch the server JSON Schema for portable bank template manifests.
+Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config. Use `hindsight_get_bank_config` to inspect resolved bank config and override counts. Use `hindsight_reset_bank_config` only when you intentionally want to clear bank config overrides and fall back to Hindsight defaults/template state. Use `hindsight_get_bank_template_schema` to fetch the server JSON Schema for portable bank template manifests. Use `hindsight_list_directives`, `hindsight_get_directive`, `hindsight_create_directive`, `hindsight_update_directive`, and `hindsight_delete_directive` to manage bank-owned hard rules.
 
 ## Setup TUI
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -95,6 +95,64 @@ Reset Hindsight bank config overrides for a selected bank.
 | --------- | ------ | -------- | ------------------------------------------- |
 | `bank`    | string | no       | Optional bank id. Defaults to project bank. |
 
+### `hindsight_list_directives`
+
+List bank-owned Hindsight directives (hard reflect rules).
+
+| Parameter    | Type                       | Required | Description                                 |
+| ------------ | -------------------------- | -------- | ------------------------------------------- |
+| `bank`       | string                     | no       | Optional bank id. Defaults to project bank. |
+| `tags`       | array<string>              | no       | Optional tag filter.                        |
+| `tagsMatch`  | string \| string \| string | no       |                                             |
+| `activeOnly` | boolean                    | no       | Only return active directives.              |
+| `limit`      | number                     | no       | Maximum directives to return.               |
+| `offset`     | number                     | no       | Pagination offset.                          |
+
+### `hindsight_get_directive`
+
+Get a bank-owned Hindsight directive by ID.
+
+| Parameter     | Type   | Required | Description                                 |
+| ------------- | ------ | -------- | ------------------------------------------- |
+| `directiveId` | string | yes      | Directive ID.                               |
+| `bank`        | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_create_directive`
+
+Create a bank-owned Hindsight directive (hard reflect rule).
+
+| Parameter  | Type          | Required | Description                                    |
+| ---------- | ------------- | -------- | ---------------------------------------------- |
+| `name`     | string        | yes      | Human-readable directive name.                 |
+| `content`  | string        | yes      | Directive text to inject into prompts.         |
+| `bank`     | string        | no       | Optional bank id. Defaults to project bank.    |
+| `priority` | number        | no       | Higher priority directives are injected first. |
+| `isActive` | boolean       | no       | Whether this directive is active.              |
+| `tags`     | array<string> | no       | Directive tags.                                |
+
+### `hindsight_update_directive`
+
+Update a bank-owned Hindsight directive.
+
+| Parameter     | Type                  | Required | Description                                 |
+| ------------- | --------------------- | -------- | ------------------------------------------- |
+| `directiveId` | string                | yes      | Directive ID.                               |
+| `bank`        | string                | no       | Optional bank id. Defaults to project bank. |
+| `name`        | string \| null        | no       | New directive name.                         |
+| `content`     | string \| null        | no       | New directive text.                         |
+| `priority`    | number \| null        | no       | New priority.                               |
+| `isActive`    | boolean \| null       | no       | New active status.                          |
+| `tags`        | array<string> \| null | no       | New tags.                                   |
+
+### `hindsight_delete_directive`
+
+Delete a bank-owned Hindsight directive.
+
+| Parameter     | Type   | Required | Description                                 |
+| ------------- | ------ | -------- | ------------------------------------------- |
+| `directiveId` | string | yes      | Directive ID.                               |
+| `bank`        | string | no       | Optional bank id. Defaults to project bank. |
+
 ### `hindsight_get_bank_template_schema`
 
 Fetch the Hindsight bank-template JSON Schema used to validate portable manifests.

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -79,6 +79,11 @@ Additional tools:
 - `hindsight_configure`
 - `hindsight_get_bank_config`
 - `hindsight_reset_bank_config`
+- `hindsight_list_directives`
+- `hindsight_get_directive`
+- `hindsight_create_directive`
+- `hindsight_update_directive`
+- `hindsight_delete_directive`
 - `hindsight_get_bank_template_schema`
 - `hindsight_export_bank_template`
 - `hindsight_import`

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -1,8 +1,11 @@
 import type {
+  CreateDirectiveRequest,
   CreateMentalModelRequest,
   GetMentalModelOptions,
+  ListDirectivesOptions,
   ListMentalModelsOptions,
   ResolvedConfig,
+  UpdateDirectiveRequest,
   UpdateMentalModelRequest,
 } from "./types.js";
 
@@ -102,6 +105,23 @@ export function bankConfigPath(bankId: string): string {
   return encodeBankPath(bankId, "/config");
 }
 
+export function directivesCollectionPath(
+  bankId: string,
+  options: ListDirectivesOptions = {},
+): string {
+  const params = new URLSearchParams();
+  for (const tag of options.tags ?? []) params.append("tags", tag);
+  if (options.tagsMatch) params.set("tags_match", options.tagsMatch);
+  if (options.activeOnly !== undefined) params.set("active_only", String(options.activeOnly));
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  return appendQuery(encodeBankPath(bankId, "/directives"), params);
+}
+
+export function directiveItemPath(bankId: string, directiveId: string): string {
+  return `${encodeBankPath(bankId, "/directives")}/${encodeURIComponent(directiveId)}`;
+}
+
 export function bankTemplateImportPath(bankId: string, options: { dryRun?: boolean } = {}): string {
   return `${encodeBankPath(bankId, "/import")}${options.dryRun ? "?dry_run=true" : ""}`;
 }
@@ -152,6 +172,30 @@ export function mentalModelHistoryPath(bankId: string, mentalModelId: string): s
 
 export function mentalModelRefreshPath(bankId: string, mentalModelId: string): string {
   return `${mentalModelItemPath(bankId, mentalModelId)}/refresh`;
+}
+
+export function createDirectiveRequestBody(
+  request: CreateDirectiveRequest,
+): Record<string, unknown> {
+  return {
+    name: request.name,
+    content: request.content,
+    ...(request.priority !== undefined ? { priority: request.priority } : {}),
+    ...(request.isActive !== undefined ? { is_active: request.isActive } : {}),
+    ...(request.tags !== undefined ? { tags: request.tags } : {}),
+  };
+}
+
+export function updateDirectiveRequestBody(
+  request: UpdateDirectiveRequest,
+): Record<string, unknown> {
+  return {
+    ...(request.name !== undefined ? { name: request.name } : {}),
+    ...(request.content !== undefined ? { content: request.content } : {}),
+    ...(request.priority !== undefined ? { priority: request.priority } : {}),
+    ...(request.isActive !== undefined ? { is_active: request.isActive } : {}),
+    ...(request.tags !== undefined ? { tags: request.tags } : {}),
+  };
 }
 
 export function createMentalModelRequestBody(

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -8,8 +8,11 @@ import {
   bankTemplateExportPath,
   bankTemplateImportPath,
   bankTemplateSchemaPath,
+  createDirectiveRequestBody,
   createHindsightRestTransport,
   createMentalModelRequestBody,
+  directiveItemPath,
+  directivesCollectionPath,
   encodeBankPath,
   mentalModelCollectionPath,
   mentalModelHistoryPath,
@@ -17,6 +20,7 @@ import {
   mentalModelRefreshPath,
   reflectRequestBody,
   updateBankConfigRequestBody,
+  updateDirectiveRequestBody,
   updateMentalModelRequestBody,
 } from "./client-rest.js";
 import { withTimeout } from "./timeout.js";
@@ -140,6 +144,36 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
     getBankTemplateSchema: () =>
       withTimeout("hindsight getBankTemplateSchema", timeoutMs, (signal) =>
         rest.request(bankTemplateSchemaPath(), { signal }),
+      ),
+    // Use direct OpenAPI REST paths for directives so list filters (tags_match, active_only,
+    // limit, offset) and nullable update fields stay aligned with server behavior.
+    listDirectives: (bankId, options) =>
+      withTimeout("hindsight listDirectives", timeoutMs, (signal) =>
+        rest.request(directivesCollectionPath(bankId, options), { signal }),
+      ),
+    getDirective: (bankId, directiveId) =>
+      withTimeout("hindsight getDirective", timeoutMs, (signal) =>
+        rest.request(directiveItemPath(bankId, directiveId), { signal }),
+      ),
+    createDirective: (bankId, request) =>
+      withTimeout("hindsight createDirective", timeoutMs, (signal) =>
+        rest.request(directivesCollectionPath(bankId), {
+          method: "POST",
+          signal,
+          body: JSON.stringify(createDirectiveRequestBody(request)),
+        }),
+      ),
+    updateDirective: (bankId, directiveId, request) =>
+      withTimeout("hindsight updateDirective", timeoutMs, (signal) =>
+        rest.request(directiveItemPath(bankId, directiveId), {
+          method: "PATCH",
+          signal,
+          body: JSON.stringify(updateDirectiveRequestBody(request)),
+        }),
+      ),
+    deleteDirective: (bankId, directiveId) =>
+      withTimeout("hindsight deleteDirective", timeoutMs, (signal) =>
+        rest.request(directiveItemPath(bankId, directiveId), { method: "DELETE", signal }),
       ),
     listMentalModels: (bankId, options) =>
       withTimeout("hindsight listMentalModels", timeoutMs, (signal) =>

--- a/extensions/memory-directive-operations.ts
+++ b/extensions/memory-directive-operations.ts
@@ -1,0 +1,67 @@
+import { resolveOperationBank } from "./bank-selection.js";
+import type {
+  CreateDirectiveRequest,
+  ListDirectivesOptions,
+  UpdateDirectiveRequest,
+} from "./types.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+
+function unavailable(name: string): Error {
+  return new Error(`Hindsight client does not support directive ${name}.`);
+}
+
+function operationBank(deps: MemoryOperationsDeps, requestedBank?: string): string {
+  return resolveOperationBank({
+    requestedBank,
+    config: deps.getConfig(),
+    projectBankId: deps.getProjectBankId(),
+  });
+}
+
+export function createDirectiveOperations(deps: MemoryOperationsDeps) {
+  return {
+    async listDirectives(args: { bank?: string; options?: ListDirectivesOptions } = {}) {
+      const client = deps.getClient();
+      if (!client.listDirectives) throw unavailable("list");
+      const bankId = operationBank(deps, args.bank);
+      const result = await client.listDirectives(bankId, args.options);
+      return { bankId, result };
+    },
+
+    async getDirective(args: { bank?: string; directiveId: string }) {
+      const client = deps.getClient();
+      if (!client.getDirective) throw unavailable("get");
+      const bankId = operationBank(deps, args.bank);
+      const result = await client.getDirective(bankId, args.directiveId);
+      return { bankId, directiveId: args.directiveId, result };
+    },
+
+    async createDirective(args: { bank?: string; request: CreateDirectiveRequest }) {
+      const client = deps.getClient();
+      if (!client.createDirective) throw unavailable("create");
+      const bankId = operationBank(deps, args.bank);
+      const result = await client.createDirective(bankId, args.request);
+      return { bankId, result };
+    },
+
+    async updateDirective(args: {
+      bank?: string;
+      directiveId: string;
+      request: UpdateDirectiveRequest;
+    }) {
+      const client = deps.getClient();
+      if (!client.updateDirective) throw unavailable("update");
+      const bankId = operationBank(deps, args.bank);
+      const result = await client.updateDirective(bankId, args.directiveId, args.request);
+      return { bankId, directiveId: args.directiveId, result };
+    },
+
+    async deleteDirective(args: { bank?: string; directiveId: string }) {
+      const client = deps.getClient();
+      if (!client.deleteDirective) throw unavailable("delete");
+      const bankId = operationBank(deps, args.bank);
+      const result = await client.deleteDirective(bankId, args.directiveId);
+      return { bankId, directiveId: args.directiveId, result };
+    },
+  };
+}

--- a/extensions/memory-operation-service.ts
+++ b/extensions/memory-operation-service.ts
@@ -7,6 +7,7 @@ import {
 import { createBankConfigOperations } from "./bank-config-operations.js";
 import { createBankTemplateOperations } from "./bank-template-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
+import { createDirectiveOperations } from "./memory-directive-operations.js";
 import { createDocumentOperations } from "./memory-document-operations.js";
 import { createMentalModelOperations } from "./memory-mental-model-operations.js";
 import { createRecallOperations } from "./memory-recall-operations.js";
@@ -60,6 +61,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createConfigOperations(deps),
     ...createBankConfigOperations(deps),
     ...createBankTemplateOperations(deps),
+    ...createDirectiveOperations(deps),
     ...createMentalModelOperations(deps),
     ...createImportOperations(deps),
     ...createSessionOperations(),

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -9,16 +9,21 @@ import { getSessionFile } from "./session.js";
 import { runHindsightSetupTui } from "./setup-tui.js";
 import {
   configureToolResponse,
+  createDirectiveToolResponse,
+  deleteDirectiveToolResponse,
   deleteDocumentToolResponse,
   exportBankTemplateToolResponse,
   gatewayImportToolResponse,
   getBankConfigToolResponse,
   getBankTemplateSchemaToolResponse,
+  getDirectiveToolResponse,
   importToolResponse,
+  listDirectivesToolResponse,
   resetBankConfigToolResponse,
   retainReceiptListToolResponse,
   retainToolResponse,
   routeMemoryToolResponse,
+  updateDirectiveToolResponse,
 } from "./tool-presenters.js";
 
 export type ToolOperation = Parameters<ExtensionAPI["registerTool"]>[0];
@@ -259,6 +264,147 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         useCwd(ctx.cwd);
         const result = await operations.resetBankConfig(params.bank ? { bank: params.bank } : {});
         return resetBankConfigToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_list_directives",
+      label: "Hindsight List Directives",
+      description: "List bank-owned Hindsight directives (hard reflect rules).",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        tags: Type.Optional(Type.Array(Type.String(), { description: "Optional tag filter." })),
+        tagsMatch: Type.Optional(
+          Type.Union([Type.Literal("any"), Type.Literal("all"), Type.Literal("exact")]),
+        ),
+        activeOnly: Type.Optional(Type.Boolean({ description: "Only return active directives." })),
+        limit: Type.Optional(Type.Number({ description: "Maximum directives to return." })),
+        offset: Type.Optional(Type.Number({ description: "Pagination offset." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.listDirectives({
+          ...(params.bank ? { bank: params.bank } : {}),
+          options: {
+            ...(params.tags ? { tags: params.tags } : {}),
+            ...(params.tagsMatch ? { tagsMatch: params.tagsMatch } : {}),
+            ...(params.activeOnly !== undefined ? { activeOnly: params.activeOnly } : {}),
+            ...(params.limit !== undefined ? { limit: params.limit } : {}),
+            ...(params.offset !== undefined ? { offset: params.offset } : {}),
+          },
+        });
+        return listDirectivesToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_directive",
+      label: "Hindsight Get Directive",
+      description: "Get a bank-owned Hindsight directive by ID.",
+      parameters: Type.Object({
+        directiveId: Type.String({ description: "Directive ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getDirective({
+          directiveId: params.directiveId,
+          ...(params.bank ? { bank: params.bank } : {}),
+        });
+        return getDirectiveToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_create_directive",
+      label: "Hindsight Create Directive",
+      description: "Create a bank-owned Hindsight directive (hard reflect rule).",
+      parameters: Type.Object({
+        name: Type.String({ description: "Human-readable directive name." }),
+        content: Type.String({ description: "Directive text to inject into prompts." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        priority: Type.Optional(
+          Type.Number({ description: "Higher priority directives are injected first." }),
+        ),
+        isActive: Type.Optional(Type.Boolean({ description: "Whether this directive is active." })),
+        tags: Type.Optional(Type.Array(Type.String(), { description: "Directive tags." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.createDirective({
+          ...(params.bank ? { bank: params.bank } : {}),
+          request: {
+            name: params.name,
+            content: params.content,
+            ...(params.priority !== undefined ? { priority: params.priority } : {}),
+            ...(params.isActive !== undefined ? { isActive: params.isActive } : {}),
+            ...(params.tags ? { tags: params.tags } : {}),
+          },
+        });
+        return createDirectiveToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_update_directive",
+      label: "Hindsight Update Directive",
+      description: "Update a bank-owned Hindsight directive.",
+      parameters: Type.Object({
+        directiveId: Type.String({ description: "Directive ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        name: Type.Optional(
+          Type.Union([Type.String(), Type.Null()], { description: "New directive name." }),
+        ),
+        content: Type.Optional(
+          Type.Union([Type.String(), Type.Null()], { description: "New directive text." }),
+        ),
+        priority: Type.Optional(
+          Type.Union([Type.Number(), Type.Null()], { description: "New priority." }),
+        ),
+        isActive: Type.Optional(
+          Type.Union([Type.Boolean(), Type.Null()], { description: "New active status." }),
+        ),
+        tags: Type.Optional(
+          Type.Union([Type.Array(Type.String()), Type.Null()], { description: "New tags." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.updateDirective({
+          directiveId: params.directiveId,
+          ...(params.bank ? { bank: params.bank } : {}),
+          request: {
+            ...(params.name !== undefined ? { name: params.name } : {}),
+            ...(params.content !== undefined ? { content: params.content } : {}),
+            ...(params.priority !== undefined ? { priority: params.priority } : {}),
+            ...(params.isActive !== undefined ? { isActive: params.isActive } : {}),
+            ...(params.tags !== undefined ? { tags: params.tags } : {}),
+          },
+        });
+        return updateDirectiveToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_delete_directive",
+      label: "Hindsight Delete Directive",
+      description: "Delete a bank-owned Hindsight directive.",
+      parameters: Type.Object({
+        directiveId: Type.String({ description: "Directive ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.deleteDirective({
+          directiveId: params.directiveId,
+          ...(params.bank ? { bank: params.bank } : {}),
+        });
+        return deleteDirectiveToolResponse(result);
       },
     }),
     defineCatalogTool({

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -17,6 +17,11 @@ export type ImportToolResult = Awaited<ReturnType<MemoryOperations["importSessio
 export type GatewayImportToolResult = Awaited<
   ReturnType<MemoryOperations["importGatewayTranscript"]>
 >;
+export type ListDirectivesToolResult = Awaited<ReturnType<MemoryOperations["listDirectives"]>>;
+export type GetDirectiveToolResult = Awaited<ReturnType<MemoryOperations["getDirective"]>>;
+export type CreateDirectiveToolResult = Awaited<ReturnType<MemoryOperations["createDirective"]>>;
+export type UpdateDirectiveToolResult = Awaited<ReturnType<MemoryOperations["updateDirective"]>>;
+export type DeleteDirectiveToolResult = Awaited<ReturnType<MemoryOperations["deleteDirective"]>>;
 export type GetBankTemplateSchemaToolResult = Awaited<
   ReturnType<MemoryOperations["getBankTemplateSchema"]>
 >;
@@ -115,6 +120,109 @@ export function importToolResponse(result: ImportToolResult): ToolTextResponse<I
     ? `Import preview: ${result.messageCount} messages would write ${result.documents.length} ${documentLabel} to ${result.bankId}. First document: ${result.documentId}. Manifest unchanged: ${result.manifestPath}.`
     : `Imported ${result.messageCount} messages into ${result.bankId} as ${result.documentId}. Manifest: ${result.manifestPath}.`;
   return { content: [{ type: "text", text }], details: result };
+}
+
+function directiveItems(result: unknown): unknown[] {
+  if (typeof result !== "object" || !result || Array.isArray(result)) return [];
+  const items = (result as { items?: unknown }).items;
+  return Array.isArray(items) ? items : [];
+}
+
+function directiveLabel(value: unknown): string {
+  if (typeof value !== "object" || !value || Array.isArray(value)) return JSON.stringify(value);
+  const record = value as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id : "unknown";
+  const name = typeof record.name === "string" ? record.name : "unnamed";
+  const active =
+    typeof record.is_active === "boolean" ? (record.is_active ? "active" : "inactive") : "unknown";
+  const priority = typeof record.priority === "number" ? record.priority : 0;
+  return `${name} (${id}) · ${active} · priority ${priority}`;
+}
+
+export function listDirectivesToolResponse(
+  result: ListDirectivesToolResult,
+): ToolTextResponse<ListDirectivesToolResult> {
+  const items = directiveItems(result.result);
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Directives in ${result.bankId}: ${items.length}`,
+          ...items.map(directiveLabel),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function getDirectiveToolResponse(
+  result: GetDirectiveToolResult,
+): ToolTextResponse<GetDirectiveToolResult> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Directive ${result.directiveId} in ${result.bankId}.`,
+          JSON.stringify(result.result, null, 2),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function createDirectiveToolResponse(
+  result: CreateDirectiveToolResult,
+): ToolTextResponse<CreateDirectiveToolResult> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Created directive in ${result.bankId}.`,
+          JSON.stringify(result.result, null, 2),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function updateDirectiveToolResponse(
+  result: UpdateDirectiveToolResult,
+): ToolTextResponse<UpdateDirectiveToolResult> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Updated directive ${result.directiveId} in ${result.bankId}.`,
+          JSON.stringify(result.result, null, 2),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function deleteDirectiveToolResponse(
+  result: DeleteDirectiveToolResult,
+): ToolTextResponse<DeleteDirectiveToolResult> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Deleted directive ${result.directiveId} in ${result.bankId}.`,
+          JSON.stringify(result.result, null, 2),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
 }
 
 function schemaSummary(schema: unknown): string {

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -195,6 +195,30 @@ export interface MentalModelTrigger {
   recall_chunks_max_tokens?: number | null;
 }
 
+export interface ListDirectivesOptions {
+  tags?: string[];
+  tagsMatch?: "any" | "all" | "exact";
+  activeOnly?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreateDirectiveRequest {
+  name: string;
+  content: string;
+  priority?: number;
+  isActive?: boolean;
+  tags?: string[];
+}
+
+export interface UpdateDirectiveRequest {
+  name?: string | null;
+  content?: string | null;
+  priority?: number | null;
+  isActive?: boolean | null;
+  tags?: string[] | null;
+}
+
 export interface CreateMentalModelRequest {
   id?: string | null;
   name: string;
@@ -303,6 +327,15 @@ export interface HindsightLikeClient {
   ): Promise<unknown>;
   exportBankTemplate?(bankId: string): Promise<BankTemplateManifest>;
   getBankTemplateSchema?(): Promise<unknown>;
+  listDirectives?(bankId: string, options?: ListDirectivesOptions): Promise<unknown>;
+  getDirective?(bankId: string, directiveId: string): Promise<unknown>;
+  createDirective?(bankId: string, request: CreateDirectiveRequest): Promise<unknown>;
+  updateDirective?(
+    bankId: string,
+    directiveId: string,
+    request: UpdateDirectiveRequest,
+  ): Promise<unknown>;
+  deleteDirective?(bankId: string, directiveId: string): Promise<unknown>;
   listMentalModels?(bankId: string, options?: ListMentalModelsOptions): Promise<unknown>;
   getMentalModel?(
     bankId: string,

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -71,6 +71,56 @@ describe("Hindsight client adapter integration", () => {
         sendJson(res, 200, { title: "BankTemplateManifest", properties: { version: {} } });
         return;
       }
+      if (
+        req.method === "GET" &&
+        req.url ===
+          "/v1/default/banks/test-bank/directives?tags=project&tags_match=all&active_only=false&limit=10&offset=1"
+      ) {
+        sendJson(res, 200, {
+          items: [{ id: "directive-1", bank_id: "test-bank", name: "Rule", content: "Use facts." }],
+        });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url === "/v1/default/banks/test-bank/directives/directive-1"
+      ) {
+        sendJson(res, 200, {
+          id: "directive-1",
+          bank_id: "test-bank",
+          name: "Rule",
+          content: "Use facts.",
+        });
+        return;
+      }
+      if (req.method === "POST" && req.url === "/v1/default/banks/test-bank/directives") {
+        sendJson(res, 200, {
+          id: "directive-2",
+          bank_id: "test-bank",
+          name: "New",
+          content: "Be exact.",
+        });
+        return;
+      }
+      if (
+        req.method === "PATCH" &&
+        req.url === "/v1/default/banks/test-bank/directives/directive-2"
+      ) {
+        sendJson(res, 200, {
+          id: "directive-2",
+          bank_id: "test-bank",
+          name: "New",
+          content: "Updated.",
+        });
+        return;
+      }
+      if (
+        req.method === "DELETE" &&
+        req.url === "/v1/default/banks/test-bank/directives/directive-2"
+      ) {
+        sendJson(res, 200, { deleted: true });
+        return;
+      }
       if (req.method === "GET" && req.url === "/v1/default/banks/test-bank/config") {
         sendJson(res, 200, { config: { retain_custom_instructions: "Read from db" } });
         return;
@@ -186,6 +236,26 @@ describe("Hindsight client adapter integration", () => {
     );
     const exportedTemplate = await client.exportBankTemplate?.("test-bank");
     const bankTemplateSchema = await client.getBankTemplateSchema?.();
+    const directives = await client.listDirectives?.("test-bank", {
+      tags: ["project"],
+      tagsMatch: "all",
+      activeOnly: false,
+      limit: 10,
+      offset: 1,
+    });
+    const directive = await client.getDirective?.("test-bank", "directive-1");
+    const createdDirective = await client.createDirective?.("test-bank", {
+      name: "New",
+      content: "Be exact.",
+      priority: 3,
+      isActive: true,
+      tags: ["project"],
+    });
+    const updatedDirective = await client.updateDirective?.("test-bank", "directive-2", {
+      content: "Updated.",
+      tags: null,
+    });
+    const deletedDirective = await client.deleteDirective?.("test-bank", "directive-2");
     const bankConfig = await client.getBankConfig?.("test-bank");
     const bankConfigUpdate = await client.updateBankConfig?.("test-bank", {
       retain_custom_instructions: "Write to db",
@@ -221,6 +291,28 @@ describe("Hindsight client adapter integration", () => {
       title: "BankTemplateManifest",
       properties: { version: {} },
     });
+    expect(directives).toEqual({
+      items: [{ id: "directive-1", bank_id: "test-bank", name: "Rule", content: "Use facts." }],
+    });
+    expect(directive).toEqual({
+      id: "directive-1",
+      bank_id: "test-bank",
+      name: "Rule",
+      content: "Use facts.",
+    });
+    expect(createdDirective).toEqual({
+      id: "directive-2",
+      bank_id: "test-bank",
+      name: "New",
+      content: "Be exact.",
+    });
+    expect(updatedDirective).toEqual({
+      id: "directive-2",
+      bank_id: "test-bank",
+      name: "New",
+      content: "Updated.",
+    });
+    expect(deletedDirective).toEqual({ deleted: true });
     expect(bankConfig).toEqual({ config: { retain_custom_instructions: "Read from db" } });
     expect(bankConfigUpdate).toEqual({ updated: true });
     expect(bankConfigReset).toEqual({ reset: true });
@@ -242,6 +334,11 @@ describe("Hindsight client adapter integration", () => {
       "POST /v1/default/banks/test-bank/import?dry_run=true",
       "GET /v1/default/banks/test-bank/export",
       "GET /v1/bank-template-schema",
+      "GET /v1/default/banks/test-bank/directives?tags=project&tags_match=all&active_only=false&limit=10&offset=1",
+      "GET /v1/default/banks/test-bank/directives/directive-1",
+      "POST /v1/default/banks/test-bank/directives",
+      "PATCH /v1/default/banks/test-bank/directives/directive-2",
+      "DELETE /v1/default/banks/test-bank/directives/directive-2",
       "GET /v1/default/banks/test-bank/config",
       "PATCH /v1/default/banks/test-bank/config",
       "DELETE /v1/default/banks/test-bank/config",
@@ -299,15 +396,23 @@ describe("Hindsight client adapter integration", () => {
       version: "1",
       bank: { retain_mission: "Retain useful facts." },
     });
-    expect(requests[10]?.body).toEqual({
+    expect(requests[11]?.body).toEqual({
+      name: "New",
+      content: "Be exact.",
+      priority: 3,
+      is_active: true,
+      tags: ["project"],
+    });
+    expect(requests[12]?.body).toEqual({ content: "Updated.", tags: null });
+    expect(requests[15]?.body).toEqual({
       updates: { retain_custom_instructions: "Write to db" },
     });
-    expect(requests[14]?.body).toEqual({
+    expect(requests[19]?.body).toEqual({
       name: "Model",
       source_query: "What should recur?",
       tags: ["source:pi"],
       max_tokens: 256,
     });
-    expect(requests[15]?.body).toEqual({ source_query: "Updated query", tags: null });
+    expect(requests[20]?.body).toEqual({ source_query: "Updated query", tags: null });
   });
 });

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -6,7 +6,10 @@ import {
   bankTemplateExportPath,
   bankTemplateImportPath,
   bankTemplateSchemaPath,
+  createDirectiveRequestBody,
   createMentalModelRequestBody,
+  directiveItemPath,
+  directivesCollectionPath,
   encodeBankPath,
   mentalModelCollectionPath,
   mentalModelHistoryPath,
@@ -14,6 +17,7 @@ import {
   mentalModelRefreshPath,
   reflectRequestBody,
   updateBankConfigRequestBody,
+  updateDirectiveRequestBody,
   updateMentalModelRequestBody,
 } from "../extensions/client-rest.js";
 
@@ -40,6 +44,20 @@ describe("Hindsight REST transport helpers", () => {
   it("encodes bank ids in REST paths", () => {
     expect(encodeBankPath("bank/id", "/reflect")).toBe("/v1/default/banks/bank%2Fid/reflect");
     expect(bankConfigPath("bank/id")).toBe("/v1/default/banks/bank%2Fid/config");
+    expect(
+      directivesCollectionPath("bank/id", {
+        tags: ["source:pi", "profile:coding"],
+        tagsMatch: "all",
+        activeOnly: false,
+        limit: 10,
+        offset: 5,
+      }),
+    ).toBe(
+      "/v1/default/banks/bank%2Fid/directives?tags=source%3Api&tags=profile%3Acoding&tags_match=all&active_only=false&limit=10&offset=5",
+    );
+    expect(directiveItemPath("bank/id", "directive/id")).toBe(
+      "/v1/default/banks/bank%2Fid/directives/directive%2Fid",
+    );
     expect(bankTemplateImportPath("bank/id", { dryRun: true })).toBe(
       "/v1/default/banks/bank%2Fid/import?dry_run=true",
     );
@@ -49,6 +67,25 @@ describe("Hindsight REST transport helpers", () => {
       updateBankConfigRequestBody({ retain_custom_instructions: "Extract carefully" }),
     ).toEqual({
       updates: { retain_custom_instructions: "Extract carefully" },
+    });
+    expect(
+      createDirectiveRequestBody({
+        name: "Rule",
+        content: "Use source facts.",
+        priority: 2,
+        isActive: false,
+        tags: ["project"],
+      }),
+    ).toEqual({
+      name: "Rule",
+      content: "Use source facts.",
+      priority: 2,
+      is_active: false,
+      tags: ["project"],
+    });
+    expect(updateDirectiveRequestBody({ content: null, isActive: true })).toEqual({
+      content: null,
+      is_active: true,
     });
   });
 

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -155,7 +155,7 @@ describe("memory operations", () => {
     ]);
   });
 
-  it("reports unavailable bank config APIs", async () => {
+  it("reports unavailable bank config and directive APIs", async () => {
     const operations = createMemoryOperations({
       getClient: () => ({
         retain: async () => undefined,
@@ -174,6 +174,28 @@ describe("memory operations", () => {
     );
     await expect(operations.getBankTemplateSchema()).rejects.toThrow(
       "Hindsight client does not support bank template schema fetch.",
+    );
+    await expect(operations.listDirectives({ bank: "project" })).rejects.toThrow(
+      "Hindsight client does not support directive list.",
+    );
+    await expect(operations.getDirective({ bank: "project", directiveId: "d" })).rejects.toThrow(
+      "Hindsight client does not support directive get.",
+    );
+    await expect(
+      operations.createDirective({
+        bank: "project",
+        request: { name: "Rule", content: "Use facts." },
+      }),
+    ).rejects.toThrow("Hindsight client does not support directive create.");
+    await expect(
+      operations.updateDirective({
+        bank: "project",
+        directiveId: "d",
+        request: { content: "Updated" },
+      }),
+    ).rejects.toThrow("Hindsight client does not support directive update.");
+    await expect(operations.deleteDirective({ bank: "project", directiveId: "d" })).rejects.toThrow(
+      "Hindsight client does not support directive delete.",
     );
   });
 
@@ -213,6 +235,26 @@ describe("memory operations", () => {
           calls.push({ method: "getBankTemplateSchema", bank: "none" });
           return { title: "BankTemplateManifest" };
         },
+        listDirectives: async (bank) => {
+          calls.push({ method: "listDirectives", bank });
+          return { items: [] };
+        },
+        getDirective: async (bank) => {
+          calls.push({ method: "getDirective", bank });
+          return { id: "directive" };
+        },
+        createDirective: async (bank, request) => {
+          calls.push({ method: "createDirective", bank, request });
+          return { id: "directive" };
+        },
+        updateDirective: async (bank, _directiveId, request) => {
+          calls.push({ method: "updateDirective", bank, request });
+          return { id: "directive" };
+        },
+        deleteDirective: async (bank) => {
+          calls.push({ method: "deleteDirective", bank });
+          return { deleted: true };
+        },
         listMentalModels: async (bank) => {
           calls.push({ method: "listMentalModels", bank });
           return { items: [] };
@@ -243,6 +285,18 @@ describe("memory operations", () => {
     await operations.getBankConfig({ bank: "global" });
     await operations.resetBankConfig({ bank: "global" });
     await operations.getBankTemplateSchema();
+    await operations.listDirectives({ bank: "global" });
+    await operations.getDirective({ bank: "global", directiveId: "directive" });
+    await operations.createDirective({
+      bank: "project",
+      request: { name: "Rule", content: "Use source facts." },
+    });
+    await operations.updateDirective({
+      bank: "global",
+      directiveId: "directive",
+      request: { content: "Updated" },
+    });
+    await operations.deleteDirective({ bank: "global", directiveId: "directive" });
     await operations.listMentalModels({ bank: "global" });
     await operations.createMentalModel({
       bank: "project",
@@ -281,6 +335,15 @@ describe("memory operations", () => {
         { method: "resetBankConfig", bank: "global-luxus" },
         { method: "getBankConfig", bank: "global-luxus" },
         { method: "getBankTemplateSchema", bank: "none" },
+        { method: "listDirectives", bank: "global-luxus" },
+        { method: "getDirective", bank: "global-luxus" },
+        {
+          method: "createDirective",
+          bank: "project-bank",
+          request: { name: "Rule", content: "Use source facts." },
+        },
+        { method: "updateDirective", bank: "global-luxus", request: { content: "Updated" } },
+        { method: "deleteDirective", bank: "global-luxus" },
         { method: "listMentalModels", bank: "global-luxus" },
         {
           method: "createMentalModel",

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { createOperationCatalog } from "../extensions/operation-catalog.js";
 import type { HindsightLikeClient } from "../extensions/types.js";
@@ -11,11 +11,39 @@ function client(): HindsightLikeClient {
     getBankConfig: async () => ({ config: {}, overrides: {} }),
     resetBankConfig: async () => ({ ok: true }),
     getBankTemplateSchema: async () => ({ title: "BankTemplateManifest", properties: {} }),
+    listDirectives: async () => ({ items: [] }),
+    getDirective: async () => ({ id: "directive", name: "Rule", content: "Use facts." }),
+    createDirective: async () => ({ id: "directive", name: "Rule", content: "Use facts." }),
+    updateDirective: async () => ({ id: "directive", name: "Rule", content: "Updated." }),
+    deleteDirective: async () => ({ deleted: true }),
     exportBankTemplate: async () => ({ version: "1" }),
   };
 }
 
 describe("operation catalog", () => {
+  it("passes nullable directive updates through the public tool surface", async () => {
+    const updateDirective = vi.fn(async () => ({ id: "directive", content: "Updated" }));
+    const catalog = createOperationCatalog({
+      getClient: () => ({ ...client(), updateDirective }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+    const tool = catalog.tools.find((candidate) => candidate.name === "hindsight_update_directive");
+
+    await tool?.execute(
+      "call",
+      { directiveId: "directive", bank: "target-bank", content: null, tags: null },
+      new AbortController().signal,
+      () => undefined,
+      { cwd: "/repo", sessionManager: {} } as never,
+    );
+
+    expect(updateDirective).toHaveBeenCalledWith("target-bank", "directive", {
+      content: null,
+      tags: null,
+    });
+  });
+
   it("declares the public tool and command surface in one catalog", () => {
     const catalog = createOperationCatalog({
       getClient: () => client(),
@@ -33,6 +61,11 @@ describe("operation catalog", () => {
       "hindsight_configure",
       "hindsight_get_bank_config",
       "hindsight_reset_bank_config",
+      "hindsight_list_directives",
+      "hindsight_get_directive",
+      "hindsight_create_directive",
+      "hindsight_update_directive",
+      "hindsight_delete_directive",
       "hindsight_get_bank_template_schema",
       "hindsight_export_bank_template",
       "hindsight_import",

--- a/tests/tool-presenters.test.ts
+++ b/tests/tool-presenters.test.ts
@@ -1,7 +1,53 @@
 import { describe, expect, it } from "vitest";
-import { getBankTemplateSchemaToolResponse } from "../extensions/tool-presenters.js";
+import {
+  createDirectiveToolResponse,
+  deleteDirectiveToolResponse,
+  getBankTemplateSchemaToolResponse,
+  getDirectiveToolResponse,
+  listDirectivesToolResponse,
+  updateDirectiveToolResponse,
+} from "../extensions/tool-presenters.js";
 
 describe("tool presenters", () => {
+  it("presents directive tool results", () => {
+    const list = listDirectivesToolResponse({
+      bankId: "bank",
+      result: {
+        items: [
+          { id: "directive-1", name: "Rule", content: "Use facts.", is_active: false, priority: 3 },
+        ],
+      },
+    });
+    expect(list.content[0]?.text).toContain("Directives in bank: 1");
+    expect(list.content[0]?.text).toContain("Rule (directive-1) · inactive · priority 3");
+
+    expect(
+      getDirectiveToolResponse({
+        bankId: "bank",
+        directiveId: "directive-1",
+        result: { id: "directive-1" },
+      }).content[0]?.text,
+    ).toContain("Directive directive-1 in bank.");
+    expect(
+      createDirectiveToolResponse({ bankId: "bank", result: { id: "directive-2" } }).content[0]
+        ?.text,
+    ).toContain("Created directive in bank.");
+    expect(
+      updateDirectiveToolResponse({
+        bankId: "bank",
+        directiveId: "directive-2",
+        result: { id: "directive-2" },
+      }).content[0]?.text,
+    ).toContain("Updated directive directive-2 in bank.");
+    expect(
+      deleteDirectiveToolResponse({
+        bankId: "bank",
+        directiveId: "directive-2",
+        result: { deleted: true },
+      }).content[0]?.text,
+    ).toContain("Deleted directive directive-2 in bank.");
+  });
+
   it("presents bank template schema summary and raw JSON", () => {
     const result = {
       schema: {


### PR DESCRIPTION
## Summary
- add bank-owned directive CRUD operation layer and tools
- add OpenAPI-aligned REST paths/request mapping for directive list/get/create/update/delete
- preserve nullable directive update fields through public tool schema
- present directive list/mutation results with raw JSON details
- document directive tools and regenerate surface reference

Refs #194.

## Review
- Pre-PR reviewer found nullable update and REST-rationale gaps; fixed.
- Final reviewer: no blockers.

## Verification
- npm test -- tests/client-rest.test.ts tests/client-integration.test.ts tests/memory-operations.test.ts tests/operation-catalog.test.ts tests/tool-presenters.test.ts
- npm run check
- npm run typecheck:tsc
- precommit hook
