### PR TITLE
feat(bank-templates): save exported manifests

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ Pi Hindsight distinguishes local Pi behavior from bank-owned Hindsight settings.
 - `Location: Project` or `Location: User` describes the Pi memory route.
 - `Bank: <bank-id>` names the concrete Hindsight bank that owns missions, config overrides, mental models, and directives.
 
-Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config. Use `hindsight_get_bank_config` to inspect resolved bank config and override counts. Use `hindsight_reset_bank_config` only when you intentionally want to clear bank config overrides and fall back to Hindsight defaults/template state. Use `hindsight_get_bank_template_schema` to fetch the server JSON Schema for portable bank template manifests. Use `hindsight_list_directives`, `hindsight_get_directive`, `hindsight_create_directive`, `hindsight_update_directive`, and `hindsight_delete_directive` to manage bank-owned hard rules.
+Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config. Use `hindsight_get_bank_config` to inspect resolved bank config and override counts. Use `hindsight_reset_bank_config` only when you intentionally want to clear bank config overrides and fall back to Hindsight defaults/template state. Use `hindsight_get_bank_template_schema` to fetch the server JSON Schema for portable bank template manifests. Use `hindsight_export_bank_template` with `outputFile` to save a portable manifest JSON file. Use `hindsight_list_directives`, `hindsight_get_directive`, `hindsight_create_directive`, `hindsight_update_directive`, and `hindsight_delete_directive` to manage bank-owned hard rules.
 
 ## Setup TUI
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -164,9 +164,10 @@ Fetch the Hindsight bank-template JSON Schema used to validate portable manifest
 
 Export a portable Hindsight bank template manifest for reuse in another project or bank.
 
-| Parameter | Type   | Required | Description                                 |
-| --------- | ------ | -------- | ------------------------------------------- |
-| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+| Parameter    | Type   | Required | Description                                                                           |
+| ------------ | ------ | -------- | ------------------------------------------------------------------------------------- |
+| `bank`       | string | no       | Optional bank id. Defaults to project bank.                                           |
+| `outputFile` | string | no       | Optional path to save the exported manifest JSON. Relative paths resolve against cwd. |
 
 ### `hindsight_import`
 

--- a/extensions/bank-template-operations.ts
+++ b/extensions/bank-template-operations.ts
@@ -1,3 +1,5 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import { resolveOperationBank } from "./bank-selection.js";
 import type { MemoryOperationsDeps } from "./memory-operation-types.js";
 import { isRecord } from "./client-rest.js";
@@ -63,7 +65,7 @@ export function createBankTemplateOperations(deps: MemoryOperationsDeps) {
       return { schema };
     },
 
-    async exportBankTemplate(args: { bank?: string }) {
+    async exportBankTemplate(args: { bank?: string; cwd?: string; outputFile?: string }) {
       const client = deps.getClient();
       if (!client.exportBankTemplate)
         throw new Error("Hindsight client does not support bank template export.");
@@ -73,7 +75,11 @@ export function createBankTemplateOperations(deps: MemoryOperationsDeps) {
         projectBankId: deps.getProjectBankId(),
       });
       const manifest = await client.exportBankTemplate(bankId);
-      return { bankId, manifest };
+      if (!args.outputFile) return { bankId, manifest };
+      const outputPath = resolve(args.cwd ?? process.cwd(), args.outputFile);
+      await mkdir(dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+      return { bankId, manifest, outputPath };
     },
 
     async importBankTemplate(args: {

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -428,12 +428,20 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         bank: Type.Optional(
           Type.String({ description: "Optional bank id. Defaults to project bank." }),
         ),
+        outputFile: Type.Optional(
+          Type.String({
+            description:
+              "Optional path to save the exported manifest JSON. Relative paths resolve against cwd.",
+          }),
+        ),
       }),
       async execute(_id, params, _signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
-        const result = await operations.exportBankTemplate(
-          params.bank ? { bank: params.bank } : {},
-        );
+        const result = await operations.exportBankTemplate({
+          ...(params.bank ? { bank: params.bank } : {}),
+          cwd: ctx.cwd,
+          ...(params.outputFile ? { outputFile: params.outputFile } : {}),
+        });
         return exportBankTemplateToolResponse(result);
       },
     }),

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -308,6 +308,7 @@ export function exportBankTemplateToolResponse(
         type: "text",
         text: [
           `Exported bank template from ${result.bankId}.`,
+          ...(result.outputPath ? [`Saved manifest: ${result.outputPath}`] : []),
           summary,
           JSON.stringify(result.manifest, null, 2),
         ].join("\n"),

--- a/tests/bank-template-operations.test.ts
+++ b/tests/bank-template-operations.test.ts
@@ -1,3 +1,7 @@
+import { readFile } from "node:fs/promises";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { describe, expect, it, vi } from "vitest";
 import {
   createBankTemplateOperations,
@@ -90,6 +94,23 @@ describe("bank template operations", () => {
       },
     });
     expect(fixture.exportBankTemplate).toHaveBeenCalledWith("global-luxus");
+  });
+
+  it("saves exported bank templates as pretty JSON", async () => {
+    const fixture = deps();
+    const operations = createBankTemplateOperations(fixture.deps);
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-template-export-"));
+
+    const result = await operations.exportBankTemplate({
+      bank: "global",
+      cwd,
+      outputFile: "exports/template.json",
+    });
+
+    expect(result.outputPath).toBe(join(cwd, "exports/template.json"));
+    await expect(readFile(join(cwd, "exports/template.json"), "utf8")).resolves.toBe(
+      `${JSON.stringify(result.manifest, null, 2)}\n`,
+    );
   });
 
   it("formats dry-run and manifest summaries", () => {

--- a/tests/changelog-generator.test.ts
+++ b/tests/changelog-generator.test.ts
@@ -10,19 +10,26 @@ const generatorPath = resolve("scripts/generate-changelog.mjs");
 
 const subprocessTimeoutMs = 10_000;
 
+function isolatedGitEnv(extra: Record<string, string> = {}) {
+  const { GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE, ...env } = process.env;
+  void GIT_DIR;
+  void GIT_WORK_TREE;
+  void GIT_INDEX_FILE;
+  return { ...env, ...extra };
+}
+
 async function git(cwd: string, args: string[]) {
-  await execFileAsync("git", args, { cwd, timeout: subprocessTimeoutMs });
+  await execFileAsync("git", args, { cwd, timeout: subprocessTimeoutMs, env: isolatedGitEnv() });
 }
 
 async function commit(cwd: string, message: string, date: string) {
   await execFileAsync("git", ["commit", "--allow-empty", "-m", message], {
     cwd,
     timeout: subprocessTimeoutMs,
-    env: {
-      ...process.env,
+    env: isolatedGitEnv({
       GIT_AUTHOR_DATE: `${date}T00:00:00Z`,
       GIT_COMMITTER_DATE: `${date}T00:00:00Z`,
-    },
+    }),
   });
 }
 
@@ -33,7 +40,7 @@ describe("generate-changelog", () => {
       await git(cwd, ["init"]);
       await git(cwd, ["config", "user.email", "test@example.com"]);
       await git(cwd, ["config", "user.name", "Test User"]);
-      await git(cwd, ["checkout", "-b", "main"]);
+      await git(cwd, ["checkout", "-B", "main"]);
       await writeFile(
         join(cwd, "package.json"),
         JSON.stringify({
@@ -50,9 +57,17 @@ describe("generate-changelog", () => {
       await git(cwd, ["checkout", "main"]);
       await git(cwd, ["merge", "--no-ff", "topic", "-m", "Merge pull request #1"]);
 
-      await execFileAsync("node", [generatorPath], { cwd, timeout: subprocessTimeoutMs });
+      await execFileAsync("node", [generatorPath], {
+        cwd,
+        timeout: subprocessTimeoutMs,
+        env: isolatedGitEnv(),
+      });
       const first = await readFile(join(cwd, "CHANGELOG.md"), "utf8");
-      await execFileAsync("node", [generatorPath], { cwd, timeout: subprocessTimeoutMs });
+      await execFileAsync("node", [generatorPath], {
+        cwd,
+        timeout: subprocessTimeoutMs,
+        env: isolatedGitEnv(),
+      });
       const second = await readFile(join(cwd, "CHANGELOG.md"), "utf8");
 
       expect(second).toBe(first);

--- a/tests/tool-presenters.test.ts
+++ b/tests/tool-presenters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createDirectiveToolResponse,
   deleteDirectiveToolResponse,
+  exportBankTemplateToolResponse,
   getBankTemplateSchemaToolResponse,
   getDirectiveToolResponse,
   listDirectivesToolResponse,
@@ -46,6 +47,18 @@ describe("tool presenters", () => {
         result: { deleted: true },
       }).content[0]?.text,
     ).toContain("Deleted directive directive-2 in bank.");
+  });
+
+  it("presents saved bank template export paths", () => {
+    const response = exportBankTemplateToolResponse({
+      bankId: "bank",
+      outputPath: "/tmp/template.json",
+      manifest: { version: "1", bank: { retain_mission: "Remember" } },
+    });
+
+    expect(response.content[0]?.text).toContain("Exported bank template from bank.");
+    expect(response.content[0]?.text).toContain("Saved manifest: /tmp/template.json");
+    expect(response.content[0]?.text).toContain("Bank overrides: 1");
   });
 
   it("presents bank template schema summary and raw JSON", () => {


### PR DESCRIPTION
## Summary

- Add optional `outputFile` to `hindsight_export_bank_template`.
- Save exported bank template manifests as pretty JSON with a trailing newline.
- Resolve relative output paths from `ctx.cwd` and create parent directories.
- Keep copyable JSON in tool output and add saved path when used.
- Make changelog generator test isolate Git hook environment so precommit works when hooks export repo Git variables and Git defaults to `main`.

## Linked issue

- Closes #209

## Scope

- Bank-template export operation/tool/presenter/docs.
- Minimal test-harness fix for a preexisting precommit blocker discovered while committing this branch.
- Does not touch #195/#202/#208 paths.

## Verification

- [x] `npm test -- tests/bank-template-operations.test.ts tests/tool-presenters.test.ts tests/operation-catalog.test.ts`
- [x] `npm test -- tests/changelog-generator.test.ts`
- [x] `npm run check`
- [x] `npm run typecheck:tsc`
- [x] Pre-PR reviewer reported no blockers.

## Release impact

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds optional `outputFile` for an existing public tool.

## Risk and rollback

Low. Output file writing is opt-in and existing JSON output remains unchanged. Roll back by reverting this PR.

## Follow-ups

None.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] Final branch contains only focused, reviewable commits.
