### PR TITLE
fix: enable docs pages workflow

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -22,9 +22,24 @@ permissions:
   contents: read
 
 jobs:
+  configure:
+    name: Configure Pages
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Enable GitHub Pages
+        uses: actions/configure-pages@v6
+        with:
+          enablement: true
+
   build:
     name: Build docs site
     runs-on: ubuntu-latest
+    needs: configure
     steps:
       - uses: actions/checkout@v6
 
@@ -36,9 +51,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --engine-strict
-
-      - name: Configure Pages
-        uses: actions/configure-pages@v6
 
       - name: Build and verify docs
         run: npm run docs:check

--- a/docs-site/src/content/docs/development/docs-site-publishing.md
+++ b/docs-site/src/content/docs/development/docs-site-publishing.md
@@ -42,9 +42,9 @@ Keep `base` set to `/pi-hindsight` unless the repository moves to a root-domain 
 
 The workflow:
 
-1. checks out the repository,
-2. installs dependencies with `npm ci --engine-strict`,
-3. configures GitHub Pages,
+1. enables/configures GitHub Pages for the repository,
+2. checks out the repository,
+3. installs dependencies with `npm ci --engine-strict`,
 4. runs `npm run docs:check`,
 5. uploads `docs-site/dist`, and
 6. deploys the artifact to GitHub Pages.


### PR DESCRIPTION
## Summary

- Enables the Docs Pages workflow to create/configure GitHub Pages before building.
- Keeps build steps read-only and scopes Pages write/id-token permissions to configuration and deployment jobs.
- Updates docs publishing docs to describe the enable/configure step.

## Linked issue

- Updates #220

## Scope

- Follow-up fix for the post-merge Docs Pages workflow failure.
- Workflow and docs only; no runtime memory behavior changes.

## Verification

- [x] `npm run docs:check`
- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

## Release impact

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Fixes public docs deployment.

## Risk and rollback

- Risk: Pages enablement may require elevated permissions; permissions are scoped to the configure job.
- Risk: manual workflow dispatch on non-main should not deploy; configure and deploy jobs are gated to `refs/heads/main`.
- Rollback: revert this workflow fix and enable Pages manually in repository settings.

## Follow-ups

- #220

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No contributor workflow or definition-of-done change.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Skipped coverage/package/smoke locally because this is workflow docs publishing only; PR CI full matrix should run because workflow files changed.
