### PR TITLE
feat: filter low-quality recall results

### DIFF
--- a/docs-site/src/content/docs/concepts/retain-recall-reflect.md
+++ b/docs-site/src/content/docs/concepts/retain-recall-reflect.md
@@ -32,6 +32,8 @@ Automatic recall runs in Pi's `context` hook. It injects an ephemeral Recall Blo
 
 Recall returns candidates, not final answers.
 
+Before rendering, Pi Hindsight drops blank memories, duplicate memory text, and prior Hindsight recall artifacts. This keeps Recall Blocks useful and prevents recall contamination from re-entering provider context.
+
 ## Reflect
 
 **Reflect** asks Hindsight to reason over stored memory for a specific question.

--- a/extensions/recall-quality-policy.ts
+++ b/extensions/recall-quality-policy.ts
@@ -1,0 +1,58 @@
+import type { RecallResultItem } from "./types.js";
+
+export type RecallQualityDropReason = "blank-memory" | "recall-contamination" | "duplicate-memory";
+
+export interface RecallQualityDecision {
+  item: RecallResultItem;
+  decision: "keep" | "drop";
+  reasons: RecallQualityDropReason[];
+}
+
+function itemText(item: RecallResultItem): string {
+  return item.text ?? item.content ?? JSON.stringify(item);
+}
+
+function normalizedMemoryText(item: RecallResultItem): string {
+  return itemText(item).replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function isRecallContamination(text: string): boolean {
+  return /<\/?hindsight[-_]memor(?:y|ies)>|customType["']?\s*:\s*["']hindsight-recall|last-recall\.json/.test(
+    text,
+  );
+}
+
+export function classifyRecallQuality(
+  item: RecallResultItem,
+  seen: Set<string>,
+): RecallQualityDecision {
+  const text = normalizedMemoryText(item);
+  const reasons: RecallQualityDropReason[] = [];
+  if (!text) reasons.push("blank-memory");
+  if (isRecallContamination(itemText(item))) reasons.push("recall-contamination");
+  if (text && seen.has(text)) reasons.push("duplicate-memory");
+  if (!reasons.length) seen.add(text);
+  return { item, decision: reasons.length ? "drop" : "keep", reasons };
+}
+
+export function filterRecallQuality(items: RecallResultItem[]): {
+  items: RecallResultItem[];
+  decisions: RecallQualityDecision[];
+  dropped: number;
+  reasonCounts: Partial<Record<RecallQualityDropReason, number>>;
+} {
+  const seen = new Set<string>();
+  const decisions = items.map((item) => classifyRecallQuality(item, seen));
+  const reasonCounts: Partial<Record<RecallQualityDropReason, number>> = {};
+  for (const decision of decisions) {
+    for (const reason of decision.reasons) reasonCounts[reason] = (reasonCounts[reason] ?? 0) + 1;
+  }
+  return {
+    items: decisions
+      .filter((decision) => decision.decision === "keep")
+      .map((decision) => decision.item),
+    decisions,
+    dropped: decisions.filter((decision) => decision.decision === "drop").length,
+    reasonCounts,
+  };
+}

--- a/extensions/recall.ts
+++ b/extensions/recall.ts
@@ -13,6 +13,7 @@ import { projectMessageText } from "./messages.js";
 import { createMemoryIdentity } from "./memory-identity.js";
 import { redactError } from "./sanitize.js";
 import { withTimeout } from "./timeout.js";
+import { filterRecallQuality } from "./recall-quality-policy.js";
 
 export interface RecallScope {
   kind?: "project" | "global";
@@ -176,7 +177,7 @@ export async function recallForContext(args: {
           ...(scope.tagsMatch ? { tagsMatch: scope.tagsMatch } : {}),
         }),
       );
-      const results = textFromRecallResponse(response);
+      const results = filterRecallQuality(textFromRecallResponse(response)).items;
       blocks.push({
         bankId: scope.bankId,
         query,

--- a/tests/recall-quality-fixtures.test.ts
+++ b/tests/recall-quality-fixtures.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { filterRecallQuality } from "../extensions/recall-quality-policy.js";
+import { recallForContext, renderRecallBlocks } from "../extensions/recall.js";
+import type { HindsightLikeClient } from "../extensions/types.js";
+
+function user(content: string): AgentMessage {
+  return { role: "user", content } as AgentMessage;
+}
+
+describe("recall quality fixtures", () => {
+  it("drops blank, duplicate, and recall-contaminated memories before rendering", () => {
+    const result = filterRecallQuality([
+      { text: "Decision: queue retain before flush.", tags: ["repo:abc"] },
+      { text: "Decision: queue retain before flush.", tags: ["repo:abc"] },
+      { text: "   " },
+      { text: "<hindsight-memory>old injected block</hindsight-memory>" },
+      { text: "<hindsight_memories>alternate injected block</hindsight_memories>" },
+      { text: "Verification: npm run check passed." },
+    ]);
+
+    expect(result.items.map((item) => item.text)).toEqual([
+      "Decision: queue retain before flush.",
+      "Verification: npm run check passed.",
+    ]);
+    expect(result.reasonCounts).toEqual({
+      "duplicate-memory": 1,
+      "blank-memory": 1,
+      "recall-contamination": 2,
+    });
+  });
+
+  it("keeps high-signal workflow memories and excludes recalled-memory artifacts in context recall", async () => {
+    const client: HindsightLikeClient = {
+      retain: async () => undefined,
+      reflect: async () => ({}),
+      recall: async () => [
+        { text: "PR #252 merged after Windows rerun; follow-up #248 next slice." },
+        { text: "PR #252 merged after Windows rerun; follow-up #248 next slice." },
+        { text: "last-recall.json contained <hindsight-memory>previous block</hindsight-memory>" },
+        { text: "Blocker: Hindsight server unavailable for live smoke." },
+      ],
+    };
+
+    const result = await recallForContext({
+      client,
+      config: DEFAULT_CONFIG,
+      scopes: [
+        { kind: "project", bankId: "project-bank", tags: ["repo:abc"], tagsMatch: "any_strict" },
+      ],
+      messages: [user("Continue #248 after PR #252.")],
+      cwd: process.cwd(),
+    });
+
+    expect(result.blocks[0]!.memoryCount).toBe(2);
+    expect(result.rendered).toContain("PR #252 merged after Windows rerun");
+    expect(result.rendered).toContain("Blocker: Hindsight server unavailable");
+    expect(result.rendered).not.toContain("last-recall.json");
+    expect(result.rendered).not.toContain("previous block");
+  });
+
+  it("renders nothing when only low-quality recall artifacts remain", () => {
+    const rendered = renderRecallBlocks([
+      {
+        bankId: "bank",
+        query: "q",
+        memoryCount: 0,
+        results: [],
+        rendered: "",
+      },
+    ]);
+
+    expect(rendered).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- Add recall-quality filtering for blank memories, duplicate memory text, and prior Hindsight recall artifacts.
- Apply the quality filter before rendering automatic Recall Blocks.
- Add recall-quality fixture coverage for workflow signal, blockers, duplicate memories, blank results, and recall contamination artifacts.
- Document the recall rendering quality filter.

## Linked issue

- Refs #248

## Scope

Third #248 slice: recall result quality filter and fixtures only.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — CI coverage gate should run for memory-path impact.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — deferred unless CI requests it.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — CI routing should decide.
- [ ] package verification requested/passed (release/package changes)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — no live Hindsight transport changed; recall filtering is covered with fake client fixtures and CI live smoke if classified.

Additional targeted checks:

- `npm run typecheck`
- `npm test -- --run tests/recall-quality-fixtures.test.ts tests/recall-format.test.ts tests/extension-hooks.test.ts`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: automatic recall rendering now suppresses blank, duplicate, and recall-contaminated memories.

## Risk and rollback

- Risk: Some duplicate memories may be intentionally redundant; the filter keeps the first exact normalized text and drops later duplicates only.
- Rollback/revert path: Revert this PR to remove `recall-quality-policy.ts` and render recall results as before.

## Follow-ups

- Continue #248 with docs/config surfacing or more fixture packs if issue breadcrumbs call for it.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
