### PR TITLE
feat: support Hindsight 0.6

### DIFF
--- a/docs-site/src/content/docs/concepts/memory-banks.md
+++ b/docs-site/src/content/docs/concepts/memory-banks.md
@@ -15,7 +15,7 @@ A **Project Bank** is selected for the current repository. It stores repository-
 - import history
 - repo-local preferences
 
-Project recall is scoped with repository tags so unrelated project memories do not leak in.
+Project recall is scoped with repository tags so unrelated project memories do not leak in. In Git worktrees, Pi Hindsight resolves the main Git worktree root so linked worktrees of the same repository share the same Project Bank.
 
 ## Global Bank / User Bank
 

--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -12,11 +12,14 @@ This reference is generated from the operation catalog and config editing regist
 
 Recall raw memories from Hindsight for this project.
 
-| Parameter        | Type   | Required | Description                                    |
-| ---------------- | ------ | -------- | ---------------------------------------------- |
-| `query`          | string | yes      | Natural language memory query                  |
-| `bank`           | string | no       | Optional bank id. Defaults to project bank.    |
-| `queryTimestamp` | string | no       | Optional ISO timestamp for time-scoped recall. |
+| Parameter        | Type                                        | Required | Description                                                                                   |
+| ---------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `query`          | string                                      | yes      | Natural language memory query                                                                 |
+| `bank`           | string                                      | no       | Optional bank id. Defaults to project bank.                                                   |
+| `queryTimestamp` | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                |
+| `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
+| `tagsMatch`      | string \| string \| string \| string        | no       |                                                                                               |
+| `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ### `hindsight_retain`
 
@@ -196,12 +199,15 @@ Import a gateway/chat transcript JSONL file into the configured user memory bank
 
 Ask Hindsight to synthesize an answer from memory. Use explicitly, not for default recall.
 
-| Parameter        | Type   | Required | Description |
-| ---------------- | ------ | -------- | ----------- |
-| `query`          | string | yes      |             |
-| `context`        | string | no       |             |
-| `bank`           | string | no       |             |
-| `responseSchema` | object | no       |             |
+| Parameter        | Type                                        | Required | Description                                                                                   |
+| ---------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `query`          | string                                      | yes      |                                                                                               |
+| `context`        | string                                      | no       |                                                                                               |
+| `bank`           | string                                      | no       |                                                                                               |
+| `responseSchema` | object                                      | no       |                                                                                               |
+| `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
+| `tagsMatch`      | string \| string \| string \| string        | no       |                                                                                               |
+| `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ## Commands
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -8,11 +8,14 @@ This reference is generated from the operation catalog and config editing regist
 
 Recall raw memories from Hindsight for this project.
 
-| Parameter        | Type   | Required | Description                                    |
-| ---------------- | ------ | -------- | ---------------------------------------------- |
-| `query`          | string | yes      | Natural language memory query                  |
-| `bank`           | string | no       | Optional bank id. Defaults to project bank.    |
-| `queryTimestamp` | string | no       | Optional ISO timestamp for time-scoped recall. |
+| Parameter        | Type                                        | Required | Description                                                                                   |
+| ---------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `query`          | string                                      | yes      | Natural language memory query                                                                 |
+| `bank`           | string                                      | no       | Optional bank id. Defaults to project bank.                                                   |
+| `queryTimestamp` | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                |
+| `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
+| `tagsMatch`      | string \| string \| string \| string        | no       |                                                                                               |
+| `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ### `hindsight_retain`
 
@@ -192,12 +195,15 @@ Import a gateway/chat transcript JSONL file into the configured user memory bank
 
 Ask Hindsight to synthesize an answer from memory. Use explicitly, not for default recall.
 
-| Parameter        | Type   | Required | Description |
-| ---------------- | ------ | -------- | ----------- |
-| `query`          | string | yes      |             |
-| `context`        | string | no       |             |
-| `bank`           | string | no       |             |
-| `responseSchema` | object | no       |             |
+| Parameter        | Type                                        | Required | Description                                                                                   |
+| ---------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `query`          | string                                      | yes      |                                                                                               |
+| `context`        | string                                      | no       |                                                                                               |
+| `bank`           | string                                      | no       |                                                                                               |
+| `responseSchema` | object                                      | no       |                                                                                               |
+| `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
+| `tagsMatch`      | string \| string \| string \| string        | no       |                                                                                               |
+| `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ## Commands
 

--- a/extensions/banking.ts
+++ b/extensions/banking.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 import { basename, resolve } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
+import { dirname } from "node:path";
+import { execFileSync } from "node:child_process";
 import type { BankSelection, ResolvedConfig } from "./types.js";
 
 function slug(value: string): string {
@@ -17,13 +19,47 @@ function hash(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 12);
 }
 
+function canonicalPath(path: string): string {
+  try {
+    return realpathSync.native(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
 export function findRepoRoot(cwd: string): string {
+  const gitRoot = findMainGitWorktreeRoot(cwd);
+  if (gitRoot) return canonicalPath(gitRoot);
+
   let current = resolve(cwd);
   while (true) {
-    if (existsSync(`${current}/.git`)) return current;
+    if (existsSync(`${current}/.git`)) return canonicalPath(current);
     const parent = resolve(current, "..");
-    if (parent === current) return resolve(cwd);
+    if (parent === current) return canonicalPath(cwd);
     current = parent;
+  }
+}
+
+function findMainGitWorktreeRoot(cwd: string): string | undefined {
+  try {
+    const git = (args: string[]) =>
+      execFileSync("git", ["rev-parse", "--path-format=absolute", ...args], {
+        cwd,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1000,
+      }).trim();
+
+    const commonDir = git(["--git-common-dir"]);
+    if (!commonDir) return undefined;
+    const gitDir = git(["--git-dir"]);
+
+    if (commonDir !== gitDir && basename(commonDir) === ".git") return dirname(commonDir);
+
+    const topLevel = git(["--show-toplevel"]);
+    return topLevel || (basename(commonDir) === ".git" ? dirname(commonDir) : commonDir);
+  } catch {
+    return undefined;
   }
 }
 

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -80,6 +80,7 @@ export function reflectRequestBody(
     responseSchema?: unknown;
     tags?: string[];
     tagsMatch?: string;
+    tagGroups?: unknown[];
   } = {},
 ): Record<string, unknown> {
   return {
@@ -87,8 +88,9 @@ export function reflectRequestBody(
     ...(options.context ? { context: options.context } : {}),
     budget: options.budget ?? "low",
     ...(options.responseSchema ? { response_schema: options.responseSchema } : {}),
-    ...(options.tags ? { tags: options.tags } : {}),
-    ...(options.tagsMatch ? { tags_match: options.tagsMatch } : {}),
+    ...(options.tagGroups ? { tag_groups: options.tagGroups } : {}),
+    ...(options.tagGroups ? {} : options.tags ? { tags: options.tags } : {}),
+    ...(options.tagGroups ? {} : options.tagsMatch ? { tags_match: options.tagsMatch } : {}),
   };
 }
 

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -53,7 +53,8 @@ async function reflect(
   },
   signal: AbortSignal,
 ): Promise<unknown> {
-  if (!args.options?.responseSchema) return args.raw.reflect(args.bankId, args.query, args.options);
+  if (!args.options?.responseSchema)
+    return args.raw.reflect(args.bankId, args.query, { ...args.options, signal });
   const response = await args.rest.request(encodeBankPath(args.bankId, "/reflect"), {
     method: "POST",
     signal,
@@ -72,24 +73,54 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
   const timeoutMs = config.hindsight.timeoutMs;
   return {
     retain: (bankId, content, options) =>
-      withTimeout("hindsight retain", timeoutMs, () =>
-        raw.retainBatch(
-          bankId,
-          [retainBatchItem(content, options)],
-          options?.async !== undefined ? { async: options.async } : {},
-        ),
+      withTimeout(
+        "hindsight retain",
+        timeoutMs,
+        (signal) =>
+          raw.retainBatch(
+            bankId,
+            [retainBatchItem(content, options)],
+            options?.async !== undefined ? { async: options.async, signal } : { signal },
+          ),
+        options?.signal,
       ),
     retainBatch: (...args) =>
-      withTimeout("hindsight retainBatch", timeoutMs, () => raw.retainBatch(...args)),
-    recall: (...args) => withTimeout("hindsight recall", timeoutMs, () => raw.recall(...args)),
+      withTimeout(
+        "hindsight retainBatch",
+        timeoutMs,
+        (signal) => {
+          const [bankId, items, options] = args;
+          return raw.retainBatch(bankId, items, { ...options, signal });
+        },
+        args[2]?.signal,
+      ),
+    recall: (...args) => {
+      const [bankId, query, options] = args;
+      return withTimeout(
+        "hindsight recall",
+        timeoutMs,
+        (signal) => {
+          return raw.recall(bankId, query, { ...options, signal });
+        },
+        options?.signal,
+      );
+    },
     reflect: (bankId, query, options) =>
-      withTimeout("hindsight reflect", timeoutMs, (signal) =>
-        reflect({ raw, rest, bankId, query, options }, signal),
+      withTimeout(
+        "hindsight reflect",
+        timeoutMs,
+        (signal) => reflect({ raw, rest, bankId, query, options }, signal),
+        options?.signal,
       ),
     createBank: (...args) =>
-      withTimeout("hindsight createBank", timeoutMs, () => raw.createBank(...args)),
+      withTimeout("hindsight createBank", timeoutMs, (signal) => {
+        const [bankId, options] = args;
+        return raw.createBank(bankId, { ...options, signal });
+      }),
     getBankProfile: (...args) =>
-      withTimeout("hindsight getBankProfile", timeoutMs, () => raw.getBankProfile(...args)),
+      withTimeout("hindsight getBankProfile", timeoutMs, (signal) =>
+        raw.getBankProfile(args[0], { signal }),
+      ),
     getBankStats: (bankId) =>
       withTimeout("hindsight getBankStats", timeoutMs, (signal) =>
         rest.request(encodeBankPath(bankId, "/stats"), { signal }),

--- a/extensions/memory-recall-operations.ts
+++ b/extensions/memory-recall-operations.ts
@@ -4,7 +4,15 @@ import { resolveOperationBank } from "./bank-selection.js";
 import { readLastRecallSnapshot, resolveLastRecallPath } from "./recall-visibility.js";
 import { pruneTranscriptRecallBlocks, scanTranscriptForRecallBlocks } from "./recall-cleanup.js";
 import { getEffectiveSessionMemoryMode, readSessionMemoryMeta } from "./session-memory-meta.js";
-import type { ResolvedConfig } from "./types.js";
+import type { HindsightTagGroup, ResolvedConfig, TagsMatch } from "./types.js";
+
+interface ExplicitRecallFilters {
+  queryTimestamp?: string;
+  tags?: string[];
+  tagsMatch?: TagsMatch;
+  tagGroups?: HindsightTagGroup[];
+  signal?: AbortSignal;
+}
 
 function recallTagsForBank(
   cwd: string,
@@ -17,6 +25,23 @@ function recallTagsForBank(
     : recallScopeTags(cwd);
 }
 
+function scopedTagFilterOptions(scopeTags: string[], filters: ExplicitRecallFilters = {}) {
+  const scopeGroup = { tags: scopeTags, match: "any_strict" } satisfies HindsightTagGroup;
+  const callerGroups = filters.tagGroups ?? [];
+  if (callerGroups.length || filters.tags?.length) {
+    const flatTagGroup = filters.tags?.length
+      ? [
+          {
+            tags: filters.tags,
+            match: filters.tagsMatch ?? "any_strict",
+          } satisfies HindsightTagGroup,
+        ]
+      : [];
+    return { tagGroups: [scopeGroup, ...flatTagGroup, ...callerGroups] };
+  }
+  return { tags: scopeTags, tagsMatch: "any_strict" as const };
+}
+
 export function createRecallOperations(deps: MemoryOperationsDeps) {
   return {
     async recall(
@@ -24,7 +49,7 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
       query: string,
       bank?: string,
       sessionFile?: string,
-      queryTimestamp?: string,
+      filters: ExplicitRecallFilters = {},
     ) {
       const meta = await readSessionMemoryMeta(cwd, sessionFile);
       if (!getEffectiveSessionMemoryMode(meta).recall)
@@ -35,14 +60,15 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
         config,
         projectBankId: deps.getProjectBankId(),
       });
+      const scopeTags = recallTagsForBank(cwd, config, deps.getProjectBankId(), bankId);
       const result = await deps.getClient().recall(bankId, query, {
         budget: config.recall.budget,
         maxTokens: config.recall.maxTokens,
-        ...(queryTimestamp || config.recall.queryTimestamp
-          ? { queryTimestamp: queryTimestamp ?? config.recall.queryTimestamp }
+        ...(filters.queryTimestamp || config.recall.queryTimestamp
+          ? { queryTimestamp: filters.queryTimestamp ?? config.recall.queryTimestamp }
           : {}),
-        tags: recallTagsForBank(cwd, config, deps.getProjectBankId(), bankId),
-        tagsMatch: "any_strict",
+        ...scopedTagFilterOptions(scopeTags, filters),
+        ...(filters.signal ? { signal: filters.signal } : {}),
       });
       return { bankId, result };
     },
@@ -53,6 +79,7 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
       context?: string,
       bank?: string,
       responseSchema?: Record<string, unknown>,
+      filters: Omit<ExplicitRecallFilters, "queryTimestamp"> = {},
     ) {
       const config = deps.getConfig();
       const bankId = resolveOperationBank({
@@ -60,12 +87,13 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
         config,
         projectBankId: deps.getProjectBankId(),
       });
+      const scopeTags = recallTagsForBank(cwd, config, deps.getProjectBankId(), bankId);
       const result = await deps.getClient().reflect(bankId, query, {
         ...(context ? { context } : {}),
         budget: config.recall.budget,
         ...(responseSchema ? { responseSchema } : {}),
-        tags: recallTagsForBank(cwd, config, deps.getProjectBankId(), bankId),
-        tagsMatch: "any_strict",
+        ...scopedTagFilterOptions(scopeTags, filters),
+        ...(filters.signal ? { signal: filters.signal } : {}),
       });
       return { bankId, result };
     },

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -28,6 +28,52 @@ import {
 
 export type ToolOperation = Parameters<ExtensionAPI["registerTool"]>[0];
 
+const tagMatchSchema = Type.Union([
+  Type.Literal("any"),
+  Type.Literal("all"),
+  Type.Literal("any_strict"),
+  Type.Literal("all_strict"),
+]);
+
+const tagGroupJsonSchema = {
+  $id: "HindsightTagGroup",
+  anyOf: [
+    {
+      type: "object",
+      required: ["tags"],
+      properties: {
+        tags: { type: "array", items: { type: "string" } },
+        match: { enum: ["any", "all", "any_strict", "all_strict"] },
+      },
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      required: ["and"],
+      properties: { and: { type: "array", items: { $ref: "HindsightTagGroup" } } },
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      required: ["or"],
+      properties: { or: { type: "array", items: { $ref: "HindsightTagGroup" } } },
+      additionalProperties: false,
+    },
+    {
+      type: "object",
+      required: ["not"],
+      properties: { not: { $ref: "HindsightTagGroup" } },
+      additionalProperties: false,
+    },
+  ],
+};
+
+const tagGroupSchema = Type.Unsafe<import("./types.js").HindsightTagGroup>(tagGroupJsonSchema);
+
+function tagGroupsSchema(description: string) {
+  return Type.Optional(Type.Array(tagGroupSchema, { description }));
+}
+
 function defineCatalogTool<TParams extends ToolDefinition["parameters"], TDetails = unknown>(
   tool: ToolDefinition<TParams, TDetails>,
 ): ToolOperation {
@@ -60,8 +106,13 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         queryTimestamp: Type.Optional(
           Type.String({ description: "Optional ISO timestamp for time-scoped recall." }),
         ),
+        tags: Type.Optional(Type.Array(Type.String(), { description: "Additional tag filter." })),
+        tagsMatch: Type.Optional(tagMatchSchema),
+        tagGroups: tagGroupsSchema(
+          "Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.",
+        ),
       }),
-      async execute(_id, params, _signal, _onUpdate, ctx) {
+      async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         const sessionFile = ctx.sessionManager.getSessionFile?.();
         const { bankId, result } = await operations.recall(
@@ -69,7 +120,15 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           params.query,
           params.bank,
           sessionFile,
-          params.queryTimestamp,
+          {
+            ...(params.queryTimestamp ? { queryTimestamp: params.queryTimestamp } : {}),
+            ...(params.tags ? { tags: params.tags } : {}),
+            ...(params.tagsMatch ? { tagsMatch: params.tagsMatch } : {}),
+            ...(params.tagGroups
+              ? { tagGroups: params.tagGroups as import("./types.js").HindsightTagGroup[] }
+              : {}),
+            ...(signal ? { signal } : {}),
+          },
         );
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -99,7 +158,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           ),
         ),
       }),
-      async execute(_id, params, _signal, _onUpdate, ctx) {
+      async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         const sessionFile = ctx.sessionManager.getSessionFile?.();
         const result = await operations.retainExplicit({
@@ -512,8 +571,13 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         context: Type.Optional(Type.String()),
         bank: Type.Optional(Type.String()),
         responseSchema: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+        tags: Type.Optional(Type.Array(Type.String(), { description: "Additional tag filter." })),
+        tagsMatch: Type.Optional(tagMatchSchema),
+        tagGroups: tagGroupsSchema(
+          "Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.",
+        ),
       }),
-      async execute(_id, params, _signal, _onUpdate, ctx) {
+      async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         const { bankId, result } = await operations.reflect(
           ctx.cwd,
@@ -521,6 +585,14 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           params.context,
           params.bank,
           params.responseSchema,
+          {
+            ...(params.tags ? { tags: params.tags } : {}),
+            ...(params.tagsMatch ? { tagsMatch: params.tagsMatch } : {}),
+            ...(params.tagGroups
+              ? { tagGroups: params.tagGroups as import("./types.js").HindsightTagGroup[] }
+              : {}),
+            ...(signal ? { signal } : {}),
+          },
         );
         return {
           content: [

--- a/extensions/timeout.ts
+++ b/extensions/timeout.ts
@@ -2,9 +2,13 @@ export async function withTimeout<T>(
   operation: string,
   timeoutMs: number,
   fn: (signal: AbortSignal) => Promise<T>,
+  parentSignal?: AbortSignal,
 ): Promise<T> {
+  if (parentSignal?.aborted) throw new Error(`${operation} aborted`);
+
   const controller = new AbortController();
   let timer: NodeJS.Timeout | undefined;
+  let removeAbortListener: (() => void) | undefined;
   try {
     const timeout = new Promise<never>((_resolve, reject) => {
       timer = setTimeout(() => {
@@ -12,8 +16,19 @@ export async function withTimeout<T>(
         reject(new Error(`${operation} timed out after ${timeoutMs}ms`));
       }, timeoutMs);
     });
-    return await Promise.race([fn(controller.signal), timeout]);
+    const abort = parentSignal
+      ? new Promise<never>((_resolve, reject) => {
+          const onAbort = () => {
+            controller.abort(parentSignal.reason);
+            reject(new Error(`${operation} aborted`));
+          };
+          parentSignal.addEventListener("abort", onAbort, { once: true });
+          removeAbortListener = () => parentSignal.removeEventListener("abort", onAbort);
+        })
+      : undefined;
+    return await Promise.race([fn(controller.signal), timeout, ...(abort ? [abort] : [])]);
   } finally {
     if (timer) clearTimeout(timer);
+    removeAbortListener?.();
   }
 }

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -1,3 +1,9 @@
+import type {
+  TagGroupAndInput,
+  TagGroupLeaf,
+  TagGroupNotInput,
+  TagGroupOrInput,
+} from "@vectorize-io/hindsight-client";
 import type { BankTemplateManifest } from "./bank-template-catalog.js";
 
 export type Budget = "low" | "mid" | "high";
@@ -6,6 +12,11 @@ export type RetainUserContent = "text";
 export type RetainAssistantContent = "text" | "toolCall" | "thinking";
 export type RetainToolResultContent = "error" | "summary" | "content";
 export type TagsMatch = "any" | "all" | "any_strict" | "all_strict";
+export type HindsightTagGroup =
+  | TagGroupLeaf
+  | TagGroupAndInput
+  | TagGroupOrInput
+  | TagGroupNotInput;
 export type MentalModelDetail = "metadata" | "content" | "full";
 export type MentalModelTagsMatch = "any" | "all" | "exact";
 export type StatusStyle = "off" | "text" | "emoji" | "nerdfont";
@@ -262,6 +273,7 @@ export interface HindsightLikeClient {
       tags?: string[];
       updateMode?: UpdateMode;
       observationScopes?: string[][];
+      signal?: AbortSignal;
     },
   ): Promise<unknown>;
   retainBatch?(
@@ -277,7 +289,12 @@ export interface HindsightLikeClient {
       observation_scopes?: string[][];
       update_mode?: UpdateMode;
     }>,
-    options?: { documentId?: string; documentTags?: string[]; async?: boolean },
+    options?: {
+      documentId?: string;
+      documentTags?: string[];
+      async?: boolean;
+      signal?: AbortSignal;
+    },
   ): Promise<unknown>;
   recall(
     bankId: string,
@@ -289,6 +306,8 @@ export interface HindsightLikeClient {
       queryTimestamp?: string;
       tags?: string[];
       tagsMatch?: TagsMatch;
+      tagGroups?: HindsightTagGroup[];
+      signal?: AbortSignal;
     },
   ): Promise<unknown>;
   reflect(
@@ -300,6 +319,8 @@ export interface HindsightLikeClient {
       responseSchema?: Record<string, unknown>;
       tags?: string[];
       tagsMatch?: TagsMatch;
+      tagGroups?: HindsightTagGroup[];
+      signal?: AbortSignal;
     },
   ): Promise<unknown>;
   createBank?(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@vectorize-io/hindsight-client": "^0.5.6",
+        "@vectorize-io/hindsight-client": "^0.6.0",
         "jsonc-parser": "^3.3.1"
       },
       "devDependencies": {
@@ -6025,9 +6025,9 @@
       }
     },
     "node_modules/@vectorize-io/hindsight-client": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.5.6.tgz",
-      "integrity": "sha512-VBMkCQP7dCy9BqkoqhZxxl5sVW6opKT3l6wexval7ZM4syTOGlmpu7BRhtFycxWmkWjXwH+XM6n4lzBoWTSPdA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.6.0.tgz",
+      "integrity": "sha512-Vp308C8XOE1Pd/bDiRW0wxVceJtB2y26GxrhLflv6jmQ0zq7EcRag3Oe2fXaf3YS+aOb2xpvIwZYGSEvov/d5Q==",
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "code-map:check": "node scripts/generate-code-map.mjs --check"
   },
   "dependencies": {
-    "@vectorize-io/hindsight-client": "^0.5.6",
+    "@vectorize-io/hindsight-client": "^0.6.0",
     "jsonc-parser": "^3.3.1"
   },
   "devDependencies": {

--- a/tests/banking.test.ts
+++ b/tests/banking.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, mkdirSync } from "node:fs";
+import { copyFileSync, mkdtempSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import type { ExecFileSyncOptions } from "node:child_process";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import {
   baseTags,
@@ -11,17 +13,89 @@ import {
 } from "../extensions/banking.js";
 import { liveDocumentId, stableSessionId } from "../extensions/session.js";
 
+function git(args: string[], cwd: string, home: string): void {
+  execFileSync("git", args, {
+    cwd,
+    stdio: "ignore",
+    env: { ...process.env, HOME: home, GIT_CONFIG_NOSYSTEM: "1" },
+  } satisfies ExecFileSyncOptions);
+}
+
 describe("banking/session identity", () => {
   it("derives stable project bank from repo root", () => {
     const root = mkdtempSync(join(tmpdir(), "pi-hindsight-repo-"));
     mkdirSync(join(root, ".git"));
     const child = join(root, "a", "b");
     mkdirSync(child, { recursive: true });
-    expect(findRepoRoot(child)).toBe(root);
+    expect(findRepoRoot(child)).toBe(realpathSync.native(root));
     expect(deriveProjectBankId(child, DEFAULT_CONFIG)).toBe(
       deriveProjectBankId(root, DEFAULT_CONFIG),
     );
   });
+
+  it("shares project identity across git linked worktrees", () => {
+    const parent = mkdtempSync(join(tmpdir(), "pi-hindsight-worktrees-"));
+    const main = join(parent, "main-repo");
+    const linked = join(realpathSync.native(parent), "feature-worktree");
+    const home = join(parent, "home");
+    mkdirSync(home);
+
+    git(["init", main], parent, home);
+    git(["config", "user.email", "pi@example.invalid"], main, home);
+    git(["config", "user.name", "Pi Test"], main, home);
+    git(["commit", "--allow-empty", "-m", "init"], main, home);
+
+    const linkedGitDir = join(realpathSync.native(main), ".git", "worktrees", "feature-worktree");
+    mkdirSync(linked, { recursive: true });
+    mkdirSync(linkedGitDir, { recursive: true });
+    writeFileSync(join(linked, ".git"), `gitdir: ${linkedGitDir}\n`);
+    writeFileSync(join(linkedGitDir, "gitdir"), `${join(linked, ".git")}\n`);
+    writeFileSync(join(linkedGitDir, "commondir"), "../..\n");
+    copyFileSync(join(realpathSync.native(main), ".git", "HEAD"), join(linkedGitDir, "HEAD"));
+    writeFileSync(join(linkedGitDir, "index"), "");
+
+    expect(findRepoRoot(linked)).toBe(realpathSync.native(main));
+    expect(deriveProjectBankId(linked, DEFAULT_CONFIG)).toBe(
+      deriveProjectBankId(main, DEFAULT_CONFIG),
+    );
+    expect(recallScopeTags(linked)).toEqual(recallScopeTags(main));
+  }, 15_000);
+
+  it("uses the submodule worktree root instead of superproject git storage", () => {
+    const parent = mkdtempSync(join(tmpdir(), "pi-hindsight-submodule-"));
+    const subSource = join(parent, "sub-source");
+    const superProject = join(parent, "super");
+    const submodule = join(superProject, "deps", "sub");
+    const home = join(parent, "home");
+    mkdirSync(home);
+
+    git(["init", subSource], parent, home);
+    git(["config", "user.email", "pi@example.invalid"], subSource, home);
+    git(["config", "user.name", "Pi Test"], subSource, home);
+    git(["commit", "--allow-empty", "-m", "init-sub"], subSource, home);
+
+    git(["init", superProject], parent, home);
+    git(["config", "user.email", "pi@example.invalid"], superProject, home);
+    git(["config", "user.name", "Pi Test"], superProject, home);
+    mkdirSync(join(superProject, "deps"), { recursive: true });
+    git(
+      [
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        realpathSync.native(subSource),
+        "deps/sub",
+      ],
+      realpathSync.native(superProject),
+      home,
+    );
+
+    expect(findRepoRoot(submodule)).toBe(realpathSync.native(submodule));
+    expect(deriveProjectBankId(submodule, DEFAULT_CONFIG)).not.toBe(
+      deriveProjectBankId(superProject, DEFAULT_CONFIG),
+    );
+  }, 15_000);
 
   it("uses stable live document ids", () => {
     expect(liveDocumentId("/tmp/session.jsonl", "/repo")).toBe(

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -219,8 +219,10 @@ describe("Hindsight client adapter integration", () => {
       observationScopes: [["repo:abc"], ["bank:test-bank"]],
     });
     const recall = await client.recall("test-bank", "query", {
-      tags: ["source:pi"],
-      tagsMatch: "any_strict",
+      tagGroups: [
+        { tags: ["source:pi"], match: "any_strict" },
+        { or: [{ tags: ["kind:decision"], match: "any_strict" }] },
+      ],
       maxTokens: 123,
       budget: "low",
       queryTimestamp: "2024-01-01T00:00:00Z",
@@ -228,6 +230,7 @@ describe("Hindsight client adapter integration", () => {
     const reflection = await client.reflect("test-bank", "query", {
       budget: "low",
       responseSchema: { type: "object", properties: { answer: { type: "string" } } },
+      tagGroups: [{ tags: ["source:pi"], match: "any_strict" }],
     });
     const templateDryRun = await client.importBankTemplate?.(
       "test-bank",
@@ -384,13 +387,16 @@ describe("Hindsight client adapter integration", () => {
       max_tokens: 123,
       budget: "low",
       query_timestamp: "2024-01-01T00:00:00Z",
-      tags: ["source:pi"],
-      tags_match: "any_strict",
+      tag_groups: [
+        { tags: ["source:pi"], match: "any_strict" },
+        { or: [{ tags: ["kind:decision"], match: "any_strict" }] },
+      ],
     });
     expect(requests[5]?.body).toMatchObject({
       query: "query",
       budget: "low",
       response_schema: { type: "object", properties: { answer: { type: "string" } } },
+      tag_groups: [{ tags: ["source:pi"], match: "any_strict" }],
     });
     expect(requests[6]?.body).toEqual({
       version: "1",

--- a/tests/client-timeout.test.ts
+++ b/tests/client-timeout.test.ts
@@ -28,4 +28,34 @@ describe("Hindsight client timeout", () => {
       );
     }
   });
+
+  it("rejects when caller aborts an in-flight call", async () => {
+    const server = createServer((_req, _res) => {
+      // Intentionally never respond before caller abort.
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing address");
+    const client = createHindsightClient({
+      ...DEFAULT_CONFIG,
+      hindsight: {
+        ...DEFAULT_CONFIG.hindsight,
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        timeoutMs: 10_000,
+      },
+    });
+    const controller = new AbortController();
+    try {
+      const pending = expect(
+        client.recall("bank", "q", { budget: "low", signal: controller.signal }),
+      ).rejects.toThrow("aborted");
+      controller.abort();
+      await pending;
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
 });

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -103,17 +103,30 @@ describe("memory operations", () => {
     });
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ops-"));
 
-    await operations.recall(cwd, "query", undefined, undefined, "2024-02-01T00:00:00Z");
+    await operations.recall(cwd, "query", undefined, undefined, {
+      queryTimestamp: "2024-02-01T00:00:00Z",
+    });
     await operations.retainExplicit({
       cwd,
       content: "content",
       context: "context",
       entities: [{ text: "Alice", type: "person" }],
     });
-    await operations.reflect(cwd, "query", undefined, undefined, {
-      type: "object",
-      properties: { answer: { type: "string" } },
-    });
+    await operations.reflect(
+      cwd,
+      "query",
+      undefined,
+      undefined,
+      {
+        type: "object",
+        properties: { answer: { type: "string" } },
+      },
+      {
+        tags: ["topic:hindsight"],
+        tagsMatch: "all_strict",
+        tagGroups: [{ tags: ["kind:decision"], match: "any_strict" }],
+      },
+    );
 
     expect(calls.find((call) => call.method === "recall")?.options).toMatchObject({
       queryTimestamp: "2024-02-01T00:00:00Z",
@@ -123,6 +136,11 @@ describe("memory operations", () => {
     });
     expect(calls.find((call) => call.method === "reflect")?.options).toMatchObject({
       responseSchema: { type: "object", properties: { answer: { type: "string" } } },
+      tagGroups: [
+        { tags: [expect.stringMatching(/^repo:/)], match: "any_strict" },
+        { tags: ["topic:hindsight"], match: "all_strict" },
+        { tags: ["kind:decision"], match: "any_strict" },
+      ],
     });
   });
 


### PR DESCRIPTION
## Summary

- Upgrade the official Hindsight TypeScript client to `^0.6.0`.
- Add Hindsight 0.6 compound `tagGroups` support to explicit recall/reflect tools while preserving Pi project/user scope isolation.
- Share project memory banks across linked Git worktrees, keep submodules isolated, and propagate timeout/tool cancellation signals into Hindsight calls.
- Update generated tool references and memory-bank docs for the new behavior.

## Linked issue

- Closes #234

## Scope

- Focused Hindsight 0.6 compatibility slice: client dependency, tag filter/tool surface, worktree-aware bank identity, cancellation propagation, docs, and regression tests.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — not requested; CI routing should decide.
- [x] package verification requested/passed (release/package changes or `ci:package`)
- [x] `npm run pack:verify` (release/package changes)
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional targeted checks:

- `npm test -- --run tests/banking.test.ts tests/memory-operations.test.ts tests/operation-catalog.test.ts tests/client-integration.test.ts`
- `npm test -- --run tests/client-timeout.test.ts`
- Live smoke ran against Hindsight API `0.6.0` at `https://h1.luxus.ai` and passed retain, recall, reflect, operations, import, and cleanup.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: Hindsight 0.6 support, explicit `tagGroups` filters for recall/reflect, linked-worktree memory-bank sharing, and better cancellation behavior.

## Risk and rollback

- Risk: Worktree bank identity changes can affect which project bank is selected for linked worktrees; recursive `tagGroups` depends on Hindsight 0.6 server/client behavior.
- Rollback/revert path: Revert this PR to restore Hindsight client `0.5.x`, previous `.git` walk identity behavior, and legacy tag-only recall/reflect filters.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable; no workflow/policy/source-of-truth change.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- Subagent review found and verified fixes for submodule/worktree identity, recursive `tagGroups`, and tool cancellation propagation.
- No ADR conflicts found.
