### PR TITLE
docs: migrate reference docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -43,8 +43,11 @@ export default defineConfig({
         {
           label: "Reference",
           items: [
+            { label: "Configuration", slug: "reference/configuration" },
             { label: "Tools and commands", slug: "reference/tools-and-commands" },
-            { label: "Surface reference", slug: "reference/surface-reference" },
+            { label: "Hooks", slug: "reference/hooks" },
+            { label: "Import controls", slug: "reference/import-controls" },
+            { label: "Generated surface reference", slug: "reference/surface-reference" },
           ],
         },
         {

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -1,0 +1,135 @@
+---
+title: "Configuration reference"
+---
+
+# Configuration reference
+
+Pi Hindsight resolves configuration from defaults, global config, project config, and environment variables.
+
+For concepts behind Project Banks, Global/User Banks, tags, metadata, Document IDs, and Update Modes, see:
+
+- [Memory Banks](../concepts/memory-banks/)
+- [Document IDs and update modes](../concepts/document-ids-update-modes/)
+- [Retain, Recall, and Reflect](../concepts/retain-recall-reflect/)
+
+## Precedence
+
+Config is loaded from:
+
+1. `~/.pi/agent/hindsight.json` or `~/.pi/agent/hindsight.jsonc`
+2. `.pi/hindsight.json` or `.pi/hindsight.jsonc` in the current repo
+3. environment variables
+
+If both `.json` and `.jsonc` exist at the same scope, `.json` wins. Config is normalized after merging. Unknown fields are ignored, and invalid values fall back to defaults.
+
+Environment variables win the effective value. Project/user stored values can still be edited for future runs after the environment override is removed.
+
+## Common environment variables
+
+```bash
+export HINDSIGHT_BASE_URL=http://localhost:8888
+export HINDSIGHT_API_KEY=...
+# or point config/env at another env var without storing the raw key:
+export HINDSIGHT_API_KEY_REF=HINDSIGHT_API_KEY
+
+export PI_HINDSIGHT_ENABLED=true
+export PI_HINDSIGHT_PROJECT_BANK_ID=pi-project-my-repo
+export PI_HINDSIGHT_USER_BANK_ID=user-luxus
+# Legacy fallback still works during migration:
+# export PI_HINDSIGHT_GLOBAL_BANK_ID=global-luxus
+```
+
+Project config SecretRef shape:
+
+```json
+{
+  "hindsight": {
+    "apiKey": { "source": "env", "name": "HINDSIGHT_API_KEY" }
+  }
+}
+```
+
+## Memory profiles
+
+- `project-only`: Project Bank enabled; user bank disabled; automatic Retain writes to the Project Bank.
+- `project+global`: project and user recall enabled; automatic Retain still writes project transcript deltas to the Project Bank by default.
+- `global-only`: Project Bank disabled; user recall enabled; automatic Retain disabled.
+
+When a profile enables user memory without an existing bank ID, setup writes `pi-global` as the default user bank ID for compatibility. Override it with `PI_HINDSIGHT_USER_BANK_ID`, `.pi/hindsight.json` `banks.user.bankId`, or the setup TUI if you prefer a different shared bank. Legacy `PI_HINDSIGHT_GLOBAL_BANK_ID` and `banks.global` configs are migrated/supported during transition.
+
+## Bank settings display
+
+Pi Hindsight distinguishes local Pi behavior from bank-owned Hindsight settings. Setup and status surfaces show both:
+
+- `Location: Project` or `Location: User` describes the Pi memory route.
+- `Bank: <bank-id>` names the concrete Hindsight bank that owns missions, config overrides, mental models, and directives.
+
+Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config.
+
+Use these tools for bank-owned settings:
+
+- `hindsight_get_bank_config`
+- `hindsight_reset_bank_config`
+- `hindsight_get_bank_template_schema`
+- `hindsight_export_bank_template`
+- `hindsight_list_directives`
+- `hindsight_get_directive`
+- `hindsight_create_directive`
+- `hindsight_update_directive`
+- `hindsight_delete_directive`
+
+## Advanced project config example
+
+Bank missions are intentionally absent from this JSON example. Hindsight bank configuration/database is the source of truth for retain, reflect, and observation mission text; Pi JSON should only select banks and extension behavior. Existing mission fields in older configs are treated as legacy fallbacks.
+
+```json
+{
+  "banks": {
+    "project": {
+      "bankId": "pi-project-my-repo",
+      "derive": "manual"
+    },
+    "user": {
+      "enabled": false,
+      "bankId": "user-luxus"
+    }
+  },
+  "recall": {
+    "budget": "mid",
+    "maxTokens": 800,
+    "types": ["observation"],
+    "roles": ["user", "assistant"],
+    "contextTurns": 2,
+    "maxQueryChars": 800,
+    "includeRepoHintsInQuery": true,
+    "storeLastRecall": false,
+    "storeLastRecallFailures": false,
+    "lastRecallPath": ".pi/hindsight/last-recall.json",
+    "topK": 8,
+    "timeoutMs": 40000,
+    "injectionPosition": "append"
+  },
+  "observations": {
+    "enabled": true,
+    "scopes": [["harness:pi"], ["repo:{repoKey}"]]
+  },
+  "retain": {
+    "queuePath": ".pi/hindsight/retain-queue.jsonl",
+    "flushIntervalMs": 30000,
+    "periodicFlushMaxJobs": 1,
+    "periodicFlushTimeoutMs": 2000,
+    "updateMode": "append",
+    "shutdownFlushMaxJobs": 10,
+    "shutdownFlushTimeoutMs": 2000
+  },
+  "import": {
+    "manifestPath": ".pi/hindsight/import-manifest.json",
+    "checkpointPath": ".pi/hindsight/import-checkpoint.json",
+    "resume": true
+  }
+}
+```
+
+## Generated editable-field reference
+
+The exact generated tool and editable config field surface lives in [Generated surface reference](./surface-reference/). Do not edit that generated page by hand; update the operation catalog, config editing registry, or generator.

--- a/docs-site/src/content/docs/reference/hooks.md
+++ b/docs-site/src/content/docs/reference/hooks.md
@@ -1,0 +1,69 @@
+---
+title: "Hooks reference"
+---
+
+# Hooks reference
+
+Pi Hindsight uses documented Pi extension lifecycle hooks. This page is a reference for what each hook path owns.
+
+For the conceptual behavior behind Retain, Recall, and queue durability, see:
+
+- [Retain, Recall, and Reflect](../concepts/retain-recall-reflect/)
+- [Retain Queue durability](../concepts/queue-durability/)
+
+## `session_start`
+
+Initializes runtime memory state.
+
+Responsibilities:
+
+- load and normalize config
+- initialize Hindsight client/runtime state
+- ensure configured banks where appropriate
+- check append capability/status
+- update setup/status facts
+
+## `context`
+
+Runs automatic Recall before answer generation.
+
+Responsibilities:
+
+- select project and optional user/global memory scopes
+- compose a fresh recall query from recent conversation context
+- fetch Hindsight memory candidates
+- format an ephemeral Recall Block
+- inject that block into provider context
+
+Recall Blocks must not be persisted into Pi transcript history or retained back into Hindsight.
+
+## `agent_end`
+
+Runs automatic Retain after a turn.
+
+Responsibilities:
+
+- respect config and session memory mode gates
+- filter already-retained transcript content using the Retain Cursor
+- project transcript messages into structured source content
+- sanitize sensitive data where possible
+- build a Retain Job with bank ID, Document ID, tags, metadata, and update mode
+- enqueue before delivery
+- attempt bounded delivery/flush
+
+## `session_shutdown`
+
+Performs best-effort queue flushing.
+
+Responsibilities:
+
+- flush queued Retain Jobs within configured shutdown bounds
+- leave undelivered jobs on disk for later retry
+
+Shutdown must not silently discard queued memory.
+
+## Tool and command registration
+
+Tools and commands are registered through the Operation Catalog and delegate to the Memory Operation Service. This keeps explicit user intents shared across tools, commands, setup flows, diagnostics, and smoke helpers.
+
+See [Tools and commands](./tools-and-commands/) and [Generated surface reference](./surface-reference/) for the exact public surface.

--- a/docs-site/src/content/docs/reference/import-controls.md
+++ b/docs-site/src/content/docs/reference/import-controls.md
@@ -1,0 +1,65 @@
+---
+title: "Import controls reference"
+---
+
+# Import controls reference
+
+Import controls preview and ingest historical Pi sessions or gateway transcripts. For the concept model, see [Historical Import](../concepts/imports/).
+
+## Commands
+
+```text
+/hindsight:import-current --dry-run
+/hindsight:import-current
+/hindsight:import-file /path/to/session.jsonl --dry-run --all-leaves
+/hindsight:import-project-sessions --dry-run
+/hindsight:import-project-sessions
+```
+
+Use `--dry-run` before writing memory.
+
+## Tools
+
+```text
+hindsight_import({ dryRun: true })
+hindsight_import_gateway({ sourceFile: "/path/to/gateway.jsonl", dryRun: true })
+```
+
+`hindsight_import` imports Pi session JSONL. `hindsight_import_gateway` imports gateway/chat transcript JSONL into the configured user memory bank by default.
+
+## Modes
+
+- `curated`: default filtered structured source chunks.
+- `raw`: explicit raw branch import for compatibility/debugging.
+- `forensic`: raw-style import that preserves artifacts such as recalled memory blocks.
+
+Raw and forensic modes preserve legacy document IDs and payload shape.
+
+## Dry-run metrics
+
+Pi session dry-runs report items such as:
+
+- document count
+- import mode/profile
+- raw message count
+- curated projection count
+- dropped non-error tool-result count
+- kept tool-error count
+- estimated chunk count
+- byte counts
+- target bank
+- checkpoint/manifest paths
+
+Gateway dry-runs report items such as:
+
+- kept event count
+- retained user-turn count
+- dropped event count/type totals
+- malformed-line count
+- target user bank
+- content hash
+- byte count
+
+## Checkpoints and manifests
+
+Historical import writes an Import Manifest and Import Checkpoint so work is inspectable, resumable, and idempotent. Curated document IDs include profile/projection/chunk information. Raw and forensic modes preserve legacy IDs.

--- a/docs-site/src/content/docs/reference/index.mdx
+++ b/docs-site/src/content/docs/reference/index.mdx
@@ -3,3 +3,13 @@ title: Reference
 ---
 
 Reference pages contain exact tool names, command names, config fields, generated surface output, and schema-oriented material.
+
+Reference pages:
+
+- [Configuration reference](./configuration/)
+- [Tools and commands](./tools-and-commands/)
+- [Hooks reference](./hooks/)
+- [Import controls reference](./import-controls/)
+- [Generated surface reference](./surface-reference/)
+
+Generated or tool-derived pages are marked as such. Concept explanations live in [Concepts](../concepts/) and are linked from reference pages rather than repeated inconsistently.

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -4,7 +4,7 @@ title: "Tools and commands"
 
 # Tools and commands
 
-For a generated reference of registered tools, commands, and editable config fields, see [`surface-reference.md`](surface-reference.md).
+For generated details of registered tools and editable config fields, see [Generated surface reference](./surface-reference/). For related concepts, see [Retain, Recall, and Reflect](../concepts/retain-recall-reflect/) and [Memory Banks](../concepts/memory-banks/).
 
 `/hindsight` is the main control center. Commands are convenience shortcuts and escape hatches for advanced workflows.
 
@@ -36,7 +36,7 @@ The `hindsight_configure` tool can write config from agents. Prefer `/hindsight`
 /hindsight:import-project-sessions
 ```
 
-Use dry-run before non-dry-run imports. See [`importing-sessions.md`](importing-sessions.md).
+Use dry-run before non-dry-run imports. See [Import controls reference](./import-controls/) and [Importing sessions](../guides/importing-sessions/).
 
 ## Queue and snapshots
 


### PR DESCRIPTION
## Summary

- Add Starlight reference pages for configuration, hooks, and import controls.
- Update reference index and sidebar navigation for config, tools/commands, hooks, imports, and generated surface output.
- Clarify generated surface reference remains generated/tool-derived.
- Link reference pages to concept docs for Retain, Recall, Reflect, banks, tags, metadata, Document IDs, and Update Modes instead of re-explaining them inconsistently.
- Preserve existing copied/root docs so old links remain practical.

## Linked issue

- Closes #205

## Scope

- Documentation-site reference content/navigation only.
- Architecture and development docs remain follow-up slice #206.

## Verification

- [x] `npm run docs:build`
- [x] `npm run check`
- [x] `npm run typecheck:tsc`
- [x] Pre-PR reviewer reported no blockers.

## Release impact

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds documentation pages to the docs site. No runtime behavior change.

## Risk and rollback

Low. Documentation-only site navigation/content. Roll back by reverting this PR.

## Follow-ups

- #206 migrates architecture and development docs.
- #199 publishes the site to GitHub Pages.
- #201 adds documentation quality checks.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] Final branch contains only focused, reviewable commits.
