### PR TITLE
docs: migrate architecture and development docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "Pi Hindsight",
+      disable404Route: true,
       social: [{ icon: "github", label: "GitHub", href: "https://github.com/luxus/pi-hindsight" }],
       sidebar: [
         {
@@ -34,6 +35,10 @@ export default defineConfig({
             { label: "Historical Import", slug: "concepts/imports" },
             { label: "Memory behavior", slug: "concepts/memory-behavior" },
             { label: "Hindsight core functions", slug: "concepts/hindsight-core-functions" },
+            {
+              label: "Starter mental model suggestions",
+              slug: "concepts/starter-mental-model-suggestions",
+            },
           ],
         },
         {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -53,17 +53,68 @@ export default defineConfig({
         {
           label: "Architecture",
           items: [
+            { label: "Lifecycle and scope", slug: "architecture/lifecycle-and-scope" },
             {
               label: "Core vs companion adapters",
               slug: "architecture/core-vs-companion-adapters",
+            },
+            { label: "Queue and import architecture", slug: "architecture/queue-and-import" },
+            {
+              label: "Diagnostics and security boundaries",
+              slug: "architecture/diagnostics-and-security",
+            },
+            {
+              label: "ADRs",
+              items: [
+                {
+                  label: "ADR 001: Memory lifecycle and scope",
+                  slug: "architecture/adr/001-memory-lifecycle-and-scope",
+                },
+                {
+                  label: "ADR 002: Explicit routing strategy seam",
+                  slug: "architecture/adr/002-explicit-routing-strategy-seam",
+                },
+                {
+                  label: "ADR 003: TUI memory mode vocabulary",
+                  slug: "architecture/adr/003-tui-memory-mode-vocabulary",
+                },
+              ],
             },
           ],
         },
         {
           label: "Development",
           items: [
+            { label: "Development setup", slug: "development/development" },
+            { label: "Testing and verification", slug: "development/testing-and-verification" },
+            { label: "CI routing", slug: "development/ci-routing" },
+            { label: "Package verification", slug: "development/package-verification" },
+            { label: "Release process", slug: "development/release" },
             { label: "Documentation architecture", slug: "development/documentation-architecture" },
-            { label: "Development", slug: "development/development" },
+            { label: "Internal and agent docs", slug: "development/internal-and-agent-docs" },
+            {
+              label: "Agent docs",
+              items: [
+                { label: "AGENTS.md", slug: "development/agents-root" },
+                { label: "CONTRIBUTING.md", slug: "development/contributing" },
+                { label: "CONTEXT.md", slug: "development/context" },
+                { label: "Issue tracker", slug: "development/agents/issue-tracker" },
+                { label: "Domain docs", slug: "development/agents/domain" },
+                { label: "Triage labels", slug: "development/agents/triage-labels" },
+              ],
+            },
+          ],
+        },
+        {
+          label: "Internal / Archive",
+          items: [
+            { label: "Internal index", slug: "internal" },
+            { label: "Architecture TODOs", slug: "internal/architecture-todos" },
+            { label: "Next opt-out design", slug: "internal/next-opt-out-design" },
+            { label: "Post-MVP roadmap", slug: "internal/post-mvp-roadmap" },
+            { label: "PR roadmap", slug: "internal/pr-roadmap" },
+            { label: "PRD", slug: "internal/prd" },
+            { label: "Coding plan", slug: "internal/coding-plan" },
           ],
         },
       ],

--- a/docs-site/src/content/docs/404.md
+++ b/docs-site/src/content/docs/404.md
@@ -1,0 +1,15 @@
+---
+title: Not found
+template: splash
+editUrl: false
+lastUpdated: false
+pagefind: false
+hero:
+  title: "404"
+  tagline: "Page not found. Check the URL or use search."
+  actions:
+    - text: Go home
+      icon: right-arrow
+      link: /
+      variant: primary
+---

--- a/docs-site/src/content/docs/architecture/adr/001-memory-lifecycle-and-scope.md
+++ b/docs-site/src/content/docs/architecture/adr/001-memory-lifecycle-and-scope.md
@@ -1,0 +1,60 @@
+---
+title: "ADR-001: Memory lifecycle and scope policy"
+---
+
+# ADR-001: Memory lifecycle and scope policy
+
+## Status
+
+Accepted
+
+## Context
+
+Pi Hindsight needs one coherent lifecycle for recall, retain, queueing, import, and diagnostics.
+
+The MVP currently has the right hook placement and Hindsight defaults, but turn-level policy is distributed across the Pi hook adapter and several helper modules. That makes the core invariant harder to test: recall must happen before provider context, recalled memory must never be retained, retain must store safe session content, writes must be queued before network flush, bank and tag scope must be correct, status must reflect actual outcomes, and failures must degrade predictably.
+
+## Decision
+
+The Pi hook adapter delegates to a MemoryLifecycle module.
+
+MemoryLifecycle owns turn-level policy:
+
+- config reload
+- selected bank scopes
+- recall execution
+- injected-memory handling
+- retain gating
+- queue orchestration
+- status transitions
+
+Memory identity is centralized in MemoryIdentity:
+
+- repo key
+- project bank ID
+- global bank scope
+- session ID
+- live document ID
+- import document ID
+- base tags
+- recall tags per bank
+
+Tools and commands call shared intent operations where the same user intent is exposed through multiple Pi surfaces.
+
+## Invariants
+
+- Recalled memory is never retained.
+- Project recall is repo-scoped.
+- Global recall has explicit non-repo scope.
+- Explicit retain always includes base scope tags.
+- Retain jobs are durably queued before network flush.
+- Disabled memory does not emit active retain or recall status.
+- Import document IDs are deterministic.
+- Historical import defaults to replace mode.
+
+## Consequences
+
+- `extensions/index.ts` becomes a thin Pi adapter.
+- Some current helpers move under lifecycle and identity modules.
+- Tests target lifecycle outcomes, not hook implementation details.
+- Hindsight HTTP request shapes, Pi JSONL parsing, secret regex internals, and UI rendering strings remain outside MemoryLifecycle.

--- a/docs-site/src/content/docs/architecture/adr/002-explicit-routing-strategy-seam.md
+++ b/docs-site/src/content/docs/architecture/adr/002-explicit-routing-strategy-seam.md
@@ -1,0 +1,168 @@
+---
+title: "ADR 002: Explicit routing strategy seam"
+---
+
+# ADR 002: Explicit routing strategy seam
+
+## Status
+
+Proposed.
+
+## Context
+
+Pi Hindsight currently defaults to safe project-local automatic retain. Global automatic retain is disabled unless `globalRetain.mode = "router"` is explicitly enabled.
+
+The current router is intentionally conservative and heuristic. It classifies candidate memory as `project`, `global`, `both`, or `skip`, and `hindsight_route_memory` exposes the decision as a dry run in explicit-only mode. This is useful, but the seam needs a clearer product contract before adding richer bank topologies such as per-user, per-agent, shared-knowledge, or explicit named banks.
+
+The main safety risk is silent global memory pollution. Better routing must not make global writes the default.
+
+## Decision
+
+Routing remains opt-in for automatic writes. `globalRetain.mode = "explicit-only"` stays the default.
+
+Pi Hindsight will treat routing as an explicit strategy seam with stable input and output shapes. The default strategy keeps today's project/global behavior. Future strategies may route to additional bank topologies only behind explicit configuration and dry-run inspection.
+
+## Routing input shape
+
+A routing strategy receives a normalized candidate:
+
+```ts
+interface RoutingCandidate {
+  content: string;
+  context?: string;
+  repo?: {
+    cwd: string;
+    name?: string;
+    branch?: string;
+    remoteUrl?: string;
+  };
+  session?: {
+    id?: string;
+    title?: string;
+    cwd?: string;
+  };
+  message?: {
+    role?: "user" | "assistant" | "system" | "tool";
+    kind?: "conversation" | "explicit-retain" | "import" | "tool-result";
+    timestamp?: string;
+  };
+  explicitTarget?: "project" | "global" | "both" | "skip" | string;
+  identity?: {
+    userId?: string;
+    agentId?: string;
+    channelId?: string;
+  };
+  config: {
+    globalRetainMode: "explicit-only" | "router";
+    projectBankId?: string;
+    globalBankId?: string;
+    globalBankEnabled?: boolean;
+  };
+  missions: {
+    project?: string;
+    global?: string;
+  };
+}
+```
+
+Only `content`, `config`, and missions are required for today's implementation. Other fields are forward-compatible context for future strategies.
+
+## Routing output shape
+
+A routing strategy returns an explainable decision:
+
+```ts
+interface RoutingDecision {
+  route: "project" | "global" | "both" | "skip" | string;
+  targets: Array<{
+    bankId: string;
+    bankRole: "project" | "global" | "user" | "agent" | "shared" | "named";
+    tags: string[];
+    updateMode?: "append" | "replace";
+  }>;
+  confidence: number;
+  reason: string;
+  matchedSignals: string[];
+  safetyNotes: string[];
+  mode: "explicit-only" | "router";
+  writes: string[];
+}
+```
+
+`hindsight_route_memory` should evolve toward this shape while preserving current fields until a compatibility break is intentional.
+
+## Safety policy
+
+- `explicit-only` means dry-run only. No automatic global writes.
+- Router mode must be opt-in and visible in `/hindsight` status/config.
+- Global writes require high confidence or explicit user action.
+- Ambiguous project+global content should prefer `both` with conservative tags, or ask/dry-run rather than silently picking global.
+- Secrets, private URLs, bearer tokens, cookies, and transient artifact paths should route to `skip` or require redaction before retain.
+- Metadata records provenance; tags control scope and visibility.
+- Recalled memory must not be routed back into retain.
+
+## Strategy seam
+
+Initial strategies:
+
+1. `project-global-default`: current project/global/both/skip classifier using missions and heuristics.
+2. `dry-run-only`: always produces an explainable decision but writes nothing.
+3. Future `named-bank`: resolves explicit named bank targets once config supports them.
+4. Future `identity-aware`: includes per-user/per-agent context only after identity source is documented.
+
+The seam should not know Pi provider internals. It should receive normalized routing input from lifecycle/tool code.
+
+## Eval fixture taxonomy
+
+Routing evals should cover at least:
+
+- durable global preference
+- stable identity preference
+- cross-project workflow habit
+- project architecture fact
+- project implementation decision
+- project delivery state
+- project-scoped user preference
+- identity-like fact embedded in project work
+- ambiguous project/global content
+- secret or credential-like content
+- transient screenshot/artifact
+- temporary command/test output
+
+Fixtures should assert:
+
+- route
+- confidence band or minimum confidence
+- matched signal categories
+- safety notes where relevant
+- write targets in router mode
+- no writes in explicit-only mode
+
+## Tool and TUI implications
+
+`hindsight_route_memory` should become the primary dry-run surface for routing decisions. It should show:
+
+- suggested route
+- confidence
+- target bank roles and IDs
+- tags that would be applied
+- reason and matched signals
+- safety notes
+- whether the current mode would write or only preview
+
+A future `/hindsight` TUI route preview can call the same operation and should avoid duplicating routing logic.
+
+## Consequences
+
+- Safe defaults remain unchanged.
+- Future routing work has a stable contract instead of adding ad hoc conditions to lifecycle retain.
+- Richer bank topologies remain possible without coupling core to a specific platform identity model.
+- More tests are required before enabling any new automatic route.
+
+## Follow-up implementation issues
+
+- #154: Update `hindsight_route_memory` presenter to include target bank roles, tags, safety notes, and explicit write/no-write status.
+- #155: Expand router eval fixtures with secret/noise/ambiguous confidence cases and safety-note assertions.
+- #156: Add a `RoutingStrategy` type and adapter boundary separate from current heuristic implementation.
+- Add a future TUI route-preview action that calls the shared routing operation.
+- Design named-bank resolver config before supporting per-user/per-agent/shared-bank targets.

--- a/docs-site/src/content/docs/architecture/adr/003-tui-memory-mode-vocabulary.md
+++ b/docs-site/src/content/docs/architecture/adr/003-tui-memory-mode-vocabulary.md
@@ -1,0 +1,104 @@
+---
+title: "ADR 003: TUI memory mode vocabulary"
+---
+
+# ADR 003: TUI memory mode vocabulary
+
+## Status
+
+Proposed.
+
+## Context
+
+Pi Hindsight already has separate controls for recall, automatic retain, explicit tools, imports, flush, and one-turn opt-out. Those controls are correct but too implementation-shaped for the `/hindsight` TUI. Users need a small vocabulary that explains what memory will do without changing the underlying safe defaults.
+
+The design should not add provider recall caching, prompt hashtag controls, automatic reflect prefetch, or new routing behavior.
+
+## Decision
+
+The TUI will describe memory behavior with four user-facing modes:
+
+1. `normal`
+2. `read-only`
+3. `ignored`
+4. future `tools-only`
+
+`normal` is the default mode. `read-only` and `ignored` map to existing session behavior. `tools-only` is reserved vocabulary for a future slice and must not appear as an enabled option until implemented.
+
+These names are TUI vocabulary, not a replacement for the lower-level config model. Existing config keys remain source of truth for recall, retain, import, and routing behavior.
+
+## Mode matrix
+
+| Mode                | Automatic recall | Automatic retain | Explicit tools and commands                                           | Import  | Flush queued jobs | Intended use                                             |
+| ------------------- | ---------------- | ---------------- | --------------------------------------------------------------------- | ------- | ----------------- | -------------------------------------------------------- |
+| `normal`            | on if configured | on if configured | allowed                                                               | allowed | allowed           | Default coding with project memory continuity.           |
+| `read-only`         | on if configured | off              | read tools allowed; explicit writes require confirmation/command path | allowed | allowed           | Use existing memory without adding new transcript facts. |
+| `ignored`           | off              | off              | explicit operations remain available from commands/tools              | allowed | allowed           | Work without automatic memory participation.             |
+| future `tools-only` | off              | off              | allowed                                                               | allowed | allowed           | No automatic memory; user manually calls tools.          |
+
+## Semantics
+
+### `normal`
+
+`normal` means Pi Hindsight follows configured automatic behavior:
+
+- recall injects ephemeral memory before answer generation when enabled
+- retain queues sanitized transcript deltas at agent end when enabled
+- global automatic retain stays governed by `globalRetain.mode`
+- explicit tools and TUI actions are available
+- imports and queue flushes are available
+
+### `read-only`
+
+`read-only` means automatic writes are disabled while reads stay available:
+
+- automatic recall can still run
+- automatic retain does not enqueue new transcript deltas
+- explicit write operations should stay visible but must remain deliberate actions
+- imports remain deliberate operations, not automatic session retention
+- queue flush remains allowed because it drains already accepted jobs
+
+### `ignored`
+
+`ignored` means automatic memory is out of the provider path:
+
+- no automatic recall injection
+- no automatic retain
+- explicit commands and tools still exist for power users
+- imports and queue maintenance are not disabled by the mode
+- status should make the automatic-memory-off state obvious
+
+### future `tools-only`
+
+`tools-only` is a reserved term for a future mode where automatic memory is off but explicit tools are first-class. It should only ship after the command/tool behavior is tested and documented as distinct from `ignored`.
+
+## TUI presentation
+
+The `/hindsight` TUI should prefer these labels when explaining session memory state:
+
+- `normal`: "Automatic recall/retain follow config."
+- `read-only`: "Recall can read; automatic retain is off."
+- `ignored`: "Automatic recall and retain are off."
+- future `tools-only`: "Automatic memory is off; explicit tools stay available."
+
+The TUI should still expose underlying facts where useful, such as recall enabled/disabled, retain enabled/disabled, global retain mode, queue state, and bank status.
+
+## Non-goals
+
+- Do not change defaults.
+- Do not add prompt hashtag controls.
+- Do not add provider recall caching.
+- Do not prefetch reflect results automatically.
+- Do not collapse import or explicit retain semantics into automatic retain.
+- Do not make global automatic retain default.
+
+## Follow-up implementation slices
+
+1. Add a presenter that derives the TUI mode label from resolved config plus session metadata.
+2. Add status facts for the mode matrix row currently in effect.
+3. Add TUI copy for `normal`, `read-only`, and `ignored`.
+4. Keep `tools-only` documented as reserved until behavior is implemented.
+
+## Consequences
+
+This gives the TUI a stable mental model without changing memory behavior. It also keeps safety boundaries explicit: automatic read/write behavior is separate from deliberate user operations such as imports, explicit retain, and queue flushing.

--- a/docs-site/src/content/docs/architecture/diagnostics-and-security.md
+++ b/docs-site/src/content/docs/architecture/diagnostics-and-security.md
@@ -1,0 +1,40 @@
+---
+title: "Diagnostics and security boundaries"
+---
+
+# Diagnostics and security boundaries
+
+Diagnostics should make memory behavior inspectable without exposing secrets or raw retained content unnecessarily.
+
+## Diagnostics boundaries
+
+Diagnostics may show:
+
+- server reachability
+- selected bank IDs
+- queue counts and error summaries
+- import manifests/checkpoints
+- retain receipt IDs
+- last recall snapshots when explicitly enabled
+
+Diagnostics should avoid printing raw retained payloads in normal mode.
+
+## Security boundaries
+
+Pi Hindsight sanitizes secrets where possible before retain and before persistence/logging. It redacts common tokens, API keys, cookies, bearer headers, and private URLs where possible.
+
+Bank IDs, Document IDs, tags, and metadata are not automatically secret. Treat them as inspectable provenance, but avoid placing credentials there.
+
+## Configuration secrets
+
+Prefer secret references such as:
+
+```json
+{
+  "hindsight": {
+    "apiKey": { "source": "env", "name": "HINDSIGHT_API_KEY" }
+  }
+}
+```
+
+Do not store raw API keys in repository-local config.

--- a/docs-site/src/content/docs/architecture/index.mdx
+++ b/docs-site/src/content/docs/architecture/index.mdx
@@ -3,3 +3,16 @@ title: Architecture
 ---
 
 Architecture pages describe implementation boundaries, lifecycle hooks, operation services, adapters, queue durability, imports, setup TUI design, and ADRs.
+
+Architecture pages:
+
+- [Lifecycle and scope](./lifecycle-and-scope/)
+- [Core vs companion adapters](./core-vs-companion-adapters/)
+- [Queue and import architecture](./queue-and-import/)
+- [Diagnostics and security boundaries](./diagnostics-and-security/)
+
+ADRs:
+
+- [ADR 001: Memory lifecycle and scope](./adr/001-memory-lifecycle-and-scope/)
+- [ADR 002: Explicit routing strategy seam](./adr/002-explicit-routing-strategy-seam/)
+- [ADR 003: TUI memory mode vocabulary](./adr/003-tui-memory-mode-vocabulary/)

--- a/docs-site/src/content/docs/architecture/lifecycle-and-scope.md
+++ b/docs-site/src/content/docs/architecture/lifecycle-and-scope.md
@@ -27,5 +27,5 @@ Pi Hindsight owns Pi integration policy. Hindsight owns Retain, Recall, Reflect,
 See also:
 
 - [ADR 001](./adr/001-memory-lifecycle-and-scope/)
-- [Hooks reference](../reference/hooks/)
-- [Memory Banks](../concepts/memory-banks/)
+- [Hooks reference](/reference/hooks/)
+- [Memory Banks](/concepts/memory-banks/)

--- a/docs-site/src/content/docs/architecture/lifecycle-and-scope.md
+++ b/docs-site/src/content/docs/architecture/lifecycle-and-scope.md
@@ -1,0 +1,31 @@
+---
+title: "Lifecycle and scope"
+---
+
+# Lifecycle and scope
+
+Pi Hindsight maps documented Pi extension hooks to Hindsight memory operations.
+
+## Hook flow
+
+- `session_start`: load config, initialize runtime, ensure bank settings when appropriate, update status.
+- `context`: build recall query, fetch memories, inject an ephemeral Recall Block.
+- `agent_end`: filter new transcript content, build a Retain Job, sanitize, enqueue, and attempt delivery.
+- `session_shutdown`: best-effort Retain Queue flush within configured bounds.
+
+## Scope boundaries
+
+- Project memory uses the selected Project Bank.
+- Optional user/global memory uses the configured Global/User Bank.
+- Tags isolate recall and retain behavior.
+- Metadata records provenance but is not the filtering boundary.
+
+## Source boundaries
+
+Pi Hindsight owns Pi integration policy. Hindsight owns Retain, Recall, Reflect, Memory Bank behavior, bank config, mental models, directives, and API request/response behavior.
+
+See also:
+
+- [ADR 001](./adr/001-memory-lifecycle-and-scope/)
+- [Hooks reference](../reference/hooks/)
+- [Memory Banks](../concepts/memory-banks/)

--- a/docs-site/src/content/docs/architecture/queue-and-import.md
+++ b/docs-site/src/content/docs/architecture/queue-and-import.md
@@ -10,7 +10,7 @@ Retain delivery and historical import both prioritize durability, provenance, an
 
 The Retain Queue writes jobs to disk before delivery. It handles retry, stale locks, malformed line quarantine, bounded shutdown flushes, and dead-letter rollover.
 
-See [Retain Queue durability](../concepts/queue-durability/) for user-facing concepts.
+See [Retain Queue durability](/concepts/queue-durability/) for user-facing concepts.
 
 ## Import architecture
 
@@ -26,4 +26,4 @@ Important boundaries:
 
 Curated imports may chunk by user turns. Raw and forensic imports preserve legacy document IDs and payload shape.
 
-See [Historical Import](../concepts/imports/) and [Import controls reference](../reference/import-controls/).
+See [Historical Import](/concepts/imports/) and [Import controls reference](/reference/import-controls/).

--- a/docs-site/src/content/docs/architecture/queue-and-import.md
+++ b/docs-site/src/content/docs/architecture/queue-and-import.md
@@ -1,0 +1,29 @@
+---
+title: "Queue and import architecture"
+---
+
+# Queue and import architecture
+
+Retain delivery and historical import both prioritize durability, provenance, and deterministic replay.
+
+## Retain Queue
+
+The Retain Queue writes jobs to disk before delivery. It handles retry, stale locks, malformed line quarantine, bounded shutdown flushes, and dead-letter rollover.
+
+See [Retain Queue durability](../concepts/queue-durability/) for user-facing concepts.
+
+## Import architecture
+
+Historical import separates parsing, projection, planning, retaining, checkpointing, and presentation.
+
+Important boundaries:
+
+- parsers read source formats
+- projection selects high-signal source content
+- retain builders preserve structured source material
+- checkpoint/manifest code owns resumability and idempotency
+- operation presenters report dry-run and write results
+
+Curated imports may chunk by user turns. Raw and forensic imports preserve legacy document IDs and payload shape.
+
+See [Historical Import](../concepts/imports/) and [Import controls reference](../reference/import-controls/).

--- a/docs-site/src/content/docs/concepts/hindsight-core-functions.md
+++ b/docs-site/src/content/docs/concepts/hindsight-core-functions.md
@@ -114,7 +114,7 @@ Good mental model examples:
 - “What recurring workflow habits matter?”
 - “What does this project consider good design?”
 
-Mental models are not raw recall. They are reusable synthesized answers. In Pi Hindsight they are explicit advanced resources. Pi's `/hindsight` TUI shows a read-only list/detail view and hands off create, edit, refresh, and delete to the Hindsight web interface. The extension must not auto-create mental models from routine sessions or refresh them in the background unless a future issue designs that policy. Starter suggestions are documented in [`starter-mental-model-suggestions.md`](starter-mental-model-suggestions.md).
+Mental models are not raw recall. They are reusable synthesized answers. In Pi Hindsight they are explicit advanced resources. Pi's `/hindsight` TUI shows a read-only list/detail view and hands off create, edit, refresh, and delete to the Hindsight web interface. The extension must not auto-create mental models from routine sessions or refresh them in the background unless a future issue designs that policy. Starter suggestions are documented in [Starter mental model suggestions](/concepts/starter-mental-model-suggestions/).
 
 Creating a mental model preserves a source query. Hindsight runs that query through reflect and stores the generated content. Refresh reruns the stored source query against newer memory.
 

--- a/docs-site/src/content/docs/concepts/index.mdx
+++ b/docs-site/src/content/docs/concepts/index.mdx
@@ -16,3 +16,4 @@ Additional concept references:
 
 - [Memory behavior](./memory-behavior/)
 - [Hindsight core functions](./hindsight-core-functions/)
+- [Starter mental model suggestions](./starter-mental-model-suggestions/)

--- a/docs-site/src/content/docs/concepts/starter-mental-model-suggestions.md
+++ b/docs-site/src/content/docs/concepts/starter-mental-model-suggestions.md
@@ -1,0 +1,81 @@
+---
+title: Starter mental model suggestions
+---
+
+# Starter mental model suggestions
+
+Mental models should start as explicit, inspectable user choices. Pi Hindsight may suggest useful recurring questions, but it must not create or refresh mental models automatically during setup.
+
+## Placement decision
+
+Starter suggestions should live in three places:
+
+1. **Docs** describe the recommended model set and safety policy.
+2. **Setup/TUI** may show the same suggestions as opt-in shortcuts after mental model operations exist.
+3. **Bank templates** may reference the same suggestions later, but templates should not silently create models unless the user explicitly imports and confirms that template behavior.
+
+The default setup path should remain lightweight. Suggestions are an advanced affordance, not a first-run requirement.
+
+## Product rules
+
+- Suggestions are explicit opt-in.
+- No suggestion creates a mental model automatically.
+- Creation should show the model name, bank, source query, and tags before submission.
+- Refresh remains explicit until a later issue defines safe refresh policy.
+- Global models must be conservative and avoid transient project details.
+- Suggested source queries should ask for durable patterns, not one-off summaries.
+- Suggested tags should reuse existing project/global visibility language.
+
+## Project-bank suggestions
+
+Project mental models should describe durable project facts and operating rules.
+
+| Name                              | Source query                                                                           | Suggested tags                       | Why it helps                                                        |
+| --------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------- |
+| Project architecture and seams    | What are the stable architecture boundaries, modules, and seams in this project?       | `project`, `architecture`, `stable`  | Helps future turns understand where changes belong.                 |
+| Testing and release process       | What test, CI, release, and verification practices does this project use?              | `project`, `workflow`, `release`     | Reduces repeated rediscovery of done criteria and release gates.    |
+| Memory safety policy              | What memory rules, safety constraints, and anti-patterns matter in this project?       | `project`, `memory-policy`, `safety` | Keeps retain/recall behavior aligned with project invariants.       |
+| Current roadmap and priorities    | What roadmap themes, active priorities, and deferred non-goals recur for this project? | `project`, `roadmap`, `priority`     | Preserves product direction without turning it into hidden backlog. |
+| Code style and naming conventions | What code style, naming, module, and testing conventions recur in this project?        | `project`, `conventions`, `style`    | Improves consistency for future implementation work.                |
+
+## Global-bank suggestions
+
+Global mental models should focus on durable collaboration preferences that help across repositories. They should avoid project-specific facts and speculative personality profiles.
+
+| Name                                   | Source query                                                                                                      | Suggested tags                               | Why it helps                                                         |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------- |
+| User collaboration preferences         | What durable preferences has the user shown for collaboration, review, autonomy, and communication?               | `global`, `user-preference`, `collaboration` | Helps agents match working style across projects.                    |
+| Coding assistant operating preferences | What durable preferences has the user shown for how coding assistants should plan, verify, commit, and use tools? | `global`, `assistant-workflow`, `preference` | Keeps agent behavior consistent without copying project-local rules. |
+| Cross-project workflow habits          | What workflow habits recur across the user's repositories, issue tracking, PR review, and release process?        | `global`, `workflow`, `cross-project`        | Captures reusable process patterns without mixing project details.   |
+| Tooling and review preferences         | What tools, checks, review loops, and quality gates does the user repeatedly prefer?                              | `global`, `tooling`, `review`                | Helps pick verification steps and review workflow faster.            |
+
+## What not to suggest
+
+Avoid starter mental models for:
+
+- secrets, credentials, private URLs, or account data
+- single-session status reports
+- speculative personality traits
+- broad autobiographical profiles
+- raw conversation summaries
+- project facts in the global bank
+- global preferences inferred from one isolated project incident
+
+## Future TUI behavior
+
+A future TUI slice should not try to recreate Hindsight's full mental model editor. If starter suggestions become interactive in Pi, prefer one of these lighter options:
+
+1. Show suggestions as read-only copy with a Hindsight web interface handoff.
+2. Offer a preview-only dry run of name, source query, tags, and target bank.
+3. Defer actual create/edit/refresh/delete to the Hindsight web interface unless a later issue explicitly reopens Pi-side editing.
+
+Pi should not hide source queries behind friendly labels.
+
+## Bank template guidance
+
+Bank template work may reuse these suggestions in one of two safe ways:
+
+- include them as documentation or setup prompts, leaving creation to the user; or
+- include model definitions only when the template import preview clearly states which mental models will be created.
+
+Templates must not create global mental models by default. Global template suggestions should require an explicit global-bank import or equivalent confirmation.

--- a/docs-site/src/content/docs/development/agents-root.md
+++ b/docs-site/src/content/docs/development/agents-root.md
@@ -1,0 +1,323 @@
+---
+title: "AGENTS.md"
+---
+
+# AGENTS.md
+
+## Project mission
+
+Build a Pi extension that gives Pi durable long-term memory through Hindsight.
+
+The extension must be:
+
+- technically aligned with official Hindsight best practices
+- idiomatic to Pi’s extension/package model
+- reliable under outages
+- easy to inspect, debug, and extend
+- safe to use as the base for future Pi extensions
+
+## Source of truth
+
+### Technical source order
+
+1. Official Hindsight docs and API behavior
+2. Official Pi `pi-mono` extension/session/package docs
+3. This repository’s PRD and coding plan
+4. Public reference repos only as implementation inspiration
+5. User notes/gists only as hypotheses, never as authority
+
+### Use these constraints
+
+- Use the official Hindsight TypeScript client
+- Treat Hindsight docs and OpenAPI behavior as source of truth
+- Treat Pi’s documented extension lifecycle as source of truth
+- Do not invent undocumented Pi internals or undocumented Hindsight request shapes
+
+### Shared contributor guidance
+
+Human and agent guidance must stay aligned. When changing source-of-truth order, contributor workflow, verification expectations, memory policy, or definition-of-done criteria, update `CONTRIBUTING.md` and this file together. `CONTEXT.md` is the shared vocabulary for both human-facing and agent-facing docs.
+
+### Work tracking
+
+GitHub Issues are the project task ledger. Use `gh` for backlog items, roadmap slices, current multi-step work, blockers, follow-ups, and done/close updates. Do not use harness-private or local hidden TODO systems as the source of truth for project work. If work needs tracking, create or update a GitHub issue before continuing.
+
+When starting from a report, review, plan, or research note, convert accepted work into GitHub issues and delete or archive the scratch note after the issues carry the actionable content. When finishing work, update or close the relevant issue with the verification performed and any follow-up issue numbers.
+
+### Continuous issue iteration
+
+When explicitly asked to continue through the backlog, keep working issue-by-issue until there are no appropriate open issues left, the user stops the loop, or a blocker requires human judgment. Prefer the next unblocked, highest-value issue. Respect explicit deferrals such as delayed issues, roadmap ordering, and source-of-truth priorities.
+
+Use this loop for each slice:
+
+1. Select or create a GitHub issue before implementation starts.
+2. Create a focused branch from up-to-date `main`.
+3. Implement the smallest vertical slice that satisfies the issue.
+4. Run targeted tests while developing, then the required repository checks.
+5. Commit with a Conventional Commit subject and without bypassing hooks.
+6. Run a review pass before opening a PR. A subagent reviewer is acceptable and encouraged for non-trivial changes.
+7. Fix review findings before PR creation unless explicitly documenting a rejected recommendation.
+8. Push the branch and open a PR with the required template completed.
+9. Watch CI without blocking foreground planning: use a managed process, scheduled reminder, or subagent/checker. If checks are still pending, set a short reminder instead of polling manually. If checks fail, inspect and fix before merge.
+10. Merge only after required checks pass and review blockers are resolved.
+11. Comment on and close the issue with delivered behavior, verification, and follow-up issues.
+12. Return to `main`, sync with `origin/main`, and continue with the next slice.
+
+Keep exactly one implementation slice active at a time unless the user explicitly asks for parallel work. Do not mix unrelated cleanup or drive-by refactors into the current branch. If a review uncovers new work outside the slice, create a follow-up issue and continue after the current PR is complete.
+
+### Commit and PR discipline for agents
+
+Agents must not push directly to `main`, tag releases, publish packages, or merge PRs unless a maintainer explicitly asks for that action. A maintainer instruction to run the continuous issue loop counts as merge authorization for PRs that satisfy the documented loop. Work should happen on a branch and flow through a PR.
+
+Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them.
+
+Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Keep commits small and logical. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
+
+Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, scope, verification, release impact, risk and rollback, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue.
+
+## Hard rules
+
+### Retain rules
+
+- Retain raw rich content, not summaries.
+- For conversations, prefer structured JSON payloads.
+- Always set `context`.
+- Use a stable `document_id` per live Pi session.
+- Use `update_mode: "append"` for ongoing live sessions.
+- Use `replace` only for deterministic historical reimports or full rebuilds.
+- Never use random `document_id`s for repeated writes to the same live session.
+- Do not retain and then expect those memories to be available for recall in the same turn.
+
+### Recall rules
+
+- Recall should happen before answer generation.
+- Recall injection must be ephemeral by default.
+- Recalled memory blocks must not be persisted into Pi transcript history.
+- Prefer Pi’s `context` hook for automatic injection.
+- Use `before_provider_request` to inspect serialization and prompt-cache effects, not as the default logic path.
+- Keep recall token budget conservative unless the task explicitly requires deep memory context.
+
+### Reflect rules
+
+- `reflect` is for synthesis and reasoning from memory.
+- `recall` is for raw facts.
+- Do not route all automatic memory behavior through `reflect`.
+- Expose `reflect` as an explicit tool/command.
+
+### Filtering rules
+
+- Use `tags` for memory scope and visibility.
+- Use `metadata` only for provenance and links back to source records.
+- Do not rely on metadata for filtering behavior.
+- Default strict tag matching whenever scope isolation matters.
+
+### Bank rules
+
+- Default to one project bank per repo.
+- Optional second global bank is allowed only through explicit config.
+- Do not default to one giant shared bank across unrelated repos.
+- If bank creation/configuration is needed, do it intentionally during initialization or setup, not accidentally on first write.
+
+### Safety rules
+
+- Sanitize secrets before retain.
+- Redact tokens, API keys, cookies, bearer headers, and private URLs where possible.
+- Do not log raw retained payloads in normal mode.
+- Keep any debug mode obviously opt-in.
+
+## Current default design
+
+### Package shape
+
+Use:
+
+- npm package
+- `extensions/` directory
+- one main entrypoint: `extensions/index.ts`
+- `memory-lifecycle.ts` for one-turn hook policy
+- `memory-operation-service.ts` for shared tool/command/setup intents
+- `memory-identity.ts` and `memory-scope.ts` for repo/session/bank/document/tag policy
+- `retain-cursor.ts` for persisted duplicate-retain prevention
+- focused modules for config, config writing, client transport, bank operations, recall formatting, retain job building, queue durability, import parsing/branches/retain orchestration, tools, commands, diagnostics, status, and setup TUI
+
+### Hook mapping
+
+- `session_start` delegates to `memory-lifecycle.initialize`:
+  - load config
+  - initialize runtime
+  - ensure bank settings if appropriate
+  - update status
+- `context` delegates to `memory-lifecycle.recall`:
+  - select project/global memory scopes
+  - compose fresh recall query
+  - fetch memory
+  - inject ephemeral memory block
+- `agent_end` delegates to `memory-lifecycle.retain`:
+  - gate retain by config
+  - filter already retained messages using persisted cursor
+  - build structured retain delta
+  - sanitize
+  - enqueue retain job before flush
+- `session_shutdown` delegates to `memory-lifecycle.shutdown`:
+  - flush queue best effort
+
+### Explicit tools
+
+Required:
+
+- `hindsight_recall`
+- `hindsight_retain`
+- `hindsight_reflect`
+
+Suggested commands:
+
+- `/hindsight:status`
+- `/hindsight:doctor`
+- `/hindsight:config`
+- `/hindsight:import`
+
+## Implementation priorities
+
+Implement in this order:
+
+1. package scaffold and config resolution
+2. Hindsight client adapter
+3. bank derivation and identity mapping
+4. automatic recall injection
+5. automatic retain queue with append mode
+6. explicit tools
+7. diagnostics commands
+8. historical session import
+9. refinement of redaction/noise filtering
+
+Do not jump ahead to advanced features before the default path is correct.
+
+## Code guidelines
+
+### Keep modules narrow
+
+Examples:
+
+- `config.ts` should not perform network I/O
+- `client.ts` should not parse Pi session JSONL
+- `import-sessions.ts` should not own queue replay logic
+- `renderers.ts` should not contain Hindsight request composition
+- tools and commands should call shared memory operation modules rather than duplicating intent behavior
+
+### Prefer deterministic functions
+
+Good candidates for pure tests:
+
+- bank ID derivation
+- tag generation
+- document ID generation
+- retain payload transformation
+- recall block formatting
+- secret redaction
+- import message projection
+
+### Avoid abstraction drift
+
+Do not build:
+
+- a generic “memory backends” layer
+- a global plugin framework for all future extensions
+- a “conversation model” wrapper if plain typed interfaces are enough
+
+## Testing requirements
+
+Every meaningful change should verify the relevant behavior.
+
+Precommit is enforced through `.githooks/pre-commit` and must run `npm run precommit` before commits. Commit message validation is enforced through `.githooks/commit-msg` and must follow Conventional Commits 1.0.0 (`<type>[optional scope]: <description>`, with `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, etc.). Never use `git commit --no-verify` or any equivalent bypass. If any hook fails, fix the issue or ask the user how to proceed.
+
+`CHANGELOG.md` is generated from Conventional Commits. Do not hand-edit release entries as source of truth; run `npm run changelog` or the `version` script so changelog content is regenerated from commit history.
+
+Minimum expected coverage:
+
+- config precedence
+- bank derivation
+- stable document IDs
+- append-vs-replace selection
+- sanitizer behavior
+- queue replay
+- import of Pi JSONL sessions
+- tool registration and schemas
+- recall injection formatting
+
+Before merging or considering a task done, always run:
+
+```bash
+npm run check
+```
+
+Also run coverage and compiler fallback for source, tests, critical paths, or full-CI work:
+
+```bash
+npm run check:coverage
+npm run typecheck:tsc
+```
+
+GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix. Package/release changes and `ci:package` also run package verification. Manual `workflow_dispatch` can run the full matrix for any PR.
+
+If release or package dependencies changed, also run:
+
+```bash
+npm run audit:signatures
+```
+
+If memory-path behavior changed, also prove the live Hindsight path before merging. Memory-path behavior includes retain payloads, recall queries/formatting, reflect calls, bank selection or creation, queue delivery, import delivery, Adapter transport, smoke helpers, and release packaging that can affect installed runtime behavior.
+
+Preferred proof is a configured-server smoke test:
+
+```bash
+npm run smoke:hindsight
+```
+
+GitHub Actions has a `Hindsight Integration` workflow that runs for memory-path changes, `memory-path`/`ci:live-smoke` labels, nightly schedule, and manual dispatch. It runs live smoke only when `HINDSIGHT_INTEGRATION_ENABLED=true`; then it uses `HINDSIGHT_BASE_URL` and optional `HINDSIGHT_API_KEY` secrets. Otherwise it skips cleanly. For memory-path PRs, do not treat an unconfigured skip as proof; either run the smoke test locally with credentials, confirm a configured workflow pass, or document why live proof is unavailable and what lower-level checks cover the risk.
+
+## Common mistakes to avoid
+
+- converting the conversation into a summary before retain
+- using random UUIDs for each retain update
+- storing recalled context back into the transcript
+- using metadata instead of tags for scope
+- calling retain and then relying on that data in the same response path
+- mixing project and global memory without explicit labeling
+- letting debug logs expose secrets
+- using provider-specific payload rewrites before the default `context` strategy is proven
+
+## Import rules
+
+Historical import is a product feature, not a throwaway script.
+
+When changing importer code:
+
+- preserve deterministic document IDs
+- preserve enough provenance for reimport
+- default to current-branch import
+- make alternate-branch import explicit
+- keep import idempotency visible and testable
+
+## Definition of done for this project
+
+A change is done only when:
+
+1. it follows the official Hindsight memory rules
+2. it uses documented Pi extension hooks
+3. tests cover the changed logic
+4. user-visible behavior is documented if changed
+5. the diff is minimal and focused
+6. no new memory anti-pattern was introduced
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues for `luxus/pi-hindsight` using the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Triage uses the default five-label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+This repo uses a single-context domain documentation layout. See `docs/agents/domain.md`.

--- a/docs-site/src/content/docs/development/agents/domain.md
+++ b/docs-site/src/content/docs/development/agents/domain.md
@@ -1,0 +1,56 @@
+---
+title: "Domain Docs"
+---
+
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This repository uses a single-context layout.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, if it exists.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+- If `CONTEXT-MAP.md` appears later, treat the repo as multi-context and read the mapped context docs relevant to the topic.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+│   └── 001-memory-lifecycle-and-scope.md
+└── extensions/
+```
+
+Multi-context repo, if introduced later:
+
+```text
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── context-a/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── context-b/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept in an issue title, a refactor proposal, a hypothesis, or a test name, use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use, or there's a real gap to note for `/grill-with-docs`.
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because..._

--- a/docs-site/src/content/docs/development/agents/issue-tracker.md
+++ b/docs-site/src/content/docs/development/agents/issue-tracker.md
@@ -1,0 +1,36 @@
+---
+title: "Issue tracker: GitHub"
+---
+
+# Issue tracker: GitHub
+
+Issues, PRDs, roadmap slices, current work, blockers, and follow-ups for this repo live as GitHub issues for `luxus/pi-hindsight`. Use the `gh` CLI for all operations.
+
+GitHub Issues are the project task ledger. Do not use harness-private TODOs, chat-only plans, local scratch reports, or hidden task lists as the source of truth for project work. If work needs tracking, create or update an issue before continuing.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc or `--body-file` for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments with `jq` when needed and fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`.
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`.
+- **Close**: `gh issue close <number> --comment "..."`.
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside this clone.
+
+## Progress conventions
+
+- Start work by fetching the relevant issue or creating one if none exists.
+- Record meaningful progress as issue comments when it affects scope, risk, blockers, or next steps.
+- Convert accepted report/review findings into issues; delete or archive the scratch report after the issues carry the actionable content.
+- Track follow-ups as new issues or comments on the parent issue, not as hidden local TODOs.
+- Close the issue with a comment that names the PR/commit and verification performed.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue in `luxus/pi-hindsight`.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs-site/src/content/docs/development/agents/triage-labels.md
+++ b/docs-site/src/content/docs/development/agents/triage-labels.md
@@ -1,0 +1,19 @@
+---
+title: "Triage Labels"
+---
+
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, such as "apply the AFK-ready triage label", use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs-site/src/content/docs/development/ci-routing.md
+++ b/docs-site/src/content/docs/development/ci-routing.md
@@ -1,0 +1,31 @@
+---
+title: "CI routing"
+---
+
+# CI routing
+
+GitHub PR CI is tiered by change impact.
+
+## Fast checks
+
+Low-impact docs/TUI changes run fast Ubuntu checks by default.
+
+## Coverage and compiler fallback
+
+Source, tests, critical paths, or explicit `ci:coverage` work runs coverage and TypeScript compiler fallback.
+
+## Full matrix
+
+Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix.
+
+## Package verification
+
+Package/release changes and `ci:package` run package verification.
+
+## Live smoke
+
+The Hindsight Integration workflow runs for memory-path changes, the `memory-path`/`ci:live-smoke` labels, nightly schedule, and manual dispatch. It only performs live smoke when configured with Hindsight credentials. An unconfigured skip is not proof for memory-path changes.
+
+## PR checklist gate
+
+Pull requests must complete the repository PR template. The checklist gate verifies required sections and checklist artifacts so verification, risk, release impact, and follow-ups are explicit.

--- a/docs-site/src/content/docs/development/context.md
+++ b/docs-site/src/content/docs/development/context.md
@@ -1,0 +1,169 @@
+---
+title: "pi-hindsight Context"
+---
+
+# pi-hindsight Context
+
+## Purpose
+
+`pi-hindsight` is a Pi extension that gives Pi durable long-term memory through Hindsight while keeping project memory isolated, recall ephemeral, and writes inspectable. The extension is designed around explicit memory boundaries: what is recalled into a turn, what is retained after a turn, what is queued for durability, and what is imported from historical sessions.
+
+Use this glossary when naming issues, tests, refactors, commands, and user-facing documentation. Prefer these terms over synonyms so agents and maintainers describe the same system in the same language.
+
+## Load-bearing terms
+
+### Hindsight
+
+The external memory service that stores banks, extracts observations, recalls relevant memory candidates, and reflects over stored memory. Hindsight API behavior is the source of truth for request shapes and supported fields.
+
+### Memory Bank
+
+An isolated Hindsight namespace. Banks are the primary boundary between unrelated memory. `pi-hindsight` normally uses one Project Bank per repository and optionally one explicitly configured Global Bank.
+
+### Project Bank
+
+The bank selected for the current repository. It stores repo-specific architecture, decisions, bugs, tasks, import history, and operational context. Project recall is scoped with repository tags so memory from other repositories does not leak in.
+
+### Global Bank
+
+An optional shared bank for durable user-level preferences, recurring workflows, and cross-project habits. It is disabled unless explicitly configured. Automatic global retain only happens in Router Mode; otherwise global writes are explicit.
+
+### Bank Alias
+
+A stable user-facing name that resolves to a real bank ID. `project` means the selected Project Bank. `global` means the configured Global Bank. Prefer aliases in tools and docs when the exact bank ID is not important.
+
+### Retain
+
+A write to Hindsight. Retain stores raw rich content, not summaries. Automatic retain writes structured session deltas after turns; explicit retain writes user-provided content through tools or commands.
+
+### Automatic Retain
+
+The `agent_end` hook path that retains new transcript content after a turn. It is gated by config and session memory mode, uses the Retain Cursor to avoid duplicate writes, sanitizes content, builds a Retain Job, enqueues it, then tries delivery.
+
+### Explicit Retain
+
+A user-triggered retain operation through a tool or command. Explicit retains are queue-first like automatic retains, but they use user-provided content and context. Explicit retains can target the Project Bank or Global Bank by alias.
+
+### Retain Job
+
+The durable unit queued before delivery to Hindsight. It contains bank ID, document ID, content, context, tags, metadata, entities, update mode, and provenance needed to retry without recomputing policy.
+
+### Retain Queue
+
+The JSONL-backed durability layer for Retain Jobs. Jobs are written before network delivery so Hindsight outages do not lose memory. Queue behavior must stay safe under malformed lines, dead-letter rollover, and concurrent Pi processes.
+
+### Queue Lock
+
+The filesystem lock that protects queue rewrites across Pi processes. It is intentionally visible and stale-lock aware because queue corruption is a memory durability failure.
+
+### Dead Letter Queue
+
+The queue destination for jobs that cannot be delivered after retry policy is exhausted or cannot be represented safely in the active queue. Dead-letter state should be inspectable and never silently discarded.
+
+### Retain Cursor
+
+The persisted marker for the last retained transcript boundary in a live session. It prevents automatic retain from writing the same messages repeatedly across turns or extension restarts.
+
+### Document ID
+
+The stable Hindsight document identifier for retained content. Live sessions use stable append-oriented document IDs. Historical imports use deterministic document IDs so reimports are idempotent. Exact document IDs are required for deletion.
+
+### Update Mode
+
+The Hindsight write behavior for a document. `append` is used for ongoing live sessions and queue retries. `replace` is used for deterministic historical reimports or explicit one-shot documents where replacement is intended.
+
+### Append Capability Probe
+
+Startup/runtime detection that confirms whether the configured Hindsight path supports append-style retain behavior. The result affects status and diagnostics; it should not silently rewrite memory policy.
+
+### Recall
+
+A read from Hindsight that retrieves memory candidates before answer generation. Recall is not synthesis and not persistence. Automatic recall injects an ephemeral memory block into the provider context, then the block is excluded from retained transcript content.
+
+### Recall Block
+
+The formatted ephemeral memory context injected into a turn. It includes recalled memory candidates and source bank labels. Recall Blocks must not be persisted into Pi transcript history or retained back into Hindsight.
+
+### Last-Recall Snapshot
+
+An opt-in local sidecar file for debugging recall behavior. When enabled, it records the latest recall query, results, rendered block, and optionally redacted recall failures. It is visibility-only and not provider cache.
+
+### Reflect
+
+An explicit Hindsight operation for synthesis and reasoning over memory. Reflect is for questions that need analysis across stored memory. Automatic memory behavior should not route every turn through Reflect.
+
+### Observation
+
+A Hindsight-extracted fact, event, entity, relationship, or pattern derived from retained content. Observation settings and scopes affect what Hindsight can infer from retained evidence.
+
+### Observation Scope
+
+A configured scope passed with retain jobs so Hindsight observations are isolated by harness, repository, and other policy boundaries. Scopes must be expanded before queueing so retries preserve the policy active when the job was created.
+
+### Import
+
+The historical session ingestion path. Import parses Pi JSONL sessions, selects branches, builds deterministic import documents, queues retain jobs, records checkpoints/manifests, and can run as a dry-run preview before writing.
+
+### Import Manifest
+
+The durable record of historical import work that has been planned or completed. It makes imports inspectable, resumable, and idempotent across repeated runs.
+
+### Import Checkpoint
+
+The per-import progress record for queued, completed, skipped, or failed import documents. Checkpoints make reimport behavior visible and help resume after outage or interruption.
+
+### Session Memory Mode
+
+Per-session control over recall and retain behavior. Modes such as normal, read-only, ignored, and next-turn opt-out gate automatic memory behavior without changing global configuration.
+
+### Next Opt-Out
+
+A one-turn session flag that skips automatic retain for the next completed turn while preserving future memory behavior. It is stronger than default retain but weaker than ignored/read-only session modes where applicable.
+
+### Memory Operation Service
+
+The shared service behind tools, commands, setup flows, and smoke tests. It owns user intents such as recall, retain, reflect, flush, delete, route, config, and import so adapters do not duplicate behavior.
+
+### Operation Catalog
+
+The single catalog that registers public tools and commands. It maps Pi-facing surfaces to Memory Operation Service calls and keeps schemas/presenters centralized.
+
+### Memory Router
+
+The opt-in policy that decides whether automatic retain should write to project, global, both, or skip. The default Global Retain mode is `explicit-only`; Router Mode must remain explicit because global-memory pollution is costly.
+
+### Redaction
+
+The safety layer that removes or masks secrets before retain, diagnostics, or debug sidecars. Tokens, API keys, cookies, bearer headers, private URLs, and known secret-like values must not be logged or retained in normal mode.
+
+## Naming rules
+
+- Use **Project Bank** and **Global Bank** when talking about bank policy.
+- Use **Retain**, **Recall**, and **Reflect** for the three Hindsight operations; do not collapse them into a generic “memory call.”
+- Use **Retain Queue**, **Retain Job**, **Queue Lock**, and **Dead Letter Queue** for durability behavior.
+- Use **Import Manifest** and **Import Checkpoint** for historical import state.
+- Use **Last-Recall Snapshot** for local recall debugging sidecars; do not call it cache.
+- Use **Recall Block** for ephemeral injected context; do not call it transcript memory.
+- Use **Memory Operation Service** for shared intent logic; use **Operation Catalog** for registration.
+- Use **Memory Router** only for the opt-in automatic retain routing policy, not for explicit retain.
+
+## Architectural boundaries
+
+- `extensions/index.ts` should stay thin and only wire Pi hooks, commands, and tools.
+- `memory-lifecycle.ts` owns turn-level hook orchestration; focused lifecycle policy modules own recall/retain details.
+- `memory-operation-service.ts` and operation modules own explicit user intents shared by tools, commands, setup, and smoke tests.
+- `client.ts` and `client-rest.ts` are the Hindsight Adapter seam; callers should not invent request shapes.
+- Queue modules own durability mechanics; lifecycle and operations should not rewrite queue files directly.
+- Import modules own historical session parsing, branch selection, planning, checkpointing, and delivery orchestration.
+- Config modules must keep parsing, normalization, writing, and TUI field metadata narrow and deterministic.
+
+## Invariants
+
+- Recall happens before answer generation and remains ephemeral.
+- Retain writes raw rich content, not summaries.
+- Live session retains use stable document IDs and `append` mode.
+- Historical imports use deterministic document IDs and `replace` mode where reimport idempotency requires it.
+- Project memory is the default; global memory requires explicit configuration and explicit writes unless Router Mode is enabled.
+- Tags define scope and visibility; metadata records provenance and links back to source records.
+- Queue-first durability applies to automatic retain, explicit retain, and imports.
+- Debug visibility must be opt-in and must redact secrets before persistence.

--- a/docs-site/src/content/docs/development/contributing.md
+++ b/docs-site/src/content/docs/development/contributing.md
@@ -1,0 +1,206 @@
+---
+title: "Contributing to pi-hindsight"
+---
+
+# Contributing to pi-hindsight
+
+Thank you for helping improve `pi-hindsight`. This repository is a Pi extension that integrates with Hindsight, so changes must protect durable memory, project/global isolation, queue durability, and secret safety.
+
+## Start here
+
+Before making a change, read:
+
+1. `CONTEXT.md` for the project vocabulary and invariants.
+2. `AGENTS.md` for source-of-truth order, memory rules, and definition of done.
+3. Any relevant ADR under `docs/adr/`.
+4. The official Hindsight and Pi documentation when changing API behavior, hook behavior, package shape, or extension lifecycle behavior.
+
+Use the terms from `CONTEXT.md` in issue titles, test names, PR descriptions, and docs. Prefer **Project Bank**, **Global Bank**, **Retain**, **Recall**, **Reflect**, **Retain Queue**, **Retain Job**, **Recall Block**, **Last-Recall Snapshot**, **Import Manifest**, **Import Checkpoint**, **Memory Operation Service**, and **Operation Catalog** over local synonyms.
+
+Human and agent guidance must stay aligned. If you change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition-of-done criteria, update both this file and `AGENTS.md` in the same PR.
+
+## Source-of-truth order
+
+Use this order when implementation choices conflict:
+
+1. Official Hindsight docs and API behavior.
+2. Official Pi extension, session, and package docs.
+3. This repository's PRDs, ADRs, and coding plans.
+4. Public reference repos as implementation inspiration only.
+5. User notes and gists as hypotheses only.
+
+Do not invent undocumented Pi internals or undocumented Hindsight request shapes. Prefer the official Hindsight TypeScript client and the documented Pi extension lifecycle.
+
+## Development setup
+
+This package targets the runtime declared in `package.json`.
+
+```bash
+npm install
+npm run check
+```
+
+`npm install` installs the repository Git hooks. Do not bypass them. The pre-commit hook runs `npm run precommit`, and the commit message hook enforces Conventional Commits.
+
+## Change discipline
+
+Keep each PR focused on one vertical slice. A good PR has:
+
+- a clear user or maintainer outcome
+- a small diff
+- tests for changed behavior
+- docs updates when behavior or workflow changes
+- no new memory anti-patterns
+
+Avoid combining architecture changes, product behavior, and release automation in the same PR unless they are inseparable.
+
+## Work tracking
+
+GitHub Issues are the project task ledger for backlog items, current work, blockers, decisions, and follow-ups. Use the `gh` CLI from this repository to create, read, comment on, label, assign, and close issues.
+
+Do not rely on local scratch files, private harness TODOs, chat-only plans, or hidden task lists as the source of truth for project work. If a change needs tracking, create or update a GitHub issue before continuing. If a report or review produces useful work, move the accepted items into GitHub issues and remove or archive the scratch report once the issues carry the actionable content.
+
+Every PR should reference the issue it advances. If a follow-up remains, add it as an issue or as a comment on the existing issue rather than leaving it only in a local note.
+
+## Continuous issue iteration
+
+When a maintainer asks an agent to continue through the backlog, the expected loop is continuous but bounded. Continue issue-by-issue until there are no appropriate open issues left, the maintainer stops the loop, or a blocker requires human judgment. Respect explicit deferrals, roadmap ordering, and source-of-truth priorities.
+
+For each slice:
+
+1. Select or create a GitHub issue before implementation starts.
+2. Create a focused branch from up-to-date `main`.
+3. Implement the smallest vertical slice that satisfies the issue.
+4. Run targeted tests during development, then the repository checks required by the change impact.
+5. Commit with a Conventional Commit subject and do not bypass hooks.
+6. Run a review pass before opening a PR. A subagent reviewer is acceptable and encouraged for non-trivial changes.
+7. Fix review findings before PR creation unless the PR explicitly documents why a recommendation was rejected.
+8. Push the branch and open a PR with the required template completed.
+9. Watch CI without blocking foreground planning. Use a managed process, scheduled reminder, or subagent/checker. If checks are still pending, set a short reminder instead of repeatedly polling. If checks fail, inspect and fix before merge.
+10. Merge only after required checks pass and review blockers are resolved.
+11. Comment on and close the issue with delivered behavior, verification, and follow-up issue links.
+12. Return to `main`, sync with `origin/main`, and continue with the next slice.
+
+Keep one implementation slice active at a time unless a maintainer explicitly asks for parallel work. Do not mix unrelated cleanup, formatting sweeps, or drive-by refactors into the current branch. If review uncovers work outside the slice, create a follow-up issue and continue after the current PR is complete.
+
+## Commit and PR discipline for agents
+
+Agents must not push directly to `main`, tag releases, publish packages, or merge PRs unless a maintainer explicitly asks for that action. A maintainer instruction to run the continuous issue loop counts as merge authorization for PRs that satisfy the documented loop. Work should happen on a branch and flow through a PR.
+
+Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them.
+
+Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Keep commits small and logical. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
+
+Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, scope, verification, release impact, risk and rollback, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue.
+
+## Memory invariants
+
+Every code change must preserve these rules:
+
+- **Retain** stores raw rich content, not summaries.
+- Automatic retain uses stable live session document IDs and `append` mode.
+- Historical imports use deterministic document IDs and preserve reimport idempotency.
+- **Recall** happens before answer generation and remains ephemeral.
+- **Recall Blocks** must not be persisted into transcript history or retained back into Hindsight.
+- **Global Bank** writes are explicit by default; automatic global retain requires explicit Router Mode.
+- Tags define scope and visibility; metadata records provenance.
+- Retain paths are queue-first.
+- Debug visibility is opt-in and must redact secrets before persistence.
+
+If a change intentionally reopens one of these invariants, document the contradiction in the PR and add or update an ADR.
+
+## Tests and verification
+
+Run the relevant targeted tests while developing, then run the checks required by the change impact before considering the work done:
+
+```bash
+npm run check
+```
+
+Run these for source, tests, critical paths, or full-CI work:
+
+```bash
+npm run check:coverage
+npm run typecheck:tsc
+```
+
+GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix. Package/release changes and `ci:package` also run package verification. Manual `workflow_dispatch` can run the full matrix for any PR.
+
+For release-path or packaging changes, also run:
+
+```bash
+npm run pack:verify
+```
+
+For memory-path behavior changes, prove the live Hindsight path before merging. Memory-path behavior includes retain payloads, recall queries/formatting, reflect calls, bank selection or creation, queue delivery, import delivery, Adapter transport, smoke helpers, and release packaging that can affect installed runtime behavior.
+
+Preferred proof is a configured smoke test:
+
+```bash
+npm run smoke:hindsight
+```
+
+The GitHub `Hindsight Integration` workflow runs automatically for memory-path changes, `memory-path`/`ci:live-smoke` labels, nightly schedule, and manual dispatch. It still skips cleanly unless `HINDSIGHT_INTEGRATION_ENABLED=true` is configured. For memory-path PRs, do not treat an unconfigured skip as proof; either run the smoke test locally with credentials, confirm a configured workflow pass, or document why live proof is unavailable and what lower-level checks cover the risk.
+
+## Commit messages
+
+Use Conventional Commits 1.0.0:
+
+```text
+<type>[optional scope]: <description>
+```
+
+Common types include `feat`, `fix`, `docs`, `test`, `refactor`, and `chore`.
+
+Examples:
+
+```text
+feat(recall): debug failed last recall
+fix(queue): quarantine malformed retain jobs
+docs: add project domain context
+```
+
+Do not use `git commit --no-verify` or any equivalent bypass.
+
+## Definition of done
+
+A change is done only when:
+
+1. it follows the official Hindsight memory rules;
+2. it uses documented Pi extension hooks;
+3. tests cover the changed logic;
+4. user-visible behavior is documented if changed;
+5. the diff is minimal and focused; and
+6. no new memory anti-pattern was introduced.
+
+## PR checklist
+
+Before opening or marking a PR ready:
+
+- [ ] I used project terms from `CONTEXT.md`.
+- [ ] I linked or updated the relevant GitHub issue, including follow-ups or blockers.
+- [ ] I kept the diff focused.
+- [ ] I preserved Retain, Recall, Reflect, bank isolation, queue-first, and redaction invariants.
+- [ ] I added or updated tests for meaningful behavior.
+- [ ] I updated README/docs when user-visible behavior changed.
+- [ ] I updated `AGENTS.md` and `CONTRIBUTING.md` together when source-of-truth order, workflow, verification, or definition-of-done guidance changed.
+- [ ] I ran `npm run check`.
+- [ ] I ran `npm run check:coverage` when touching source, tests, or critical paths.
+- [ ] I ran `npm run typecheck:tsc` when touching source or critical paths.
+- [ ] I requested or confirmed full matrix when touching runtime-sensitive paths, queue/import/memory paths, package/release code, workflows, or platform-sensitive behavior.
+- [ ] I ran `npm run audit:signatures` when touching release/package dependencies.
+- [ ] I ran `npm run smoke:hindsight` or confirmed a configured `Hindsight Integration` pass when memory-path behavior changed; if unavailable, I documented the limitation.
+
+## Architecture guidance
+
+Prefer deep modules with narrow interfaces. Keep these boundaries intact:
+
+- `extensions/index.ts` wires Pi hooks, commands, and tools.
+- lifecycle modules own turn-level automatic memory policy.
+- Memory Operation Service modules own explicit user intents.
+- the Hindsight Adapter seam owns Hindsight request behavior.
+- queue modules own queue files, locks, retries, and dead letters.
+- import modules own historical session parsing, planning, checkpointing, and delivery.
+- config modules keep parsing, normalization, writing, and TUI metadata deterministic and narrow.
+
+When adding a new config setting, update the defaults, normalization, types, writer, TUI/config editing registry if appropriate, tests, diagnostics, and docs as a single focused slice.

--- a/docs-site/src/content/docs/development/index.mdx
+++ b/docs-site/src/content/docs/development/index.mdx
@@ -3,3 +3,17 @@ title: Development
 ---
 
 Development pages describe contributor setup, verification, GitHub issue workflow, release process, documentation architecture, and agent guidance.
+
+Development pages:
+
+- [Development setup](./development/)
+- [Testing and verification](./testing-and-verification/)
+- [CI routing](./ci-routing/)
+- [Package verification](./package-verification/)
+- [Release process](./release/)
+- [Documentation architecture](./documentation-architecture/)
+- [Internal and agent docs](./internal-and-agent-docs/)
+- [Contributing](./contributing/)
+- [Agent guidance](./agents-root/)
+- [Project context](./context/)
+- [Security policy](./security/)

--- a/docs-site/src/content/docs/development/internal-and-agent-docs.md
+++ b/docs-site/src/content/docs/development/internal-and-agent-docs.md
@@ -10,20 +10,20 @@ Agent-facing, maintainer-only, and historical planning documents are linked from
 
 Agent docs explain repository workflow and domain guidance for coding agents. They should stay aligned with `AGENTS.md`, `CONTRIBUTING.md`, and `CONTEXT.md`.
 
-- [AGENTS.md](./agents-root/)
-- [CONTRIBUTING.md](./contributing/)
-- [CONTEXT.md](./context/)
-- [Issue tracker](./agents/issue-tracker/)
-- [Domain docs](./agents/domain/)
-- [Triage labels](./agents/triage-labels/)
+- [AGENTS.md](/development/agents-root/)
+- [CONTRIBUTING.md](/development/contributing/)
+- [CONTEXT.md](/development/context/)
+- [Issue tracker](/development/agents/issue-tracker/)
+- [Domain docs](/development/agents/domain/)
+- [Triage labels](/development/agents/triage-labels/)
 
 ## Internal and archive docs
 
 Internal docs include PR roadmaps, architecture TODOs, product requirements, coding plans, and superseded design notes. Convert actionable content to GitHub issues before deleting or archiving these pages.
 
-- [Architecture TODOs](../internal/architecture-todos/)
-- [Next opt-out design](../internal/next-opt-out-design/)
-- [Post-MVP roadmap](../internal/post-mvp-roadmap/)
-- [PR roadmap](../internal/pr-roadmap/)
-- [PRD](../internal/prd/)
-- [Coding plan](../internal/coding-plan/)
+- [Architecture TODOs](/internal/architecture-todos/)
+- [Next opt-out design](/internal/next-opt-out-design/)
+- [Post-MVP roadmap](/internal/post-mvp-roadmap/)
+- [PR roadmap](/internal/pr-roadmap/)
+- [PRD](/internal/prd/)
+- [Coding plan](/internal/coding-plan/)

--- a/docs-site/src/content/docs/development/internal-and-agent-docs.md
+++ b/docs-site/src/content/docs/development/internal-and-agent-docs.md
@@ -1,0 +1,29 @@
+---
+title: "Internal and agent docs"
+---
+
+# Internal and agent docs
+
+Agent-facing, maintainer-only, and historical planning documents are linked from the documentation site so they are discoverable, but they are not primary user-facing product docs.
+
+## Agent docs
+
+Agent docs explain repository workflow and domain guidance for coding agents. They should stay aligned with `AGENTS.md`, `CONTRIBUTING.md`, and `CONTEXT.md`.
+
+- [AGENTS.md](./agents-root/)
+- [CONTRIBUTING.md](./contributing/)
+- [CONTEXT.md](./context/)
+- [Issue tracker](./agents/issue-tracker/)
+- [Domain docs](./agents/domain/)
+- [Triage labels](./agents/triage-labels/)
+
+## Internal and archive docs
+
+Internal docs include PR roadmaps, architecture TODOs, product requirements, coding plans, and superseded design notes. Convert actionable content to GitHub issues before deleting or archiving these pages.
+
+- [Architecture TODOs](../internal/architecture-todos/)
+- [Next opt-out design](../internal/next-opt-out-design/)
+- [Post-MVP roadmap](../internal/post-mvp-roadmap/)
+- [PR roadmap](../internal/pr-roadmap/)
+- [PRD](../internal/prd/)
+- [Coding plan](../internal/coding-plan/)

--- a/docs-site/src/content/docs/development/package-verification.md
+++ b/docs-site/src/content/docs/development/package-verification.md
@@ -1,0 +1,41 @@
+---
+title: "Package verification"
+---
+
+# Package verification
+
+Pi Hindsight is distributed as an npm package. Packaging checks protect installed runtime behavior.
+
+## Published contents
+
+The `package.json` `files` array is the source of truth for package contents. Documentation-site source and generated build output are not runtime package files unless explicitly added.
+
+Before changing package contents, check:
+
+```bash
+npm pack --dry-run
+```
+
+## Dependency and signature checks
+
+For package dependency changes, run:
+
+```bash
+npm run audit:signatures
+```
+
+## Release checks
+
+Before merging a release PR or manually publishing a release, confirm:
+
+```bash
+npm run check
+npm run check:coverage
+npm run typecheck:tsc
+npm run smoke:hindsight
+npm run check:release
+```
+
+## Trusted publishing
+
+Release automation publishes through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.

--- a/docs-site/src/content/docs/development/release.md
+++ b/docs-site/src/content/docs/development/release.md
@@ -1,0 +1,113 @@
+---
+title: "Release"
+---
+
+# Release
+
+Release automation uses [`release-please`](https://github.com/googleapis/release-please) to turn Conventional Commits on `main` into a release PR. The release PR updates `package.json`, `package-lock.json`, `.release-please-manifest.json`, and `CHANGELOG.md`.
+
+After the release PR merges, release-please creates the tag and GitHub release. The existing `Release` workflow then verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
+
+## Release checks
+
+Before merging a release PR or manually publishing a release, run or confirm:
+
+```bash
+npm run check
+npm run check:coverage
+npm run typecheck:tsc
+npm run audit:signatures
+npm run pack:verify
+```
+
+For memory-path changes, also prove the live Hindsight path:
+
+```bash
+export HINDSIGHT_BASE_URL=http://localhost:8888
+# export HINDSIGHT_API_KEY=... # if needed
+npm run smoke:hindsight
+```
+
+`check:release` combines the normal check suite, coverage, secondary `tsc` typecheck, audit signatures, pack verification, and live smoke:
+
+```bash
+npm run check:release
+```
+
+## Release PR flow
+
+1. Merge feature and fix PRs into `main` with Conventional Commit subjects.
+2. The `Release Please` workflow opens or updates a release PR.
+3. Review the release PR changelog, version bump, and manifest update.
+4. Confirm release/package verification passes. Use the `ci:package` or `ci:full` labels if additional gates are needed.
+5. Merge the release PR.
+6. Release-please creates the `v*.*.*` tag and GitHub release.
+7. The `Release` workflow verifies the tag and publishes to npm through trusted publishing.
+
+Manual `Release Please` workflow dispatch can refresh the release PR if needed.
+
+## Local changelog fallback
+
+`npm run changelog` and the `version` script remain available for local inspection or emergency manual releases. They are not the normal source of truth once release-please is active. Do not hand-edit generated release entries as the source of truth.
+
+## Live smoke
+
+The smoke test creates a temporary bank, retains a unique marker with `updateMode: "append"`, recalls it, and runs `reflect`.
+
+It also exercises:
+
+- official Hindsight client path
+- extension Adapter path (`createHindsightClient`)
+- memory operations service
+- explicit retain/flush/recall/reflect/receipts
+- tiny Pi JSONL import dry-run/write/recall flow
+- GitHub Actions Markdown summary output
+- temporary-bank cleanup on success
+
+Step markers include:
+
+```text
+bank_ok
+retain_ok
+recall_ok
+reflect_ok
+adapter_retain_ok
+adapter_recall_ok
+adapter_reflect_ok
+operations_retain_ok
+operations_flush_ok
+operations_recall_ok
+operations_reflect_ok
+operations_receipts_ok
+import_dry_run_ok
+import_ok
+import_recall_ok
+cleanup_ok
+```
+
+Successful temp banks are cleaned up. Failure artifacts are kept for debugging. If `PI_HINDSIGHT_SMOKE_BANK_ID` points at a configured bank, cleanup is skipped.
+
+## GitHub live integration
+
+The `Hindsight Integration` workflow runs on PRs, nightly schedule, and manual dispatch. It runs live smoke only when enabled.
+
+Required repository variable:
+
+- `HINDSIGHT_INTEGRATION_ENABLED=true`
+
+Required secret when enabled:
+
+- `HINDSIGHT_BASE_URL`
+
+Optional secret and variables:
+
+- `HINDSIGHT_API_KEY`
+- `HINDSIGHT_SMOKE_ATTEMPTS`, default `20`
+- `HINDSIGHT_SMOKE_CLEANUP_TIMEOUT_MS`, default `5000`
+- `PI_HINDSIGHT_SMOKE_BANK_ID`
+
+An unconfigured workflow skip is not release proof for memory-path changes.
+
+## Manual publish fallback
+
+Manual workflow dispatch of the `Release` workflow can verify only, or publish when `publish=true`. Use this fallback only when the normal release-please tag flow is blocked and a maintainer explicitly approves the manual release.

--- a/docs-site/src/content/docs/development/security.md
+++ b/docs-site/src/content/docs/development/security.md
@@ -1,0 +1,56 @@
+---
+title: "Security Policy"
+---
+
+# Security Policy
+
+## Supported versions
+
+Security fixes target the current `main` branch and the latest published npm package version when a package has been released. Runtime compatibility is defined in `package.json`.
+
+## Reporting a vulnerability
+
+Please report security issues privately. Do not open a public GitHub issue for vulnerabilities involving secrets, credential exposure, unsafe memory retention, Hindsight API misuse, or release-token handling.
+
+Send a private report through GitHub Security Advisories if available for this repository. If advisories are not available, contact the repository owner privately and include enough detail to reproduce the issue.
+
+A useful report includes:
+
+- affected version or commit
+- operating system and Node/npm versions
+- relevant configuration with secrets removed
+- steps to reproduce
+- expected and actual behavior
+- impact assessment
+- whether Hindsight, Pi, or this extension appears to be the vulnerable component
+
+## Security scope
+
+Security-sensitive areas include:
+
+- secret redaction before Retain, diagnostics, logs, or Last-Recall Snapshot writes
+- Project Bank and Global Bank isolation
+- Retain Queue durability and malformed queue handling
+- exact document deletion behavior
+- import of historical Pi JSONL sessions
+- Hindsight API key handling and `SecretRef` behavior
+- release workflow, provenance, and npm publishing credentials
+- debug modes that write local sidecars or extra diagnostics
+
+## Memory safety expectations
+
+`pi-hindsight` must not retain secrets in normal operation. The extension redacts common API keys, bearer tokens, GitHub tokens, password-style environment assignments, and credentials embedded in URLs before automatic retain.
+
+When working on security-sensitive memory paths:
+
+- retain raw rich content, not summaries, but sanitize it first
+- keep Recall Blocks ephemeral
+- do not persist recalled memory into transcript history
+- keep Last-Recall Snapshot and failure diagnostics opt-in
+- redact errors before writing debug sidecars
+- do not log raw retained payloads in normal mode
+- require exact document IDs and explicit confirmation for destructive deletion
+
+## Maintainer response
+
+Maintainers should acknowledge private vulnerability reports promptly, reproduce the issue on a private branch or fork, add a regression test when feasible, and publish a fix with a clear security note. If a report affects upstream Hindsight or Pi behavior, coordinate with the relevant upstream project rather than inventing undocumented request shapes or lifecycle assumptions.

--- a/docs-site/src/content/docs/development/testing-and-verification.md
+++ b/docs-site/src/content/docs/development/testing-and-verification.md
@@ -1,0 +1,49 @@
+---
+title: "Testing and verification"
+---
+
+# Testing and verification
+
+Before considering a change done, run the checks required by its impact.
+
+## Default checks
+
+```bash
+npm run check
+```
+
+For source, tests, critical paths, CI, release, package, or full-CI work, also run:
+
+```bash
+npm run check:coverage
+npm run typecheck:tsc
+```
+
+For documentation-site changes, run:
+
+```bash
+npm run docs:build
+```
+
+## Memory-path changes
+
+Memory-path behavior includes Retain payloads, Recall queries/formatting, Reflect calls, bank selection, queue delivery, import delivery, Adapter transport, smoke helpers, and package/release changes that can affect installed runtime behavior.
+
+For memory-path changes, prove the live Hindsight path when possible:
+
+```bash
+npm run smoke:hindsight
+```
+
+If live proof is unavailable, document why and what lower-level checks cover the risk.
+
+## Release/package changes
+
+For release or package dependency changes, run:
+
+```bash
+npm run audit:signatures
+npm run check:release
+```
+
+Also confirm package verification CI or `npm pack --dry-run` when packaging contents are affected.

--- a/docs-site/src/content/docs/internal/architecture-todos.md
+++ b/docs-site/src/content/docs/internal/architecture-todos.md
@@ -1,0 +1,25 @@
+---
+title: "Architecture Notes"
+---
+
+# Architecture Notes
+
+These notes record deepening work completed after the mission/global-memory pass and the remaining conditions for reopening broader architecture changes.
+
+## Memory routing
+
+- Keep `globalRetain.mode = "explicit-only"` as the default.
+- Router mode is explicit opt-in and now routes automatic retain through a mission-aware Adapter before enqueueing project/global/both/skip writes.
+- Evaluation fixtures cover balanced project/global/both/skip decisions across style, identity, workflow, implementation, delivery, and ephemeral artifact cases. Future work: add an LLM-backed Adapter behind the same Interface only if heuristic quality is not enough.
+
+## Config editing
+
+- Config editing registry owns field metadata, layer/source display composition, input parsing, input defaults, and patch intent builders. Adding one setting should usually touch the registry plus config writer tests, not a separate action switch.
+
+## Document deletion UX
+
+- Recent explicit retain receipts are persisted, available through `hindsight_retain_receipts`, and surfaced in `/hindsight` status facts so users can find exact document IDs for deletion.
+
+## Historical import queue seam
+
+- Import delivery now has an import-specific queue seam, records queued-but-not-delivered imports as `queued` in checkpoints/results, and normalizes equivalent cwd paths before project-scope checks.

--- a/docs-site/src/content/docs/internal/coding-plan.md
+++ b/docs-site/src/content/docs/internal/coding-plan.md
@@ -1,0 +1,828 @@
+---
+title: "coding-plan.md"
+---
+
+# coding-plan.md
+
+## Overview
+
+Build a Pi extension package that integrates Hindsight as long-term memory for coding sessions.
+
+The extension should:
+
+- recall relevant memory before response generation
+- retain structured session deltas after each completed prompt
+- expose explicit Hindsight tools for recall, retain, and reflect
+- support project-scoped memory with an optional shared/global bank
+- support import of existing Pi session JSONL files
+- remain inspectable, testable, and safe to evolve into more Pi extensions later
+
+## Goals
+
+- Ship a stable MVP for Pi ↔ Hindsight memory integration
+- Follow official Hindsight best practices:
+  - retain raw rich content
+  - always set `context`
+  - use stable `document_id`
+  - use `update_mode: "append"` for live sessions
+  - use `tags` for visibility/scope
+- Follow Pi extension/package conventions so the codebase can become a reusable package
+- Keep automatic memory flow simple and deterministic
+- Keep explicit tools available for user-controlled workflows
+- Make migration/import a first-class feature
+
+## Non-goals
+
+- Reimplement Hindsight retrieval or reflection logic in the extension
+- Build a multi-host or multi-tenant orchestration layer in v1
+- Store recalled memory blocks back into Pi transcript history
+- Depend on undocumented Pi internals
+- Build a generic “all memory systems” abstraction
+
+## Assumptions
+
+- Exact Pi SDK version is unspecified; target the current extension APIs documented in `pi-mono` as of April 2026
+- Exact Hindsight deployment mode is unspecified; support both self-hosted and cloud through the official TypeScript client
+- Exact Hindsight bank missions/disposition are project-defined and supplied via config defaults
+- The package will initially be npm-based and locally testable with `pi -e` and `pi install`
+
+## Architecture
+
+### Component map
+
+1. **Config resolver**
+   - Loads package defaults
+   - Applies global config
+   - Applies project-local config
+   - Applies environment overrides
+   - Produces one resolved runtime config object
+
+2. **Session mapper**
+   - Derives project/session identity
+   - Builds stable `document_id`
+   - Builds tag sets
+   - Tracks parent/fork lineage for import and retain provenance
+
+3. **Hindsight client adapter**
+   - Wraps `@vectorize-io/hindsight-client`
+   - Adds retries, timeouts, and typed request helpers
+   - Provides bank ensure/get/update helpers
+
+4. **Recall engine**
+   - Composes recall query from current prompt + optional recent turns
+   - Calls one or two banks (project, optional global)
+   - Merges, formats, and injects ephemeral memory block
+
+5. **Retain engine**
+   - Builds structured JSON transcript delta
+   - Sanitizes secrets and optionally drops low-signal tool noise
+   - Enqueues durable write job
+   - Flushes queue in background or on command
+
+6. **Tool surface**
+   - `hindsight_recall`
+   - `hindsight_retain`
+   - `hindsight_reflect`
+   - optional admin/status commands
+
+7. **Importer**
+   - Reads Pi JSONL session files
+   - Walks branch lineage
+   - Converts messages to Hindsight retain payloads
+   - Replays historical sessions deterministically
+
+## Entity relationship model
+
+```mermaid
+erDiagram
+    PROJECT ||--o{ PI_SESSION : contains
+    PI_SESSION ||--o{ PI_BRANCH : may_have
+    PI_SESSION ||--|| HINDSIGHT_DOCUMENT : maps_to
+    HINDSIGHT_BANK ||--o{ HINDSIGHT_DOCUMENT : contains
+    HINDSIGHT_DOCUMENT ||--o{ MEMORY_UNIT : yields
+    MEMORY_UNIT }o--o{ ENTITY : links_to
+
+    PROJECT {
+      string repoKey
+      string cwd
+      string bankId
+    }
+
+    PI_SESSION {
+      string sessionFile
+      string sessionId
+      datetime startedAt
+      string leafId
+    }
+
+    PI_BRANCH {
+      string leafId
+      string parentLeafId
+      string summary
+    }
+
+    HINDSIGHT_BANK {
+      string bankId
+      string mode
+    }
+
+    HINDSIGHT_DOCUMENT {
+      string documentId
+      string updateMode
+      string context
+      datetime timestamp
+    }
+
+    MEMORY_UNIT {
+      string memoryId
+      string type
+      string text
+    }
+
+    ENTITY {
+      string entityId
+      string text
+      string entityType
+    }
+```
+
+## Event flow mapping
+
+| Pi hook / surface            | Trigger                            | Extension action                                                            | Hindsight operation         | Notes                                    |
+| ---------------------------- | ---------------------------------- | --------------------------------------------------------------------------- | --------------------------- | ---------------------------------------- |
+| `session_start`              | startup, reload, new, resume, fork | load config, restore state, preflight client, ensure bank config if enabled | optional bank create/update | do not recall here; no user query yet    |
+| `context`                    | before each LLM call               | compose recall query, fetch memories, inject ephemeral memory block         | `recall`                    | preferred default injection point        |
+| `before_provider_request`    | final provider payload built       | inspect/verify final injection placement                                    | none                        | debug hook; not primary business logic   |
+| `agent_end`                  | one full prompt completed          | build retain delta, sanitize, enqueue jobs                                  | `retain`                    | preferred auto-retain point              |
+| `session_shutdown`           | runtime tear-down                  | flush queue best-effort, persist transient state                            | none / queued retain replay | never lose acknowledged jobs             |
+| tool: `hindsight_recall`     | explicit agent tool call           | run direct memory lookup                                                    | `recall`                    | returns structured result                |
+| tool: `hindsight_retain`     | explicit agent tool call           | store a specific fact/decision                                              | `retain`                    | supports explicit tags/context           |
+| tool: `hindsight_reflect`    | explicit agent tool call           | server-side memory synthesis                                                | `reflect`                   | use for analysis, not baseline auto-flow |
+| command: `/hindsight:import` | user command                       | import selected session(s)                                                  | `retain`                    | uses `replace` for deterministic replays |
+
+## Recommended hook strategy
+
+### Automatic recall
+
+Use `context` as the primary injection point.
+
+Why:
+
+- it is Pi’s native “modify messages before LLM call” hook
+- it supports ephemeral injection
+- it avoids mutating saved transcript history
+- it is easier to test than provider-specific prompt rewriting
+
+### Automatic retain
+
+Use `agent_end` as the default auto-retain point.
+
+Why:
+
+- it maps to “after the prompt completed”
+- it avoids write/read races in the same turn
+- it cleanly captures user message + assistant answer + meaningful tool results
+
+### Diagnostics
+
+Use `before_provider_request` only to inspect final payload shape and prompt-cache behavior.
+
+## Data contracts
+
+### Resolved config
+
+```ts
+export interface ResolvedConfig {
+  enabled: boolean;
+
+  hindsight: {
+    baseUrl: string;
+    apiKey?: string;
+    timeoutMs: number;
+  };
+
+  banks: {
+    project: {
+      enabled: boolean;
+      bankId?: string;
+      derive: "repo" | "cwd" | "manual";
+    };
+    global: {
+      enabled: boolean;
+      bankId?: string;
+    };
+  };
+
+  recall: {
+    enabled: boolean;
+    budget: "low" | "mid" | "high";
+    maxTokens: number;
+    types: Array<"world" | "experience" | "observation">;
+    contextTurns: number;
+    injectionMode: "context";
+    includeFactsInDebug: boolean;
+  };
+
+  retain: {
+    enabled: boolean;
+    async: boolean;
+    updateMode: "append" | "replace";
+    content: {
+      user: string[];
+      assistant: string[];
+      toolResult: string[];
+    };
+    redactSecrets: boolean;
+    queuePath: string;
+  };
+
+  import: {
+    includeBranches: "current-only" | "all-leaves";
+    includeCompactionSummaries: boolean;
+    includeBranchSummaries: boolean;
+    replaceExistingImportedDocs: boolean;
+  };
+}
+```
+
+### Recall block
+
+```ts
+export interface RecallBlock {
+  bankId: string;
+  query: string;
+  rendered: string;
+  memoryCount: number;
+  results: Array<{
+    id: string;
+    text: string;
+    type: "world" | "experience" | "observation";
+    tags?: string[];
+    metadata?: Record<string, string>;
+    occurred_start?: string | null;
+  }>;
+}
+```
+
+### Retain job
+
+```ts
+export interface RetainJob {
+  id: string;
+  bankId: string;
+  createdAt: string;
+  documentId: string;
+  updateMode: "append" | "replace";
+  item: {
+    content: string;
+    context: string;
+    timestamp?: string;
+    tags?: string[];
+    metadata?: Record<string, string>;
+  };
+  retries: number;
+}
+```
+
+## Retain payload format
+
+### Preferred live-session format
+
+```json
+[
+  {
+    "role": "user",
+    "timestamp": "2026-04-25T10:00:00.000Z",
+    "content": "Please refactor the settings loader."
+  },
+  {
+    "role": "assistant",
+    "timestamp": "2026-04-25T10:00:06.000Z",
+    "content": "I will inspect config precedence and propose a minimal patch."
+  },
+  {
+    "role": "toolResult",
+    "timestamp": "2026-04-25T10:00:07.000Z",
+    "toolName": "read",
+    "content": "src/config.ts ..."
+  }
+]
+```
+
+### Required per-item fields
+
+- `context`: descriptive source label, for example:
+  - `Pi coding session for repo "acme-api", leaf abc123`
+- `document_id`: stable per session, for example:
+  - `pi-session:<session-uuid>`
+- `timestamp`: session start timestamp for live append stream
+- `tags`:
+  - `source:pi`
+  - `repo:<repo-key>`
+  - `session:<session-id>`
+  - optional `branch:<leaf-id>`
+  - optional `scope:global`
+
+### Metadata examples
+
+```json
+{
+  "pi_session_file": "/home/user/.pi/agent/sessions/...jsonl",
+  "pi_leaf_id": "abc123ef",
+  "cwd": "/work/repo",
+  "imported": "false"
+}
+```
+
+## Design option comparison
+
+### Payload format
+
+| Option                  | Pros                                                                | Cons                              | Decision      |
+| ----------------------- | ------------------------------------------------------------------- | --------------------------------- | ------------- |
+| JSON conversation array | richest structure; best fact extraction; preserves timestamps/roles | slightly more work to build       | **Choose**    |
+| Prefixed plaintext      | simpler/debuggable                                                  | weaker structure; easier to drift | fallback only |
+| Pre-summarized text     | tiny payload                                                        | loses causal/temporal structure   | reject        |
+
+### Bank strategy
+
+| Option                              | Pros                                              | Cons                                 | Decision                         |
+| ----------------------------------- | ------------------------------------------------- | ------------------------------------ | -------------------------------- |
+| One bank per project/repo           | strong isolation; easy debugging                  | no automatic cross-project carryover | **Primary**                      |
+| Project bank + optional global bank | good default for coding + cross-project learnings | two-bank merge logic                 | **Primary with optional global** |
+| Single shared bank with tags        | fewer banks to manage                             | more routing/visibility mistakes     | later/advanced                   |
+| One bank per session                | perfect isolation                                 | poor continuity; too fragmented      | reject                           |
+
+### Injection target
+
+| Option                                      | Pros                                  | Cons                                          | Decision          |
+| ------------------------------------------- | ------------------------------------- | --------------------------------------------- | ----------------- |
+| `context` hook                              | ephemeral; transcript-safe; Pi-native | exact provider serialization must be verified | **Choose**        |
+| `before_agent_start` system prompt mutation | simple mental model                   | can make static prompt less cache-friendly    | opt-in experiment |
+| `before_provider_request` payload rewrite   | maximal control                       | provider-specific and brittle                 | debug only        |
+
+### Retain boundary
+
+| Option                  | Pros                                  | Cons                                             | Decision    |
+| ----------------------- | ------------------------------------- | ------------------------------------------------ | ----------- |
+| `turn_end`              | fine-grained                          | multi-turn agent loops can over-fragment content | maybe later |
+| `agent_end`             | matches user prompt lifecycle; simple | slightly coarser                                 | **Choose**  |
+| `session_shutdown` only | few writes                            | higher data-loss risk                            | reject      |
+
+## Repo layout
+
+```text
+pi-hindsight/
+├── AGENTS.md
+├── AGENTS.neutral.md
+├── README.md
+├── coding-plan.md
+├── prd.md
+├── package.json
+├── tsconfig.json
+├── extensions/
+│   ├── index.ts
+│   ├── config.ts
+│   ├── banking.ts
+│   ├── client.ts
+│   ├── recall.ts
+│   ├── retain.ts
+│   ├── sanitize.ts
+│   ├── session.ts
+│   ├── inject.ts
+│   ├── queue.ts
+│   ├── tools.ts
+│   ├── commands.ts
+│   ├── renderers.ts
+│   └── import-sessions.ts
+├── docs/
+│   ├── architecture.md
+│   ├── config.md
+│   └── import.md
+├── tests/
+│   ├── config.test.ts
+│   ├── banking.test.ts
+│   ├── sanitize.test.ts
+│   ├── recall-format.test.ts
+│   ├── import-session.test.ts
+│   ├── queue.test.ts
+│   └── smoke/
+│       └── live-hindsight.test.ts
+└── fixtures/
+    └── sessions/
+```
+
+## Recommended file list
+
+### Core
+
+- `extensions/index.ts`
+  - registers hooks, commands, tools, renderers
+- `extensions/config.ts`
+  - resolve config precedence
+- `extensions/client.ts`
+  - Hindsight client factory
+- `extensions/banking.ts`
+  - derive bank IDs, ensure bank profile
+- `extensions/recall.ts`
+  - compose recall query, call Hindsight, merge results
+- `extensions/inject.ts`
+  - create ephemeral Pi context message
+- `extensions/retain.ts`
+  - build transcript delta, enqueue flush jobs
+- `extensions/queue.ts`
+  - JSONL durable queue
+- `extensions/sanitize.ts`
+  - redact secrets, filter noisy tool output
+- `extensions/import-sessions.ts`
+  - parse JSONL, branch walking, historical replay
+
+### UX and controls
+
+- `extensions/tools.ts`
+  - explicit Hindsight tools
+- `extensions/commands.ts`
+  - status/doctor/import/setup commands
+- `extensions/renderers.ts`
+  - custom memory notice rendering
+
+### Tests
+
+- `tests/import-session.test.ts`
+  - verifies JSONL → retain payload mapping
+- `tests/queue.test.ts`
+  - verifies offline buffering and replay
+- `tests/live-hindsight.test.ts`
+  - verifies real Hindsight integration when configured
+
+## Milestones
+
+```mermaid
+gantt
+    title Pi–Hindsight integration timeline
+    dateFormat  YYYY-MM-DD
+    axisFormat  %b %d
+
+    section Foundation
+    Package scaffold and scripts          :a1, 2026-04-28, 2d
+    Config resolver and client adapter    :a2, after a1, 3d
+
+    section Automatic memory
+    Recall query builder and injection    :b1, after a2, 4d
+    Retain builder and append queue       :b2, after b1, 4d
+
+    section Explicit controls
+    Manual tools and status commands      :c1, after b2, 3d
+    Custom renderers and diagnostics      :c2, after c1, 2d
+
+    section Import and hardening
+    Session JSONL importer                :d1, after c2, 4d
+    Redaction and noise filtering         :d2, after d1, 2d
+    Unit and smoke tests                  :d3, after d2, 4d
+
+    section Release
+    Docs, AGENTS, README, publish prep    :e1, after d3, 3d
+```
+
+## Implementation phases
+
+### Phase 1: package skeleton
+
+Deliver:
+
+- `package.json`
+- `tsconfig.json`
+- extension entrypoint
+- config loading
+- Hindsight client factory
+- one `/hindsight:status` command
+
+Exit criteria:
+
+- extension loads in Pi
+- client health check works
+- config resolution is deterministic
+
+### Phase 2: auto recall
+
+Deliver:
+
+- current-prompt recall query composer
+- project-bank recall
+- ephemeral injection renderer
+- debug inspection command
+
+Exit criteria:
+
+- recalled facts appear in model context
+- no recall block is persisted to transcript
+- provider payload inspection confirms placement
+
+### Phase 3: auto retain
+
+Deliver:
+
+- transcript delta builder
+- sanitizer
+- JSONL queue
+- append-mode document writes
+
+Exit criteria:
+
+- conversation writes use stable `document_id`
+- repeated prompt cycles append cleanly
+- outage simulation stores jobs locally and replays later
+
+### Phase 4: explicit tools and commands
+
+Deliver:
+
+- `hindsight_recall`
+- `hindsight_retain`
+- `hindsight_reflect`
+- `/hindsight:doctor`
+- `/hindsight:import`
+
+Exit criteria:
+
+- tools are visible and typed
+- reflect returns structured or textual answers on demand
+- doctor command catches config/connectivity failures
+
+### Phase 5: import/migration
+
+Deliver:
+
+- Pi session parser
+- current-branch import
+- all-leaf import option
+- import manifest / dedupe
+
+Exit criteria:
+
+- historical Pi sessions ingest once only
+- reimport with `replace` produces deterministic update behavior
+- branch/fork provenance is preserved in tags/metadata
+
+## Minimal code snippets
+
+### Extension skeleton
+
+```ts
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+import { registerCommands } from "./commands.js";
+import { registerTools } from "./tools.js";
+import { createRuntime } from "./runtime.js";
+
+export default function hindsightExtension(pi: ExtensionAPI) {
+  const runtime = createRuntime(pi);
+
+  registerCommands(pi, runtime);
+  registerTools(pi, runtime);
+
+  pi.on("session_start", async (_event, ctx) => {
+    await runtime.initialize(ctx);
+  });
+
+  pi.on("context", async (event, ctx) => {
+    return runtime.injectRecall(event, ctx);
+  });
+
+  pi.on("agent_end", async (event, ctx) => {
+    await runtime.enqueueRetain(event, ctx);
+  });
+
+  pi.on("session_shutdown", async () => {
+    await runtime.flushBestEffort();
+  });
+}
+```
+
+### Hindsight retain helper
+
+```ts
+import { HindsightClient } from "@vectorize-io/hindsight-client";
+
+export async function appendSessionDelta(args: {
+  client: HindsightClient;
+  bankId: string;
+  documentId: string;
+  context: string;
+  timestamp: string;
+  tags: string[];
+  metadata: Record<string, string>;
+  contentJson: string;
+}) {
+  await args.client.retain(args.bankId, args.contentJson, {
+    document_id: args.documentId,
+    update_mode: "append",
+    context: args.context,
+    timestamp: new Date(args.timestamp),
+    tags: args.tags,
+    metadata: args.metadata,
+    async: true,
+  } as any);
+}
+```
+
+### Recall helper
+
+```ts
+export async function recallForPrompt(client: any, bankId: string, query: string, tags?: string[]) {
+  return client.recall(bankId, query, {
+    budget: "mid",
+    maxTokens: 800,
+    tags,
+    tagsMatch: "all_strict",
+    queryTimestamp: new Date().toISOString(),
+  });
+}
+```
+
+## Testing strategy
+
+### Unit tests
+
+- config precedence
+- bank derivation
+- stable `document_id` generation
+- retain payload builder
+- secret redaction
+- noisy tool filtering
+- queue append/replay
+- importer branch walking
+
+### Integration tests
+
+- live `recall`
+- live `retain` append
+- live `reflect`
+- create/get/list/update/delete document
+- project bank + optional global bank merge
+
+### Smoke scenarios
+
+1. New repo, no bank exists
+2. Existing bank, recall works on first prompt
+3. Hindsight unavailable during retain, queue stores job
+4. Restart Pi, queue replays
+5. Import old session JSONL, memories appear
+6. Forked session import preserves provenance tags
+
+## Commands
+
+### Development
+
+```bash
+npm install
+npm run build
+npm run typecheck
+npm test
+```
+
+### Local load in Pi
+
+```bash
+pi -e ./extensions/index.ts
+```
+
+### Install as local package
+
+```bash
+pi install .
+```
+
+### Suggested package scripts
+
+```json
+{
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "smoke": "node ./tests/smoke/live-hindsight.test.js"
+  }
+}
+```
+
+## Migration and import strategy
+
+### Goals
+
+- import existing Pi session files without duplicates
+- preserve enough provenance to reprocess later
+- support later reingestion when missions/tagging rules change
+
+### Source model
+
+Pi sessions are JSONL trees. Import should:
+
+1. read header
+2. index entries by `id`
+3. identify leaf or leaves
+4. walk each leaf back to root
+5. reverse into chronological order
+6. extract relevant message objects
+
+### Import modes
+
+#### Current branch only
+
+Best default.
+
+- imports the active branch path
+- simplest semantics
+- avoids duplicating alternate branches by surprise
+
+#### All leaves
+
+Advanced mode.
+
+- imports each leaf path as its own document
+- tags each document with `branch:<leaf-id>`
+- useful for longitudinal experiments
+
+### Historical document IDs
+
+Use:
+
+- session import:
+  - `pi-import:<session-uuid>:leaf:<leaf-id>`
+- live session continuation:
+  - `pi-session:<session-uuid>`
+
+### Imported tags
+
+- `source:pi`
+- `imported:true`
+- `repo:<repo-key>`
+- `session:<session-id>`
+- `branch:<leaf-id>`
+- optional `forked:true`
+
+### Imported metadata
+
+- session file path
+- cwd
+- parent session path if present
+- import timestamp
+- session header timestamp
+
+### Import content rules
+
+Include:
+
+- user messages
+- assistant messages
+- meaningful tool results
+- optional compaction summaries as explicit synthetic entries
+
+Exclude by default:
+
+- ephemeral recall injection notices
+- decorative custom messages
+- low-signal operational tool spam
+
+### Import update behavior
+
+- finished historical import: `replace`
+- live current session continuation: `append`
+
+### Import manifest
+
+Maintain a local manifest file, for example:
+
+```json
+{
+  "imports": {
+    "pi-import:abc:leaf:def": {
+      "sourceFile": "/path/session.jsonl",
+      "importedAt": "2026-04-25T12:00:00.000Z",
+      "contentHash": "..."
+    }
+  }
+}
+```
+
+Use this to prevent accidental duplicate imports.
+
+## Risks and mitigations
+
+| Risk                                           | Impact                                        | Mitigation                                                                   |
+| ---------------------------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------- |
+| recall injected in the wrong provider position | degraded prompt caching or weak memory effect | inspect with `before_provider_request`; keep injection strategy configurable |
+| over-retaining noisy tool output               | memory clutter                                | default meaningful-only tool retention + sanitizer                           |
+| duplicate historical imports                   | noisy banks                                   | manifest + deterministic import IDs                                          |
+| secrets retained into memory                   | severe                                        | mandatory redaction pipeline before enqueue                                  |
+| cross-project leakage                          | wrong recall                                  | per-project bank default; strict tags where needed                           |
+| write failures during outage                   | memory loss                                   | local JSONL queue with replay                                                |
+
+## Open questions
+
+- Should v1 ship with optional global-bank dual recall, or only project bank?
+- Should branch summaries and compaction summaries be imported by default or opt-in?
+- How aggressive should secret redaction be before false positives become annoying?
+- Should `hindsight_reflect` return plain text only, or allow structured schemas in the tool contract?
+- Do we want a static project bank ID by config, or deterministic repo-derived IDs by default?

--- a/docs-site/src/content/docs/internal/index.mdx
+++ b/docs-site/src/content/docs/internal/index.mdx
@@ -1,0 +1,18 @@
+---
+title: "Internal and archive"
+---
+
+# Internal and archive
+
+These pages are maintainer-facing planning or archive material. They are discoverable, but they are not primary user-facing documentation.
+
+Before deleting or archiving an internal page, convert any remaining actionable content into GitHub issues.
+
+Pages:
+
+- [Architecture TODOs](./architecture-todos/)
+- [Next opt-out design](./next-opt-out-design/)
+- [Post-MVP roadmap](./post-mvp-roadmap/)
+- [PR roadmap](./pr-roadmap/)
+- [PRD](./prd/)
+- [Coding plan](./coding-plan/)

--- a/docs-site/src/content/docs/internal/next-opt-out-design.md
+++ b/docs-site/src/content/docs/internal/next-opt-out-design.md
@@ -1,0 +1,168 @@
+---
+title: "One-turn memory opt-out design"
+---
+
+# One-turn memory opt-out design
+
+This document defines the preferred one-turn memory control for Pi Hindsight. It intentionally avoids prompt hashtag parsing such as `#nomem`.
+
+## Problem
+
+Users sometimes need a fast way to keep the next agent run out of automatic memory retention without changing the whole session mode.
+
+Examples:
+
+- The next prompt contains throwaway sensitive material.
+- The next run is exploratory noise that should not become project memory.
+- The user wants a quick one-shot control discoverable through Pi command autocomplete.
+
+## Decision
+
+Implemented in PR #55.
+
+Use an explicit command:
+
+```text
+/hindsight:next-opt-out
+```
+
+Do not parse prompt hashtags.
+
+## Why command-based control
+
+Pi command autocomplete makes the command discoverable by typing `next`, `opt`, or `out`.
+
+A command is better than prompt parsing because it is:
+
+- explicit in command history
+- independent of Markdown syntax
+- testable without parsing arbitrary prose
+- less likely to be copied by agents into generated content
+- easier to reason about during import and cursor handling
+
+## Current semantics
+
+`/hindsight:next-opt-out` applies once to the next completed agent run in the current session.
+
+It disables automatic retain for that run only.
+
+It does not disable recall. The user may still want memory context to answer the prompt, while not retaining the new prompt/result.
+
+It does not affect explicit memory tools. If an agent or user explicitly calls `hindsight_retain`, that explicit retain remains intentional and should still work.
+
+It does not affect historical import. Import reads the transcript as source material and is governed by import commands, not transient one-turn state.
+
+It stores state outside provider-visible messages, alongside existing session memory metadata.
+
+After the next completed agent run is skipped, the opt-out flag is consumed and cleared.
+
+## Interactions
+
+### `/hindsight:mode ignored`
+
+Ignored mode already disables recall and retain for the session. `next-opt-out` is redundant while ignored mode is active.
+
+### `/hindsight:mode read-only`
+
+Read-only mode already disables retain while allowing recall. `next-opt-out` is redundant while read-only mode is active.
+
+### `/hindsight:retain off`
+
+Retain off already disables automatic retain for the session. `next-opt-out` is redundant while retain is off.
+
+### Retain cursor
+
+When `next-opt-out` skips a run, the retain cursor should mark the skipped projected messages as handled. Otherwise those messages could be retained on a later overlapping `agent_end` event after the one-turn opt-out expires.
+
+This matches current read-only and ignored mode behavior.
+
+### Recall
+
+Recall remains enabled unless another session mode disables it. This keeps the command narrow and avoids surprising users who only wanted to prevent storage.
+
+A future command could add recall control explicitly, but it should not be overloaded into this first command.
+
+## User-facing behavior
+
+Command:
+
+```text
+/hindsight:next-opt-out
+```
+
+Success message:
+
+```text
+Hindsight will skip automatic retain for the next agent run in this session. nextRetain=off
+```
+
+Session status should show pending one-turn opt-out:
+
+```text
+Hindsight session mode=normal; recall=true; retain=true; nextRetain=off; tags=none
+```
+
+When consumed, the activity notification says:
+
+```text
+Hindsight skipped retain for this run due to next-opt-out.
+```
+
+## Storage shape
+
+Extend session memory metadata with a non-provider-visible field:
+
+```json
+{
+  "nextRetainMode": "off"
+}
+```
+
+The default is `"normal"`.
+
+Clearing the one-turn opt-out normalizes the field back to `"normal"`.
+
+## Implemented tests
+
+Tests assert external behavior, not internal helper details.
+
+Covered:
+
+- session metadata persists and consumes a one-turn retain opt-out
+- next `agent_end` skips automatic retain
+- skipped messages are added to retain cursor so they are not retained later
+- opt-out clears after one completed agent run
+
+Additional coverage added after implementation:
+
+- command handler sets a pending one-turn retain opt-out
+- `/hindsight:session` reports pending opt-out
+- explicit `hindsight_retain` still queues normally while next opt-out is pending
+- historical import ignores next opt-out state
+
+Additional coverage added after fail-closed hardening:
+
+- recall still runs while next retain is off
+- ignored/read-only/retain-off modes remain stronger than next opt-out
+- next opt-out remains pending if retain cursor marking fails
+
+## Out of scope
+
+- `#nomem` or any prompt hashtag parsing
+- routing control through prompt text
+- disabling explicit retain tool calls
+- changing historical import behavior
+- provider recall cache
+- persisted recall transcript messages
+
+## Future options
+
+Possible future commands, only if real use justifies them:
+
+```text
+/hindsight:next-recall off
+/hindsight:next-mode ignored
+/hindsight:next-retain off
+```
+
+Do not add aliases until the core command proves useful.

--- a/docs-site/src/content/docs/internal/post-mvp-roadmap.md
+++ b/docs-site/src/content/docs/internal/post-mvp-roadmap.md
@@ -1,0 +1,311 @@
+---
+title: "Post-MVP Roadmap"
+---
+
+# Post-MVP Roadmap
+
+This roadmap records the completed post-MVP hardening pass after `docs/pr-roadmap.md`. Current and future work lives in GitHub Issues; treat this file as historical context, not the task ledger.
+
+## Product rule
+
+Do not promote a deferred idea into implementation just because it appears in a roadmap. Deferred means the idea has known risks and must be re-justified before implementation.
+
+The default memory path remains:
+
+```text
+ephemeral recall
+queue-first retain
+stable document IDs
+append for live sessions
+tag-scoped project/global memory
+explicit tools and commands
+```
+
+## Safe next work
+
+### PR 8: Document risky memory modes
+
+**Status:** completed.
+
+**Purpose:** Explain why several tempting features are deferred and what safe alternatives already exist.
+
+**Scope:**
+
+- Add a README/docs section for risky memory modes.
+- Explain persisted recall transcript risks.
+- Explain provider recall cache risks.
+- Explain hashtag prompt-control risks.
+- Point users to safe alternatives:
+  - ephemeral recall
+  - `recall.storeLastRecall` sidecar
+  - `/hindsight:last-recall`
+  - `/hindsight:mode`
+  - `/hindsight:retain`
+
+**Acceptance criteria:**
+
+- The docs clearly say these features are not planned for the default path.
+- A future LLM agent can explain why these ideas are deferred without re-litigating them.
+- No code behavior changes.
+
+**Checks:**
+
+```bash
+npm run format
+```
+
+### PR 9: Improve last-recall inspection UX
+
+**Status:** completed.
+
+**Purpose:** Make cached recall useful for inspection without reusing stale recall as provider context.
+
+**Scope:**
+
+- Improve `/hindsight:last-recall` output.
+- Show useful summary fields:
+  - snapshot timestamp
+  - bank IDs
+  - query excerpt
+  - memory counts per bank
+  - sidecar file path
+- Consider an explicit JSON/detail mode if it fits the command style.
+- Keep the sidecar opt-in and local-only.
+- Do not reuse last recall as automatic provider context.
+
+**Acceptance criteria:**
+
+- Users can inspect the latest recall without opening JSON manually.
+- The command makes clear that last recall is for visibility, not automatic reuse.
+- Tests cover missing, malformed, and valid snapshots.
+
+**Checks:**
+
+```bash
+npm run check
+npm run typecheck:tsc
+```
+
+### PR 10: Design command-based one-turn opt-out
+
+**Status:** completed.
+
+**Purpose:** Give users fast memory control without prompt hashtag parsing.
+
+**Design direction:** use explicit Pi commands, not `#nomem`.
+
+Preferred command shape:
+
+```text
+/hindsight:next-opt-out
+```
+
+Possible future variants, not currently implemented:
+
+```text
+/hindsight:next-retain off
+/hindsight:next-mode ignored
+/hindsight:next-recall off
+```
+
+Reason for a dedicated command:
+
+- Pi command autocomplete makes it discoverable by typing `next`, `opt`, or `out`.
+- It avoids parsing user prompts and Markdown headings.
+- It is explicit in the command history.
+- It can have precise behavior and tests.
+
+Resolved design decisions:
+
+- The command disables automatic retain only.
+- It applies to the next completed agent run.
+- Session-wide modes such as `read-only`, `ignored`, and `/hindsight:retain off` remain stronger than this one-turn flag.
+- The flag is persisted in session metadata until consumed.
+- It does not affect historical imports.
+
+Implemented command:
+
+```text
+/hindsight:next-opt-out
+```
+
+Behavior:
+
+- Applies once to the next agent run in the current session.
+- Disables automatic retain for that run.
+- Leaves recall enabled unless the command later grows a `--recall` option.
+- Does not affect explicit `hindsight_retain` tool calls.
+- Does not affect historical import.
+- Records non-provider-visible session metadata so it is inspectable and testable.
+
+**Scope:**
+
+- Document the design and test plan first.
+- Implement the exact accepted behavior only.
+- Do not implement hashtag parsing.
+
+**Acceptance criteria:**
+
+- The command name and one-turn semantics are documented.
+- Import/cursor/session-mode interactions are specified.
+- The out-of-scope list explicitly rejects prompt hashtags for now.
+
+**Implemented outcome:**
+
+- PR #55 added `/hindsight:next-opt-out`.
+- The command sets `nextRetainMode=off` in non-provider-visible session metadata.
+- The next `agent_end` skips automatic retain, marks skipped messages in the retain cursor, clears the flag, and leaves recall, import, and explicit retain unchanged.
+- `/hindsight:session` reports `nextRetain`.
+
+**Checks:**
+
+```bash
+npm run format
+```
+
+### PR 11: Global codebase review loop
+
+**Status:** completed.
+
+**Purpose:** Review the whole extension after MVP hardening and before more feature work.
+
+**Process:**
+
+1. Run multiple reviewer agents in parallel.
+2. Include comparison context from `noctuid/pi-hindsight`.
+3. Check official Hindsight docs/client behavior where relevant.
+4. Group findings by severity:
+   - correctness
+   - safety/security
+   - Hindsight best-practice alignment
+   - Pi lifecycle alignment
+   - test gaps
+   - docs/onboarding gaps
+5. Fix only real issues.
+6. Pre-review each fix before PR.
+7. Request Codex review on the PR.
+8. Repeat until reviewers and Codex find no blockers.
+
+**Acceptance criteria:**
+
+- Findings are recorded in a GitHub issue or issue comment.
+- Every accepted finding has either a fix, test, doc update, or explicit no-action decision.
+- The loop stops only when remaining findings are deferred/non-blocking.
+
+**Completed outcome:**
+
+- Review findings were handled through PRs #41-#54.
+- Final blocker recheck returned LGTM.
+- Remaining reference-only ideas without blockers stay deferred until a new design discussion.
+
+**Checks:**
+
+```bash
+npm run check
+npm run typecheck:tsc
+npm run smoke:hindsight # when live behavior changes and server is available
+```
+
+## Completed hardening follow-up
+
+After the MVP hardening pass and global review loop, a second small-PR hardening pass closed the remaining roadmap/report gaps without changing the default memory policy.
+
+Completed outcomes:
+
+- Cross-platform CI now runs normal checks on Ubuntu, macOS, and Windows.
+- Dependency review, Dependabot, npm audit signatures, trusted publishing, and GitHub default CodeQL cover the supply-chain/release path.
+- The release workflow publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC and no npm token in the workflow.
+- Live smoke covers the official Hindsight client, extension Adapter, memory operations service, import flow, GitHub step summary output, and successful temporary-bank cleanup.
+- Memory-path PRs must prove the live path with local smoke or a configured `Hindsight Integration` pass; an unconfigured skip is not proof.
+- Coverage gates were raised and now include queue, queue lock, JSONL queue store, import, config, lifecycle, and transport Modules.
+- Repeated stress tests cover queue lock contention, malformed queue recovery, retry/dead-letter rollover, and import project-cwd path normalization.
+- Config editing parse/default/patch behavior moved into the config editing registry so settings have better Locality.
+- Router evaluation fixtures now cover balanced project/global/both/skip cases while `globalRetain.mode = "explicit-only"` remains the default.
+
+Remaining explicit deferred ideas below still require a new design discussion before implementation.
+
+## Explicitly deferred ideas
+
+These remain deferred and should not be implemented without a new design discussion.
+
+### Persisted recall messages in Pi transcript history
+
+Why deferred:
+
+- Old recall blocks can be resent to providers if filtering is absent.
+- Uninstalling the extension can turn custom recall blocks into prompt pollution.
+- Recalled memory can accidentally be retained back into Hindsight.
+- It complicates import, cleanup, and transcript semantics.
+
+Safe alternative:
+
+- Keep recall ephemeral.
+- Use `recall.storeLastRecall` and `/hindsight:last-recall` for visibility.
+
+### Provider recall cache
+
+Why deferred:
+
+- Recall is query-dependent.
+- Cached recall can serve stale or irrelevant memory.
+- It makes wrong answers faster and harder to debug.
+
+Safe alternative:
+
+- Keep fresh recall per turn.
+- Cache only for inspection via sidecar snapshots.
+
+### Prompt hashtag controls such as `#nomem`
+
+Why deferred:
+
+- Markdown headings and normal prose use `#`.
+- Prompt parsing creates edge cases and invisible policy decisions.
+- It complicates retain cursor and historical import semantics.
+
+Safe alternative:
+
+- Use explicit commands such as `/hindsight:mode`, `/hindsight:retain`, and `/hindsight:next-opt-out`.
+
+### Linked hosts / multi-Hindsight-server routing
+
+Why deferred:
+
+- Multiple banks cover most separation needs.
+- Multi-server routing adds latency and configuration complexity.
+- The use case is not yet proven.
+
+### Generic memory backend abstraction
+
+Why deferred:
+
+- One backend does not justify a broad abstraction.
+- Hindsight best practices would be diluted into lowest-common-denominator behavior.
+
+### Automatic mental-model management
+
+Why deferred:
+
+- Mental models are powerful but need clear product governance.
+- Automatic updates can create stale or overconfident profiles.
+
+### Bank administration UI
+
+Why deferred:
+
+- Hindsight already has bank administration tooling.
+- Destructive admin operations are risky inside a coding-agent extension.
+
+### OpenClaw-style dynamic routing
+
+Why deferred:
+
+- The current `project-only`, `project+global`, and `global-only` profiles are easier to audit.
+- Dynamic routing makes memory provenance harder to reason about.
+
+### Large prompt or skill bundles
+
+Why deferred:
+
+- They increase maintenance burden and onboarding size.
+- Tool descriptions and docs are enough for the current MVP.

--- a/docs-site/src/content/docs/internal/pr-roadmap.md
+++ b/docs-site/src/content/docs/internal/pr-roadmap.md
@@ -1,0 +1,354 @@
+---
+title: "PR Roadmap"
+---
+
+# PR Roadmap
+
+This roadmap records the completed MVP hardening plan for `@luxusai/pi-hindsight`. Current and future work lives in GitHub Issues; treat this file as historical context, not the task ledger.
+
+The goal is to keep the extension simple by default while preserving enough flexibility for real Pi and Hindsight workflows.
+
+## Product line
+
+The extension should be a conservative Pi integration for Hindsight, not a broad memory framework.
+
+The default experience is:
+
+```text
+project-only memory
+context-hook ephemeral recall
+agent_end structured retain
+durable queue
+stable document IDs
+append mode for live sessions
+strict repo tags
+explicit recall/retain/reflect tools
+small command surface
+```
+
+Advanced behavior should remain opt-in and inspectable. If a feature makes the default mental model harder, defer it unless it fixes a correctness or safety problem.
+
+## Hindsight invariants
+
+Every PR must preserve these rules:
+
+- Retain raw rich content, preferably structured JSON. Do not pre-summarize conversations before retain.
+- Always set `context` on retain items.
+- Use stable, meaningful `document_id` values.
+- Use `update_mode: "append"` for ongoing live sessions when the server supports it.
+- Use `replace` only for deterministic historical imports or rebuilds.
+- Use tags for recall scope and visibility. Use metadata only for provenance and source links.
+- Recall before answer generation.
+- Keep automatic recall ephemeral by default. Do not persist recalled memory into Pi transcript history.
+- Do not retain recalled memory blocks back into Hindsight.
+- Do not expect a retain write to be available for recall in the same turn.
+- Use `reflect` only for explicit synthesis, not for the baseline automatic recall path.
+- Queue retain jobs before network I/O so outages do not lose acknowledged memory intent.
+- Sanitize secrets before automatic retain and avoid raw payloads in normal logs or diagnostics.
+
+## Current baseline
+
+Implemented and expected to stay:
+
+- Pi extension entrypoint and package metadata.
+- Config resolution from defaults, global config, project config, and environment.
+- `project-only`, `project+global`, and `global-only` memory profiles.
+- Deterministic project bank derivation and stable live-session document IDs.
+- Official Hindsight TypeScript client adapter.
+- Bank ensure with mission support.
+- Automatic recall through Pi's `context` hook.
+- Bank-aware recall query composition with role, turn, max-query, timeout, budget, top-K, and injection-position controls.
+- Ephemeral `<hindsight-memory>` injection by default.
+- Optional sidecar last-recall snapshot and cleanup command for accidentally persisted recall blocks.
+- Automatic retain through Pi's `agent_end` hook.
+- Structured retain projection with configurable roles, tool calls, tool results, stripped fields, and secret redaction.
+- Durable JSONL retain queue with lock directory, retry limit, and dead-letter queue.
+- Queue-first explicit `hindsight_retain` tool.
+- Append capability probe with clear failure when append is unsupported.
+- Retain cursor to prevent duplicate append writes from overlapping transcripts.
+- Observation scope config and expansion.
+- Per-session memory mode, retain toggle, and manual tags.
+- Historical import for current session, explicit file, and project-scoped sessions.
+- Import dry-run, all-leaves option, manifest, checkpoint, and resume behavior.
+- Setup TUI, status, doctor, debug, init, import, flush, session, mode, retain, tag, last-recall, and recall-cleanup commands.
+- Local and CI checks plus configured-server smoke path.
+
+## PR sequence
+
+### PR 1: Documentation reset and roadmap alignment
+
+**Status:** completed.
+
+**Purpose:** Make README and docs match the implementation that already exists.
+
+**Scope:**
+
+- Add this roadmap.
+- Replace the older implementation checklist with this roadmap.
+- Update README status from early scaffold to working MVP/pre-release.
+- Add a compact feature-status section with implemented, planned, and deferred items.
+- Link README to this roadmap for implementation order.
+
+**Files likely to change:**
+
+- `README.md`
+- `docs/pr-roadmap.md`
+
+**Acceptance criteria:**
+
+- A new contributor can tell what is implemented and what is still planned without reading code.
+- An LLM agent can use `docs/pr-roadmap.md` as the next-work source of truth.
+- README does not promise unimplemented behavior as finished.
+
+**Checks:**
+
+```bash
+npm run format
+```
+
+### PR 2: Best-practice regression test pack
+
+**Status:** completed.
+
+**Purpose:** Lock Hindsight best practices into tests so future feature work cannot regress memory correctness.
+
+**Scope:**
+
+Add or tighten tests for:
+
+- raw structured JSON retain payloads, not summaries
+- required retain `context`
+- stable live `documentId`
+- live `append` update mode
+- import `replace` semantics only where deterministic
+- tag-based project/global scope separation
+- metadata used for provenance only
+- recalled `<hindsight-memory>` blocks excluded from retain projection
+- explicit retain queue-first behavior
+- secret redaction before queue write
+
+**Files likely to change:**
+
+- `tests/retain*.test.ts`
+- `tests/messages.test.ts`
+- `tests/recall*.test.ts`
+- `tests/import*.test.ts`
+- `tests/memory-scope.test.ts`
+
+**Acceptance criteria:**
+
+- Each invariant in the roadmap has at least one focused test or an explicit note explaining where it is covered.
+- Tests fail if recalled memory is retained or if live retain uses unstable IDs.
+
+**Checks:**
+
+```bash
+npm run check
+npm run typecheck:tsc
+```
+
+### PR 3: Minimal configuration pass
+
+**Status:** completed.
+
+**Purpose:** Keep the public mental model small while preserving advanced config.
+
+**Scope:**
+
+- Restructure README configuration docs around profiles first.
+- Show a minimal config before the full advanced config.
+- Move advanced field explanations into a dedicated section or table.
+- Ensure setup TUI labels describe user intent, not internal fields.
+- Clarify that `project-only` is the safest default.
+
+**Files likely to change:**
+
+- `README.md`
+- `extensions/setup-tui.ts`
+- `extensions/config.ts`
+- config/setup tests if labels or defaults change
+
+**Acceptance criteria:**
+
+- A user can start with base URL + project bank only.
+- Advanced fields remain documented but do not dominate the quick path.
+- No default behavior changes unless tests are updated deliberately.
+
+**Checks:**
+
+```bash
+npm run check
+npm run typecheck:tsc
+```
+
+### PR 4: Operational failure-mode hardening
+
+**Status:** completed.
+
+**Purpose:** Make outages and incompatible Hindsight servers boring and diagnosable.
+
+**Scope:**
+
+- Review queue lock timeout behavior under multiple processes.
+- Review dead-letter diagnostics and remediation hints.
+- Ensure append capability failures produce clear messages.
+- Ensure shutdown flush bounds are visible and documented.
+- Add tests for corrupt queue lines, stale locks, failed flushes, and unsupported append.
+
+**Files likely to change:**
+
+- `extensions/queue.ts`
+- `extensions/capabilities.ts`
+- `extensions/retain-durable.ts`
+- `extensions/diagnostics.ts`
+- `README.md`
+- queue/capability tests
+
+**Acceptance criteria:**
+
+- Hindsight down means memory jobs stay on disk.
+- Unsupported append cannot silently overwrite previous live memory.
+- Doctor/debug tells the user what to do next without showing raw memory content.
+
+**Checks:**
+
+```bash
+npm run check
+npm run typecheck:tsc
+```
+
+### PR 5: Memory quality defaults
+
+**Status:** completed.
+
+**Purpose:** Improve extracted memory quality without increasing everyday config complexity.
+
+**Scope:**
+
+- Review default bank missions for project and global banks.
+- Review default observation scopes.
+- Document when to change missions, scopes, and recall types.
+- Add tests that bank ensure sends the intended missions and observation settings.
+- Add smoke-test notes for validating retention quality against a live server.
+
+**Files likely to change:**
+
+- `extensions/config.ts`
+- `extensions/bank-operations.ts`
+- `extensions/observation-scopes.ts`
+- `README.md`
+- diagnostics and bank tests
+
+**Acceptance criteria:**
+
+- Project memory extracts repo decisions, constraints, bugs, fixes, and continuity.
+- Global memory extracts durable preferences and workflows, not project transcript dumps by default.
+- Observation-scope errors are easy to understand.
+
+**Checks:**
+
+```bash
+npm run check
+npm run typecheck:tsc
+npm run smoke:hindsight # when a configured server is available
+```
+
+### PR 6: Historical import UX final pass
+
+**Status:** completed.
+
+**Purpose:** Make old-session import safe enough for real use.
+
+**Scope:**
+
+- Review dry-run output for usefulness before writing.
+- Confirm project-session discovery is narrow and safe.
+- Confirm all-leaves import is explicit.
+- Confirm manifest/checkpoint/resume behavior is visible in debug.
+- Add examples for preview, current import, file import, and project import.
+
+**Files likely to change:**
+
+- `extensions/import-*.ts`
+- `extensions/memory-operations.ts`
+- `extensions/commands.ts`
+- `README.md`
+- import tests
+
+**Acceptance criteria:**
+
+- User can preview exactly what will be written.
+- Re-running import is deterministic and does not create random duplicate documents.
+- Branch import behavior is explicit.
+
+**Checks:**
+
+```bash
+npm run check
+npm run typecheck:tsc
+```
+
+### PR 7: Release readiness
+
+**Status:** completed.
+
+**Purpose:** Prepare a small public release without adding features.
+
+**Scope:**
+
+- Verify package files and extension entrypoint.
+- Verify README install instructions.
+- Run full checks and live smoke where available.
+- Regenerate changelog from Conventional Commits.
+- Confirm no local-only paths remain in docs except development examples.
+- Confirm secrets and generated files are ignored.
+
+**Files likely to change:**
+
+- `README.md`
+- `CHANGELOG.md`
+- `package.json`
+- `.npmignore` or package `files` if needed
+- CI workflow docs if needed
+
+**Acceptance criteria:**
+
+- Package can be installed by path and from npm tarball.
+- README describes pre-release status honestly.
+- Release check commands pass or documented live-server smoke is delegated to CI.
+
+**Checks:**
+
+```bash
+npm run check
+npm run typecheck:tsc
+npm run smoke:hindsight # when available
+npm pack --dry-run
+```
+
+## Deferred ideas
+
+These are intentionally not in the near-term PR sequence:
+
+- Persisting recalled memories into Pi transcript history.
+- Linked hosts or multi-Hindsight-server routing.
+- Cached recall context.
+- Hashtag-based controls such as `#nomem`.
+- Generic memory-backend abstractions.
+- Automatic mental-model management.
+- Bank administration UI beyond setup guidance.
+- OpenClaw-style multitenant dynamic routing.
+- Large prompt-template or skill bundles.
+
+## LLM handoff rules
+
+When an LLM agent continues this work:
+
+1. Pick the earliest PR whose status is `next` or `planned` and whose prerequisites are done.
+2. Keep the PR small. Do not combine unrelated roadmap items.
+3. Preserve all Hindsight invariants above.
+4. Update README only for user-visible behavior.
+5. Add or update tests for memory routing, IDs, queueing, retain payloads, recall injection, or import behavior.
+6. Run `npm run check`, `npm run check:coverage`, and `npm run typecheck:tsc` before calling the PR done.
+7. If memory-path behavior changed, prove the live path with `npm run smoke:hindsight` or a configured `Hindsight Integration` pass; an unconfigured skip is not proof.
+8. Do not add deferred ideas unless the user explicitly reopens scope.

--- a/docs-site/src/content/docs/internal/prd.md
+++ b/docs-site/src/content/docs/internal/prd.md
@@ -1,0 +1,330 @@
+---
+title: "prd.md"
+---
+
+# prd.md
+
+## Product name
+
+Pi Hindsight Extension
+
+## Summary
+
+Persistent memory for Pi, backed by Hindsight.
+
+The extension gives Pi:
+
+- automatic pre-response recall
+- automatic post-response memory retention
+- explicit memory tools for recall, retain, and reflect
+- historical Pi session import
+- project-scoped memory with optional shared/global carryover
+
+## Problem
+
+Pi sessions are local and durable, but they are not long-term semantic memory by themselves.
+
+Without a dedicated memory layer:
+
+- important project decisions are trapped in transcript history
+- cross-session continuity depends on re-reading or summarization
+- branch/fork history is hard to reuse semantically
+- the agent does not automatically retrieve relevant context from older sessions
+
+Hindsight solves the memory side:
+
+- `retain` extracts facts from raw conversation/documents
+- `recall` retrieves relevant memories
+- `reflect` synthesizes answers from memory
+
+The product problem is to connect Pi’s lifecycle cleanly to those capabilities.
+
+## Goals
+
+### Primary goals
+
+- Remember repo-specific decisions across Pi sessions
+- Preserve memory quality by following Hindsight best practices
+- Keep memory injection ephemeral and transcript-safe
+- Support explicit memory tools when the model or user wants them
+- Make import/reimport of old Pi sessions possible
+
+### Secondary goals
+
+- Support an optional global/shared bank for cross-project learnings
+- Expose operational diagnostics
+- Make the extension a reusable foundation for future Pi extensions
+
+## Non-goals
+
+- Build a general MCP memory server
+- Recreate the Hindsight Control Plane inside Pi
+- Solve every multi-user or multi-host routing pattern in v1
+- Automatically generate mental models in MVP
+- Turn Pi into a multi-tenant SaaS memory hub
+
+## Users
+
+### Primary user
+
+A developer using Pi for ongoing code work who wants the agent to remember:
+
+- architecture decisions
+- project conventions
+- ongoing tasks
+- preferences and repeated patterns
+- lessons from prior debugging/refactoring sessions
+
+### Secondary user
+
+A power user creating multiple Pi extensions who wants:
+
+- a clean package architecture
+- reusable config/runtime patterns
+- reliable AGENTS guidance for future extension work
+
+## Core use cases
+
+### Use case: ongoing repository memory
+
+A user returns to the same repo after several Pi sessions.
+The extension recalls relevant prior decisions before the next answer.
+
+### Use case: explicit memory query
+
+The agent or user wants to ask memory directly:
+
+- “What decisions did we make about config precedence?”
+- “What’s the latest understanding of this bug?”
+- “Summarize what we know about the auth refactor.”
+
+### Use case: durable write after work
+
+At the end of a successful prompt cycle, the extension writes the structured delta to Hindsight using append mode.
+
+### Use case: bootstrap from old sessions
+
+A user already has Pi JSONL session history and wants to seed memory banks from it.
+
+## Product scope
+
+## In scope for MVP
+
+- project-scoped bank
+- optional global bank
+- auto recall
+- auto retain with append
+- explicit tools:
+  - `hindsight_recall`
+  - `hindsight_retain`
+  - `hindsight_reflect`
+- status/doctor/import commands
+- JSONL durable queue
+- historical Pi session import
+
+## Out of scope for MVP
+
+- linked hosts / multi-server recall
+- advanced bank admin UI
+- auto-created mental model workflows
+- collaborative/team multi-user routing
+- provider-specific prompt-engineering modes beyond one safe default
+
+## Functional requirements
+
+### Automatic recall
+
+- On each LLM call, the extension must be able to recall project-relevant memories
+- Recall must be based on the current prompt and optional recent-turn context
+- Recalled memory injection must not be persisted into the transcript
+- Recall should support one or two banks:
+  - project bank
+  - optional global bank
+
+### Automatic retain
+
+- After a completed prompt lifecycle, the extension must build a structured JSON delta
+- The retain write must use a stable session-linked `document_id`
+- Live-session writes must default to `update_mode: "append"`
+- Writes should be queueable and replayable after outages
+
+### Explicit tools
+
+- `hindsight_recall`
+  - returns raw memory facts
+- `hindsight_retain`
+  - stores explicit project insights/decisions
+- `hindsight_reflect`
+  - asks Hindsight to synthesize an answer from memory
+
+### Import
+
+- Import Pi session JSONL files
+- Support current-branch import
+- Optionally support all-leaf import
+- Support deterministic reimport without duplicates
+
+### Diagnostics
+
+- show whether Hindsight is reachable
+- show effective config
+- show active bank IDs
+- show queue depth
+- show import status
+
+## Non-functional requirements
+
+### Reliability
+
+- No acknowledged retain job should be silently lost
+- Temporary Hindsight outages must degrade to queueing, not data loss
+
+### Safety
+
+- Secrets and sensitive values should be redacted before retain
+- Cross-project leakage should be prevented by bank strategy and strict tags
+
+### Inspectability
+
+- It must be easy to see:
+  - which banks are used
+  - when recall occurred
+  - when retain occurred
+  - what config source won
+
+### Maintainability
+
+- Package structure must support future extensions
+- Runtime logic must be split by concern: config, banking, recall, retain, import, commands, tools
+
+## Product design decisions
+
+| Decision           | Chosen default                | Why                                             |
+| ------------------ | ----------------------------- | ----------------------------------------------- |
+| retain payload     | JSON conversation array       | best extraction quality                         |
+| live update mode   | `append`                      | correct for growing session transcripts         |
+| auto recall point  | `context` hook                | ephemeral and transcript-safe                   |
+| auto retain point  | `agent_end`                   | aligns with prompt completion                   |
+| bank model         | per-project + optional global | high-value default for coding workflows         |
+| filtering          | tags, not metadata            | matches Hindsight visibility model              |
+| explicit synthesis | `reflect` tool                | better than forcing all answers through reflect |
+
+## User experience
+
+### Expected default experience
+
+1. User opens Pi in a repo
+2. Extension initializes
+3. On first relevant prompt, memory is recalled automatically
+4. User gets an answer already informed by prior sessions
+5. After the prompt completes, the session delta is retained automatically
+6. If Hindsight is down, a compact retain notice indicates queueing instead of failure
+
+### Explicit controls
+
+Commands:
+
+- `/hindsight:status`
+- `/hindsight:doctor`
+- `/hindsight:config`
+- `/hindsight:import`
+
+Tools:
+
+- `hindsight_recall`
+- `hindsight_retain`
+- `hindsight_reflect`
+
+## Success criteria
+
+### MVP acceptance
+
+- user can install and load the extension
+- project bank is resolved deterministically
+- automatic recall works before responses
+- automatic retain works after responses
+- append mode updates the same document across a session
+- queue survives process restart
+- explicit tools work
+- at least one historical Pi session can be imported successfully
+
+### Quality acceptance
+
+- no recall block is persisted into imported transcripts
+- retain payload is structured JSON, not summary text
+- `context` is always set
+- `document_id` is stable for the same live session
+- secret redaction has tests
+- queue replay has tests
+- import has tests
+
+## Release phases
+
+### MVP
+
+- project bank
+- auto recall
+- auto retain
+- explicit tools
+- import
+- diagnostics
+
+### Phase 2
+
+- optional global bank merge
+- richer operational filtering
+- structured-output mode for `hindsight_reflect`
+- repository-specific bank missions
+
+### Phase 3
+
+- curated mental model support
+- optional approval workflows
+- more advanced UX around import and diagnostics
+
+## Metrics
+
+### Product metrics
+
+- recall success rate
+- retain success rate
+- queued job replay success rate
+- import success count
+- median recall latency
+- median retain enqueue latency
+
+### Quality metrics
+
+- duplicate import rate
+- redaction failure count
+- cross-bank routing mistakes
+- user-visible “memory used” rate on repeated sessions
+
+## Risks
+
+### Over-injection
+
+Too much recalled content can crowd the prompt.
+Mitigation: keep `maxTokens` conservative and tune formatting.
+
+### Memory clutter
+
+Retaining noisy tool chatter can reduce recall quality.
+Mitigation: meaningful-only tool retention and sanitizer.
+
+### Wrong routing
+
+Shared-bank or weak bank derivation can cause leakage.
+Mitigation: repository bank default and strict tags.
+
+### Hidden complexity
+
+Too many config knobs too early makes the extension hard to trust.
+Mitigation: small default surface, advanced options later.
+
+## Open questions
+
+- Should the global bank be enabled only by explicit opt-in?
+- Should imported branch summaries be kept or ignored by default?
+- Which tool results are “meaningful” enough to retain automatically?
+- Do we want one project bank per repo root, or a fully manual bank mapping mode in MVP?

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -8,9 +8,9 @@ Pi Hindsight resolves configuration from defaults, global config, project config
 
 For concepts behind Project Banks, Global/User Banks, tags, metadata, Document IDs, and Update Modes, see:
 
-- [Memory Banks](../concepts/memory-banks/)
-- [Document IDs and update modes](../concepts/document-ids-update-modes/)
-- [Retain, Recall, and Reflect](../concepts/retain-recall-reflect/)
+- [Memory Banks](/concepts/memory-banks/)
+- [Document IDs and update modes](/concepts/document-ids-update-modes/)
+- [Retain, Recall, and Reflect](/concepts/retain-recall-reflect/)
 
 ## Precedence
 
@@ -132,4 +132,4 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
 
 ## Generated editable-field reference
 
-The exact generated tool and editable config field surface lives in [Generated surface reference](./surface-reference/). Do not edit that generated page by hand; update the operation catalog, config editing registry, or generator.
+The exact generated tool and editable config field surface lives in [Generated surface reference](/reference/surface-reference/). Do not edit that generated page by hand; update the operation catalog, config editing registry, or generator.

--- a/docs-site/src/content/docs/reference/hooks.md
+++ b/docs-site/src/content/docs/reference/hooks.md
@@ -8,8 +8,8 @@ Pi Hindsight uses documented Pi extension lifecycle hooks. This page is a refere
 
 For the conceptual behavior behind Retain, Recall, and queue durability, see:
 
-- [Retain, Recall, and Reflect](../concepts/retain-recall-reflect/)
-- [Retain Queue durability](../concepts/queue-durability/)
+- [Retain, Recall, and Reflect](/concepts/retain-recall-reflect/)
+- [Retain Queue durability](/concepts/queue-durability/)
 
 ## `session_start`
 
@@ -66,4 +66,4 @@ Shutdown must not silently discard queued memory.
 
 Tools and commands are registered through the Operation Catalog and delegate to the Memory Operation Service. This keeps explicit user intents shared across tools, commands, setup flows, diagnostics, and smoke helpers.
 
-See [Tools and commands](./tools-and-commands/) and [Generated surface reference](./surface-reference/) for the exact public surface.
+See [Tools and commands](/reference/tools-and-commands/) and [Generated surface reference](/reference/surface-reference/) for the exact public surface.

--- a/docs-site/src/content/docs/reference/import-controls.md
+++ b/docs-site/src/content/docs/reference/import-controls.md
@@ -4,7 +4,7 @@ title: "Import controls reference"
 
 # Import controls reference
 
-Import controls preview and ingest historical Pi sessions or gateway transcripts. For the concept model, see [Historical Import](../concepts/imports/).
+Import controls preview and ingest historical Pi sessions or gateway transcripts. For the concept model, see [Historical Import](/concepts/imports/).
 
 ## Commands
 

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -4,7 +4,7 @@ title: "Tools and commands"
 
 # Tools and commands
 
-For generated details of registered tools and editable config fields, see [Generated surface reference](./surface-reference/). For related concepts, see [Retain, Recall, and Reflect](../concepts/retain-recall-reflect/) and [Memory Banks](../concepts/memory-banks/).
+For generated details of registered tools and editable config fields, see [Generated surface reference](/reference/surface-reference/). For related concepts, see [Retain, Recall, and Reflect](/concepts/retain-recall-reflect/) and [Memory Banks](/concepts/memory-banks/).
 
 `/hindsight` is the main control center. Commands are convenience shortcuts and escape hatches for advanced workflows.
 
@@ -36,7 +36,7 @@ The `hindsight_configure` tool can write config from agents. Prefer `/hindsight`
 /hindsight:import-project-sessions
 ```
 
-Use dry-run before non-dry-run imports. See [Import controls reference](./import-controls/) and [Importing sessions](../guides/importing-sessions/).
+Use dry-run before non-dry-run imports. See [Import controls reference](/reference/import-controls/) and [Importing sessions](/guides/importing-sessions/).
 
 ## Queue and snapshots
 

--- a/scripts/generate-surface-reference.ts
+++ b/scripts/generate-surface-reference.ts
@@ -8,6 +8,16 @@ import type { MemoryOperationsDeps } from "../extensions/memory-operation-servic
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const outputPath = join(root, "docs", "surface-reference.md");
+const docsSiteOutputPath = join(
+  root,
+  "docs-site",
+  "src",
+  "content",
+  "docs",
+  "reference",
+  "surface-reference.md",
+);
+const docsSiteFrontmatter = `---\ntitle: "Generated surface reference"\n---\n\n`;
 
 type JsonSchema = {
   type?: string;
@@ -126,12 +136,15 @@ export function generateSurfaceReference(): string {
 }
 
 const generated = generateSurfaceReference();
+const docsSiteGenerated = `${docsSiteFrontmatter}${generated}`;
 if (process.argv.includes("--check")) {
   const current = readFileSync(outputPath, "utf8");
-  if (current !== generated) {
-    console.error("docs/surface-reference.md is stale. Run npm run surface-reference.");
+  const docsSiteCurrent = readFileSync(docsSiteOutputPath, "utf8");
+  if (current !== generated || docsSiteCurrent !== docsSiteGenerated) {
+    console.error("Surface reference docs are stale. Run npm run surface-reference.");
     process.exit(1);
   }
 } else {
   writeFileSync(outputPath, generated);
+  writeFileSync(docsSiteOutputPath, docsSiteGenerated);
 }


### PR DESCRIPTION
## Summary

- Migrates architecture, development, ADR, agent, and internal/archive docs into the Starlight docs site.
- Adds sidebar sections for architecture, development, agent docs, and internal/archive material with public vs contributor vs maintainer boundaries.
- Fixes Starlight clean-URL links, adds an explicit 404 page following current Starlight behavior, and keeps the docs-site generated surface reference checked by the generator.

## Linked issue

- Closes #206

## Scope

- Docs-site content and navigation only.
- Surface-reference generator updated so the docs-site generated copy cannot drift from the canonical generated reference.

## Verification

- [x] `npm run docs:build`
- [x] internal markdown link scan
- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

## Release impact

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Docs-site navigation/content only. Changelog can be generated from conventional commits.

## Risk and rollback

- Risk: copied docs can become stale; generated surface reference is now checked for the docs-site copy too.
- Risk: sidebar or links can point at wrong clean URLs; docs build and link scan were run.
- Rollback: revert this docs-only PR.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No workflow/policy change; migrated existing guidance into docs-site navigation.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Skipped coverage, full matrix, package verification, pack verify, and live smoke because this is a docs-site/navigation slice with no memory-path or package/release behavior change.
