### PR TITLE
feat: show import quality reason counts

### DIFF
--- a/extensions/import-curation-policy.ts
+++ b/extensions/import-curation-policy.ts
@@ -36,6 +36,7 @@ export interface CuratedImportProjection {
   projectedBytes: number;
   droppedToolResultCount: number;
   droppedToolResultBytes: number;
+  droppedTools: Array<{ name: string; count: number; bytes: number }>;
   topDroppedTools: Array<{ name: string; count: number; bytes: number }>;
   keptToolErrorCount: number;
   keptToolErrorBytes: number;
@@ -211,6 +212,14 @@ export function buildCuratedImportProjection(
       0,
     ),
     estimatedChunkCount: Math.max(1, Math.ceil(importByteLength(projected) / 8_000)),
+    droppedTools: [...droppedTools]
+      .map(([name, value]) => ({ name, ...value }))
+      .sort(
+        (left, right) =>
+          right.bytes - left.bytes ||
+          right.count - left.count ||
+          left.name.localeCompare(right.name),
+      ),
     topDroppedTools: [...droppedTools]
       .map(([name, value]) => ({ name, ...value }))
       .sort(

--- a/extensions/import-presentation.ts
+++ b/extensions/import-presentation.ts
@@ -9,9 +9,11 @@ export type ImportDocumentSummaryResult = {
     projectedBytes?: number;
     droppedToolResultCount?: number;
     droppedToolResultBytes?: number;
+    droppedTools?: Array<{ name: string; count: number; bytes: number }>;
     topDroppedTools?: Array<{ name: string; count: number; bytes: number }>;
     keptToolErrorCount?: number;
     keptToolErrorBytes?: number;
+    classificationReasonCounts?: Record<string, number>;
     estimatedDocumentCount?: number;
     estimatedChunkCount?: number;
     importMode?: "curated" | "raw" | "forensic";
@@ -35,6 +37,51 @@ export type ImportProjectPresentationResult = {
   messageCount: number;
   malformedLineCount: number;
 };
+
+function sumReasonCounts(
+  documents: ImportDocumentSummaryResult["documents"],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const document of documents) {
+    for (const [reason, count] of Object.entries(document.classificationReasonCounts ?? {})) {
+      counts[reason] = (counts[reason] ?? 0) + count;
+    }
+  }
+  return counts;
+}
+
+function formatReasonCounts(counts: Record<string, number>): string {
+  return Object.entries(counts)
+    .filter((entry): entry is [string, number] => entry[1] > 0)
+    .sort(
+      ([leftReason, leftCount], [rightReason, rightCount]) =>
+        rightCount - leftCount || leftReason.localeCompare(rightReason),
+    )
+    .map(([reason, count]) => `${reason}:${count}`)
+    .join(",");
+}
+
+function formatTopDroppedTools(documents: ImportDocumentSummaryResult["documents"]): string {
+  const totals = new Map<string, { count: number; bytes: number }>();
+  for (const document of documents) {
+    for (const tool of document.droppedTools ?? document.topDroppedTools ?? []) {
+      const current = totals.get(tool.name) ?? { count: 0, bytes: 0 };
+      totals.set(tool.name, {
+        count: current.count + tool.count,
+        bytes: current.bytes + tool.bytes,
+      });
+    }
+  }
+  return [...totals]
+    .map(([name, value]) => ({ name, ...value }))
+    .sort(
+      (left, right) =>
+        right.bytes - left.bytes || right.count - left.count || left.name.localeCompare(right.name),
+    )
+    .slice(0, 3)
+    .map((tool) => `${tool.name}:${tool.count}`)
+    .join(",");
+}
 
 export function importDocumentSummary(result: ImportDocumentSummaryResult): string {
   const modes = [...new Set(result.documents.map((document) => document.updateMode))].join(",");
@@ -73,12 +120,15 @@ export function importDocumentSummary(result: ImportDocumentSummaryResult): stri
   const importModes = [
     ...new Set(result.documents.map((document) => document.importMode).filter(Boolean)),
   ].join(",");
+  const reasonCounts = formatReasonCounts(sumReasonCounts(result.documents));
+  const topDroppedTools = formatTopDroppedTools(result.documents);
   const forensicWarning = importModes.includes("forensic")
     ? "; WARNING forensic mode preserves recalled memory blocks for audit-only use"
     : "";
+  const qualityDetails = `${reasonCounts ? `; reasons=${reasonCounts}` : ""}${topDroppedTools ? `; topDroppedTools=${topDroppedTools}` : ""}`;
   const quality =
     rawMessages || droppedToolResults || rawBytes || projectedBytes
-      ? `; mode=${importModes || "unknown"}; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; keptToolErrors=${keptErrors}; estimatedChunks=${estimatedChunks}; bytes=${projectedBytes}/${rawBytes}${forensicWarning}`
+      ? `; mode=${importModes || "unknown"}; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; keptToolErrors=${keptErrors}; estimatedChunks=${estimatedChunks}; bytes=${projectedBytes}/${rawBytes}${qualityDetails}${forensicWarning}`
       : "";
   return `documents=${result.documents.length}; update=${modes || "n/a"}; status=${statuses || "n/a"}${malformed}${quality}`;
 }

--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -37,6 +37,7 @@ export interface ImportDocumentPreview {
   projectedBytes?: number;
   droppedToolResultCount?: number;
   droppedToolResultBytes?: number;
+  droppedTools?: Array<{ name: string; count: number; bytes: number }>;
   topDroppedTools?: Array<{ name: string; count: number; bytes: number }>;
   keptToolErrorCount?: number;
   keptToolErrorBytes?: number;
@@ -212,6 +213,7 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
             projectedBytes: importByteLength(chunkMessages.map((message) => message.data)),
             droppedToolResultCount: 0,
             droppedToolResultBytes: 0,
+            droppedTools: [],
             topDroppedTools: [],
             keptToolErrorCount: chunkMessages.filter(
               (message) => message.data.role === "toolResult" && message.data.isError === true,
@@ -281,6 +283,7 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
       projectedBytes: projection.projectedBytes,
       droppedToolResultCount: projection.droppedToolResultCount,
       droppedToolResultBytes: projection.droppedToolResultBytes,
+      ...("droppedTools" in projection ? { droppedTools: projection.droppedTools } : {}),
       topDroppedTools: projection.topDroppedTools,
       keptToolErrorCount: projection.keptToolErrorCount,
       keptToolErrorBytes: projection.keptToolErrorBytes,

--- a/tests/import-presentation.test.ts
+++ b/tests/import-presentation.test.ts
@@ -16,12 +16,55 @@ describe("import presentation", () => {
             droppedToolResultCount: 2,
             keptToolErrorCount: 1,
             estimatedChunkCount: 1,
+            topDroppedTools: [
+              { name: "read", count: 2, bytes: 900 },
+              { name: "grep", count: 1, bytes: 100 },
+            ],
+            classificationReasonCounts: {
+              "tool-filter-excluded": 2,
+              "tool-error-kept": 1,
+              "assistant-text": 1,
+            },
             importMode: "forensic",
           },
         ],
       }),
     ).toContain(
-      "mode=forensic; projected=3/5 messages; droppedToolResults=2; keptToolErrors=1; estimatedChunks=1; bytes=400/1000; WARNING forensic mode preserves recalled memory blocks for audit-only use",
+      "mode=forensic; projected=3/5 messages; droppedToolResults=2; keptToolErrors=1; estimatedChunks=1; bytes=400/1000; reasons=tool-filter-excluded:2,assistant-text:1,tool-error-kept:1; topDroppedTools=read:2,grep:1; WARNING forensic mode preserves recalled memory blocks for audit-only use",
+    );
+  });
+
+  it("aggregates complete dropped-tool totals before slicing preview output", () => {
+    const documents = [0, 1].map((chunk) => ({
+      updateMode: "replace",
+      status: "pending",
+      rawMessageCount: 10,
+      projectedMessageCount: 5,
+      rawBytes: 10_000,
+      projectedBytes: 1_000,
+      droppedToolResultCount: 6,
+      keptToolErrorCount: 0,
+      estimatedChunkCount: 1,
+      importMode: "curated" as const,
+      topDroppedTools: [
+        { name: `one-off-${chunk}-1`, count: 1, bytes: 1_000 },
+        { name: `one-off-${chunk}-2`, count: 1, bytes: 900 },
+        { name: `one-off-${chunk}-3`, count: 1, bytes: 800 },
+        { name: `one-off-${chunk}-4`, count: 1, bytes: 700 },
+        { name: `one-off-${chunk}-5`, count: 1, bytes: 600 },
+      ],
+      droppedTools: [
+        { name: `one-off-${chunk}-1`, count: 1, bytes: 1_000 },
+        { name: `one-off-${chunk}-2`, count: 1, bytes: 900 },
+        { name: `one-off-${chunk}-3`, count: 1, bytes: 800 },
+        { name: `one-off-${chunk}-4`, count: 1, bytes: 700 },
+        { name: `one-off-${chunk}-5`, count: 1, bytes: 600 },
+        { name: "recurring-medium", count: 3, bytes: 550 },
+      ],
+    }));
+
+    expect(importDocumentSummary({ documents })).toContain(
+      "topDroppedTools=recurring-medium:6,one-off-0-1:1,one-off-1-1:1",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Show curated import classification reason counts in import preview/presentation summaries.
- Aggregate and display the top dropped tools by count/bytes so preview output explains the biggest noise sources.
- Keep the existing concise one-line import summary while adding stable `reasons=` and `topDroppedTools=` fields.

## Linked issue

- Refs #248

## Scope

Sixth #248 slice: import preview observability for quality counts only. No import filtering behavior change.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — CI coverage gate should run if classified.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — not needed unless CI requests it.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — CI routing should decide.
- [ ] package verification requested/passed (release/package changes)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — no live Hindsight transport changed.

Additional targeted checks:

- `npm run typecheck`
- `npm test -- --run tests/import-presentation.test.ts tests/import-quality-fixtures.test.ts tests/import-sessions.test.ts`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: import previews now show concise quality reason counts and top dropped tools.

## Risk and rollback

- Risk: Import preview output includes more detail; output remains concise and deterministic.
- Rollback/revert path: Revert this PR to remove `reasons=` and `topDroppedTools=` from import summaries.

## Follow-ups

- Continue #248 with remaining core-memory observability/parity slices if appropriate.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
