### PR TITLE
docs: fix Starlight card icons

### DIFF
--- a/docs-site/src/content/docs/concepts/index.mdx
+++ b/docs-site/src/content/docs/concepts/index.mdx
@@ -20,7 +20,7 @@ Concept pages explain how Pi Hindsight uses Hindsight without repeating command 
     Stable live-session IDs, append mode, replace mode, and import idempotency.
     [Read](./document-ids-update-modes/)
   </Card>
-  <Card title="Queue durability" icon="refresh">
+  <Card title="Queue durability" icon="list-format">
     Queue-first retain, retry, malformed-line quarantine, and dead-letter behavior.
     [Read](./queue-durability/)
   </Card>

--- a/docs-site/src/content/docs/guides/index.mdx
+++ b/docs-site/src/content/docs/guides/index.mdx
@@ -16,7 +16,7 @@ Guides answer “how do I do this now?” Use Concepts for mental models and Ref
     Inspect server reachability, active banks, retain queue state, imports, and receipts. [Check
     status](./use-hindsight-status/)
   </Card>
-  <Card title="Import sessions" icon="refresh">
+  <Card title="Import sessions" icon="download">
     Preview and import historical Pi session JSONL files. [Import sessions](./importing-sessions/)
   </Card>
   <Card title="Inspect recalls and receipts" icon="magnifier">
@@ -27,7 +27,7 @@ Guides answer “how do I do this now?” Use Concepts for mental models and Ref
     Flush queued jobs, inspect failed jobs, and recover after a Hindsight outage. [Recover
     queue](./recover-retain-queue/)
   </Card>
-  <Card title="Run smoke tests" icon="check-circle">
+  <Card title="Run smoke tests" icon="approve-check-circle">
     Prove the live memory path after memory-path changes. [Run smoke test](./run-local-smoke-test/)
   </Card>
 </CardGrid>

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -68,7 +68,7 @@ flowchart LR
     Compare project-only, project+global, and global-only modes. [Memory
     profiles](/pi-hindsight/start/memory-profiles/)
   </Card>
-  <Card title="Import old sessions" icon="refresh">
+  <Card title="Import old sessions" icon="download">
     Preview and import Pi session JSONL history with deterministic document IDs. [Importing
     sessions](/pi-hindsight/guides/importing-sessions/)
   </Card>

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -11,6 +11,16 @@ const astroConfigPath = process.env.ASTRO_CONFIG_PATH
 const packageManifestPath = process.env.PACKAGE_MANIFEST_PATH
   ? resolve(process.env.PACKAGE_MANIFEST_PATH)
   : join(process.cwd(), "package.json");
+const starlightIconsPath = process.env.STARLIGHT_ICONS_PATH
+  ? resolve(process.env.STARLIGHT_ICONS_PATH)
+  : join(
+      process.cwd(),
+      "node_modules",
+      "@astrojs",
+      "starlight",
+      "components-internals",
+      "Icons.ts",
+    );
 const explicitLinkCheckPaths = process.env.README_LINK_PATHS
   ? process.env.README_LINK_PATHS.split(",")
       .map((path) => path.trim())
@@ -22,6 +32,7 @@ const sidebarSlugPattern = /slug:\s*["']([^"']+)["']/g;
 const markdownLinkPattern = /\[[^\]]*\]\(([^)]+)\)/g;
 const frontmatterPattern = /^---\n([\s\S]*?)\n---\n?/u;
 const frontmatterLinkPattern = /^\s*link:\s*["']?([^"'\s]+)["']?\s*$/gmu;
+const cardIconPattern = /<Card\b[^>]*\bicon=["']([^"']+)["'][^>]*>/g;
 const titlePattern = /^title:\s*(?:"([^"]+)"|'([^']+)'|(.+))\s*$/mu;
 const allowedUnlistedSlugs = new Set([
   "",
@@ -164,11 +175,24 @@ function packageFileSet() {
   return files;
 }
 
+function starlightIconSet() {
+  if (!existsSync(starlightIconsPath)) return undefined;
+  const content = readFileSync(starlightIconsPath, "utf8");
+  const objectBody =
+    content.match(/export const BuiltInIcons = \{([\s\S]*?)\n\};/u)?.[1] ?? content;
+  const icons = new Set();
+  for (const match of objectBody.matchAll(/^\s*(?:["']([^"']+)["']|([A-Za-z][\w-]*))\s*:/gmu)) {
+    icons.add(match[1] ?? match[2]);
+  }
+  return icons;
+}
+
 const astroConfig = readFileSync(astroConfigPath, "utf8");
 const baseMatch = astroConfig.match(/base:\s*["']([^"']+)["']/u);
 const astroBase = baseMatch?.[1]?.replace(/^\//u, "").replace(/[\\/]$/u, "");
 const files = walk(docsRoot);
 const slugs = new Set(files.map(slugForFile));
+const starlightIcons = starlightIconSet();
 const sidebarSlugs = new Set(
   [...astroConfig.matchAll(sidebarSlugPattern)].map((match) => match[1]),
 );
@@ -198,6 +222,17 @@ for (const file of files) {
 
   for (const match of content.matchAll(markdownLinkPattern)) {
     validateDocsHref(file, match[1]);
+  }
+
+  if (starlightIcons) {
+    for (const match of content.matchAll(cardIconPattern)) {
+      const icon = match[1];
+      if (!starlightIcons.has(icon)) {
+        errors.push(
+          `${relative(process.cwd(), file)} uses unsupported Starlight Card icon: ${icon}`,
+        );
+      }
+    }
   }
 }
 

--- a/tests/check-docs.test.mjs
+++ b/tests/check-docs.test.mjs
@@ -16,13 +16,18 @@ function fixture() {
   const astroConfigPath = join(root, "astro.config.mjs");
   const packageManifestPath = join(root, "package.json");
   const readmePath = join(root, "README.md");
+  const starlightIconsPath = join(root, "Icons.ts");
   writeFileSync(packageManifestPath, JSON.stringify({ files: ["docs"] }, null, 2));
   writeFileSync(readmePath, "# Fixture\n\n[Start](docs/start/getting-started.md)\n");
+  writeFileSync(
+    starlightIconsPath,
+    "export const BuiltInIcons = { rocket: '', document: '', 'approve-check-circle': '' };\n",
+  );
   writeFileSync(
     astroConfigPath,
     `export default { integrations: [{ name: "starlight", options: { sidebar: [{ label: "Start", items: [{ label: "Getting started", slug: "start/getting-started" }] }] } }] };\n`,
   );
-  return { root, docsRoot, astroConfigPath, packageManifestPath, readmePath };
+  return { root, docsRoot, astroConfigPath, packageManifestPath, readmePath, starlightIconsPath };
 }
 
 function runCheck({ docsRoot, astroConfigPath }, options = {}) {
@@ -31,6 +36,7 @@ function runCheck({ docsRoot, astroConfigPath }, options = {}) {
     DOCS_ROOT: docsRoot,
     ASTRO_CONFIG_PATH: astroConfigPath,
     PACKAGE_MANIFEST_PATH: join(docsRoot, "..", "package.json"),
+    STARLIGHT_ICONS_PATH: join(docsRoot, "..", "Icons.ts"),
   };
   if (options.explicitReadmePaths !== false) {
     env.README_LINK_PATHS = join(docsRoot, "..", "README.md");
@@ -126,6 +132,16 @@ describe("docs quality check", () => {
     );
 
     expect(() => runCheck(paths)).toThrow(/links to missing docs route/u);
+  });
+
+  it("fails when MDX uses an unsupported Starlight Card icon", () => {
+    const paths = fixture();
+    writeFileSync(
+      join(paths.docsRoot, "index.mdx"),
+      '---\ntitle: Home\n---\n\nimport { Card } from "@astrojs/starlight/components";\n\n<Card title="Bad" icon="refresh">Bad icon</Card>\n',
+    );
+
+    expect(() => runCheck(paths)).toThrow(/unsupported Starlight Card icon: refresh/u);
   });
 
   it("fails when README links to a missing local file", () => {


### PR DESCRIPTION
## Summary

- Replace unsupported Starlight Card icons flagged by Codex on #226.
- Add docs-link checker coverage for unsupported Starlight Card icon values.

## Linked issue

- Closes #227

## Scope

- Docs-site MDX card icon names.
- Docs checker/test coverage for Starlight built-in card icons.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — skipped; docs/checker-only fix.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — skipped; no runtime source changed.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — skipped; docs/checker-only fix.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — skipped; package contents unchanged.
- [ ] `npm run pack:verify` (release/package changes) — skipped; package/release path not changed.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — skipped; no memory-path behavior changed.

Additional verification:

- [x] `npm run docs:check`
- [x] `npm test -- --run tests/check-docs.test.mjs`

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

No release notes needed. Fixes docs icon correctness and drift guard.

## Risk and rollback

- Risk: checker parses Starlight built-in icon names from installed Starlight source and could need adjustment if Starlight changes the export shape.
- Rollback/revert path: revert this PR to remove icon validation and restore previous icon names.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. — not applicable; no guidance change.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Addresses the Codex review comment on #226 about unsupported Starlight Card icons.
