### PR TITLE
docs: add Starlight LLM copy button

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 import mermaid from "astro-mermaid";
 import starlight from "@astrojs/starlight";
+import starlightLLMButton from "starlight-llm-button";
 
 export default defineConfig({
   site: "https://luxus.github.io/pi-hindsight",
@@ -20,6 +21,17 @@ export default defineConfig({
     starlight({
       title: "Pi Hindsight",
       disable404Route: true,
+      plugins: [
+        starlightLLMButton({
+          customText: {
+            copy: "Copy page for LLM",
+            copied: "Copied page markdown",
+            error: "Could not copy page markdown",
+          },
+          preCopyPrompt:
+            "Use this Pi Hindsight documentation page as source context. Preserve technical terms and cite page headings when useful.\n\n",
+        }),
+      ],
       social: [{ icon: "github", label: "GitHub", href: "https://github.com/luxus/pi-hindsight" }],
       sidebar: [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "oxfmt": "^0.47.0",
         "oxlint": "^1.61.0",
         "oxlint-tsgolint": "^0.22.0",
+        "starlight-llm-button": "^0.0.8",
         "tsx": "4.21.0",
         "typebox": "1.1.37",
         "typescript": "^6.0.3",
@@ -6765,6 +6766,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
@@ -13238,6 +13246,21 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/starlight-llm-button": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/starlight-llm-button/-/starlight-llm-button-0.0.8.tgz",
+      "integrity": "sha512-yQc0I3svf5AEGR6/x7O65j6JCSux/bncpWPmbDwq6kr9klMplE0BZLFmf0n+ovawe3/Lmp0drwtDxaq0UidjJg==",
+      "dev": true,
+      "dependencies": {
+        "change-case": "^5.4.4"
+      },
+      "engines": {
+        "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      },
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.32"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "oxfmt": "^0.47.0",
     "oxlint": "^1.61.0",
     "oxlint-tsgolint": "^0.22.0",
+    "starlight-llm-button": "^0.0.8",
     "tsx": "4.21.0",
     "typebox": "1.1.37",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary

- Add `starlight-llm-button` to the docs site.
- Configure a "Copy page for LLM" action in the Starlight table-of-contents area.
- Add a short Pi Hindsight source-context prompt before copied page Markdown.

## Linked issue

- Closes #229

## Scope

- Docs-site Astro/Starlight config.
- Docs-site dev dependency and lockfile.
- No runtime extension behavior changed.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — skipped; docs-site dependency/config only.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — skipped; no runtime source changed.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — skipped locally; CI classifier may decide based on package lock changes.
- [x] package verification requested/passed (release/package changes or `ci:package`)
- [x] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — skipped; no memory-path behavior changed.

Additional verification:

- [x] `npm run docs:check`
- [x] `npm run audit:signatures`
- [x] built docs output includes `llm-copy-markdown-btn` and `Copy page for LLM`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Docs site users get a new Copy page for LLM button.

## Risk and rollback

- Risk: the plugin overrides Starlight's TableOfContents component; future Starlight changes could require plugin updates.
- Rollback/revert path: revert this PR to remove the plugin config and dependency.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. — not applicable; no guidance change.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Per current workflow preference, do not merge until Codex either reacts with thumbs-up or leaves a review/comment.
