### PR TITLE
docs: tighten agent PR rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,8 @@
 
 ## Release impact
 
+Check exactly one:
+
 - [ ] No release impact
 - [ ] User-visible change
 - [ ] Package/release path change
@@ -30,7 +32,8 @@ Explain changelog/release notes impact, or say none.
 
 ## Risk and rollback
 
--
+- Risk:
+- Rollback/revert path:
 
 ## Follow-ups
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,11 @@ Keep exactly one implementation slice active at a time unless the user explicitl
 
 Agents must not push directly to `main`, tag releases, publish packages, or merge PRs unless a maintainer explicitly asks for that action. A maintainer instruction to run the continuous issue loop counts as merge authorization for PRs that satisfy the documented loop. Work should happen on a branch and flow through a PR.
 
-Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them.
+Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them. If the user asks for work without an issue, create or identify the issue first unless the change is trivial and purely conversational.
 
-Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Keep commits small and logical. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
+Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Issue #195 tracks release-automation alignment, so commit subjects and PR release-impact notes must stay useful for generated changelogs. Keep commits small and logical: one reviewed behavior/docs/workflow change per commit unless splitting would create noise. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
 
-Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, scope, verification, release impact, risk and rollback, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue.
+Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, focused scope, verification, exactly one release-impact choice, risk and rollback/revert path, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue. Do not leave placeholder PR text such as `TODO`, `TBD`, or naked template bullets.
 
 ## Hard rules
 
@@ -308,7 +308,10 @@ A change is done only when:
 3. tests cover the changed logic
 4. user-visible behavior is documented if changed
 5. the diff is minimal and focused
-6. no new memory anti-pattern was introduced
+6. the branch/PR is linked to a GitHub issue
+7. verification is summarized in the PR or issue
+8. the PR description has concrete scope, release impact, risk/rollback, and follow-up notes
+9. no new memory anti-pattern was introduced
 
 ## Agent skills
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,11 @@ Keep one implementation slice active at a time unless a maintainer explicitly as
 
 Agents must not push directly to `main`, tag releases, publish packages, or merge PRs unless a maintainer explicitly asks for that action. A maintainer instruction to run the continuous issue loop counts as merge authorization for PRs that satisfy the documented loop. Work should happen on a branch and flow through a PR.
 
-Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them.
+Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them. If the user asks for work without an issue, create or identify the issue first unless the change is trivial and purely conversational.
 
-Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Keep commits small and logical. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
+Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Issue #195 tracks release-automation alignment, so commit subjects and PR release-impact notes must stay useful for generated changelogs. Keep commits small and logical: one reviewed behavior/docs/workflow change per commit unless splitting would create noise. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
 
-Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, scope, verification, release impact, risk and rollback, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue.
+Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, focused scope, verification, exactly one release-impact choice, risk and rollback/revert path, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue. Do not leave placeholder PR text such as `TODO`, `TBD`, or naked template bullets.
 
 ## Memory invariants
 
@@ -172,8 +172,11 @@ A change is done only when:
 2. it uses documented Pi extension hooks;
 3. tests cover the changed logic;
 4. user-visible behavior is documented if changed;
-5. the diff is minimal and focused; and
-6. no new memory anti-pattern was introduced.
+5. the diff is minimal and focused;
+6. the branch/PR is linked to a GitHub issue;
+7. verification is summarized in the PR or issue;
+8. the PR description has concrete scope, release impact, risk/rollback, and follow-up notes; and
+9. no new memory anti-pattern was introduced.
 
 ## PR checklist
 

--- a/docs-site/src/content/docs/development/agents-root.md
+++ b/docs-site/src/content/docs/development/agents-root.md
@@ -68,11 +68,11 @@ Keep exactly one implementation slice active at a time unless the user explicitl
 
 Agents must not push directly to `main`, tag releases, publish packages, or merge PRs unless a maintainer explicitly asks for that action. A maintainer instruction to run the continuous issue loop counts as merge authorization for PRs that satisfy the documented loop. Work should happen on a branch and flow through a PR.
 
-Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them.
+Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them. If the user asks for work without an issue, create or identify the issue first unless the change is trivial and purely conversational.
 
-Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Keep commits small and logical. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
+Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Issue #195 tracks release-automation alignment, so commit subjects and PR release-impact notes must stay useful for generated changelogs. Keep commits small and logical: one reviewed behavior/docs/workflow change per commit unless splitting would create noise. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
 
-Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, scope, verification, release impact, risk and rollback, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue.
+Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, focused scope, verification, exactly one release-impact choice, risk and rollback/revert path, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue. Do not leave placeholder PR text such as `TODO`, `TBD`, or naked template bullets.
 
 ## Hard rules
 
@@ -312,7 +312,10 @@ A change is done only when:
 3. tests cover the changed logic
 4. user-visible behavior is documented if changed
 5. the diff is minimal and focused
-6. no new memory anti-pattern was introduced
+6. the branch/PR is linked to a GitHub issue
+7. verification is summarized in the PR or issue
+8. the PR description has concrete scope, release impact, risk/rollback, and follow-up notes
+9. no new memory anti-pattern was introduced
 
 ## Agent skills
 

--- a/docs-site/src/content/docs/development/contributing.md
+++ b/docs-site/src/content/docs/development/contributing.md
@@ -87,11 +87,11 @@ Keep one implementation slice active at a time unless a maintainer explicitly as
 
 Agents must not push directly to `main`, tag releases, publish packages, or merge PRs unless a maintainer explicitly asks for that action. A maintainer instruction to run the continuous issue loop counts as merge authorization for PRs that satisfy the documented loop. Work should happen on a branch and flow through a PR.
 
-Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them.
+Before implementation starts, link the change to a GitHub issue. Keep each branch and PR to one focused vertical slice. Do not bundle drive-by refactors, formatting sweeps, or unrelated cleanup unless the issue explicitly asks for them. If the user asks for work without an issue, create or identify the issue first unless the change is trivial and purely conversational.
 
-Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Keep commits small and logical. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
+Use Conventional Commits for final commit subjects because release automation, changelog generation, and release notes consume them as source of truth. Issue #195 tracks release-automation alignment, so commit subjects and PR release-impact notes must stay useful for generated changelogs. Keep commits small and logical: one reviewed behavior/docs/workflow change per commit unless splitting would create noise. Clean up noisy WIP commits before review when the workflow allows it. Never bypass Git hooks or checks with `--no-verify` or equivalent flags.
 
-Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, scope, verification, release impact, risk and rollback, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue.
+Every PR must complete the repository PR template. The template is intentionally machine-checkable: linked issue, focused scope, verification, exactly one release-impact choice, risk and rollback/revert path, follow-ups, and agent checklist. If a check was skipped, the PR must say why. If follow-up work remains, link a GitHub issue. Do not leave placeholder PR text such as `TODO`, `TBD`, or naked template bullets.
 
 ## Memory invariants
 
@@ -176,8 +176,11 @@ A change is done only when:
 2. it uses documented Pi extension hooks;
 3. tests cover the changed logic;
 4. user-visible behavior is documented if changed;
-5. the diff is minimal and focused; and
-6. no new memory anti-pattern was introduced.
+5. the diff is minimal and focused;
+6. the branch/PR is linked to a GitHub issue;
+7. verification is summarized in the PR or issue;
+8. the PR description has concrete scope, release impact, risk/rollback, and follow-up notes; and
+9. no new memory anti-pattern was introduced.
 
 ## PR checklist
 

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -25,6 +25,17 @@ export function section(body, heading) {
   return pattern.exec(body)?.[1]?.trim() ?? "";
 }
 
+function hasSubstantiveContent(value) {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .some((line) => line && !/^[-*]?\s*(todo|tbd|n\/a|none|#?)$/i.test(line));
+}
+
+function checkedLines(value, labelPattern) {
+  return value.split("\n").filter((line) => /^- \[[xX]\]/.test(line) && labelPattern.test(line));
+}
+
 export function validatePrBody(body) {
   const errors = [];
   const text = body.trim();
@@ -39,9 +50,19 @@ export function validatePrBody(body) {
     }
   }
 
+  const summary = section(text, "Summary");
+  if (!hasSubstantiveContent(summary)) {
+    errors.push("Summary section must describe the change.");
+  }
+
   const linkedIssue = section(text, "Linked issue");
   if (!/(close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|updates?)\s+#\d+/i.test(linkedIssue)) {
     errors.push("Linked issue section must include Closes/Fixes/Resolves/Refs/Updates #<number>.");
+  }
+
+  const scope = section(text, "Scope");
+  if (!hasSubstantiveContent(scope)) {
+    errors.push("Scope section must describe the focused vertical slice.");
   }
 
   const verification = section(text, "Verification");
@@ -56,12 +77,17 @@ export function validatePrBody(body) {
   }
 
   const releaseImpact = section(text, "Release impact");
-  if (
-    !/- \[[xX]\] (No release impact|User-visible change|Package\/release path change)/.test(
-      releaseImpact,
-    )
-  ) {
+  const releaseImpactChoices = checkedLines(
+    releaseImpact,
+    /(No release impact|User-visible change|Package\/release path change)/,
+  );
+  if (releaseImpactChoices.length !== 1) {
     errors.push("Release impact section must check exactly one impact option.");
+  }
+
+  const risk = section(text, "Risk and rollback");
+  if (!hasSubstantiveContent(risk) || !/rollback|revert|back out|disable/i.test(risk)) {
+    errors.push("Risk and rollback section must describe risk and rollback/revert path.");
   }
 
   const followUps = section(text, "Follow-ups");
@@ -75,8 +101,14 @@ export function validatePrBody(body) {
       "Agent checklist must confirm AGENTS.md and CONTRIBUTING.md were read and followed.",
     );
   }
+  if (!/- \[[xX]\] I linked the issue before implementation/.test(agentChecklist)) {
+    errors.push("Agent checklist must confirm issue linkage before implementation.");
+  }
   if (!/- \[[xX]\] Final branch contains only focused, reviewable commits/.test(agentChecklist)) {
     errors.push("Agent checklist must confirm focused, reviewable commits.");
+  }
+  if (!/- \[[xX]\] I did not bypass hooks or checks/.test(agentChecklist)) {
+    errors.push("Agent checklist must confirm hooks/checks were not bypassed.");
   }
 
   return errors;

--- a/tests/pr-body-check.test.mjs
+++ b/tests/pr-body-check.test.mjs
@@ -36,7 +36,9 @@ None.
 ## Agent checklist
 
 - [x] I read and followed \`AGENTS.md\` and \`CONTRIBUTING.md\`.
+- [x] I linked the issue before implementation.
 - [x] Final branch contains only focused, reviewable commits.
+- [x] I did not bypass hooks or checks.
 `;
 
 describe("check-pr-body", () => {
@@ -62,5 +64,52 @@ describe("check-pr-body", () => {
     );
 
     expect(validatePrBody(body)).toContain("Verification section must check `npm run check`.");
+  });
+
+  it("rejects placeholder summary and scope sections", () => {
+    const body = validBody
+      .replace("- Add release guardrails.", "- TODO")
+      .replace("- Docs and workflow only.", "- TBD");
+
+    expect(validatePrBody(body)).toEqual([
+      "Summary section must describe the change.",
+      "Scope section must describe the focused vertical slice.",
+    ]);
+  });
+
+  it("requires exactly one release impact choice", () => {
+    const body = validBody.replace(
+      "- [x] No release impact\n- [ ] User-visible change\n- [ ] Package/release path change",
+      "- [x] No release impact\n- [x] User-visible change\n- [ ] Package/release path change",
+    );
+
+    expect(validatePrBody(body)).toContain(
+      "Release impact section must check exactly one impact option.",
+    );
+  });
+
+  it("requires risk plus rollback or revert guidance", () => {
+    const body = validBody.replace("Low. Revert docs/workflow changes.", "Low.");
+
+    expect(validatePrBody(body)).toContain(
+      "Risk and rollback section must describe risk and rollback/revert path.",
+    );
+  });
+
+  it("requires issue linkage and no-bypass confirmations in the agent checklist", () => {
+    const body = validBody
+      .replace(
+        "- [x] I linked the issue before implementation.",
+        "- [ ] I linked the issue before implementation.",
+      )
+      .replace(
+        "- [x] I did not bypass hooks or checks.",
+        "- [ ] I did not bypass hooks or checks.",
+      );
+
+    expect(validatePrBody(body)).toEqual([
+      "Agent checklist must confirm issue linkage before implementation.",
+      "Agent checklist must confirm hooks/checks were not bypassed.",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Tightens agent commit and PR rules in `AGENTS.md` and `CONTRIBUTING.md` with issue-first, focused-slice, no-main-push, no-drive-by, no-hook-bypass, and release-automation guidance.
- Updates the PR template to require exactly one release-impact choice and explicit risk plus rollback/revert notes.
- Strengthens the PR checklist gate to reject placeholder summary/scope text, multiple release-impact choices, missing rollback guidance, and missing agent confirmations.

## Linked issue

- Closes #202
- Refs #195

## Scope

- Agent contribution guidance, PR template, PR-body validation, mirrored docs-site guidance, and validation tests.
- No runtime memory behavior changes.

## Verification

- [x] `npm run docs:check`
- [x] `npm test -- tests/pr-body-check.test.mjs`
- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Contributor/agent workflow guidance changes. Changelog can be generated from the conventional commit.

## Risk and rollback

- Risk: PR body validation could reject previously acceptable but vague PR descriptions.
- Rollback/revert path: revert this PR to restore the earlier looser checklist gate and guidance.

## Follow-ups

- #195

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

This changes contributor workflow/definition-of-done guidance, so both files and their docs-site mirrors were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Skipped package verification, pack verify, full matrix, and live smoke locally because this is documentation/checklist enforcement with no package contents, release workflow, or memory-path behavior change.
