### PR TITLE
test: add import quality fixtures

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,6 +100,26 @@ A configured scope passed with retain jobs so Hindsight observations are isolate
 
 The historical session ingestion path. Import parses Pi JSONL sessions, selects branches, builds deterministic import documents, queues retain jobs, records checkpoints/manifests, and can run as a dry-run preview before writing.
 
+### Durable Signal
+
+Raw source evidence worth keeping in memory because it records a fact, decision, task, bug, error, verification result, issue/PR/commit reference, blocker, follow-up, or project workflow outcome.
+
+### Import Noise
+
+Transcript material that should not become durable source truth by default, such as streaming UI records, process/status chatter, repeated successful command output, large file reads, and other replay artifacts.
+
+### Tool Evidence
+
+Tool output that carries memory value. Failed tool results are usually durable evidence when kept concise. Large successful tool output is usually import noise unless a strict policy explicitly keeps a small low-noise summary.
+
+### Workflow Signal
+
+Durable Signal about project execution: selected issues, branches, PRs, commits, review decisions, CI and smoke verification, release gates, blockers, and follow-up work.
+
+### Recall Contamination
+
+Persisting a Recall Block, Last-Recall Snapshot, or other previously injected memory back into Hindsight as if it were new source evidence. Recall contamination must be prevented in live retain and historical import.
+
 ### Import Manifest
 
 The durable record of historical import work that has been planned or completed. It makes imports inspectable, resumable, and idempotent across repeated runs.

--- a/docs-site/src/content/docs/concepts/imports.md
+++ b/docs-site/src/content/docs/concepts/imports.md
@@ -6,6 +6,14 @@ title: "Historical Import"
 
 Import is not generic summarization. Curated import keeps filtered structured source material so Hindsight still receives evidence with provenance.
 
+## Quality vocabulary
+
+- **Durable signal**: raw source evidence worth keeping because it records facts, decisions, tasks, bugs, errors, verification, issues, PRs, commits, blockers, follow-ups, or workflow outcomes.
+- **Import noise**: transcript material that should not become source truth by default, such as streaming UI records, process/status chatter, repeated successful output, large file reads, and replay artifacts.
+- **Tool evidence**: tool output with memory value. Failed tool results are usually useful evidence when kept concise; large successful tool output is usually noise.
+- **Workflow signal**: project execution evidence such as issue selection, branch/PR/commit references, review decisions, CI/smoke checks, release gates, blockers, and follow-ups.
+- **Recall contamination**: retaining or importing prior Recall Blocks or Last-Recall artifacts as if they were new source evidence. Curated import and live retain must avoid it.
+
 ## Modes
 
 - `curated`: default high-signal projection for normal historical imports.

--- a/extensions/import-curation-policy.ts
+++ b/extensions/import-curation-policy.ts
@@ -1,0 +1,188 @@
+import type { ResolvedConfig } from "./types.js";
+import { isInjectedHindsightMemory, projectMessages } from "./messages.js";
+
+export type CuratedImportKeepReason =
+  | "user-text"
+  | "assistant-text"
+  | "tool-error-kept"
+  | "message-kept";
+
+export type CuratedImportDropReason =
+  | "successful-tool-output"
+  | "recalled-memory"
+  | "empty-projection";
+
+export type CuratedImportReason = CuratedImportKeepReason | CuratedImportDropReason;
+
+export interface CuratedImportClassification {
+  original: Record<string, unknown>;
+  stableMessage: Record<string, unknown>;
+  projectedMessages: Record<string, unknown>[];
+  decision: "keep" | "drop";
+  reasons: CuratedImportReason[];
+  rawBytes: number;
+  projectedBytes: number;
+  toolName?: string;
+  toolResultDropped?: boolean;
+  toolErrorKept?: boolean;
+}
+
+export interface CuratedImportProjection {
+  messages: Record<string, unknown>[];
+  rawBytes: number;
+  projectedBytes: number;
+  droppedToolResultCount: number;
+  droppedToolResultBytes: number;
+  topDroppedTools: Array<{ name: string; count: number; bytes: number }>;
+  keptToolErrorCount: number;
+  keptToolErrorBytes: number;
+  estimatedChunkCount: number;
+  classificationReasonCounts: Partial<Record<CuratedImportReason, number>>;
+  classifications: CuratedImportClassification[];
+}
+
+export function importByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+export function importToolName(message: Record<string, unknown>): string {
+  const name = message.name ?? message.toolName ?? message.tool;
+  return typeof name === "string" && name.trim() ? name : "unknown";
+}
+
+export function stableProjectionMessage(message: Record<string, unknown>): Record<string, unknown> {
+  const timestamp = message.timestamp;
+  const parsedTimestamp = typeof timestamp === "string" ? Date.parse(timestamp) : undefined;
+  return {
+    ...message,
+    timestamp:
+      typeof timestamp === "number"
+        ? timestamp
+        : typeof parsedTimestamp === "number" && Number.isFinite(parsedTimestamp)
+          ? parsedTimestamp
+          : 0,
+  };
+}
+
+function mergeImportProvenance(
+  original: Record<string, unknown>,
+  projectedMessages: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  return projectedMessages.map((message) => ({
+    ...(original.id !== undefined ? { id: original.id } : {}),
+    ...(original.parentId !== undefined ? { parentId: original.parentId } : {}),
+    ...message,
+  }));
+}
+
+function keepReason(message: Record<string, unknown>): CuratedImportKeepReason {
+  if (message.role === "user") return "user-text";
+  if (message.role === "assistant") return "assistant-text";
+  if (message.role === "toolResult" && message.isError === true) return "tool-error-kept";
+  return "message-kept";
+}
+
+function dropReasons(
+  message: Record<string, unknown>,
+  projectedMessages: Record<string, unknown>[],
+): CuratedImportDropReason[] {
+  if (isInjectedHindsightMemory(message)) return ["recalled-memory"];
+  if (!projectedMessages.length && message.role === "toolResult" && message.isError !== true)
+    return ["successful-tool-output"];
+  return ["empty-projection"];
+}
+
+export function classifyCuratedImportMessage(
+  message: Record<string, unknown>,
+  config: ResolvedConfig,
+): CuratedImportClassification {
+  const stableMessage = stableProjectionMessage(message);
+  const projectedMessages = mergeImportProvenance(
+    stableMessage,
+    projectMessages([stableMessage as never], config),
+  );
+  const decision = projectedMessages.length ? "keep" : "drop";
+  const reasons =
+    decision === "keep"
+      ? [keepReason(stableMessage)]
+      : dropReasons(stableMessage, projectedMessages);
+  const rawBytes = importByteLength(stableMessage);
+  const projectedBytes = importByteLength(projectedMessages);
+  return {
+    original: message,
+    stableMessage,
+    projectedMessages,
+    decision,
+    reasons,
+    rawBytes,
+    projectedBytes,
+    ...(stableMessage.role === "toolResult" ? { toolName: importToolName(stableMessage) } : {}),
+    ...(stableMessage.role === "toolResult" && decision === "drop"
+      ? { toolResultDropped: true }
+      : {}),
+    ...(stableMessage.role === "toolResult" && stableMessage.isError === true && decision === "keep"
+      ? { toolErrorKept: true }
+      : {}),
+  };
+}
+
+function incrementReasonCounts(
+  counts: Partial<Record<CuratedImportReason, number>>,
+  reasons: CuratedImportReason[],
+): void {
+  for (const reason of reasons) counts[reason] = (counts[reason] ?? 0) + 1;
+}
+
+export function buildCuratedImportProjection(
+  messages: Array<{ data: Record<string, unknown> }>,
+  config: ResolvedConfig,
+): CuratedImportProjection {
+  const droppedTools = new Map<string, { count: number; bytes: number }>();
+  const classificationReasonCounts: Partial<Record<CuratedImportReason, number>> = {};
+  const classifications = messages.map((message) =>
+    classifyCuratedImportMessage(message.data, config),
+  );
+  const projected = classifications.flatMap((classification) => {
+    incrementReasonCounts(classificationReasonCounts, classification.reasons);
+    if (classification.toolResultDropped) {
+      const name = classification.toolName ?? "unknown";
+      const current = droppedTools.get(name) ?? { count: 0, bytes: 0 };
+      droppedTools.set(name, {
+        count: current.count + 1,
+        bytes: current.bytes + classification.rawBytes,
+      });
+    }
+    return classification.projectedMessages;
+  });
+  const keptToolErrors = classifications.filter((classification) => classification.toolErrorKept);
+  return {
+    messages: projected,
+    rawBytes: classifications.reduce((total, classification) => total + classification.rawBytes, 0),
+    projectedBytes: importByteLength(projected),
+    droppedToolResultCount: [...droppedTools.values()].reduce(
+      (total, tool) => total + tool.count,
+      0,
+    ),
+    droppedToolResultBytes: [...droppedTools.values()].reduce(
+      (total, tool) => total + tool.bytes,
+      0,
+    ),
+    keptToolErrorCount: keptToolErrors.length,
+    keptToolErrorBytes: keptToolErrors.reduce(
+      (total, classification) => total + classification.rawBytes,
+      0,
+    ),
+    estimatedChunkCount: Math.max(1, Math.ceil(importByteLength(projected) / 8_000)),
+    topDroppedTools: [...droppedTools]
+      .map(([name, value]) => ({ name, ...value }))
+      .sort(
+        (left, right) =>
+          right.bytes - left.bytes ||
+          right.count - left.count ||
+          left.name.localeCompare(right.name),
+      )
+      .slice(0, 5),
+    classificationReasonCounts,
+    classifications,
+  };
+}

--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -4,11 +4,16 @@ import { baseTags } from "./banking.js";
 import { redactSecrets } from "./sanitize.js";
 import { hashImportContent, type ImportManifestEntry } from "./import-manifest.js";
 import { createMemoryIdentity } from "./memory-identity.js";
-import { isInjectedHindsightMemory, projectMessages } from "./messages.js";
+import { isInjectedHindsightMemory } from "./messages.js";
 import { expandObservationScopes } from "./observation-scopes.js";
 import type { ImportBranch } from "./import-branches.js";
 import type { ParsedSession } from "./import-parser.js";
 import { deliverImportRetain } from "./import-delivery.js";
+import {
+  buildCuratedImportProjection,
+  importByteLength,
+  stableProjectionMessage,
+} from "./import-curation-policy.js";
 
 export interface ImportRetainArgs {
   sessionFile: string;
@@ -35,6 +40,7 @@ export interface ImportDocumentPreview {
   topDroppedTools?: Array<{ name: string; count: number; bytes: number }>;
   keptToolErrorCount?: number;
   keptToolErrorBytes?: number;
+  classificationReasonCounts?: Record<string, number>;
   estimatedDocumentCount?: number;
   estimatedChunkCount?: number;
   importMode?: ResolvedConfig["import"]["mode"];
@@ -81,92 +87,6 @@ function resolvedParentSessionId(parsed: ParsedSession, cwd: string): string | u
     parsed.parentSessionId ??
     (parsed.parentSessionFile ? stableSessionId(parsed.parentSessionFile, cwd) : undefined)
   );
-}
-
-function byteLength(value: unknown): number {
-  return Buffer.byteLength(JSON.stringify(value), "utf8");
-}
-
-function toolName(message: Record<string, unknown>): string {
-  const name = message.name ?? message.toolName ?? message.tool;
-  return typeof name === "string" && name.trim() ? name : "unknown";
-}
-
-function stableProjectionMessage(message: Record<string, unknown>): Record<string, unknown> {
-  const timestamp = message.timestamp;
-  const parsedTimestamp = typeof timestamp === "string" ? Date.parse(timestamp) : undefined;
-  return {
-    ...message,
-    timestamp:
-      typeof timestamp === "number"
-        ? timestamp
-        : typeof parsedTimestamp === "number" && Number.isFinite(parsedTimestamp)
-          ? parsedTimestamp
-          : 0,
-  };
-}
-
-function buildCuratedImportProjection(
-  messages: Array<{ data: Record<string, unknown> }>,
-  config: ResolvedConfig,
-): {
-  messages: Record<string, unknown>[];
-  rawBytes: number;
-  projectedBytes: number;
-  droppedToolResultCount: number;
-  droppedToolResultBytes: number;
-  topDroppedTools: Array<{ name: string; count: number; bytes: number }>;
-  keptToolErrorCount: number;
-  keptToolErrorBytes: number;
-  estimatedChunkCount: number;
-} {
-  const droppedTools = new Map<string, { count: number; bytes: number }>();
-  let keptToolErrorCount = 0;
-  let keptToolErrorBytes = 0;
-  const projected = messages.flatMap((message) => {
-    const stableMessage = stableProjectionMessage(message.data);
-    const projectedMessage = projectMessages([stableMessage as never], config);
-    if (
-      projectedMessage.length &&
-      stableMessage.role === "toolResult" &&
-      stableMessage.isError === true
-    ) {
-      keptToolErrorCount += 1;
-      keptToolErrorBytes += byteLength(stableMessage);
-    }
-    if (!projectedMessage.length && stableMessage.role === "toolResult") {
-      const name = toolName(stableMessage);
-      const bytes = byteLength(stableMessage);
-      const current = droppedTools.get(name) ?? { count: 0, bytes: 0 };
-      droppedTools.set(name, { count: current.count + 1, bytes: current.bytes + bytes });
-    }
-    return projectedMessage;
-  });
-  return {
-    messages: projected,
-    rawBytes: messages.reduce((total, message) => total + byteLength(message.data), 0),
-    projectedBytes: byteLength(projected),
-    droppedToolResultCount: [...droppedTools.values()].reduce(
-      (total, tool) => total + tool.count,
-      0,
-    ),
-    droppedToolResultBytes: [...droppedTools.values()].reduce(
-      (total, tool) => total + tool.bytes,
-      0,
-    ),
-    keptToolErrorCount,
-    keptToolErrorBytes,
-    estimatedChunkCount: Math.max(1, Math.ceil(byteLength(projected) / 8_000)),
-    topDroppedTools: [...droppedTools]
-      .map(([name, value]) => ({ name, ...value }))
-      .sort(
-        (left, right) =>
-          right.bytes - left.bytes ||
-          right.count - left.count ||
-          left.name.localeCompare(right.name),
-      )
-      .slice(0, 5),
-  };
 }
 
 const CURATED_PROJECTION_VERSION = "curated-turns-v1";
@@ -223,7 +143,8 @@ function chunkCuratedMessages(
     const wouldOverflowTurns = turnCount >= config.import.turnsPerDocument;
     const wouldOverflowBytes =
       chunk.length > 0 &&
-      byteLength(nextMessages.map((entry) => entry.message.data)) > config.import.maxDocumentBytes;
+      importByteLength(nextMessages.map((entry) => entry.message.data)) >
+        config.import.maxDocumentBytes;
     if (wouldOverflowTurns || wouldOverflowBytes) flush();
     chunk.push(...turn.messages);
     turnCount += 1;
@@ -284,8 +205,11 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
         ? buildCuratedImportProjection(chunkMessages, args.config)
         : {
             messages: chunkMessages.map((message) => stableProjectionMessage(message.data)),
-            rawBytes: chunkMessages.reduce((total, message) => total + byteLength(message.data), 0),
-            projectedBytes: byteLength(chunkMessages.map((message) => message.data)),
+            rawBytes: chunkMessages.reduce(
+              (total, message) => total + importByteLength(message.data),
+              0,
+            ),
+            projectedBytes: importByteLength(chunkMessages.map((message) => message.data)),
             droppedToolResultCount: 0,
             droppedToolResultBytes: 0,
             topDroppedTools: [],
@@ -296,10 +220,10 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
               .filter(
                 (message) => message.data.role === "toolResult" && message.data.isError === true,
               )
-              .reduce((total, message) => total + byteLength(message.data), 0),
+              .reduce((total, message) => total + importByteLength(message.data), 0),
             estimatedChunkCount: Math.max(
               1,
-              Math.ceil(byteLength(chunkMessages.map((message) => message.data)) / 8_000),
+              Math.ceil(importByteLength(chunkMessages.map((message) => message.data)) / 8_000),
             ),
           };
     const importProfile = mode === "curated" ? curatedImportProfile(args.config) : undefined;
@@ -331,7 +255,8 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
               : "raw-v1",
         ...(mode === "curated" ? { chunkIndex: chunk.index, messageRange } : {}),
         projectedMessageCount: projection.messages.length,
-        messages: chunkMessages.map((message) => message.data),
+        messages:
+          mode === "curated" ? projection.messages : chunkMessages.map((message) => message.data),
       },
       null,
       2,
@@ -359,6 +284,9 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
       topDroppedTools: projection.topDroppedTools,
       keptToolErrorCount: projection.keptToolErrorCount,
       keptToolErrorBytes: projection.keptToolErrorBytes,
+      ...("classificationReasonCounts" in projection
+        ? { classificationReasonCounts: projection.classificationReasonCounts }
+        : {}),
       estimatedDocumentCount: chunks.length,
       estimatedChunkCount: projection.estimatedChunkCount,
       importMode: mode,

--- a/tests/helpers/memory-quality-fixtures.ts
+++ b/tests/helpers/memory-quality-fixtures.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { HindsightLikeClient } from "../../extensions/types.js";
+
+export interface TranscriptMessageFixture {
+  id: string;
+  parentId?: string | null;
+  message: Record<string, unknown>;
+  timestamp?: string;
+}
+
+export interface WrittenTranscriptFixture {
+  dir: string;
+  sessionFile: string;
+}
+
+export function userMessage(id: string, content: string): TranscriptMessageFixture {
+  return { id, message: { role: "user", content } };
+}
+
+export function assistantMessage(id: string, content: string): TranscriptMessageFixture {
+  return { id, message: { role: "assistant", content } };
+}
+
+export function toolResult(
+  id: string,
+  name: string,
+  content: string,
+  options: { isError?: boolean } = {},
+): TranscriptMessageFixture {
+  return {
+    id,
+    message: {
+      role: "toolResult",
+      toolName: name,
+      name,
+      content,
+      isError: Boolean(options.isError),
+    },
+  };
+}
+
+export function recalledMemoryBlock(id: string): TranscriptMessageFixture {
+  return {
+    id,
+    message: {
+      role: "assistant",
+      customType: "hindsight-recall",
+      content:
+        "<hindsight-memory>previous retained fact that must not become source truth</hindsight-memory>",
+    },
+  };
+}
+
+export function processStatusNoise(id: string, content: string): Record<string, unknown> {
+  return { type: "process-status", id, content };
+}
+
+export function progressNoise(id: string, content: string): Record<string, unknown> {
+  return { type: "progress", id, content };
+}
+
+export function writePiTranscriptFixture(
+  name: string,
+  messages: TranscriptMessageFixture[],
+  noise: Record<string, unknown>[] = [],
+): WrittenTranscriptFixture {
+  const dir = mkdtempSync(join(tmpdir(), `pi-hindsight-${name}-`));
+  mkdirSync(join(dir, ".git"));
+  const sessionFile = join(dir, "session.jsonl");
+  const lines = [JSON.stringify({ type: "session", id: `${name}-session`, cwd: dir })];
+  let previousId: string | null = null;
+  for (const message of messages) {
+    const parentId = message.parentId === undefined ? previousId : message.parentId;
+    lines.push(
+      JSON.stringify({
+        type: "message",
+        id: message.id,
+        parentId,
+        ...(message.timestamp ? { timestamp: message.timestamp } : {}),
+        message: message.message,
+      }),
+    );
+    previousId = message.id;
+  }
+  for (const entry of noise) lines.push(JSON.stringify(entry));
+  writeFileSync(sessionFile, lines.join("\n"));
+  return { dir, sessionFile };
+}
+
+export function captureRetainClient(): HindsightLikeClient & {
+  retained: Array<{ bankId: string; content: string; options: unknown }>;
+} {
+  const retained: Array<{ bankId: string; content: string; options: unknown }> = [];
+  return {
+    retained,
+    retain: async (bankId, content, options) => {
+      retained.push({ bankId, content, options });
+    },
+    recall: async () => [],
+    reflect: async () => ({}),
+  };
+}
+
+export function parsedRetainedMessages(content: string): Record<string, unknown>[] {
+  const parsed = JSON.parse(content) as { messages?: Record<string, unknown>[] };
+  return parsed.messages ?? [];
+}

--- a/tests/import-quality-fixtures.test.ts
+++ b/tests/import-quality-fixtures.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { importPiSession } from "../extensions/import-sessions.js";
+import {
+  assistantMessage,
+  captureRetainClient,
+  parsedRetainedMessages,
+  processStatusNoise,
+  progressNoise,
+  recalledMemoryBlock,
+  toolResult,
+  userMessage,
+  writePiTranscriptFixture,
+} from "./helpers/memory-quality-fixtures.js";
+
+describe("memory quality import fixtures", () => {
+  it("keeps normal coding-session signal while dropping noisy successful tool output", async () => {
+    const fixture = writePiTranscriptFixture("quality-normal-coding", [
+      userMessage("u1", "Fix queue replay bug and keep issue #248 updated."),
+      toolResult("read1", "read", "large file output that should not become durable memory"),
+      toolResult("bash1", "bash", "npm test failed: expected queue length 1, received 0", {
+        isError: true,
+      }),
+      assistantMessage("a1", "Decision: preserve queue-first retain and add regression coverage."),
+    ]);
+    const client = captureRetainClient();
+
+    const result = await importPiSession({
+      sessionFile: fixture.sessionFile,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      client,
+    });
+
+    expect(result.documents[0]).toMatchObject({
+      rawMessageCount: 4,
+      projectedMessageCount: 3,
+      droppedToolResultCount: 1,
+      keptToolErrorCount: 1,
+      classificationReasonCounts: {
+        "user-text": 1,
+        "successful-tool-output": 1,
+        "tool-error-kept": 1,
+        "assistant-text": 1,
+      },
+    });
+    const retainedMessages = parsedRetainedMessages(client.retained[0]!.content);
+    expect(retainedMessages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ role: "user", content: expect.stringContaining("#248") }),
+        expect.objectContaining({
+          role: "toolResult",
+          toolName: "bash",
+          isError: true,
+          content: expect.stringContaining("npm test failed"),
+        }),
+        expect.objectContaining({
+          role: "assistant",
+          content: expect.stringContaining("Decision: preserve queue-first retain"),
+        }),
+      ]),
+    );
+    expect(retainedMessages[0]).toMatchObject({ id: "u1", parentId: null });
+    expect(retainedMessages[1]).toMatchObject({ id: "bash1", parentId: "read1" });
+    expect(JSON.stringify(retainedMessages)).not.toContain("large file output");
+  });
+
+  it("ignores UI/process chatter and repeated successful tool output in curated import", async () => {
+    const fixture = writePiTranscriptFixture(
+      "quality-process-noise",
+      [
+        userMessage("u1", "Continue review loop."),
+        toolResult("proc1", "process", "Refreshing checks status every 30 seconds"),
+        toolResult("proc2", "process", "Refreshing checks status every 30 seconds"),
+        toolResult("proc3", "process", "Refreshing checks status every 30 seconds"),
+        assistantMessage("a1", "Checks still pending; watcher continues."),
+      ],
+      [processStatusNoise("p1", "watcher pending"), progressNoise("p2", "spinner: waiting for CI")],
+    );
+
+    const result = await importPiSession({
+      sessionFile: fixture.sessionFile,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      dryRun: true,
+      client: { retain: async () => undefined, recall: async () => [], reflect: async () => ({}) },
+    });
+
+    expect(result.documents[0]).toMatchObject({
+      rawMessageCount: 5,
+      projectedMessageCount: 2,
+      droppedToolResultCount: 3,
+      topDroppedTools: [{ name: "process", count: 3, bytes: expect.any(Number) }],
+      classificationReasonCounts: {
+        "user-text": 1,
+        "successful-tool-output": 3,
+        "assistant-text": 1,
+      },
+    });
+  });
+
+  it("preserves workflow signals but never imports recalled memory blocks as source truth", async () => {
+    const fixture = writePiTranscriptFixture("quality-workflow-recall", [
+      recalledMemoryBlock("r1"),
+      userMessage("u1", "Start issue #248 slice 1 on branch feat/memory-quality-fixtures-248."),
+      assistantMessage(
+        "a1",
+        "Opened PR #251, commit abc1234, verification: npm run check passed; follow-up: add recall fixture.",
+      ),
+    ]);
+    const client = captureRetainClient();
+
+    const result = await importPiSession({
+      sessionFile: fixture.sessionFile,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      client,
+    });
+
+    expect(result.documents[0]).toMatchObject({
+      rawMessageCount: 2,
+      projectedMessageCount: 2,
+      droppedToolResultCount: 0,
+      classificationReasonCounts: {
+        "user-text": 1,
+        "assistant-text": 1,
+      },
+    });
+    const retained = client.retained[0]!.content;
+    expect(retained).toContain("issue #248");
+    expect(retained).toContain("PR #251");
+    expect(retained).toContain("verification: npm run check passed");
+    expect(retained).not.toContain("hindsight-memory");
+    expect(retained).not.toContain("previous retained fact");
+  });
+});


### PR DESCRIPTION
## Summary

- Add memory-quality vocabulary for durable signal, import noise, tool evidence, workflow signal, and recall contamination.
- Extract curated import classification into `extensions/import-curation-policy.ts` with typed keep/drop decisions and stable reason counts.
- Add import-quality fixture helpers plus three curated-import fixtures covering coding sessions, UI/process noise, workflow signal, and recall contamination.
- Fix curated import retained payloads to store projected messages instead of raw chunk messages.

## Linked issue

- Refs #248

## Scope

First #248 slice: quality vocabulary, fixture harness, behavior-preserving classifier extraction, and curated import regression fixtures. No new public tool family.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — deferred to later #248 memory-path slices unless CI requests it.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — deferred to later #248 memory-path slices unless CI requests it.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — CI routing should decide.
- [ ] package verification requested/passed (release/package changes)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — no live Hindsight behavior changed; fake-client import fixtures and full check cover this slice.

Additional targeted checks:

- `npm test -- --run tests/import-quality-fixtures.test.ts tests/import-sessions.test.ts`
- `npm run typecheck`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: curated import quality fixtures and projected-message import behavior make imports less noisy and safer against recall contamination.

## Risk and rollback

- Risk: Curated import content now uses projected messages in retained payloads; this matches existing preview metrics but changes payload contents by dropping successful tool output instead of only reporting it as dropped.
- Rollback/revert path: Revert this PR to restore previous inline curation logic and raw chunk message import payloads.

## Follow-ups

- Continue #248 with richer noise classification and recall-quality fixtures.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable; vocabulary was added to `CONTEXT.md`, not workflow/source-of-truth policy.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- Subagent review attempt crashed in harness shutdown before returning findings; local checks passed.

