### PR TITLE
docs: trim README setup details

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,6 @@ Pi Hindsight recalls relevant project memory before model calls, retains structu
 
 The extension is inspired by [`noctuid/pi-hindsight`](https://github.com/noctuid/pi-hindsight). This version keeps the same useful idea, then tightens project isolation, queue durability, diagnostics, and release hardening.
 
-## Compatibility
-
-Supported runtime and package ranges are declared in `package.json` and enforced in CI with `npm ci --engine-strict`.
-
-- Node.js: `>=24 <25`
-- npm: `>=11 <12`
-- Pi peer package: `@mariozechner/pi-coding-agent >=0.72.1 <0.73.0`
-- TypeBox peer package: `typebox >=1.1.24 <2`
-
 ## Install
 
 Install from GitHub:
@@ -37,9 +28,9 @@ Package name: `@luxusai/pi-hindsight`.
 
 1. Start or choose a Hindsight server:
    - [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
-   - [Local Hindsight installation](https://hindsight.vectorize.io/developer/installation)
+   - [Self-hosted Hindsight installation](https://hindsight.vectorize.io/developer/installation); use Hindsight's built-in llama.cpp/local-LLM option when you want a no-LLM-API-key private setup
 2. Open Pi in your repo and run `/hindsight`.
-3. Configure the Hindsight API URL. The default local URL is `http://localhost:8888`.
+3. Configure the Hindsight API URL. The default self-hosted URL is `http://localhost:8888`.
 4. Choose the narrowest memory profile that fits the repo: `project-only`, `project+global`, or `global-only`.
 5. Start coding. Recall happens before provider calls; retain happens after completed agent runs.
 

--- a/docs-site/src/content/docs/development/package-verification.md
+++ b/docs-site/src/content/docs/development/package-verification.md
@@ -4,6 +4,17 @@ title: "Package verification"
 
 Pi Hindsight is distributed as an npm package. Packaging checks protect installed runtime behavior.
 
+## Runtime compatibility
+
+Supported runtime and package ranges are declared in `package.json` and enforced in CI with `npm ci --engine-strict`.
+
+- Node.js: `>=24 <25`
+- npm: `>=11 <12`
+- Pi peer package: `@mariozechner/pi-coding-agent >=0.72.1 <0.73.0`
+- TypeBox peer package: `typebox >=1.1.24 <2`
+
+Keep this compatibility detail in maintainer docs instead of the README unless the install story changes.
+
 ## Published contents
 
 The `package.json` `files` array is the source of truth for package contents. Documentation-site source and generated build output are not runtime package files unless explicitly added.

--- a/docs-site/src/content/docs/start/getting-started.md
+++ b/docs-site/src/content/docs/start/getting-started.md
@@ -21,9 +21,11 @@ pi install /path/to/pi-hindsight
 Use one of these paths:
 
 - [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
-- [Local Hindsight installation](https://hindsight.vectorize.io/developer/installation)
+- [Self-hosted Hindsight installation](https://hindsight.vectorize.io/developer/installation)
 
-For local development, the expected default URL is:
+For self-hosted setup, prefer Hindsight's built-in llama.cpp/local-LLM option when you want a private setup without an external LLM API key. That path requires Hindsight's `local-llm` extra; otherwise configure a normal LLM provider and API key as described in the Hindsight installation and model docs.
+
+The expected self-hosted default URL is:
 
 ```text
 http://localhost:8888

--- a/docs-site/src/content/docs/start/installation.md
+++ b/docs-site/src/content/docs/start/installation.md
@@ -19,12 +19,14 @@ pi install /path/to/pi-hindsight
 
 ## Choose a Hindsight server
 
-Use Hindsight Cloud or a local Hindsight API server:
+Use Hindsight Cloud or a self-hosted Hindsight API server:
 
 - [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
-- [Local Hindsight installation](https://hindsight.vectorize.io/developer/installation)
+- [Self-hosted Hindsight installation](https://hindsight.vectorize.io/developer/installation)
 
-For local development, the conventional URL is:
+For self-hosted setup, prefer Hindsight's built-in llama.cpp/local-LLM option when you want a private setup without an external LLM API key. That path requires Hindsight's `local-llm` extra; otherwise configure a normal LLM provider and API key as described in the Hindsight installation and model docs.
+
+The conventional self-hosted URL is:
 
 ```text
 http://localhost:8888

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,9 +19,11 @@ pi install /path/to/pi-hindsight
 Use one of these paths:
 
 - [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
-- [Local Hindsight installation](https://hindsight.vectorize.io/developer/installation)
+- [Self-hosted Hindsight installation](https://hindsight.vectorize.io/developer/installation)
 
-For local development, the expected default URL is:
+For self-hosted setup, prefer Hindsight's built-in llama.cpp/local-LLM option when you want a private setup without an external LLM API key. That path requires Hindsight's `local-llm` extra; otherwise configure a normal LLM provider and API key as described in the Hindsight installation and model docs.
+
+The expected self-hosted default URL is:
 
 ```text
 http://localhost:8888


### PR DESCRIPTION
## Summary

- Remove the runtime compatibility section from the README.
- Keep runtime compatibility details in the less-prominent package verification docs.
- Rename Hindsight server setup language from local to self-hosted.
- Recommend Hindsight's embedded model option for self-hosted setup.

## Linked issue

- Closes #231

## Scope

- README and setup/installation documentation wording only.
- No runtime extension behavior changed.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — skipped; docs-only wording change.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — skipped; no runtime source changed.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — skipped; docs-only wording change.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — skipped; package contents unchanged.
- [ ] `npm run pack:verify` (release/package changes) — skipped; package/release path not changed.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — skipped; no memory-path behavior changed.

Additional verification:

- [x] `npm run docs:check`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

README and setup docs wording changed.

## Risk and rollback

- Risk: embedded model wording may need adjustment if official Hindsight setup docs rename that option.
- Rollback/revert path: revert this PR to restore previous README/setup wording.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. — not applicable; no guidance change.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Per workflow preference, do not merge until Codex either reacts with thumbs-up or leaves a review/comment.
