### PR TITLE
docs: migrate start and concepts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,10 +11,27 @@ export default defineConfig({
       title: "Pi Hindsight",
       social: [{ icon: "github", label: "GitHub", href: "https://github.com/luxus/pi-hindsight" }],
       sidebar: [
-        { label: "Start", items: [{ label: "Getting started", slug: "start/getting-started" }] },
+        {
+          label: "Start",
+          items: [
+            { label: "Getting started", slug: "start/getting-started" },
+            { label: "Installation", slug: "start/installation" },
+            { label: "Setup TUI", slug: "start/setup-tui" },
+            { label: "Memory profiles", slug: "start/memory-profiles" },
+            { label: "Minimal configuration", slug: "start/minimal-config" },
+          ],
+        },
         {
           label: "Concepts",
           items: [
+            { label: "Memory Banks", slug: "concepts/memory-banks" },
+            { label: "Retain, Recall, and Reflect", slug: "concepts/retain-recall-reflect" },
+            {
+              label: "Document IDs and update modes",
+              slug: "concepts/document-ids-update-modes",
+            },
+            { label: "Retain Queue durability", slug: "concepts/queue-durability" },
+            { label: "Historical Import", slug: "concepts/imports" },
             { label: "Memory behavior", slug: "concepts/memory-behavior" },
             { label: "Hindsight core functions", slug: "concepts/hindsight-core-functions" },
           ],

--- a/docs-site/src/content/docs/concepts/document-ids-update-modes.md
+++ b/docs-site/src/content/docs/concepts/document-ids-update-modes.md
@@ -1,0 +1,39 @@
+---
+title: "Document IDs and update modes"
+---
+
+# Document IDs and update modes
+
+A **Document ID** is the stable Hindsight document identifier for retained content. A stable ID prevents duplicate memory documents and makes deletion/reimport behavior inspectable.
+
+## Live sessions
+
+Live Pi sessions use stable document IDs and `update_mode: "append"`.
+
+Append mode lets Pi Hindsight retain new session deltas over time without replacing earlier evidence. A Retain Cursor records which transcript boundary was already retained so retries and restarts do not duplicate content.
+
+## Historical imports
+
+Historical imports use deterministic document IDs.
+
+Curated imports include session identity, branch/leaf identity, import profile, projection version, chunk index, and message range. This makes reimports idempotent and lets the importer resume from checkpoints.
+
+Raw and forensic import modes preserve legacy raw IDs and payload shape for audit/debug use.
+
+## Update modes
+
+Use `append` for:
+
+- ongoing live sessions
+- incremental logs
+- queue retries for the same live source
+
+Use `replace` for:
+
+- deterministic historical reimports
+- full rebuilds
+- one-shot explicit documents where replacement is intended
+
+## Deletion
+
+Deletion requires the exact bank ID and exact Document ID. Pi Hindsight exposes retain receipts and import manifests/checkpoints so document identity remains inspectable.

--- a/docs-site/src/content/docs/concepts/imports.md
+++ b/docs-site/src/content/docs/concepts/imports.md
@@ -1,0 +1,35 @@
+---
+title: "Historical Import"
+---
+
+# Historical Import
+
+**Import** is the historical session ingestion path. It parses Pi JSONL sessions or gateway transcripts, builds deterministic source documents, queues Retain Jobs, and records manifests/checkpoints.
+
+Import is not generic summarization. Curated import keeps filtered structured source material so Hindsight still receives evidence with provenance.
+
+## Modes
+
+- `curated`: default high-signal projection for normal historical imports.
+- `raw`: explicit raw branch import for compatibility/debugging.
+- `forensic`: raw-style import that preserves recalled memory blocks and other artifacts for audit use.
+
+Raw and forensic modes preserve legacy document IDs and payload shape.
+
+## Profiles
+
+Setup-selected bank templates can inform import defaults:
+
+- coding/project template → repo-scoped Pi agent sessions
+- assistant/personal template → gateway/chat transcripts
+- general/user template → conversation/open-thread import
+
+Source types are explicit. Pi Hindsight does not silently mix repo sessions and gateway transcripts.
+
+## Dry-run first
+
+Historical import should be previewed before writing. Dry-run reports include counts for raw/projected messages, dropped tool output, kept errors, estimated chunks, malformed lines, target banks, and checkpoint/manifest paths.
+
+## Provenance
+
+Import records provenance in tags and metadata. Use tags for filtering and metadata for traceability back to source sessions, branches, conversations, and chunks.

--- a/docs-site/src/content/docs/concepts/index.mdx
+++ b/docs-site/src/content/docs/concepts/index.mdx
@@ -3,3 +3,16 @@ title: Concepts
 ---
 
 Concept pages explain how Pi Hindsight uses Hindsight Memory Banks, Retain, Recall, Reflect, imports, session memory modes, and safety boundaries.
+
+Core concepts:
+
+- [Memory Banks](./memory-banks/)
+- [Retain, Recall, and Reflect](./retain-recall-reflect/)
+- [Document IDs and update modes](./document-ids-update-modes/)
+- [Retain Queue durability](./queue-durability/)
+- [Historical Import](./imports/)
+
+Additional concept references:
+
+- [Memory behavior](./memory-behavior/)
+- [Hindsight core functions](./hindsight-core-functions/)

--- a/docs-site/src/content/docs/concepts/memory-banks.md
+++ b/docs-site/src/content/docs/concepts/memory-banks.md
@@ -1,0 +1,55 @@
+---
+title: "Memory Banks"
+---
+
+# Memory Banks
+
+A **Memory Bank** is an isolated Hindsight namespace. Banks are the main boundary that prevents unrelated memory from mixing.
+
+## Project Bank
+
+A **Project Bank** is selected for the current repository. It stores repository-specific memory such as:
+
+- architecture decisions
+- bugs and fixes
+- project conventions
+- tools and libraries
+- import history
+- repo-local preferences
+
+Project recall is scoped with repository tags so unrelated project memories do not leak in.
+
+## Global Bank / User Bank
+
+A **Global Bank** is an optional cross-project bank for durable user-level memory such as:
+
+- stable preferences
+- recurring workflows
+- coding habits
+- assistant collaboration style
+
+The user-facing UI may call this **User** memory where that is clearer. The tool alias `global` remains supported for compatibility.
+
+Automatic Global Bank writes are disabled by default. Use explicit Retain or intentionally enable Router Mode when cross-project writes are desired.
+
+## Bank Alias
+
+A **Bank Alias** is a stable name that resolves to a real Hindsight bank ID:
+
+- `project` resolves to the selected Project Bank.
+- `global` resolves to the configured Global/User Bank.
+
+Aliases are useful in tools and documentation when the exact bank ID is not important.
+
+## Tags and metadata
+
+Use tags to filter and isolate memory. Use metadata for provenance.
+
+Examples:
+
+- `source:pi`
+- `repo:pi-hindsight`
+- `session:<session-id>`
+- `profile:coding`
+
+Do not rely on metadata for filtering behavior when scope isolation matters.

--- a/docs-site/src/content/docs/concepts/queue-durability.md
+++ b/docs-site/src/content/docs/concepts/queue-durability.md
@@ -1,0 +1,47 @@
+---
+title: "Retain Queue durability"
+---
+
+# Retain Queue durability
+
+Pi Hindsight is queue-first. A **Retain Job** is written to disk before delivery to Hindsight.
+
+This protects memory during:
+
+- Hindsight outages
+- network failures
+- Pi process shutdowns
+- retryable server errors
+
+## Retain Queue
+
+The **Retain Queue** is a JSONL-backed durability layer. Jobs include bank ID, Document ID, content, context, tags, metadata, entities, update mode, and provenance.
+
+The queue supports:
+
+- in-process mutex
+- filesystem lock directory for cross-process safety
+- stale-lock detection
+- malformed-line quarantine
+- dead-letter rollover after exhausted retries
+- diagnostics that summarize state without logging raw retained content
+
+## Flush paths
+
+Flush queued jobs with:
+
+```text
+/hindsight:flush
+```
+
+Retain attempts and shutdown also try to flush pending jobs. Periodic flushing can be enabled with `retain.flushIntervalMs` and bounded by periodic/shutdown limits.
+
+## Dead Letter Queue
+
+The **Dead Letter Queue** stores jobs that cannot be delivered after retry policy is exhausted or cannot be represented safely in the active queue.
+
+Dead-letter jobs should remain inspectable and should never be silently discarded.
+
+## Safety
+
+Queue diagnostics must not print raw retained payloads in normal mode. Secrets are sanitized before retain jobs are queued where possible.

--- a/docs-site/src/content/docs/concepts/retain-recall-reflect.md
+++ b/docs-site/src/content/docs/concepts/retain-recall-reflect.md
@@ -1,0 +1,55 @@
+---
+title: "Retain, Recall, and Reflect"
+---
+
+# Retain, Recall, and Reflect
+
+Pi Hindsight uses the three core Hindsight operations without collapsing them into one generic “memory” action.
+
+```text
+Retain  = store source material
+Recall  = retrieve relevant memory candidates
+Reflect = reason over memory for a question
+```
+
+## Retain
+
+**Retain** writes raw rich content to Hindsight.
+
+Pi Hindsight retains structured session deltas, explicit user-provided content, and curated historical import chunks. Retain should preserve source evidence rather than pre-summarizing it.
+
+Important fields:
+
+- `context`: what kind of content is being retained
+- `document_id`: stable source/document identity
+- `update_mode`: `append` for live sessions, `replace` for deterministic reimports
+- `tags`: scope and visibility
+- `metadata`: provenance and links back to source records
+
+## Recall
+
+**Recall** retrieves memory candidates before answer generation.
+
+Automatic recall runs in Pi's `context` hook. It injects an ephemeral Recall Block into provider context. That block is not written into the Pi transcript by this extension and must not be retained back into Hindsight.
+
+Recall returns candidates, not final answers.
+
+## Reflect
+
+**Reflect** asks Hindsight to reason over stored memory for a specific question.
+
+Use Reflect for:
+
+- pattern investigation
+- contradictions
+- design history
+- “why did this happen?” questions
+- memory-grounded synthesis
+
+Do not route all automatic memory behavior through Reflect. Pi Hindsight exposes Reflect as an explicit tool/command path.
+
+## Mental models
+
+Mental models are saved Hindsight reflect responses for recurring questions. They are useful for stable project or user context, but they are not replacements for source import material.
+
+Pi Hindsight can list mental models and offer explicit refresh/create flows after imports. Routine session retain does not silently create or refresh mental models.

--- a/docs-site/src/content/docs/start/index.mdx
+++ b/docs-site/src/content/docs/start/index.mdx
@@ -3,3 +3,10 @@ title: Start
 ---
 
 Begin with [Getting started](./getting-started/) to install Pi Hindsight, choose a Hindsight server, run guided setup, and verify the first memory profile.
+
+First journey:
+
+- [Installation](./installation/)
+- [Setup TUI](./setup-tui/)
+- [Memory profiles](./memory-profiles/)
+- [Minimal configuration](./minimal-config/)

--- a/docs-site/src/content/docs/start/installation.md
+++ b/docs-site/src/content/docs/start/installation.md
@@ -1,0 +1,45 @@
+---
+title: "Installation"
+---
+
+# Installation
+
+Pi Hindsight is a Pi package. Install it into Pi, then point it at a Hindsight server.
+
+## Install from GitHub
+
+```bash
+pi install https://github.com/luxus/pi-hindsight
+```
+
+## Install from a local checkout
+
+```bash
+git clone https://github.com/luxus/pi-hindsight
+pi install /path/to/pi-hindsight
+```
+
+## Choose a Hindsight server
+
+Use Hindsight Cloud or a local Hindsight API server:
+
+- [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
+- [Local Hindsight installation](https://hindsight.vectorize.io/developer/installation)
+
+For local development, the conventional URL is:
+
+```text
+http://localhost:8888
+```
+
+Pi Hindsight treats official Hindsight API behavior as the source of truth. Local Pi config selects banks and behavior; Hindsight owns Memory Bank storage, Retain, Recall, Reflect, bank config, mental models, and directives.
+
+## Next step
+
+Open Pi in a repository and run:
+
+```text
+/hindsight
+```
+
+If the repository has no project config yet, guided setup starts first.

--- a/docs-site/src/content/docs/start/memory-profiles.md
+++ b/docs-site/src/content/docs/start/memory-profiles.md
@@ -1,0 +1,39 @@
+---
+title: "Memory profiles"
+---
+
+# Memory profiles
+
+Choose the narrowest memory route that fits the repository.
+
+## `project-only`
+
+Safest default.
+
+- Recall reads the Project Bank.
+- Automatic Retain writes session deltas to the Project Bank.
+- Global/User memory is not used by default.
+
+Use this for sensitive repositories, client work, or any project where memory must stay isolated.
+
+## `project+global`
+
+Best for most personal coding.
+
+- Project facts stay in the Project Bank.
+- Durable user preferences and cross-project habits can be recalled from the configured Global/User Bank.
+- Automatic Retain still writes project transcript deltas to the Project Bank by default.
+
+Global/User writes remain explicit unless Router Mode is intentionally enabled.
+
+## `global-only`
+
+Broad shared recall.
+
+- Project Bank is disabled.
+- Automatic Retain is disabled because there is no project-scoped write route.
+- Use explicit Retain when you intentionally want Global/User memory.
+
+## Terminology note
+
+The product is migrating user-facing UI from “global” toward “user” where that is clearer. The glossary still uses **Global Bank** for the configured cross-project bank term. Tool aliases may still accept `global` for compatibility.

--- a/docs-site/src/content/docs/start/minimal-config.md
+++ b/docs-site/src/content/docs/start/minimal-config.md
@@ -1,0 +1,55 @@
+---
+title: "Minimal configuration"
+---
+
+# Minimal configuration
+
+A minimal project-local config points Pi Hindsight at your Hindsight server:
+
+```json
+{
+  "hindsight": {
+    "baseUrl": "http://localhost:8888"
+  }
+}
+```
+
+To pin the Project Bank ID:
+
+```json
+{
+  "hindsight": {
+    "baseUrl": "http://localhost:8888"
+  },
+  "banks": {
+    "project": {
+      "derive": "manual",
+      "bankId": "pi-project-my-repo"
+    }
+  }
+}
+```
+
+## Bank-owned settings
+
+Pi JSON selects banks and local behavior. Hindsight bank config owns bank settings such as:
+
+- Retain mission
+- Reflect mission
+- observations mission
+- disposition traits
+- mental models
+- directives
+- bank template overrides
+
+Use Pi Hindsight tools and setup flow to inspect or apply bank-owned settings. Do not treat local Pi JSON as the source of truth for missions, mental models, or directives.
+
+## Environment override
+
+For local development or temporary testing, set:
+
+```bash
+export HINDSIGHT_BASE_URL=http://localhost:8888
+```
+
+If your Hindsight server requires authentication, set the configured API key variable for your environment.

--- a/docs-site/src/content/docs/start/setup-tui.md
+++ b/docs-site/src/content/docs/start/setup-tui.md
@@ -1,0 +1,65 @@
+---
+title: "Setup TUI"
+---
+
+# Setup TUI
+
+Run the setup TUI from Pi:
+
+```text
+/hindsight
+```
+
+The TUI shows:
+
+- memory status
+- selected Project Bank and optional Global/User Bank
+- Hindsight server reachability
+- Retain Queue state
+- import state
+- recent Retain receipts
+- editable local Pi configuration fields
+- read-only mental model inventory
+
+## Guided setup
+
+If no project config exists, `/hindsight` starts guided setup before the advanced TUI.
+
+Guided setup helps you choose:
+
+1. memory profile
+2. project and/or user bank target
+3. built-in or custom bank template
+4. optional dry-run-first historical import
+5. optional post-import mental model refresh
+
+Bank templates and mental models are Hindsight bank-owned settings. Pi Hindsight does not store mission text or directive definitions as normal Pi JSON source of truth.
+
+## Keyboard controls
+
+- `h`/`l` or `<`/`>`: switch tabs
+- `j`/`k`: move between settings
+- `Enter`: edit selected setting
+- `r`: remove the selected setting's active override
+- `f`: flush queued Retain Jobs
+- `m`: open the read-only mental model list/detail view
+- `d`: deployment setup
+- `g`: rerun guided setup
+
+## First checks
+
+After setup, confirm:
+
+- memory is enabled
+- expected profile is active
+- expected Project Bank is selected
+- optional Global/User Bank is selected only when intended
+- Hindsight server is reachable
+- Retain Queue path is visible
+
+Preview imports before writing memory:
+
+```text
+/hindsight:import-current --dry-run
+/hindsight:import-project-sessions --dry-run
+```


### PR DESCRIPTION
## Summary

- Add first user journey pages to the Starlight site: installation, setup TUI, memory profiles, and minimal configuration.
- Add core concept pages for Memory Banks, Retain/Recall/Reflect, Document IDs/update modes, Retain Queue durability, and Historical Import.
- Update Starlight sidebar and section index pages so migrated content is reachable from the site navigation.
- Keep legacy copied docs in place for compatibility and deeper reference links.

## Linked issue

- Closes #198

## Scope

- Documentation-site content/navigation only.
- Reference docs and architecture/development docs remain follow-up slices.

## Verification

- [x] `npm run docs:build`
- [x] `npm run check`
- [x] `npm run typecheck:tsc`
- [x] Pre-PR reviewer reported no blockers.

## Release impact

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds documentation pages to the docs site. No runtime package behavior change.

## Risk and rollback

Low. Documentation-only site navigation/content. Roll back by reverting this PR.

## Follow-ups

- #205 migrates reference docs.
- #206 migrates architecture and development docs.
- #199 publishes the site to GitHub Pages.
- #201 adds documentation quality checks.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] Final branch contains only focused, reviewable commits.
