### PR TITLE
test: cover recall query quality

### DIFF
--- a/extensions/recall.ts
+++ b/extensions/recall.ts
@@ -9,7 +9,7 @@ import type {
   ResolvedConfig,
   TagsMatch,
 } from "./types.js";
-import { projectMessageText } from "./messages.js";
+import { isInjectedHindsightMemory, projectMessageText } from "./messages.js";
 import { createMemoryIdentity } from "./memory-identity.js";
 import { redactError } from "./sanitize.js";
 import { withTimeout } from "./timeout.js";
@@ -60,10 +60,6 @@ function messageContent(message: AgentMessage): string {
 function formatQueryMessage(message: AgentMessage): string | undefined {
   const content = messageContent(message).trim();
   return content ? `${messageRole(message)}: ${content}` : undefined;
-}
-
-function isInjectedHindsightMemory(message: AgentMessage): boolean {
-  return messageContent(message).trim().startsWith("<hindsight-memory>");
 }
 
 export function truncateRecallQuery(query: string, maxChars: number): string {

--- a/tests/recall-query-quality.test.ts
+++ b/tests/recall-query-quality.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { composeRecallQuery } from "../extensions/recall.js";
+
+describe("recall query quality", () => {
+  it("uses recent workflow signal, repo hints, and bounded query context", () => {
+    const messages = [
+      { role: "user", content: "old task should fall out", timestamp: 1 },
+      { role: "assistant", content: "PR #252 merged; follow-up #248 next slice.", timestamp: 2 },
+      { role: "user", content: "Continue #248 recall quality fixture work.", timestamp: 3 },
+    ] as unknown as AgentMessage[];
+
+    const query = composeRecallQuery(messages, {
+      roles: ["user", "assistant"],
+      contextTurns: 2,
+      maxQueryChars: 220,
+      preamble: "Find relevant project memory.",
+      hints: ["scope:project", "repo:abc123", "cwd:pi-hindsight"],
+      includeDate: true,
+      now: new Date("2026-05-06T00:00:00.000Z"),
+    });
+
+    expect(query).toContain("Find relevant project memory.");
+    expect(query).toContain("Current date: 2026-05-06");
+    expect(query).toContain("Context hints: scope:project; repo:abc123; cwd:pi-hindsight");
+    expect(query).toContain("PR #252 merged");
+    expect(query).toContain("Continue #248");
+    expect(query).not.toContain("old task should fall out");
+    expect(query.length).toBeLessThanOrEqual(220);
+  });
+
+  it("ignores both recall block delimiters and custom recall message metadata", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: "<hindsight-memory>old memory</hindsight-memory>",
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: "<hindsight_memories>old memory</hindsight_memories>",
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        customType: "hindsight-recall",
+        content: "prior recall snapshot",
+        timestamp: 3,
+      },
+      { role: "user", content: "Need current design decision history.", timestamp: 4 },
+    ] as unknown as AgentMessage[];
+
+    const query = composeRecallQuery(messages, {
+      roles: ["user", "assistant"],
+      contextTurns: 4,
+      maxQueryChars: 500,
+    });
+
+    expect(query).toBe("user: Need current design decision history.");
+  });
+});


### PR DESCRIPTION
## Summary

- Reuse the shared injected-memory detector when composing recall queries.
- Add recall query quality fixtures covering bounded workflow signal, project hints, date/preamble context, and both recall-block delimiters.
- Ensure `customType: "hindsight-recall"` and alternate `<hindsight_memories>` blocks are excluded from recall queries.

## Linked issue

- Refs #248

## Scope

Fifth #248 slice: recall query contamination fixture coverage and shared detector reuse. No public surface change.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — CI coverage gate should run if classified.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — not needed unless CI requests it.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — CI routing should decide.
- [ ] package verification requested/passed (release/package changes)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — no live Hindsight transport changed.

Additional targeted checks:

- `npm run typecheck`
- `npm test -- --run tests/recall-query-quality.test.ts tests/recall-format.test.ts`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: recall queries now consistently ignore all injected Hindsight recall block forms.

## Risk and rollback

- Risk: Recall queries exclude more injected recall artifacts; this is intended and aligns with retain/import contamination policy.
- Rollback/revert path: Revert this PR to restore the previous local recall-query detector.

## Follow-ups

- Continue #248 with remaining parity/roundtrip/observability slices if appropriate.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
