### PR TITLE
docs: add documentation quality checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,12 @@ Before merging or considering a task done, always run:
 npm run check
 ```
 
+`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
+
+```bash
+npm run docs:check
+```
+
 Also run coverage and compiler fallback for source, tests, critical paths, or full-CI work:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,12 @@ Run the relevant targeted tests while developing, then run the checks required b
 npm run check
 ```
 
+`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
+
+```bash
+npm run docs:check
+```
+
 Run these for source, tests, critical paths, or full-CI work:
 
 ```bash

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -95,6 +95,7 @@ export default defineConfig({
             { label: "CI routing", slug: "development/ci-routing" },
             { label: "Package verification", slug: "development/package-verification" },
             { label: "Release process", slug: "development/release" },
+            { label: "Security policy", slug: "development/security" },
             { label: "Documentation architecture", slug: "development/documentation-architecture" },
             { label: "Internal and agent docs", slug: "development/internal-and-agent-docs" },
             {

--- a/docs-site/src/content/docs/development/agents-root.md
+++ b/docs-site/src/content/docs/development/agents-root.md
@@ -249,6 +249,12 @@ Before merging or considering a task done, always run:
 npm run check
 ```
 
+`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
+
+```bash
+npm run docs:check
+```
+
 Also run coverage and compiler fallback for source, tests, critical paths, or full-CI work:
 
 ```bash

--- a/docs-site/src/content/docs/development/contributing.md
+++ b/docs-site/src/content/docs/development/contributing.md
@@ -117,6 +117,12 @@ Run the relevant targeted tests while developing, then run the checks required b
 npm run check
 ```
 
+`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
+
+```bash
+npm run docs:check
+```
+
 Run these for source, tests, critical paths, or full-CI work:
 
 ```bash

--- a/docs-site/src/content/docs/development/testing-and-verification.md
+++ b/docs-site/src/content/docs/development/testing-and-verification.md
@@ -19,11 +19,13 @@ npm run check:coverage
 npm run typecheck:tsc
 ```
 
-For documentation-site changes, run:
+For documentation-site changes, run the focused docs check while iterating:
 
 ```bash
-npm run docs:build
+npm run docs:check
 ```
+
+`docs:check` verifies generated surface-reference freshness, validates internal docs links/sidebar routes, and builds the Astro/Starlight site. `npm run check` includes `docs:check`, so the normal fast local and PR paths catch docs failures before merge.
 
 ## Memory-path changes
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "format:fix": "oxfmt --write --no-error-on-unmatched-pattern \"extensions/**/*.ts\" \"tests/**/*.ts\" \"tests/**/*.mjs\" \"scripts/**/*.mjs\" \"scripts/**/*.ts\" \"docs/**/*.md\" \"README.md\" \"CONTEXT.md\" \"CONTRIBUTING.md\" \"SECURITY.md\" \"CHANGELOG.md\" \"package.json\" \"package-lock.json\" \"tsconfig.json\" \"vitest.config.ts\" \".oxfmtrc.json\" \".commitlintrc.json\" \"*.yml\" \".github/**/*.yml\" \".github/**/*.md\" \"docs-site/src/content/docs/**/*.md\" \"docs-site/src/content/docs/**/*.mdx\" \"astro.config.mjs\" \"docs-site/src/content.config.ts\"",
     "surface-reference": "tsx scripts/generate-surface-reference.ts",
     "surface-reference:check": "tsx scripts/generate-surface-reference.ts --check",
-    "check": "npm run surface-reference:check && npm run format && npm run lint && npm run typecheck && npm test",
+    "check": "npm run docs:check && npm run format && npm run lint && npm run typecheck && npm test",
     "check:ci": "npm run check && npm run check:coverage",
     "check:release": "npm run check && npm run check:coverage && npm run typecheck:tsc && npm run audit:signatures && npm run pack:verify && npm run smoke:hindsight",
     "install-hooks": "node scripts/install-hooks.mjs",
@@ -60,7 +60,9 @@
     "release:verify": "node scripts/verify-release.mjs",
     "pr:check": "node scripts/check-pr-body.mjs",
     "docs:dev": "astro dev",
-    "docs:build": "astro build"
+    "docs:build": "astro build",
+    "docs:links": "node scripts/check-docs.mjs",
+    "docs:check": "npm run surface-reference:check && npm run docs:links && npm run docs:build"
   },
   "dependencies": {
     "@vectorize-io/hindsight-client": "^0.5.6",

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, extname, join, normalize, relative, resolve, sep } from "node:path";
+
+const docsRoot = process.env.DOCS_ROOT
+  ? resolve(process.env.DOCS_ROOT)
+  : join(process.cwd(), "docs-site", "src", "content", "docs");
+const astroConfigPath = process.env.ASTRO_CONFIG_PATH
+  ? resolve(process.env.ASTRO_CONFIG_PATH)
+  : join(process.cwd(), "astro.config.mjs");
+const markdownExtensions = new Set([".md", ".mdx"]);
+const sidebarSlugPattern = /slug:\s*["']([^"']+)["']/g;
+const markdownLinkPattern = /\[[^\]]*\]\(([^)]+)\)/g;
+const allowedUnlistedSlugs = new Set([
+  "",
+  "404",
+  "architecture",
+  "concepts",
+  "development",
+  "guides",
+  "reference",
+  "start",
+]);
+
+const errors = [];
+
+function walk(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return walk(path);
+    return markdownExtensions.has(extname(entry.name)) ? [path] : [];
+  });
+}
+
+function slugForFile(file) {
+  const withoutExtension = relative(docsRoot, file).replace(/\.(md|mdx)$/u, "");
+  return withoutExtension
+    .split(sep)
+    .join("/")
+    .replace(/(^|\/)index$/u, "");
+}
+
+function candidatesForSlug(slug) {
+  const target = join(docsRoot, slug.replace(/^\//u, "").replace(/[\\/]$/u, ""));
+  return [`${target}.md`, `${target}.mdx`, join(target, "index.md"), join(target, "index.mdx")];
+}
+
+function slugExists(slug) {
+  if (slug === "") return true;
+  return candidatesForSlug(slug).some((candidate) => existsSync(candidate));
+}
+
+function relativeLinkExists(fromFile, href) {
+  const target = normalize(join(dirname(fromFile), href)).replace(/[\\/]$/u, "");
+  const candidates = extname(target)
+    ? [target]
+    : [`${target}.md`, `${target}.mdx`, join(target, "index.md"), join(target, "index.mdx")];
+  return candidates.some((candidate) => existsSync(candidate));
+}
+
+function isExternalOrAnchor(href) {
+  return /^(https?:|mailto:|#)/iu.test(href);
+}
+
+const astroConfig = readFileSync(astroConfigPath, "utf8");
+const baseMatch = astroConfig.match(/base:\s*["']([^"']+)["']/u);
+const astroBase = baseMatch?.[1]?.replace(/^\//u, "").replace(/[\\/]$/u, "");
+const files = walk(docsRoot);
+const slugs = new Set(files.map(slugForFile));
+const sidebarSlugs = new Set(
+  [...astroConfig.matchAll(sidebarSlugPattern)].map((match) => match[1]),
+);
+
+for (const slug of sidebarSlugs) {
+  if (!slugExists(slug)) {
+    errors.push(`Sidebar slug does not resolve to a docs page: ${slug}`);
+  }
+}
+
+for (const slug of slugs) {
+  if (!allowedUnlistedSlugs.has(slug) && !sidebarSlugs.has(slug)) {
+    errors.push(`Docs page missing sidebar navigation entry: ${slug}`);
+  }
+}
+
+for (const file of files) {
+  const content = readFileSync(file, "utf8");
+  for (const match of content.matchAll(markdownLinkPattern)) {
+    const rawHref = match[1].trim().replace(/^<|>$/gu, "");
+    const href = rawHref.split(/[\s#?]/u)[0];
+    if (!href || isExternalOrAnchor(href)) continue;
+
+    if (href.startsWith("/")) {
+      const rawSlug = href.replace(/^\//u, "").replace(/[\\/]$/u, "");
+      const slug =
+        astroBase && rawSlug.startsWith(`${astroBase}/`)
+          ? rawSlug.slice(astroBase.length + 1)
+          : rawSlug;
+      if (!slugExists(slug)) {
+        errors.push(`${relative(process.cwd(), file)} links to missing docs route: ${href}`);
+      }
+      continue;
+    }
+
+    if (!relativeLinkExists(file, href)) {
+      errors.push(`${relative(process.cwd(), file)} links to missing file: ${href}`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Documentation quality checks failed:\n");
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(
+  `Documentation quality checks passed (${files.length} pages, ${sidebarSlugs.size} sidebar entries).`,
+);

--- a/tests/check-docs.test.mjs
+++ b/tests/check-docs.test.mjs
@@ -1,0 +1,78 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const script = fileURLToPath(new URL("../scripts/check-docs.mjs", import.meta.url));
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "pi-hindsight-docs-"));
+  const docsRoot = join(root, "docs");
+  mkdirSync(join(docsRoot, "start"), { recursive: true });
+  writeFileSync(join(docsRoot, "index.mdx"), "---\ntitle: Home\n---\n");
+  writeFileSync(join(docsRoot, "start", "getting-started.md"), "---\ntitle: Start\n---\n");
+  const astroConfigPath = join(root, "astro.config.mjs");
+  writeFileSync(
+    astroConfigPath,
+    `export default { integrations: [{ name: "starlight", options: { sidebar: [{ label: "Start", items: [{ label: "Getting started", slug: "start/getting-started" }] }] } }] };\n`,
+  );
+  return { docsRoot, astroConfigPath };
+}
+
+function runCheck({ docsRoot, astroConfigPath }) {
+  return execFileSync(process.execPath, [script], {
+    env: { ...process.env, DOCS_ROOT: docsRoot, ASTRO_CONFIG_PATH: astroConfigPath },
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+describe("docs quality check", () => {
+  it("passes when sidebar slugs and internal links resolve", () => {
+    const paths = fixture();
+    expect(runCheck(paths)).toContain("Documentation quality checks passed");
+  });
+
+  it("fails when a docs page is missing from sidebar navigation", () => {
+    const paths = fixture();
+    writeFileSync(join(paths.docsRoot, "start", "extra.md"), "---\ntitle: Extra\n---\n");
+
+    expect(() => runCheck(paths)).toThrow(/missing sidebar navigation entry/u);
+  });
+
+  it("fails when a sidebar slug points to a missing page", () => {
+    const paths = fixture();
+    writeFileSync(
+      paths.astroConfigPath,
+      `export default { integrations: [{ name: "starlight", options: { sidebar: [{ label: "Start", items: [{ label: "Missing", slug: "start/missing" }] }] } }] };\n`,
+    );
+
+    expect(() => runCheck(paths)).toThrow(/Sidebar slug does not resolve/u);
+  });
+
+  it("accepts query strings and configured Astro base in internal docs links", () => {
+    const paths = fixture();
+    writeFileSync(
+      paths.astroConfigPath,
+      `export default { base: "/pi-hindsight", integrations: [{ name: "starlight", options: { sidebar: [{ label: "Start", items: [{ label: "Getting started", slug: "start/getting-started" }] }] } }] };\n`,
+    );
+    writeFileSync(
+      join(paths.docsRoot, "start", "getting-started.md"),
+      "---\ntitle: Start\n---\n\n[Self](/pi-hindsight/start/getting-started/?view=full#top)\n",
+    );
+
+    expect(runCheck(paths)).toContain("Documentation quality checks passed");
+  });
+
+  it("fails when an internal docs link points to a missing page", () => {
+    const paths = fixture();
+    writeFileSync(
+      join(paths.docsRoot, "start", "getting-started.md"),
+      "---\ntitle: Start\n---\n\n[Missing](/start/missing/)\n",
+    );
+
+    expect(() => runCheck(paths)).toThrow(/links to missing docs route/u);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `docs:check` as the focused documentation verification path and wires it into `npm run check`.
- Adds `scripts/check-docs.mjs` to validate Starlight sidebar slugs, missing docs navigation entries, and internal docs links/routes.
- Adds coverage for the docs checker and updates contributor/agent docs to explain when to run docs checks.

## Linked issue

- Closes #201

## Scope

- Documentation quality scripts, npm script wiring, tests, and contributor docs.
- No runtime memory behavior changes.

## Verification

- [x] `npm run docs:check`
- [x] `npm test -- tests/check-docs.test.mjs`
- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

## Release impact

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Contributor-facing docs checks are now available through npm scripts and the normal check path. Changelog can be generated from conventional commits.

## Risk and rollback

- Risk: docs checker could be too strict for intentionally unlisted pages; allowed section/index/404 pages are explicitly exempted.
- Risk: internal link parsing could false-positive on deployed base paths or query strings; tests cover both.
- Rollback: revert this PR to return `npm run check` to the previous surface-reference-only docs verification.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

This changes verification guidance, so `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Skipped full matrix, package verification, pack verify, and live smoke because this is docs/checking infrastructure only with no runtime memory-path or package/release behavior change.

A first `npm run check` hit an existing queue stress timeout; targeted queue rerun passed, then full `npm run check` passed twice (manual rerun and precommit).
