### PR TITLE
docs: make docs site the primary landing surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,7 +245,7 @@ Before merging or considering a task done, always run:
 npm run check
 ```
 
-`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
+`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, validates packaged Markdown links, enforces GitHub Pages base-prefixed docs links, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
 
 ```bash
 npm run docs:check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ Run the relevant targeted tests while developing, then run the checks required b
 npm run check
 ```
 
-`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
+`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, validates packaged Markdown links, enforces GitHub Pages base-prefixed docs links, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
 
 ```bash
 npm run docs:check

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Persistent memory for [Pi](https://github.com/mariozechner/pi) backed by [Hindsight](https://hindsight.vectorize.io/).
 
-Documentation site: <https://luxus.github.io/pi-hindsight/>
+**Documentation:** <https://luxus.github.io/pi-hindsight/>
 
 Pi Hindsight recalls relevant project memory before model calls, retains structured session deltas after completed agent runs, and exposes explicit memory tools for direct retain/recall/reflect operations.
 
-The extension is heavily inspired by [`noctuid/pi-hindsight`](https://github.com/noctuid/pi-hindsight). This version keeps the same useful idea, then tightens project isolation, queue durability, diagnostics, and release hardening.
+The extension is inspired by [`noctuid/pi-hindsight`](https://github.com/noctuid/pi-hindsight). This version keeps the same useful idea, then tightens project isolation, queue durability, diagnostics, and release hardening.
 
 ## Compatibility
 
@@ -16,66 +16,6 @@ Supported runtime and package ranges are declared in `package.json` and enforced
 - npm: `>=11 <12`
 - Pi peer package: `@mariozechner/pi-coding-agent >=0.72.1 <0.73.0`
 - TypeBox peer package: `typebox >=1.1.24 <2`
-
-## Mental model
-
-Hindsight separates storage, retrieval, and reasoning:
-
-```text
-Retain  = store raw contextual memory
-Recall  = retrieve relevant memory candidates
-Reflect = analyze memory for patterns or answers
-```
-
-Everything lives in a **memory bank**. This extension defaults to a project bank per repo so unrelated projects do not leak into each other. A user bank is optional and explicit.
-
-```mermaid
-flowchart LR
-  A[Pi conversation] --> B[Retain raw structured content]
-  B --> C[Hindsight memory bank]
-  D[Future prompt] --> E[Recall relevant candidates]
-  E --> F[Ephemeral context block]
-  C --> E
-  C --> G[Reflect for deeper analysis]
-```
-
-Sharp rules:
-
-- Retain raw rich content, not summaries.
-- Use stable document IDs for live sessions.
-- Keep recall ephemeral; do not write recalled memory back into transcripts.
-- Use tags and banks for scope.
-- Keep user memory opt-in and intentional.
-
-See [`docs/hindsight-core-functions.md`](docs/hindsight-core-functions.md) and [`docs/memory-behavior.md`](docs/memory-behavior.md) for details.
-
-## Current status
-
-This is a working MVP and still pre-release. The core memory path is implemented and the first hardening roadmap is complete.
-
-Implemented:
-
-- automatic recall through Pi's `context` hook
-- automatic retain through Pi's `agent_end` hook
-- queue-first retain with lock, retry, malformed-line quarantine, and dead-letter handling
-- stable live-session document IDs
-- project/user memory profiles
-- historical Pi session import with manifest and checkpoint support
-- setup/status TUI through `/hindsight`
-- explicit tools and command shortcuts for advanced use
-- CI on Ubuntu, macOS, and Windows
-- release verification, trusted publishing, dependency review, audit signatures, and live Hindsight smoke tests
-
-Intentionally deferred:
-
-- persisted recall messages in Pi transcript history
-- cached recall context
-- hashtag controls such as `#nomem`
-- generic memory-backend abstraction
-- automatic mental-model management
-- broad bank administration UI beyond setup/config guidance
-
-See [`docs/risky-memory-modes.md`](docs/risky-memory-modes.md) for why these remain deferred. Pi Hindsight stays Pi-first; framework adapters such as LiteLLM, CrewAI, Pydantic AI, OpenAI Agents, and Vercel AI SDK belong in companion packages or examples. See [`docs/core-vs-companion-adapters.md`](docs/core-vs-companion-adapters.md).
 
 ## Install
 
@@ -98,123 +38,36 @@ Package name: `@luxusai/pi-hindsight`.
 1. Start or choose a Hindsight server:
    - [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
    - [Local Hindsight installation](https://hindsight.vectorize.io/developer/installation)
-
-2. Open Pi in your repo and run:
-
-   ```text
-   /hindsight
-   ```
-
-3. Configure the Hindsight API URL. The default local URL is:
-
-   ```text
-   http://localhost:8888
-   ```
-
-4. Choose a memory profile:
-   - `project-only`: safest default; repo memory stays in a project bank.
-   - `project+global`: recalls project memory plus durable user preferences.
-   - `global-only`: user-only shared memory; automatic project retain is disabled.
-
+2. Open Pi in your repo and run `/hindsight`.
+3. Configure the Hindsight API URL. The default local URL is `http://localhost:8888`.
+4. Choose the narrowest memory profile that fits the repo: `project-only`, `project+global`, or `global-only`.
 5. Start coding. Recall happens before provider calls; retain happens after completed agent runs.
 
-For a minimal project-local config:
+See the [getting started guide](https://luxus.github.io/pi-hindsight/start/getting-started/) for setup details.
 
-```json
-{
-  "hindsight": {
-    "baseUrl": "http://localhost:8888"
-  }
-}
-```
+## Safety defaults
 
-For a stable human-chosen project bank:
+- Project memory stays in a project bank by default.
+- Global/user memory is opt-in and explicitly configured.
+- Recall injection is ephemeral; recalled memory is not written back into transcripts.
+- Automatic retain redacts common secrets before writing memory.
+- Exact document deletion requires exact bank ID, exact document ID, and `confirm: true`.
 
-```json
-{
-  "hindsight": {
-    "baseUrl": "http://localhost:8888"
-  },
-  "banks": {
-    "project": {
-      "derive": "manual",
-      "bankId": "pi-project-my-repo"
-    }
-  }
-}
-```
+See [memory behavior](https://luxus.github.io/pi-hindsight/concepts/memory-behavior/) and [session memory modes](https://luxus.github.io/pi-hindsight/concepts/session-memory-modes/) for details.
 
-See [`docs/configuration.md`](docs/configuration.md) for config precedence, environment variables, advanced fields, and examples.
+## Documentation
 
-## Common commands
-
-`/hindsight` is the main control center.
-
-Useful shortcuts:
-
-```text
-/hindsight:init                         # write a minimal project config
-/hindsight:import-current --dry-run     # preview current session import
-/hindsight:import-project-sessions      # import repo-scoped Pi sessions
-/hindsight:flush                        # flush queued retain jobs
-/hindsight:last-recall                  # inspect opt-in last recall snapshot
-/hindsight:mode read-only               # recall only; no automatic retain
-/hindsight:next-opt-out                 # skip automatic retain once
-```
-
-See [`docs/tools-and-commands.md`](docs/tools-and-commands.md) for the full command and tool surface. Generated tools, commands, and config fields are listed in [`docs/surface-reference.md`](docs/surface-reference.md).
-
-## Historical import
-
-Historical import can import the current Pi session, an explicit JSONL path, or repo-scoped sessions from the active session directory. Imports use deterministic document IDs and maintain checkpoint/manifest files under `.pi/hindsight/`.
-
-Preview before writing:
-
-```text
-/hindsight:import-current --dry-run
-/hindsight:import-project-sessions --dry-run
-```
-
-Project session discovery scans only the current session directory and keeps `.jsonl` sessions whose parsed `cwd` normalizes to the current repo/cwd. Equivalent paths such as trailing separators, `.` segments, `..` traversal back to the repo, and resolved absolute paths are treated as the same project.
-
-See [`docs/importing-sessions.md`](docs/importing-sessions.md) for import options, checkpoint behavior, and rebuild guidance.
-
-## Configuration files
-
-Config is resolved from:
-
-1. `~/.pi/agent/hindsight.json` or `.jsonc`
-2. `.pi/hindsight.json` or `.jsonc` in the current repo
-3. environment variables
-
-If both `.json` and `.jsonc` exist at the same scope, `.json` wins. Environment variables win over files.
-
-Common environment variables:
-
-```bash
-export HINDSIGHT_BASE_URL=http://localhost:8888
-export HINDSIGHT_API_KEY=...
-export PI_HINDSIGHT_PROJECT_BANK_ID=pi-project-my-repo
-export PI_HINDSIGHT_USER_BANK_ID=user-luxus
-```
-
-## Safety
-
-The extension redacts common API keys, bearer tokens, GitHub tokens, password-style environment assignments, and credentials embedded in URLs before automatic retain.
-
-Debug sidecars such as last-recall snapshots are opt-in and local. They may contain memory text and query excerpts, so enable them only when local disk visibility is acceptable.
-
-Exact document deletion is available through `hindsight_delete_document`, requiring exact bank, exact document ID, and `confirm: true`.
+- [Start](https://luxus.github.io/pi-hindsight/start/) — install and first setup
+- [Concepts](https://luxus.github.io/pi-hindsight/concepts/) — memory model, banks, queue, imports, safety
+- [Guides](https://luxus.github.io/pi-hindsight/guides/) — task workflows for setup, diagnostics, imports, and recovery
+- [Reference](https://luxus.github.io/pi-hindsight/reference/) — tools, commands, config, hooks, generated surface
+- [Development](https://luxus.github.io/pi-hindsight/development/) — contributor setup, checks, release, docs workflow
 
 ## Development
-
-Install dependencies and run checks:
 
 ```bash
 npm install
 npm run check
-npm run check:coverage
-npm run typecheck:tsc
 ```
 
 Run Pi with the local extension:
@@ -223,30 +76,4 @@ Run Pi with the local extension:
 pi -e ./extensions/index.ts
 ```
 
-Before release-path changes, also run:
-
-```bash
-npm run audit:signatures
-npm run pack:verify
-```
-
-For memory-path behavior changes, prove the live path with local smoke or a configured `Hindsight Integration` workflow pass:
-
-```bash
-export HINDSIGHT_BASE_URL=http://localhost:8888
-npm run smoke:hindsight
-```
-
-See [`docs/development.md`](docs/development.md) and [`docs/release.md`](docs/release.md) for maintainer details.
-
-## Documentation map
-
-- [`docs/getting-started.md`](docs/getting-started.md) — first setup and profiles
-- [`docs/configuration.md`](docs/configuration.md) — config files, env vars, examples
-- [`docs/memory-behavior.md`](docs/memory-behavior.md) — recall, retain, queue, scope, safety
-- [`docs/importing-sessions.md`](docs/importing-sessions.md) — historical import
-- [`docs/tools-and-commands.md`](docs/tools-and-commands.md) — explicit tools and command shortcuts
-- [`docs/development.md`](docs/development.md) — local development and checks
-- [`docs/release.md`](docs/release.md) — release and smoke verification
-- [`docs/architecture-todos.md`](docs/architecture-todos.md) — architecture notes and deferred deepening
-- [`docs/post-mvp-roadmap.md`](docs/post-mvp-roadmap.md) — completed follow-up hardening and deferred ideas
+For maintainer details, see [Development setup](https://luxus.github.io/pi-hindsight/development/development/) and [Release process](https://luxus.github.io/pi-hindsight/development/release/).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "astro/config";
+import mermaid from "astro-mermaid";
 import starlight from "@astrojs/starlight";
 
 export default defineConfig({
@@ -7,6 +8,15 @@ export default defineConfig({
   srcDir: "./docs-site/src",
   outDir: "./docs-site/dist",
   integrations: [
+    mermaid({
+      autoTheme: true,
+      enableLog: false,
+      mermaidConfig: {
+        flowchart: {
+          curve: "basis",
+        },
+      },
+    }),
     starlight({
       title: "Pi Hindsight",
       disable404Route: true,
@@ -32,6 +42,7 @@ export default defineConfig({
               slug: "concepts/document-ids-update-modes",
             },
             { label: "Retain Queue durability", slug: "concepts/queue-durability" },
+            { label: "Session memory modes", slug: "concepts/session-memory-modes" },
             { label: "Historical Import", slug: "concepts/imports" },
             { label: "Memory behavior", slug: "concepts/memory-behavior" },
             { label: "Hindsight core functions", slug: "concepts/hindsight-core-functions" },
@@ -43,7 +54,14 @@ export default defineConfig({
         },
         {
           label: "Guides",
-          items: [{ label: "Importing sessions", slug: "guides/importing-sessions" }],
+          items: [
+            { label: "Configure memory profiles", slug: "guides/configure-memory-profiles" },
+            { label: "Use /hindsight status", slug: "guides/use-hindsight-status" },
+            { label: "Importing sessions", slug: "guides/importing-sessions" },
+            { label: "Inspect recalls and receipts", slug: "guides/inspect-recalls-and-receipts" },
+            { label: "Recover Retain Queue", slug: "guides/recover-retain-queue" },
+            { label: "Run local smoke test", slug: "guides/run-local-smoke-test" },
+          ],
         },
         {
           label: "Reference",
@@ -51,7 +69,10 @@ export default defineConfig({
             { label: "Configuration", slug: "reference/configuration" },
             { label: "Tools and commands", slug: "reference/tools-and-commands" },
             { label: "Hooks", slug: "reference/hooks" },
+            { label: "Memory modes", slug: "reference/memory-modes" },
             { label: "Import controls", slug: "reference/import-controls" },
+            { label: "Bank template manifest", slug: "reference/bank-template-manifest" },
+            { label: "Hindsight API links", slug: "reference/hindsight-api-links" },
             { label: "Generated surface reference", slug: "reference/surface-reference" },
           ],
         },
@@ -101,6 +122,18 @@ export default defineConfig({
             { label: "Code map", slug: "development/code-map" },
             { label: "Internal and agent docs", slug: "development/internal-and-agent-docs" },
             {
+              label: "Maintainer archive",
+              items: [
+                { label: "Internal index", slug: "internal" },
+                { label: "Architecture TODOs", slug: "internal/architecture-todos" },
+                { label: "Next opt-out design", slug: "internal/next-opt-out-design" },
+                { label: "Post-MVP roadmap", slug: "internal/post-mvp-roadmap" },
+                { label: "PR roadmap", slug: "internal/pr-roadmap" },
+                { label: "PRD", slug: "internal/prd" },
+                { label: "Coding plan", slug: "internal/coding-plan" },
+              ],
+            },
+            {
               label: "Agent docs",
               items: [
                 { label: "AGENTS.md", slug: "development/agents-root" },
@@ -111,18 +144,6 @@ export default defineConfig({
                 { label: "Triage labels", slug: "development/agents/triage-labels" },
               ],
             },
-          ],
-        },
-        {
-          label: "Internal / Archive",
-          items: [
-            { label: "Internal index", slug: "internal" },
-            { label: "Architecture TODOs", slug: "internal/architecture-todos" },
-            { label: "Next opt-out design", slug: "internal/next-opt-out-design" },
-            { label: "Post-MVP roadmap", slug: "internal/post-mvp-roadmap" },
-            { label: "PR roadmap", slug: "internal/pr-roadmap" },
-            { label: "PRD", slug: "internal/prd" },
-            { label: "Coding plan", slug: "internal/coding-plan" },
           ],
         },
       ],

--- a/docs-site/src/content/docs/404.md
+++ b/docs-site/src/content/docs/404.md
@@ -10,6 +10,6 @@ hero:
   actions:
     - text: Go home
       icon: right-arrow
-      link: /
+      link: /pi-hindsight/
       variant: primary
 ---

--- a/docs-site/src/content/docs/architecture/lifecycle-and-scope.md
+++ b/docs-site/src/content/docs/architecture/lifecycle-and-scope.md
@@ -25,5 +25,5 @@ Pi Hindsight owns Pi integration policy. Hindsight owns Retain, Recall, Reflect,
 See also:
 
 - [ADR 001](./adr/001-memory-lifecycle-and-scope/)
-- [Hooks reference](/reference/hooks/)
-- [Memory Banks](/concepts/memory-banks/)
+- [Hooks reference](/pi-hindsight/reference/hooks/)
+- [Memory Banks](/pi-hindsight/concepts/memory-banks/)

--- a/docs-site/src/content/docs/architecture/queue-and-import.md
+++ b/docs-site/src/content/docs/architecture/queue-and-import.md
@@ -8,7 +8,7 @@ Retain delivery and historical import both prioritize durability, provenance, an
 
 The Retain Queue writes jobs to disk before delivery. It handles retry, stale locks, malformed line quarantine, bounded shutdown flushes, and dead-letter rollover.
 
-See [Retain Queue durability](/concepts/queue-durability/) for user-facing concepts.
+See [Retain Queue durability](/pi-hindsight/concepts/queue-durability/) for user-facing concepts.
 
 ## Import architecture
 
@@ -24,4 +24,4 @@ Important boundaries:
 
 Curated imports may chunk by user turns. Raw and forensic imports preserve legacy document IDs and payload shape.
 
-See [Historical Import](/concepts/imports/) and [Import controls reference](/reference/import-controls/).
+See [Historical Import](/pi-hindsight/concepts/imports/) and [Import controls reference](/pi-hindsight/reference/import-controls/).

--- a/docs-site/src/content/docs/concepts/hindsight-core-functions.md
+++ b/docs-site/src/content/docs/concepts/hindsight-core-functions.md
@@ -112,7 +112,7 @@ Good mental model examples:
 - “What recurring workflow habits matter?”
 - “What does this project consider good design?”
 
-Mental models are not raw recall. They are reusable synthesized answers. In Pi Hindsight they are explicit advanced resources. Pi's `/hindsight` TUI shows a read-only list/detail view and hands off create, edit, refresh, and delete to the Hindsight web interface. The extension must not auto-create mental models from routine sessions or refresh them in the background unless a future issue designs that policy. Starter suggestions are documented in [Starter mental model suggestions](/concepts/starter-mental-model-suggestions/).
+Mental models are not raw recall. They are reusable synthesized answers. In Pi Hindsight they are explicit advanced resources. Pi's `/hindsight` TUI shows a read-only list/detail view and hands off create, edit, refresh, and delete to the Hindsight web interface. The extension must not auto-create mental models from routine sessions or refresh them in the background unless a future issue designs that policy. Starter suggestions are documented in [Starter mental model suggestions](/pi-hindsight/concepts/starter-mental-model-suggestions/).
 
 Creating a mental model preserves a source query. Hindsight runs that query through reflect and stores the generated content. Refresh reruns the stored source query against newer memory.
 

--- a/docs-site/src/content/docs/concepts/index.mdx
+++ b/docs-site/src/content/docs/concepts/index.mdx
@@ -1,18 +1,39 @@
 ---
 title: Concepts
+description: Memory model, bank boundaries, Retain, Recall, Reflect, imports, queue durability, and safety invariants.
 ---
 
-Concept pages explain how Pi Hindsight uses Hindsight Memory Banks, Retain, Recall, Reflect, imports, session memory modes, and safety boundaries.
+import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Core concepts:
+Concept pages explain how Pi Hindsight uses Hindsight without repeating command or schema reference.
 
-- [Memory Banks](./memory-banks/)
-- [Retain, Recall, and Reflect](./retain-recall-reflect/)
-- [Document IDs and update modes](./document-ids-update-modes/)
-- [Retain Queue durability](./queue-durability/)
-- [Historical Import](./imports/)
+<CardGrid>
+  <Card title="Memory Banks" icon="laptop">
+    Project and Global/User Bank boundaries, scope isolation, and default bank policy.
+    [Read](./memory-banks/)
+  </Card>
+  <Card title="Retain, Recall, Reflect" icon="open-book">
+    The three Hindsight operations and how Pi Hindsight routes them.
+    [Read](./retain-recall-reflect/)
+  </Card>
+  <Card title="Document IDs" icon="document">
+    Stable live-session IDs, append mode, replace mode, and import idempotency.
+    [Read](./document-ids-update-modes/)
+  </Card>
+  <Card title="Queue durability" icon="refresh">
+    Queue-first retain, retry, malformed-line quarantine, and dead-letter behavior.
+    [Read](./queue-durability/)
+  </Card>
+  <Card title="Session memory modes" icon="setting">
+    Risk boundaries for read-only, opt-out, and deferred memory controls.
+    [Read](./session-memory-modes/)
+  </Card>
+  <Card title="Historical Import" icon="puzzle">
+    Import manifests, checkpoints, deterministic document IDs, and safe previews. [Read](./imports/)
+  </Card>
+</CardGrid>
 
-Additional concept references:
+Additional background:
 
 - [Memory behavior](./memory-behavior/)
 - [Hindsight core functions](./hindsight-core-functions/)

--- a/docs-site/src/content/docs/concepts/session-memory-modes.md
+++ b/docs-site/src/content/docs/concepts/session-memory-modes.md
@@ -1,0 +1,48 @@
+---
+title: "Session memory modes"
+description: Risk boundaries for read-only, ignored, next-turn opt-out, and deferred memory modes.
+---
+
+Session memory modes control automatic Recall and automatic Retain. Prefer the narrowest mode that fits the work.
+
+## Normal mode
+
+Normal mode uses the selected profile:
+
+- Recall runs before provider calls.
+- Retain runs after completed agent runs.
+- Project memory writes use stable live-session document IDs.
+
+## Read-only mode
+
+Read-only mode allows Recall but disables automatic Retain.
+
+Use it when you want memory context but do not want the current session written back automatically.
+
+```text
+/hindsight:mode read-only
+```
+
+## Ignored mode
+
+Ignored mode turns off automatic memory behavior.
+
+Use it for sensitive work, experiments, or debugging where memory should not affect prompts.
+
+```text
+/hindsight:mode ignored
+```
+
+## Next-turn opt-out
+
+Next-turn opt-out skips automatic retain once, then returns to the previous mode.
+
+```text
+/hindsight:next-opt-out
+```
+
+Use it after a turn that contains sensitive or noisy content.
+
+## Deferred controls
+
+Hashtag-style controls such as `#nomem`, persisted recall messages, cached recall context, and automatic mental-model management remain deferred because they create persistence and prompt-history risks. See [Next opt-out design](../internal/next-opt-out-design/) for internal design context.

--- a/docs-site/src/content/docs/development/code-map.md
+++ b/docs-site/src/content/docs/development/code-map.md
@@ -25,7 +25,7 @@ Disable by removing this page from `astro.config.mjs` navigation and excluding `
 
 ## Extension entrypoint and lifecycle
 
-Related hand-authored docs: [Extension entrypoint and lifecycle](/architecture/lifecycle-and-scope/)
+Related hand-authored docs: [Extension entrypoint and lifecycle](/pi-hindsight/architecture/lifecycle-and-scope/)
 
 - `extensions/index.ts` — Registers Pi hooks, tools, commands, and setup surface.
 - `extensions/memory-lifecycle.ts` — Coordinates session start, context recall, agent-end retain, and shutdown.
@@ -35,7 +35,7 @@ Related hand-authored docs: [Extension entrypoint and lifecycle](/architecture/l
 
 ## Operation service and explicit surface
 
-Related hand-authored docs: [Operation service and explicit surface](/reference/tools-and-commands/)
+Related hand-authored docs: [Operation service and explicit surface](/pi-hindsight/reference/tools-and-commands/)
 
 - `extensions/memory-operation-service.ts` — Shared service used by tools, commands, setup, and maintenance intents.
 - `extensions/operation-catalog.ts` — Registry for command/tool operation metadata.
@@ -45,7 +45,7 @@ Related hand-authored docs: [Operation service and explicit surface](/reference/
 
 ## Identity, scope, and routing
 
-Related hand-authored docs: [Identity, scope, and routing](/concepts/memory-banks/)
+Related hand-authored docs: [Identity, scope, and routing](/pi-hindsight/concepts/memory-banks/)
 
 - `extensions/memory-identity.ts` — Derives stable repo/session/document identity.
 - `extensions/memory-scope.ts` — Selects project/global scopes and tags.
@@ -55,7 +55,7 @@ Related hand-authored docs: [Identity, scope, and routing](/concepts/memory-bank
 
 ## Retain Queue and durable delivery
 
-Related hand-authored docs: [Retain Queue and durable delivery](/concepts/queue-durability/)
+Related hand-authored docs: [Retain Queue and durable delivery](/pi-hindsight/concepts/queue-durability/)
 
 - `extensions/retain-queue.ts` — Queues retain jobs before delivery.
 - `extensions/queue.ts` — Queue record helpers and public queue operations.
@@ -67,7 +67,7 @@ Related hand-authored docs: [Retain Queue and durable delivery](/concepts/queue-
 
 ## Historical import
 
-Related hand-authored docs: [Historical import](/guides/importing-sessions/)
+Related hand-authored docs: [Historical import](/pi-hindsight/guides/importing-sessions/)
 
 - `extensions/import-sessions.ts` — Imports Pi session JSONL history.
 - `extensions/import-gateway-transcript.ts` — Imports gateway/chat transcript JSONL.
@@ -80,7 +80,7 @@ Related hand-authored docs: [Historical import](/guides/importing-sessions/)
 
 ## Diagnostics, status, and safety
 
-Related hand-authored docs: [Diagnostics, status, and safety](/architecture/diagnostics-and-security/)
+Related hand-authored docs: [Diagnostics, status, and safety](/pi-hindsight/architecture/diagnostics-and-security/)
 
 - `extensions/diagnostics.ts` — Collects doctor/diagnostic results.
 - `extensions/status.ts` — Builds user-facing status summaries.
@@ -91,7 +91,7 @@ Related hand-authored docs: [Diagnostics, status, and safety](/architecture/diag
 
 ## Configuration and setup TUI
 
-Related hand-authored docs: [Configuration and setup TUI](/start/setup-tui/)
+Related hand-authored docs: [Configuration and setup TUI](/pi-hindsight/start/setup-tui/)
 
 - `extensions/config.ts` — Loads and resolves extension config.
 - `extensions/config-normalize.ts` — Normalizes config defaults and legacy shapes.

--- a/docs-site/src/content/docs/development/internal-and-agent-docs.md
+++ b/docs-site/src/content/docs/development/internal-and-agent-docs.md
@@ -8,20 +8,20 @@ Agent-facing, maintainer-only, and historical planning documents are linked from
 
 Agent docs explain repository workflow and domain guidance for coding agents. They should stay aligned with `AGENTS.md`, `CONTRIBUTING.md`, and `CONTEXT.md`.
 
-- [AGENTS.md](/development/agents-root/)
-- [CONTRIBUTING.md](/development/contributing/)
-- [CONTEXT.md](/development/context/)
-- [Issue tracker](/development/agents/issue-tracker/)
-- [Domain docs](/development/agents/domain/)
-- [Triage labels](/development/agents/triage-labels/)
+- [AGENTS.md](/pi-hindsight/development/agents-root/)
+- [CONTRIBUTING.md](/pi-hindsight/development/contributing/)
+- [CONTEXT.md](/pi-hindsight/development/context/)
+- [Issue tracker](/pi-hindsight/development/agents/issue-tracker/)
+- [Domain docs](/pi-hindsight/development/agents/domain/)
+- [Triage labels](/pi-hindsight/development/agents/triage-labels/)
 
 ## Internal and archive docs
 
 Internal docs include PR roadmaps, architecture TODOs, product requirements, coding plans, and superseded design notes. Convert actionable content to GitHub issues before deleting or archiving these pages.
 
-- [Architecture TODOs](/internal/architecture-todos/)
-- [Next opt-out design](/internal/next-opt-out-design/)
-- [Post-MVP roadmap](/internal/post-mvp-roadmap/)
-- [PR roadmap](/internal/pr-roadmap/)
-- [PRD](/internal/prd/)
-- [Coding plan](/internal/coding-plan/)
+- [Architecture TODOs](/pi-hindsight/internal/architecture-todos/)
+- [Next opt-out design](/pi-hindsight/internal/next-opt-out-design/)
+- [Post-MVP roadmap](/pi-hindsight/internal/post-mvp-roadmap/)
+- [PR roadmap](/pi-hindsight/internal/pr-roadmap/)
+- [PRD](/pi-hindsight/internal/prd/)
+- [Coding plan](/pi-hindsight/internal/coding-plan/)

--- a/docs-site/src/content/docs/development/testing-and-verification.md
+++ b/docs-site/src/content/docs/development/testing-and-verification.md
@@ -23,7 +23,7 @@ For documentation-site changes, run the focused docs check while iterating:
 npm run docs:check
 ```
 
-`docs:check` verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, and builds the Astro/Starlight site. `npm run check` includes `docs:check`, so the normal fast local and PR paths catch docs failures before merge.
+`docs:check` verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, packaged Markdown links, GitHub Pages base-prefixed docs links, and the Astro/Starlight build. `npm run check` includes `docs:check`, so the normal fast local and PR paths catch docs failures before merge.
 
 For publishing details, see [Docs site publishing](./docs-site-publishing/).
 

--- a/docs-site/src/content/docs/guides/configure-memory-profiles.md
+++ b/docs-site/src/content/docs/guides/configure-memory-profiles.md
@@ -1,0 +1,63 @@
+---
+title: "Configure memory profiles"
+description: Choose a memory scope and map it to Pi Hindsight configuration.
+---
+
+Use the narrowest memory route that fits the repository. Start with `project-only` unless you intentionally want cross-project user memory.
+
+## Choose a profile
+
+| Profile          | Recall reads                                  | Automatic retain writes | Best for                                   |
+| ---------------- | --------------------------------------------- | ----------------------- | ------------------------------------------ |
+| `project-only`   | Project Bank                                  | Project Bank            | client work, sensitive repos, shared repos |
+| `project+global` | Project Bank plus configured Global/User Bank | Project Bank            | personal coding with durable preferences   |
+| `global-only`    | Global/User Bank                              | disabled by default     | intentional user-only memory               |
+
+## Configure through `/hindsight`
+
+1. Run `/hindsight`.
+2. Open guided setup if prompted, or rerun it from the TUI.
+3. Set the Hindsight base URL.
+4. Choose the memory profile.
+5. Confirm the project and user/global bank IDs.
+6. Save the project config when the profile should travel with the repo.
+
+## Configure by file
+
+A minimal project config points at a Hindsight server:
+
+```json
+{
+  "hindsight": {
+    "baseUrl": "http://localhost:8888"
+  }
+}
+```
+
+Pin a human-chosen Project Bank when stability matters:
+
+```json
+{
+  "hindsight": {
+    "baseUrl": "http://localhost:8888"
+  },
+  "banks": {
+    "project": {
+      "derive": "manual",
+      "bankId": "pi-project-my-repo"
+    }
+  }
+}
+```
+
+## Verify
+
+Run `/hindsight` and confirm:
+
+- expected profile is active
+- expected Project Bank is selected
+- Global/User Bank only appears when explicitly configured
+- automatic retain is enabled only where expected
+- retain queue path is visible
+
+See [Memory profiles](../start/memory-profiles/) for profile semantics and [Configuration reference](../reference/configuration/) for exact fields.

--- a/docs-site/src/content/docs/guides/index.mdx
+++ b/docs-site/src/content/docs/guides/index.mdx
@@ -1,5 +1,33 @@
 ---
 title: Guides
+description: Task-focused workflows for setup, imports, diagnostics, recovery, and verification.
 ---
 
-Guides are task-oriented workflows for configuration, setup, imports, diagnostics, template export/import, and outage recovery.
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+Guides answer “how do I do this now?” Use Concepts for mental models and Reference for exact fields.
+
+<CardGrid>
+  <Card title="Configure memory profiles" icon="setting">
+    Choose project-only, project+global, or global-only behavior and map that choice to config.
+    [Configure profiles](./configure-memory-profiles/)
+  </Card>
+  <Card title="Use `/hindsight` status" icon="information">
+    Inspect server reachability, active banks, retain queue state, imports, and receipts. [Check
+    status](./use-hindsight-status/)
+  </Card>
+  <Card title="Import sessions" icon="refresh">
+    Preview and import historical Pi session JSONL files. [Import sessions](./importing-sessions/)
+  </Card>
+  <Card title="Inspect recalls and receipts" icon="magnifier">
+    Debug what memory was recalled and what retain jobs were accepted. [Inspect
+    memory](./inspect-recalls-and-receipts/)
+  </Card>
+  <Card title="Recover retain queue" icon="puzzle">
+    Flush queued jobs, inspect failed jobs, and recover after a Hindsight outage. [Recover
+    queue](./recover-retain-queue/)
+  </Card>
+  <Card title="Run smoke tests" icon="check-circle">
+    Prove the live memory path after memory-path changes. [Run smoke test](./run-local-smoke-test/)
+  </Card>
+</CardGrid>

--- a/docs-site/src/content/docs/guides/inspect-recalls-and-receipts.md
+++ b/docs-site/src/content/docs/guides/inspect-recalls-and-receipts.md
@@ -1,0 +1,53 @@
+---
+title: "Inspect recalls and retain receipts"
+description: Debug what memory was recalled and what retain jobs were accepted.
+---
+
+Pi Hindsight keeps recall inspection opt-in so normal transcript history does not persist recalled memory blocks.
+
+## Inspect the last recall
+
+Use:
+
+```text
+/hindsight:last-recall
+```
+
+Use this when you need to answer:
+
+- what query was sent to Hindsight
+- which memory scopes were used
+- which candidates were injected
+- whether the recall block was omitted because no relevant memory was found
+
+Treat last-recall snapshots as sensitive local debug data because they can include memory text and query excerpts.
+
+## Inspect retain receipts
+
+Use the explicit receipt tool when available:
+
+```text
+hindsight_retain_receipts
+```
+
+Receipts help identify exact retained document IDs before deletion or deeper debugging.
+
+## Delete exact retained content
+
+Exact deletion is intentionally strict. Use:
+
+```text
+hindsight_delete_document
+```
+
+Deletion requires:
+
+- exact Memory Bank ID
+- exact Document ID
+- `confirm: true`
+
+Do not guess IDs. Inspect receipts or import manifests first.
+
+## Keep debug data local
+
+Do not paste recall snapshots or retained payloads into public issues without redaction. They may include project facts, paths, or user preferences.

--- a/docs-site/src/content/docs/guides/recover-retain-queue.md
+++ b/docs-site/src/content/docs/guides/recover-retain-queue.md
@@ -1,0 +1,52 @@
+---
+title: "Recover the Retain Queue"
+description: Flush queued retain jobs and recover after Hindsight outages or failed writes.
+---
+
+Pi Hindsight enqueues retain jobs before flushing them to Hindsight. This keeps completed agent runs durable during short outages.
+
+## Check queue state
+
+Open:
+
+```text
+/hindsight
+```
+
+Confirm:
+
+- queue path is visible
+- pending job count is expected
+- malformed-line or dead-letter state is not growing
+- Hindsight server URL is reachable
+
+## Flush queued jobs
+
+Use either the TUI flush action or:
+
+```text
+/hindsight:flush
+```
+
+If the flush succeeds, pending jobs should fall and recent receipts should update.
+
+## If Hindsight is down
+
+1. Confirm the Hindsight server is running.
+2. Confirm `HINDSIGHT_BASE_URL` or config points at the expected server.
+3. Leave the queue files in place.
+4. Restart Pi or run `/hindsight:flush` after the server returns.
+
+Do not delete queue files unless you intentionally want to discard pending retain jobs.
+
+## If jobs keep failing
+
+Inspect status first, then check whether the failure is caused by:
+
+- wrong server URL
+- missing API key
+- missing or deleted bank
+- invalid bank template setup
+- malformed queue line quarantined by the queue reader
+
+Create a bug report with redacted status output if the queue cannot recover after the server and bank config are valid.

--- a/docs-site/src/content/docs/guides/run-local-smoke-test.md
+++ b/docs-site/src/content/docs/guides/run-local-smoke-test.md
@@ -1,0 +1,40 @@
+---
+title: "Run a local smoke test"
+description: Prove the live Hindsight memory path after memory-path or package changes.
+---
+
+Use the live smoke test when a change can affect installed runtime memory behavior.
+
+Memory-path changes include retain payloads, recall queries or formatting, Reflect calls, bank selection or creation, queue delivery, import delivery, adapter transport, smoke helpers, and release packaging that can affect installed behavior.
+
+## Configure Hindsight
+
+Point the test at a reachable Hindsight server:
+
+```bash
+export HINDSIGHT_BASE_URL=http://localhost:8888
+```
+
+If your server needs a key:
+
+```bash
+export HINDSIGHT_API_KEY=...
+```
+
+## Run smoke
+
+```bash
+npm run smoke:hindsight
+```
+
+A successful run proves the local code can reach Hindsight and exercise the configured live path.
+
+## CI alternative
+
+The GitHub Actions Hindsight Integration workflow can run the smoke path when configured with:
+
+- `HINDSIGHT_INTEGRATION_ENABLED=true`
+- `HINDSIGHT_BASE_URL`
+- optional `HINDSIGHT_API_KEY`
+
+For memory-path pull requests, an unconfigured skip is not proof. Run local smoke, get a configured workflow pass, or document why live proof is unavailable and which lower-level checks reduce risk.

--- a/docs-site/src/content/docs/guides/use-hindsight-status.md
+++ b/docs-site/src/content/docs/guides/use-hindsight-status.md
@@ -1,0 +1,56 @@
+---
+title: "Use /hindsight status"
+description: Inspect server reachability, active banks, retain queue state, imports, and retain receipts.
+---
+
+Use `/hindsight` as the control center for runtime memory status.
+
+## Open status
+
+In Pi, run:
+
+```text
+/hindsight
+```
+
+The setup TUI shows:
+
+- Hindsight server URL and reachability
+- active memory profile
+- Project Bank and Global/User Bank IDs
+- automatic recall/retain mode
+- Retain Queue path and pending jobs
+- recent retain receipts
+- import manifest and checkpoint paths
+
+## First checks
+
+After setup, confirm:
+
+1. the expected server URL is active
+2. the expected memory profile is active
+3. the Project Bank is selected for project memory
+4. Global/User Bank appears only when configured intentionally
+5. Retain Queue path exists and is writable
+6. recent retain receipts appear after completed agent runs
+
+## Useful actions
+
+From the TUI:
+
+- flush queued retain jobs
+- rerun guided setup
+- open mental model details
+- remove selected config overrides
+- inspect deployment setup fields
+
+Use command shortcuts when you do not need the full TUI:
+
+```text
+/hindsight:flush
+/hindsight:last-recall
+/hindsight:import-current --dry-run
+/hindsight:import-project-sessions --dry-run
+```
+
+See [Tools and commands](../reference/tools-and-commands/) for the full command surface.

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -1,14 +1,79 @@
 ---
 title: Pi Hindsight documentation
+description: Durable Hindsight-backed memory for Pi, scoped by repository and safe by default.
+template: splash
+hero:
+  tagline: Durable memory for Pi, scoped by repo.
+  actions:
+    - text: Get started
+      link: /pi-hindsight/start/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: Configuration reference
+      link: /pi-hindsight/reference/configuration/
+      icon: document
 ---
 
-Pi Hindsight gives Pi durable project memory through Hindsight while keeping memory scoped, inspectable, and safe.
+import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Use this documentation through the target information architecture defined in [Documentation architecture](./development/documentation-architecture/):
+Pi Hindsight recalls relevant project memory before model calls, retains structured session deltas after agent runs, and exposes explicit memory tools when you want direct control.
 
-- **Start**: installation and first setup.
-- **Concepts**: memory model, banks, retain, recall, reflect, imports, and safety.
-- **Guides**: task-focused setup, import, diagnostics, and recovery workflows.
-- **Reference**: exact tools, commands, config, and generated surface details.
-- **Architecture**: design seams, ADRs, and implementation boundaries.
-- **Development**: contributor workflow, checks, release process, and agent guidance.
+<CardGrid>
+  <Card title="Start" icon="rocket">
+    Install the extension, connect Hindsight, choose a memory profile, and verify the first run.
+    [Begin setup →](/pi-hindsight/start/getting-started/)
+  </Card>
+  <Card title="Concepts" icon="open-book">
+    Understand Memory Banks, Retain, Recall, Reflect, queue durability, imports, and safety rules.
+    [Learn the model →](/pi-hindsight/concepts/)
+  </Card>
+  <Card title="Guides" icon="setting">
+    Follow task workflows for profiles, setup/status checks, imports, recall inspection, queue
+    recovery, and smoke tests. [Pick a workflow →](/pi-hindsight/guides/)
+  </Card>
+  <Card title="Reference" icon="document">
+    Look up exact config fields, tools, commands, hooks, import controls, and generated surface
+    details. [Open reference →](/pi-hindsight/reference/)
+  </Card>
+</CardGrid>
+
+## Memory path
+
+```mermaid
+flowchart LR
+  conversation[Pi conversation] --> retain[Retain raw structured content]
+  retain --> bank[Project Memory Bank]
+  prompt[Future prompt] --> recall[Recall relevant candidates]
+  bank --> recall
+  recall --> context[Ephemeral context block]
+  bank --> reflect[Reflect for synthesis]
+```
+
+## Safety defaults
+
+- Project memory stays in a project bank by default.
+- Global/user memory is opt-in and explicitly configured.
+- Recall injection is ephemeral; recalled memory is not written back into transcripts.
+- Retain uses stable document IDs and queue durability.
+- Automatic retain redacts common secrets before writing memory.
+
+## Where to go next
+
+<CardGrid>
+  <Card title="Five-minute setup" icon="right-arrow">
+    Use the shortest successful path from install to verified memory. [Getting
+    started](/pi-hindsight/start/getting-started/)
+  </Card>
+  <Card title="Choose memory scope" icon="laptop">
+    Compare project-only, project+global, and global-only modes. [Memory
+    profiles](/pi-hindsight/start/memory-profiles/)
+  </Card>
+  <Card title="Import old sessions" icon="refresh">
+    Preview and import Pi session JSONL history with deterministic document IDs. [Importing
+    sessions](/pi-hindsight/guides/importing-sessions/)
+  </Card>
+  <Card title="Troubleshoot memory" icon="information">
+    Inspect status, recalls, receipts, queue state, and smoke-test output. [Status and setup
+    guide](/pi-hindsight/guides/use-hindsight-status/)
+  </Card>
+</CardGrid>

--- a/docs-site/src/content/docs/reference/bank-template-manifest.md
+++ b/docs-site/src/content/docs/reference/bank-template-manifest.md
@@ -1,0 +1,33 @@
+---
+title: "Bank template manifest reference"
+description: Bank template import/export expectations and safety rules.
+---
+
+Bank template manifests describe Hindsight bank setup that can be exported, reviewed, dry-run, and imported.
+
+## Where manifests are used
+
+Pi Hindsight can use manifests through:
+
+- guided setup in `/hindsight`
+- explicit bank template import/export tools
+- Hindsight control plane workflows
+- Hindsight REST endpoints for bank template import
+
+## Rules
+
+- Treat official Hindsight docs and API behavior as source of truth for manifest shape.
+- Dry-run manifests before applying them.
+- Keep manifests reviewable as JSON.
+- Do not treat generated or exported manifests as product-design source of truth.
+- Do not paste manifests containing private bank identifiers into public issues without review.
+
+## Typical workflow
+
+1. Export or obtain a manifest.
+2. Review bank name, mental models, directives, and metadata.
+3. Dry-run import.
+4. Apply only after the result matches the intended bank setup.
+5. Verify bank status in `/hindsight`.
+
+See [Starter mental model suggestions](../concepts/starter-mental-model-suggestions/) for concept background and [Hindsight API links](./hindsight-api-links/) for official API references.

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -6,9 +6,9 @@ Pi Hindsight resolves configuration from defaults, global config, project config
 
 For concepts behind Project Banks, Global/User Banks, tags, metadata, Document IDs, and Update Modes, see:
 
-- [Memory Banks](/concepts/memory-banks/)
-- [Document IDs and update modes](/concepts/document-ids-update-modes/)
-- [Retain, Recall, and Reflect](/concepts/retain-recall-reflect/)
+- [Memory Banks](/pi-hindsight/concepts/memory-banks/)
+- [Document IDs and update modes](/pi-hindsight/concepts/document-ids-update-modes/)
+- [Retain, Recall, and Reflect](/pi-hindsight/concepts/retain-recall-reflect/)
 
 ## Precedence
 
@@ -130,4 +130,4 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
 
 ## Generated editable-field reference
 
-The exact generated tool and editable config field surface lives in [Generated surface reference](/reference/surface-reference/). Do not edit that generated page by hand; update the operation catalog, config editing registry, or generator.
+The exact generated tool and editable config field surface lives in [Generated surface reference](/pi-hindsight/reference/surface-reference/). Do not edit that generated page by hand; update the operation catalog, config editing registry, or generator.

--- a/docs-site/src/content/docs/reference/hindsight-api-links.md
+++ b/docs-site/src/content/docs/reference/hindsight-api-links.md
@@ -1,0 +1,25 @@
+---
+title: "Hindsight API links"
+description: Official Hindsight docs and API references for behavior that Pi Hindsight must not redefine.
+---
+
+Official Hindsight documentation and API behavior are the source of truth for Hindsight concepts and request/response shapes.
+
+## Official docs
+
+- [Hindsight documentation](https://hindsight.vectorize.io/)
+- [Hindsight developer installation](https://hindsight.vectorize.io/developer/installation)
+- [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
+
+## Pi Hindsight policy
+
+Pi Hindsight defines repository-specific policy around Hindsight:
+
+- default Project Bank derivation
+- optional Global/User Bank config
+- automatic Recall injection through Pi context hooks
+- queue-first automatic Retain
+- deterministic import document IDs
+- local diagnostics and setup commands
+
+When this documentation conflicts with official Hindsight behavior, follow official Hindsight docs and fix Pi Hindsight documentation or implementation.

--- a/docs-site/src/content/docs/reference/hooks.md
+++ b/docs-site/src/content/docs/reference/hooks.md
@@ -6,8 +6,8 @@ Pi Hindsight uses documented Pi extension lifecycle hooks. This page is a refere
 
 For the conceptual behavior behind Retain, Recall, and queue durability, see:
 
-- [Retain, Recall, and Reflect](/concepts/retain-recall-reflect/)
-- [Retain Queue durability](/concepts/queue-durability/)
+- [Retain, Recall, and Reflect](/pi-hindsight/concepts/retain-recall-reflect/)
+- [Retain Queue durability](/pi-hindsight/concepts/queue-durability/)
 
 ## `session_start`
 
@@ -64,4 +64,4 @@ Shutdown must not silently discard queued memory.
 
 Tools and commands are registered through the Operation Catalog and delegate to the Memory Operation Service. This keeps explicit user intents shared across tools, commands, setup flows, diagnostics, and smoke helpers.
 
-See [Tools and commands](/reference/tools-and-commands/) and [Generated surface reference](/reference/surface-reference/) for the exact public surface.
+See [Tools and commands](/pi-hindsight/reference/tools-and-commands/) and [Generated surface reference](/pi-hindsight/reference/surface-reference/) for the exact public surface.

--- a/docs-site/src/content/docs/reference/import-controls.md
+++ b/docs-site/src/content/docs/reference/import-controls.md
@@ -2,7 +2,7 @@
 title: "Import controls reference"
 ---
 
-Import controls preview and ingest historical Pi sessions or gateway transcripts. For the concept model, see [Historical Import](/concepts/imports/).
+Import controls preview and ingest historical Pi sessions or gateway transcripts. For the concept model, see [Historical Import](/pi-hindsight/concepts/imports/).
 
 ## Commands
 

--- a/docs-site/src/content/docs/reference/index.mdx
+++ b/docs-site/src/content/docs/reference/index.mdx
@@ -1,15 +1,36 @@
 ---
 title: Reference
+description: Exact config fields, tools, commands, hooks, import controls, generated surface output, and external API pointers.
 ---
 
-Reference pages contain exact tool names, command names, config fields, generated surface output, and schema-oriented material.
+import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Reference pages:
+Reference pages are for exact names and contracts. Use Guides when you want a workflow.
 
-- [Configuration reference](./configuration/)
-- [Tools and commands](./tools-and-commands/)
-- [Hooks reference](./hooks/)
-- [Import controls reference](./import-controls/)
-- [Generated surface reference](./surface-reference/)
-
-Generated or tool-derived pages are marked as such. Concept explanations live in [Concepts](../concepts/) and are linked from reference pages rather than repeated inconsistently.
+<CardGrid>
+  <Card title="Configuration" icon="setting">
+    Config file locations, precedence, environment variables, and bank derivation fields.
+    [Open](./configuration/)
+  </Card>
+  <Card title="Tools and commands" icon="puzzle">
+    Explicit memory tools, command shortcuts, and command intent groups.
+    [Open](./tools-and-commands/)
+  </Card>
+  <Card title="Hooks" icon="laptop">
+    Pi extension hook mapping for session start, context, agent end, and shutdown. [Open](./hooks/)
+  </Card>
+  <Card title="Memory modes" icon="open-book">
+    Exact behavior for normal, read-only, disabled, and next-turn opt-out modes.
+    [Open](./memory-modes/)
+  </Card>
+  <Card title="Bank templates" icon="document">
+    Bank template manifest import/export shape and safety rules. [Open](./bank-template-manifest/)
+  </Card>
+  <Card title="Hindsight API links" icon="external">
+    Official Hindsight docs and API references that remain the behavior source of truth.
+    [Open](./hindsight-api-links/)
+  </Card>
+  <Card title="Generated surface" icon="information">
+    Generated tools, commands, config fields, and diagnostics surface. [Open](./surface-reference/)
+  </Card>
+</CardGrid>

--- a/docs-site/src/content/docs/reference/memory-modes.md
+++ b/docs-site/src/content/docs/reference/memory-modes.md
@@ -1,0 +1,22 @@
+---
+title: "Memory modes reference"
+description: Exact automatic recall and retain behavior for supported session memory modes.
+---
+
+| Mode              | Automatic Recall | Automatic Retain | Intended use                            |
+| ----------------- | ---------------- | ---------------- | --------------------------------------- |
+| normal            | enabled          | enabled          | default memory behavior                 |
+| read-only         | enabled          | disabled         | use memory without writing this session |
+| ignored           | disabled         | disabled         | sensitive or isolated work              |
+| next-turn opt-out | unchanged        | skipped once     | skip one noisy or sensitive retain      |
+
+## Commands
+
+```text
+/hindsight:mode read-only
+/hindsight:mode ignored
+/hindsight:mode normal
+/hindsight:next-opt-out
+```
+
+See [Session memory modes](../concepts/session-memory-modes/) for risk guidance.

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -2,7 +2,7 @@
 title: "Tools and commands"
 ---
 
-For generated details of registered tools and editable config fields, see [Generated surface reference](/reference/surface-reference/). For related concepts, see [Retain, Recall, and Reflect](/concepts/retain-recall-reflect/) and [Memory Banks](/concepts/memory-banks/).
+For generated details of registered tools and editable config fields, see [Generated surface reference](/pi-hindsight/reference/surface-reference/). For related concepts, see [Retain, Recall, and Reflect](/pi-hindsight/concepts/retain-recall-reflect/) and [Memory Banks](/pi-hindsight/concepts/memory-banks/).
 
 `/hindsight` is the main control center. Commands are convenience shortcuts and escape hatches for advanced workflows.
 
@@ -34,7 +34,7 @@ The `hindsight_configure` tool can write config from agents. Prefer `/hindsight`
 /hindsight:import-project-sessions
 ```
 
-Use dry-run before non-dry-run imports. See [Import controls reference](/reference/import-controls/) and [Importing sessions](/guides/importing-sessions/).
+Use dry-run before non-dry-run imports. See [Import controls reference](/pi-hindsight/reference/import-controls/) and [Importing sessions](/pi-hindsight/guides/importing-sessions/).
 
 ## Queue and snapshots
 

--- a/docs-site/src/content/docs/start/index.mdx
+++ b/docs-site/src/content/docs/start/index.mdx
@@ -1,12 +1,26 @@
 ---
 title: Start
+description: Install Pi Hindsight, connect a Hindsight server, choose a memory profile, and run first checks.
 ---
 
-Begin with [Getting started](./getting-started/) to install Pi Hindsight, choose a Hindsight server, run guided setup, and verify the first memory profile.
+import { Card, CardGrid } from "@astrojs/starlight/components";
 
-First journey:
+Start pages get you from no memory to a verified Pi Hindsight setup with minimal conceptual load.
 
-- [Installation](./installation/)
-- [Setup TUI](./setup-tui/)
-- [Memory profiles](./memory-profiles/)
-- [Minimal configuration](./minimal-config/)
+<CardGrid>
+  <Card title="Getting started" icon="rocket">
+    The shortest path from install to verified project memory. [Start here](./getting-started/)
+  </Card>
+  <Card title="Installation" icon="download">
+    Install from GitHub or a local checkout and confirm runtime compatibility.
+    [Install](./installation/)
+  </Card>
+  <Card title="Guided setup" icon="setting">
+    Use `/hindsight` to configure the server, banks, profile, and queue state. [Open setup
+    guide](./setup-tui/)
+  </Card>
+  <Card title="Memory profiles" icon="laptop">
+    Pick project-only, project+global, or global-only memory scope. [Compare
+    profiles](./memory-profiles/)
+  </Card>
+</CardGrid>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,17 @@
         "jsonc-parser": "^3.3.1"
       },
       "devDependencies": {
-        "@astrojs/starlight": "^0.38.4",
+        "@astrojs/starlight": "^0.38.5",
         "@commitlint/cli": "^20.5.2",
         "@commitlint/config-conventional": "^20.5.3",
         "@mariozechner/pi-coding-agent": "0.72.1",
+        "@mermaid-js/layout-elk": "^0.2.1",
         "@types/node": "^24.12.2",
         "@typescript/native-preview": "7.0.0-dev.20260426.1",
         "@vitest/coverage-v8": "^3.2.4",
         "astro": "^6.2.2",
+        "astro-mermaid": "^2.0.1",
+        "mermaid": "^11.14.0",
         "oxfmt": "^0.47.0",
         "oxlint": "^1.61.0",
         "oxlint-tsgolint": "^0.22.0",
@@ -50,6 +53,30 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@antfu/install-pkg/node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -191,40 +218,40 @@
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.38.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.38.4.tgz",
-      "integrity": "sha512-TGFIr2aVC+gcZCPQzJOO4ZnA/yL3jRnsUDcKlVdEhxhxaOQnWr9lZ9MRScg9zU6uh3HVeZAmmjkLCdTlHdcaZA==",
+      "version": "0.38.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.38.5.tgz",
+      "integrity": "sha512-35xLSOtZDAMAilHG2zAEZoJ4AaPb+doYOvxuuRTAnmIBSOvujffOAHv3/rr6W/LJtkhBU38PjRDJ4i8QT1uGVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/markdown-remark": "^7.0.0",
-        "@astrojs/mdx": "^5.0.0",
-        "@astrojs/sitemap": "^3.7.1",
+        "@astrojs/markdown-remark": "^7.1.1",
+        "@astrojs/mdx": "^5.0.4",
+        "@astrojs/sitemap": "^3.7.2",
         "@pagefind/default-ui": "^1.3.0",
         "@types/hast": "^3.0.4",
         "@types/js-yaml": "^4.0.9",
         "@types/mdast": "^4.0.4",
-        "astro-expressive-code": "^0.41.6",
+        "astro-expressive-code": "^0.42.0",
         "bcp-47": "^2.1.0",
-        "hast-util-from-html": "^2.0.1",
-        "hast-util-select": "^6.0.2",
-        "hast-util-to-string": "^3.0.0",
-        "hastscript": "^9.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "hast-util-select": "^6.0.4",
+        "hast-util-to-string": "^3.0.1",
+        "hastscript": "^9.0.1",
         "i18next": "^23.11.5",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "klona": "^2.0.6",
-        "magic-string": "^0.30.17",
-        "mdast-util-directive": "^3.0.0",
-        "mdast-util-to-markdown": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "mdast-util-directive": "^3.1.0",
+        "mdast-util-to-markdown": "^2.1.2",
         "mdast-util-to-string": "^4.0.0",
         "pagefind": "^1.3.0",
-        "rehype": "^13.0.1",
-        "rehype-format": "^5.0.0",
-        "remark-directive": "^3.0.0",
+        "rehype": "^13.0.2",
+        "rehype-format": "^5.0.1",
+        "remark-directive": "^4.0.0",
         "ultrahtml": "^1.6.0",
         "unified": "^11.0.5",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.2"
+        "unist-util-visit": "^5.1.0",
+        "vfile": "^6.0.3"
       },
       "peerDependencies": {
         "astro": "^6.0.0"
@@ -1145,6 +1172,13 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
@@ -1157,6 +1191,48 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@clack/core": {
       "version": "1.3.0",
@@ -2022,9 +2098,9 @@
       }
     },
     "node_modules/@expressive-code/core": {
-      "version": "0.41.7",
-      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.41.7.tgz",
-      "integrity": "sha512-ck92uZYZ9Wba2zxkiZLsZGi9N54pMSAVdrI9uW3Oo9AtLglD5RmrdTwbYPCT2S/jC36JGB2i+pnQtBm/Ib2+dg==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.42.0.tgz",
+      "integrity": "sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2040,118 +2116,34 @@
       }
     },
     "node_modules/@expressive-code/plugin-frames": {
-      "version": "0.41.7",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.41.7.tgz",
-      "integrity": "sha512-diKtxjQw/979cTglRFaMCY/sR6hWF0kSMg8jsKLXaZBSfGS0I/Hoe7Qds3vVEgeoW+GHHQzMcwvgx/MOIXhrTA==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.42.0.tgz",
+      "integrity": "sha512-XtkPm+941Uta7Y+81Acv+OA/20F1NJmJhCX6UYGKpqEIGqplNh3PTOhcURp6tcruhlzJcWcvpWy6Oigz3SrjqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.41.7"
+        "@expressive-code/core": "^0.42.0"
       }
     },
     "node_modules/@expressive-code/plugin-shiki": {
-      "version": "0.41.7",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.41.7.tgz",
-      "integrity": "sha512-DL605bLrUOgqTdZ0Ot5MlTaWzppRkzzqzeGEu7ODnHF39IkEBbFdsC7pbl3LbUQ1DFtnfx6rD54k/cdofbW6KQ==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.42.0.tgz",
+      "integrity": "sha512-PMKey/kLmewttAHQezL+Y5Fx3vVssfDi3+FJOYQQS2mXP3tQspFELtKKAfsXfmSXdToZYgwoO69HJndqfE+09g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.41.7",
-        "shiki": "^3.2.2"
-      }
-    },
-    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/core": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
-      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.5"
-      }
-    },
-    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/engine-javascript": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
-      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "oniguruma-to-es": "^4.3.4"
-      }
-    },
-    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
-      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/langs": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
-      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/themes": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
-      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/types": "3.23.0"
-      }
-    },
-    "node_modules/@expressive-code/plugin-shiki/node_modules/@shikijs/types": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
-      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@expressive-code/plugin-shiki/node_modules/shiki": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
-      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@shikijs/core": "3.23.0",
-        "@shikijs/engine-javascript": "3.23.0",
-        "@shikijs/engine-oniguruma": "3.23.0",
-        "@shikijs/langs": "3.23.0",
-        "@shikijs/themes": "3.23.0",
-        "@shikijs/types": "3.23.0",
-        "@shikijs/vscode-textmate": "^10.0.2",
-        "@types/hast": "^3.0.4"
+        "@expressive-code/core": "^0.42.0",
+        "shiki": "^4.0.2"
       }
     },
     "node_modules/@expressive-code/plugin-text-markers": {
-      "version": "0.41.7",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.41.7.tgz",
-      "integrity": "sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.42.0.tgz",
+      "integrity": "sha512-l59lUx8fq1v5g6SpmbDjiU0+7IdfbiWnAyRmtTVSpfhyq+nZMN4UcmYyu2b9Mynhzt7Gr+O+cXyEPDNb2AVWVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.41.7"
+        "@expressive-code/core": "^0.42.0"
       }
     },
     "node_modules/@google/genai": {
@@ -2177,6 +2169,25 @@
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.2"
       }
     },
     "node_modules/@img/colour": {
@@ -3190,6 +3201,30 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/@mermaid-js/layout-elk": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.2.1.tgz",
+      "integrity": "sha512-MX9jwhMyd5zDcFsYcl3duDUkKhjVRUCGEQrdCeNV5hCIR6+3FuDDbRbFmvVbAu15K1+juzsYGG+K8MDvCY1Amg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "elkjs": "^0.9.3"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
       }
     },
     "node_modules/@mistralai/mistralai": {
@@ -5393,6 +5428,290 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -5426,6 +5745,13 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -5511,6 +5837,14 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -5677,6 +6011,17 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vectorize-io/hindsight-client": {
       "version": "0.5.6",
@@ -6120,16 +6465,38 @@
       }
     },
     "node_modules/astro-expressive-code": {
-      "version": "0.41.7",
-      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.41.7.tgz",
-      "integrity": "sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.42.0.tgz",
+      "integrity": "sha512-aiTePi2Cn0mJPYWZSzP1GcxCinX9mNtJyCCshVVPSg1yRwM7ADvFJOx0FnS440M9t65hp8JH//dc2qr22Bm4ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "rehype-expressive-code": "^0.41.7"
+        "rehype-expressive-code": "^0.42.0"
       },
       "peerDependencies": {
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta"
+      }
+    },
+    "node_modules/astro-mermaid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/astro-mermaid/-/astro-mermaid-2.0.1.tgz",
+      "integrity": "sha512-JTyB62FMFJpwS/1yUplmrugL0yr0flBVYZw6mf3s7pVlh+CHCeZTXyj3KCCWtFhnPLAdM+PYld0D+gxN/SysLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-meta-resolve": "^4.2.0",
+        "mdast-util-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@mermaid-js/layout-elk": "^0.2.0",
+        "astro": ">=4",
+        "mermaid": "^10.0.0 || ^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@mermaid-js/layout-elk": {
+          "optional": true
+        }
       }
     },
     "node_modules/astro/node_modules/es-module-lexer": {
@@ -6452,6 +6819,36 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+      "integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.18.1"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -6641,6 +7038,13 @@
         "dot-prop": "^5.1.0"
       }
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
@@ -6704,6 +7108,16 @@
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
@@ -6885,6 +7299,557 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -6894,6 +7859,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -6957,6 +7929,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/dequal": {
@@ -7083,6 +8065,16 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -7137,6 +8129,13 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/elkjs": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+      "dev": true,
+      "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -7476,16 +8475,16 @@
       }
     },
     "node_modules/expressive-code": {
-      "version": "0.41.7",
-      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.41.7.tgz",
-      "integrity": "sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.42.0.tgz",
+      "integrity": "sha512-V5DtJLEKuj4wf9O6IRtPtRObkMVy2ggR+S0MdjrTw6m58krZnDioyhW1si3Y04c5YPeooP4nd85Yq9NwEVHS4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@expressive-code/core": "^0.41.7",
-        "@expressive-code/plugin-frames": "^0.41.7",
-        "@expressive-code/plugin-shiki": "^0.41.7",
-        "@expressive-code/plugin-text-markers": "^0.41.7"
+        "@expressive-code/core": "^0.42.0",
+        "@expressive-code/plugin-frames": "^0.42.0",
+        "@expressive-code/plugin-shiki": "^0.42.0",
+        "@expressive-code/plugin-text-markers": "^0.42.0"
       }
     },
     "node_modules/extend": {
@@ -7984,6 +8983,13 @@
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
       }
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -8543,6 +9549,19 @@
         "@babel/runtime": "^7.23.2"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -8628,6 +9647,16 @@
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -8978,6 +10007,39 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+      "dev": true
+    },
     "node_modules/klona": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
@@ -9000,10 +10062,43 @@
         "url": "https://liberapay.com/Koromix"
       }
     },
+    "node_modules/langium": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
+      "integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.3",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -9520,6 +10615,63 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mermaid/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -9592,9 +10744,9 @@
       }
     },
     "node_modules/micromark-extension-directive": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
-      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10355,6 +11507,19 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -10954,6 +12119,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
@@ -11046,6 +12218,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -11370,13 +12572,13 @@
       }
     },
     "node_modules/rehype-expressive-code": {
-      "version": "0.41.7",
-      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.41.7.tgz",
-      "integrity": "sha512-25f8ZMSF1d9CMscX7Cft0TSQIqdwjce2gDOvQ+d/w0FovsMwrSt3ODP4P3Z7wO1jsIJ4eYyaDRnIR/27bd/EMQ==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.42.0.tgz",
+      "integrity": "sha512-8rp/1YMEVVSYbtz+bFBx+uSx3vA4i4T8RwRm5Q/IWbucQnnQqQ0hDqtmKOr8tv+59Cik6cu5aH3WPo0I7csuTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expressive-code": "^0.41.7"
+        "expressive-code": "^0.42.0"
       }
     },
     "node_modules/rehype-format": {
@@ -11459,15 +12661,15 @@
       }
     },
     "node_modules/remark-directive": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
-      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-directive": "^3.0.0",
-        "micromark-extension-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -11691,6 +12893,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
@@ -11736,6 +12945,26 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -11755,6 +12984,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -12212,6 +13448,13 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12493,6 +13736,16 @@
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -13124,6 +14377,61 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -71,14 +71,17 @@
     "jsonc-parser": "^3.3.1"
   },
   "devDependencies": {
-    "@astrojs/starlight": "^0.38.4",
+    "@astrojs/starlight": "^0.38.5",
     "@commitlint/cli": "^20.5.2",
     "@commitlint/config-conventional": "^20.5.3",
     "@mariozechner/pi-coding-agent": "0.72.1",
+    "@mermaid-js/layout-elk": "^0.2.1",
     "@types/node": "^24.12.2",
     "@typescript/native-preview": "7.0.0-dev.20260426.1",
     "@vitest/coverage-v8": "^3.2.4",
     "astro": "^6.2.2",
+    "astro-mermaid": "^2.0.1",
+    "mermaid": "^11.14.0",
     "oxfmt": "^0.47.0",
     "oxlint": "^1.61.0",
     "oxlint-tsgolint": "^0.22.0",

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, extname, join, normalize, relative, resolve, sep } from "node:path";
 
 const docsRoot = process.env.DOCS_ROOT
@@ -8,10 +8,20 @@ const docsRoot = process.env.DOCS_ROOT
 const astroConfigPath = process.env.ASTRO_CONFIG_PATH
   ? resolve(process.env.ASTRO_CONFIG_PATH)
   : join(process.cwd(), "astro.config.mjs");
+const packageManifestPath = process.env.PACKAGE_MANIFEST_PATH
+  ? resolve(process.env.PACKAGE_MANIFEST_PATH)
+  : join(process.cwd(), "package.json");
+const explicitLinkCheckPaths = process.env.README_LINK_PATHS
+  ? process.env.README_LINK_PATHS.split(",")
+      .map((path) => path.trim())
+      .filter(Boolean)
+      .map((path) => resolve(path))
+  : undefined;
 const markdownExtensions = new Set([".md", ".mdx"]);
 const sidebarSlugPattern = /slug:\s*["']([^"']+)["']/g;
 const markdownLinkPattern = /\[[^\]]*\]\(([^)]+)\)/g;
 const frontmatterPattern = /^---\n([\s\S]*?)\n---\n?/u;
+const frontmatterLinkPattern = /^\s*link:\s*["']?([^"'\s]+)["']?\s*$/gmu;
 const titlePattern = /^title:\s*(?:"([^"]+)"|'([^']+)'|(.+))\s*$/mu;
 const allowedUnlistedSlugs = new Set([
   "",
@@ -34,6 +44,15 @@ function walk(dir) {
   });
 }
 
+function walkAllFiles(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return walkAllFiles(path);
+    return [path];
+  });
+}
+
 function slugForFile(file) {
   const withoutExtension = relative(docsRoot, file).replace(/\.(md|mdx)$/u, "");
   return withoutExtension
@@ -52,12 +71,16 @@ function slugExists(slug) {
   return candidatesForSlug(slug).some((candidate) => existsSync(candidate));
 }
 
-function relativeLinkExists(fromFile, href) {
+function resolveRelativeLink(fromFile, href) {
   const target = normalize(join(dirname(fromFile), href)).replace(/[\\/]$/u, "");
   const candidates = extname(target)
     ? [target]
     : [`${target}.md`, `${target}.mdx`, join(target, "index.md"), join(target, "index.mdx")];
-  return candidates.some((candidate) => existsSync(candidate));
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function relativeLinkExists(fromFile, href) {
+  return Boolean(resolveRelativeLink(fromFile, href));
 }
 
 function isExternalOrAnchor(href) {
@@ -80,6 +103,65 @@ function hasDuplicateTitleHeading(content) {
   if (!title) return false;
   const body = content.replace(frontmatterPattern, "");
   return new RegExp(`^\\s*#\\s+${escapeRegExp(title)}\\s*$`, "imu").test(body);
+}
+
+function validateDocsHref(file, rawHref) {
+  const href = rawHref
+    .trim()
+    .replace(/^<|>$/gu, "")
+    .split(/[\s#?]/u)[0];
+  if (!href || isExternalOrAnchor(href)) return;
+
+  if (href.startsWith("/")) {
+    const rawSlug = href.replace(/^\//u, "").replace(/[\\/]$/u, "");
+    if (astroBase && rawSlug !== astroBase && !rawSlug.startsWith(`${astroBase}/`)) {
+      errors.push(
+        `${relative(process.cwd(), file)} links to unbased docs route: ${href}; use /${astroBase}/... so published GitHub Pages links resolve`,
+      );
+      return;
+    }
+
+    const slug =
+      astroBase && rawSlug === astroBase
+        ? ""
+        : astroBase && rawSlug.startsWith(`${astroBase}/`)
+          ? rawSlug.slice(astroBase.length + 1)
+          : rawSlug;
+    if (!slugExists(slug)) {
+      errors.push(`${relative(process.cwd(), file)} links to missing docs route: ${href}`);
+    }
+    return;
+  }
+
+  if (!relativeLinkExists(file, href)) {
+    errors.push(`${relative(process.cwd(), file)} links to missing file: ${href}`);
+  }
+}
+
+function packageFileSet() {
+  if (!existsSync(packageManifestPath)) return new Set();
+
+  const manifestDir = dirname(packageManifestPath);
+  const manifest = JSON.parse(readFileSync(packageManifestPath, "utf8"));
+  const files = new Set(
+    ["package.json", "README.md", "CHANGELOG.md", "LICENSE", "LICENSE.md"]
+      .map((path) => join(manifestDir, path))
+      .filter((path) => existsSync(path))
+      .map((path) => resolve(path)),
+  );
+
+  for (const entry of manifest.files ?? []) {
+    const path = join(manifestDir, entry);
+    if (!existsSync(path)) continue;
+
+    if (statSync(path).isDirectory()) {
+      for (const file of walkAllFiles(path)) files.add(resolve(file));
+    } else {
+      files.add(resolve(path));
+    }
+  }
+
+  return files;
 }
 
 const astroConfig = readFileSync(astroConfigPath, "utf8");
@@ -109,25 +191,45 @@ for (const file of files) {
     errors.push(`${relative(process.cwd(), file)} repeats its frontmatter title as an H1`);
   }
 
+  const frontmatter = frontmatterPattern.exec(content)?.[1];
+  for (const match of frontmatter?.matchAll(frontmatterLinkPattern) ?? []) {
+    validateDocsHref(file, match[1]);
+  }
+
+  for (const match of content.matchAll(markdownLinkPattern)) {
+    validateDocsHref(file, match[1]);
+  }
+}
+
+const packagedFiles = packageFileSet();
+const linkCheckPaths =
+  explicitLinkCheckPaths ??
+  [...packagedFiles].filter((file) => markdownExtensions.has(extname(file)));
+
+for (const file of linkCheckPaths) {
+  if (!existsSync(file)) {
+    errors.push(`README link check target does not exist: ${relative(process.cwd(), file)}`);
+    continue;
+  }
+
+  const content = readFileSync(file, "utf8");
+  const isPackagedSource = packagedFiles.has(resolve(file));
+
   for (const match of content.matchAll(markdownLinkPattern)) {
     const rawHref = match[1].trim().replace(/^<|>$/gu, "");
     const href = rawHref.split(/[\s#?]/u)[0];
-    if (!href || isExternalOrAnchor(href)) continue;
+    if (!href || isExternalOrAnchor(href) || href.startsWith("/")) continue;
 
-    if (href.startsWith("/")) {
-      const rawSlug = href.replace(/^\//u, "").replace(/[\\/]$/u, "");
-      const slug =
-        astroBase && rawSlug.startsWith(`${astroBase}/`)
-          ? rawSlug.slice(astroBase.length + 1)
-          : rawSlug;
-      if (!slugExists(slug)) {
-        errors.push(`${relative(process.cwd(), file)} links to missing docs route: ${href}`);
-      }
+    const target = resolveRelativeLink(file, href);
+    if (!target) {
+      errors.push(`${relative(process.cwd(), file)} links to missing file: ${href}`);
       continue;
     }
 
-    if (!relativeLinkExists(file, href)) {
-      errors.push(`${relative(process.cwd(), file)} links to missing file: ${href}`);
+    if (isPackagedSource && !packagedFiles.has(resolve(target))) {
+      errors.push(
+        `${relative(process.cwd(), file)} links to unpackaged local file: ${href}; use a published docs URL or include the target in package files`,
+      );
     }
   }
 }

--- a/scripts/generate-code-map.mjs
+++ b/scripts/generate-code-map.mjs
@@ -15,7 +15,7 @@ const outputPath = join(
 const sections = [
   {
     title: "Extension entrypoint and lifecycle",
-    doc: "/architecture/lifecycle-and-scope/",
+    doc: "/pi-hindsight/architecture/lifecycle-and-scope/",
     files: [
       ["extensions/index.ts", "Registers Pi hooks, tools, commands, and setup surface."],
       [
@@ -35,7 +35,7 @@ const sections = [
   },
   {
     title: "Operation service and explicit surface",
-    doc: "/reference/tools-and-commands/",
+    doc: "/pi-hindsight/reference/tools-and-commands/",
     files: [
       [
         "extensions/memory-operation-service.ts",
@@ -49,7 +49,7 @@ const sections = [
   },
   {
     title: "Identity, scope, and routing",
-    doc: "/concepts/memory-banks/",
+    doc: "/pi-hindsight/concepts/memory-banks/",
     files: [
       ["extensions/memory-identity.ts", "Derives stable repo/session/document identity."],
       ["extensions/memory-scope.ts", "Selects project/global scopes and tags."],
@@ -60,7 +60,7 @@ const sections = [
   },
   {
     title: "Retain Queue and durable delivery",
-    doc: "/concepts/queue-durability/",
+    doc: "/pi-hindsight/concepts/queue-durability/",
     files: [
       ["extensions/retain-queue.ts", "Queues retain jobs before delivery."],
       ["extensions/queue.ts", "Queue record helpers and public queue operations."],
@@ -73,7 +73,7 @@ const sections = [
   },
   {
     title: "Historical import",
-    doc: "/guides/importing-sessions/",
+    doc: "/pi-hindsight/guides/importing-sessions/",
     files: [
       ["extensions/import-sessions.ts", "Imports Pi session JSONL history."],
       ["extensions/import-gateway-transcript.ts", "Imports gateway/chat transcript JSONL."],
@@ -87,7 +87,7 @@ const sections = [
   },
   {
     title: "Diagnostics, status, and safety",
-    doc: "/architecture/diagnostics-and-security/",
+    doc: "/pi-hindsight/architecture/diagnostics-and-security/",
     files: [
       ["extensions/diagnostics.ts", "Collects doctor/diagnostic results."],
       ["extensions/status.ts", "Builds user-facing status summaries."],
@@ -99,7 +99,7 @@ const sections = [
   },
   {
     title: "Configuration and setup TUI",
-    doc: "/start/setup-tui/",
+    doc: "/pi-hindsight/start/setup-tui/",
     files: [
       ["extensions/config.ts", "Loads and resolves extension config."],
       ["extensions/config-normalize.ts", "Normalizes config defaults and legacy shapes."],

--- a/tests/check-docs.test.mjs
+++ b/tests/check-docs.test.mjs
@@ -14,16 +14,30 @@ function fixture() {
   writeFileSync(join(docsRoot, "index.mdx"), "---\ntitle: Home\n---\n");
   writeFileSync(join(docsRoot, "start", "getting-started.md"), "---\ntitle: Start\n---\n");
   const astroConfigPath = join(root, "astro.config.mjs");
+  const packageManifestPath = join(root, "package.json");
+  const readmePath = join(root, "README.md");
+  writeFileSync(packageManifestPath, JSON.stringify({ files: ["docs"] }, null, 2));
+  writeFileSync(readmePath, "# Fixture\n\n[Start](docs/start/getting-started.md)\n");
   writeFileSync(
     astroConfigPath,
     `export default { integrations: [{ name: "starlight", options: { sidebar: [{ label: "Start", items: [{ label: "Getting started", slug: "start/getting-started" }] }] } }] };\n`,
   );
-  return { docsRoot, astroConfigPath };
+  return { root, docsRoot, astroConfigPath, packageManifestPath, readmePath };
 }
 
-function runCheck({ docsRoot, astroConfigPath }) {
+function runCheck({ docsRoot, astroConfigPath }, options = {}) {
+  const env = {
+    ...process.env,
+    DOCS_ROOT: docsRoot,
+    ASTRO_CONFIG_PATH: astroConfigPath,
+    PACKAGE_MANIFEST_PATH: join(docsRoot, "..", "package.json"),
+  };
+  if (options.explicitReadmePaths !== false) {
+    env.README_LINK_PATHS = join(docsRoot, "..", "README.md");
+  }
+
   return execFileSync(process.execPath, [script], {
-    env: { ...process.env, DOCS_ROOT: docsRoot, ASTRO_CONFIG_PATH: astroConfigPath },
+    env,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -66,6 +80,34 @@ describe("docs quality check", () => {
     expect(runCheck(paths)).toContain("Documentation quality checks passed");
   });
 
+  it("fails when Astro base is configured and a root-absolute docs link omits it", () => {
+    const paths = fixture();
+    writeFileSync(
+      paths.astroConfigPath,
+      `export default { base: "/pi-hindsight", integrations: [{ name: "starlight", options: { sidebar: [{ label: "Start", items: [{ label: "Getting started", slug: "start/getting-started" }] }] } }] };\n`,
+    );
+    writeFileSync(
+      join(paths.docsRoot, "start", "getting-started.md"),
+      "---\ntitle: Start\n---\n\n[Self](/start/getting-started/)\n",
+    );
+
+    expect(() => runCheck(paths)).toThrow(/links to unbased docs route/u);
+  });
+
+  it("fails when Astro base is configured and a frontmatter action link omits it", () => {
+    const paths = fixture();
+    writeFileSync(
+      paths.astroConfigPath,
+      `export default { base: "/pi-hindsight", integrations: [{ name: "starlight", options: { sidebar: [{ label: "Start", items: [{ label: "Getting started", slug: "start/getting-started" }] }] } }] };\n`,
+    );
+    writeFileSync(
+      join(paths.docsRoot, "index.mdx"),
+      "---\ntitle: Home\nhero:\n  actions:\n    - text: Start\n      link: /start/getting-started/\n---\n",
+    );
+
+    expect(() => runCheck(paths)).toThrow(/links to unbased docs route/u);
+  });
+
   it("fails when a page repeats its frontmatter title as an H1", () => {
     const paths = fixture();
     writeFileSync(
@@ -84,5 +126,40 @@ describe("docs quality check", () => {
     );
 
     expect(() => runCheck(paths)).toThrow(/links to missing docs route/u);
+  });
+
+  it("fails when README links to a missing local file", () => {
+    const paths = fixture();
+    writeFileSync(paths.readmePath, "# Fixture\n\n[Missing](docs/missing.md)\n");
+
+    expect(() => runCheck(paths)).toThrow(/README\.md links to missing file/u);
+  });
+
+  it("fails when packaged README links to an unpackaged local file", () => {
+    const paths = fixture();
+    writeFileSync(paths.packageManifestPath, JSON.stringify({ files: ["README.md"] }, null, 2));
+    writeFileSync(paths.readmePath, "# Fixture\n\n[Start](docs/start/getting-started.md)\n");
+
+    expect(() => runCheck(paths)).toThrow(/links to unpackaged local file/u);
+  });
+
+  it("checks packaged markdown links by default", () => {
+    const paths = fixture();
+    writeFileSync(paths.packageManifestPath, JSON.stringify({ files: ["README.md"] }, null, 2));
+    writeFileSync(paths.readmePath, "# Fixture\n\n[Start](docs/start/getting-started.md)\n");
+
+    expect(() => runCheck(paths, { explicitReadmePaths: false })).toThrow(
+      /links to unpackaged local file/u,
+    );
+  });
+
+  it("accepts README anchors, query strings, and external docs links", () => {
+    const paths = fixture();
+    writeFileSync(
+      paths.readmePath,
+      "# Fixture\n\n[Start](docs/start/getting-started.md?view=full#top)\n[Section](#section)\n[Site](https://luxus.github.io/pi-hindsight/start/getting-started/)\n",
+    );
+
+    expect(runCheck(paths)).toContain("Documentation quality checks passed");
   });
 });


### PR DESCRIPTION
## Summary

- Trim README into a compact repository landing page that points users to the published docs site.
- Polish the Starlight docs home and section indexes with cards, CTAs, Mermaid memory flow, and clearer IA.
- Add task guides/reference pages for memory profiles, status, recall/receipt inspection, queue recovery, smoke tests, memory modes, bank templates, and Hindsight API links.
- Add `astro-mermaid`, update Starlight to the latest `0.38.5`, and harden docs checks for packaged Markdown links and GitHub Pages base-prefixed routes.

## Linked issue

- Closes #225

## Scope

- Documentation and docs-site only.
- Docs checker/test updates for link drift prevention.
- Dev dependency updates for Starlight/Mermaid docs rendering.
- Contributor/agent guidance sync for the expanded docs verification behavior.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — skipped; docs/checker/docs-site dependency change only, no runtime source behavior.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — skipped; `npm run check` typecheck passed and no runtime TypeScript source changed.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — skipped; no runtime/platform/workflow change.
- [x] package verification requested/passed (release/package changes or `ci:package`)
- [x] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — skipped; no memory-path behavior changed.

Additional verification:

- [x] `npm run docs:check`
- [x] `npm run audit:signatures`
- [x] reviewer subagent pass: no blockers after fixes
- [x] built home links verified to use `/pi-hindsight/...` under GitHub Pages base

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Docs and README presentation changed. No runtime behavior or installed extension surface changed.

## Risk and rollback

- Risk: docs-site route/base-link mistakes could break published navigation; Mermaid dependency increases docs build bundle size.
- Rollback/revert path: revert this PR to restore the previous README/docs-site shape and dependency set.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- `astro-mermaid` must run before Starlight in `astro.config.mjs`; this PR uses that order.
- Docs checker now rejects unbased root-absolute docs links when Astro `base` is configured, including frontmatter action links.
