### PR TITLE
docs: publish docs site

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,66 @@
+name: Docs Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "astro.config.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - "docs-site/**"
+      - "scripts/check-docs.mjs"
+      - "scripts/generate-code-map.mjs"
+      - "scripts/generate-surface-reference.ts"
+      - ".github/workflows/docs-pages.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: docs-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build docs site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --engine-strict
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Build and verify docs
+        run: npm run docs:check
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: docs-site/dist
+
+  deploy:
+    name: Deploy docs site
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Persistent memory for [Pi](https://github.com/mariozechner/pi) backed by [Hindsight](https://hindsight.vectorize.io/).
 
+Documentation site: <https://luxus.github.io/pi-hindsight/>
+
 Pi Hindsight recalls relevant project memory before model calls, retains structured session deltas after completed agent runs, and exposes explicit memory tools for direct retain/recall/reflect operations.
 
 The extension is heavily inspired by [`noctuid/pi-hindsight`](https://github.com/noctuid/pi-hindsight). This version keeps the same useful idea, then tightens project isolation, queue durability, diagnostics, and release hardening.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -97,6 +97,7 @@ export default defineConfig({
             { label: "Release process", slug: "development/release" },
             { label: "Security policy", slug: "development/security" },
             { label: "Documentation architecture", slug: "development/documentation-architecture" },
+            { label: "Docs site publishing", slug: "development/docs-site-publishing" },
             { label: "Code map", slug: "development/code-map" },
             { label: "Internal and agent docs", slug: "development/internal-and-agent-docs" },
             {

--- a/docs-site/src/content/docs/development/docs-site-publishing.md
+++ b/docs-site/src/content/docs/development/docs-site-publishing.md
@@ -1,0 +1,59 @@
+---
+title: "Docs site publishing"
+---
+
+# Docs site publishing
+
+Pi Hindsight publishes the Astro/Starlight documentation site to GitHub Pages from GitHub Actions.
+
+Published URL: <https://luxus.github.io/pi-hindsight/>
+
+## Local preview
+
+Install dependencies and run the local dev server:
+
+```bash
+npm install
+npm run docs:dev
+```
+
+Build and verify the same docs checks used by CI:
+
+```bash
+npm run docs:check
+```
+
+`docs:check` verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, and the Astro/Starlight build.
+
+## GitHub Pages path
+
+The site is configured for the repository project path in `astro.config.mjs`:
+
+```js
+site: "https://luxus.github.io/pi-hindsight",
+base: "/pi-hindsight",
+```
+
+Keep `base` set to `/pi-hindsight` unless the repository moves to a root-domain Pages deployment. This makes absolute docs links and built assets work under GitHub Pages project hosting.
+
+## Deployment workflow
+
+`.github/workflows/docs-pages.yml` runs on pushes to `main` that touch docs-site inputs and on manual `workflow_dispatch`.
+
+The workflow:
+
+1. checks out the repository,
+2. installs dependencies with `npm ci --engine-strict`,
+3. configures GitHub Pages,
+4. runs `npm run docs:check`,
+5. uploads `docs-site/dist`, and
+6. deploys the artifact to GitHub Pages.
+
+Pull requests do not publish. PR validation comes from the normal Check workflow because `npm run check` includes `npm run docs:check`.
+
+## Troubleshooting
+
+- If generated docs are stale, run `npm run surface-reference` or `npm run code-map`, then re-run `npm run docs:check`.
+- If a docs link fails locally but works in the browser, prefer relative source links for same-section docs pages. Absolute deployed-site links must include the Pages base path.
+- If deployment fails before upload, inspect the build step first; Pages deployment only receives the already-built `docs-site/dist` artifact.
+- If the deployed site has broken assets, verify `site` and `base` in `astro.config.mjs` still match the GitHub Pages project URL.

--- a/docs-site/src/content/docs/development/index.mdx
+++ b/docs-site/src/content/docs/development/index.mdx
@@ -12,6 +12,7 @@ Development pages:
 - [Package verification](./package-verification/)
 - [Release process](./release/)
 - [Documentation architecture](./documentation-architecture/)
+- [Docs site publishing](./docs-site-publishing/)
 - [Code map](./code-map/)
 - [Internal and agent docs](./internal-and-agent-docs/)
 - [Contributing](./contributing/)

--- a/docs-site/src/content/docs/development/testing-and-verification.md
+++ b/docs-site/src/content/docs/development/testing-and-verification.md
@@ -25,7 +25,9 @@ For documentation-site changes, run the focused docs check while iterating:
 npm run docs:check
 ```
 
-`docs:check` verifies generated surface-reference freshness, validates internal docs links/sidebar routes, and builds the Astro/Starlight site. `npm run check` includes `docs:check`, so the normal fast local and PR paths catch docs failures before merge.
+`docs:check` verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, and builds the Astro/Starlight site. `npm run check` includes `docs:check`, so the normal fast local and PR paths catch docs failures before merge.
+
+For publishing details, see [Docs site publishing](./docs-site-publishing/).
 
 ## Memory-path changes
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pi",
     "pi-package"
   ],
-  "homepage": "https://github.com/luxus/pi-hindsight#readme",
+  "homepage": "https://luxus.github.io/pi-hindsight/",
   "bugs": {
     "url": "https://github.com/luxus/pi-hindsight/issues"
   },


### PR DESCRIPTION
## Summary

- Adds a GitHub Pages deployment workflow for the Astro/Starlight docs site.
- Links the published Pages URL from README and package metadata.
- Adds maintainer docs for local preview, GitHub Pages project-path behavior, deployment workflow, and troubleshooting.

## Linked issue

- Closes #199

## Scope

- GitHub Pages workflow, docs-site publishing docs, README/package metadata URL, and docs-site navigation.
- No runtime memory behavior changes.

## Verification

- [x] `npm run docs:check`
- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

## Release impact

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Publishes the docs site to <https://luxus.github.io/pi-hindsight/> after merge to `main`. Changelog can be generated from conventional commits.

## Risk and rollback

- Risk: Pages deployment could publish from non-main refs; deploy job is gated to `refs/heads/main`.
- Risk: Pages permissions could be broader than needed; deploy permissions are scoped to the deploy job, while build keeps read-only permissions.
- Risk: project-path hosting can break assets or root links; `astro.config.mjs` sets `site` and `base`, and docs explain how to troubleshoot.
- Rollback: revert this PR to remove the Pages workflow and published URL metadata.

## Follow-ups

- #220

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No contributor workflow or definition-of-done change; this adds deployment docs under the existing docs-check workflow.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Skipped package verification, pack verify, and live smoke because this is docs publishing only with no runtime memory-path or package contents change. Full matrix should run in PR because workflow files changed.
