### PR TITLE
test: cover import to recall roundtrip

### DIFF
--- a/tests/import-recall-roundtrip.test.ts
+++ b/tests/import-recall-roundtrip.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { importPiSession } from "../extensions/import-sessions.js";
+import { recallForContext } from "../extensions/recall.js";
+import type { HindsightLikeClient } from "../extensions/types.js";
+import {
+  assistantMessage,
+  captureRetainClient,
+  parsedRetainedMessages,
+  recalledMemoryBlock,
+  toolResult,
+  userMessage,
+  writePiTranscriptFixture,
+} from "./helpers/memory-quality-fixtures.js";
+
+function textField(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value ?? "");
+}
+
+function recallClientFromImportedMessages(retained: {
+  options: unknown;
+  content: string;
+}): HindsightLikeClient {
+  const options = retained.options as { tags?: string[] };
+  const messages = parsedRetainedMessages(retained.content);
+  return {
+    retain: async () => undefined,
+    reflect: async () => ({}),
+    recall: async (_bankId, _query, recallOptions) => {
+      const tags = options.tags ?? [];
+      const requestedTags = recallOptions?.tags ?? [];
+      const matchesScope =
+        requestedTags.length === 0 || requestedTags.some((tag) => tags.includes(tag));
+      if (!matchesScope) return [];
+      return messages.map((message) => ({
+        text: `${textField(message.role)}: ${textField(message.content)}`,
+        tags,
+      }));
+    },
+  };
+}
+
+describe("import to recall roundtrip quality", () => {
+  it("preserves durable signal through curated import and recall while excluding known noise", async () => {
+    const fixture = writePiTranscriptFixture("roundtrip-quality", [
+      userMessage("u1", "Fix retain queue race for issue #248."),
+      toolResult("read1", "read", "huge source file output should not survive roundtrip"),
+      toolResult("bash1", "bash", "npm test failed: expected 2 got 1", { isError: true }),
+      assistantMessage(
+        "a1",
+        "Decision: keep queue-first retain behavior; PR #260 will add regression coverage.",
+      ),
+      recalledMemoryBlock("r1"),
+    ]);
+    const importClient = captureRetainClient();
+
+    const imported = await importPiSession({
+      sessionFile: fixture.sessionFile,
+      bankId: "project-bank",
+      config: DEFAULT_CONFIG,
+      client: importClient,
+    });
+    const retained = importClient.retained[0]!;
+    const importedTags = (retained.options as { tags?: string[] }).tags ?? [];
+    const repoTag = importedTags.find((tag) => tag.startsWith("repo:"));
+    expect(repoTag).toBeDefined();
+    const recall = await recallForContext({
+      client: recallClientFromImportedMessages(retained),
+      config: DEFAULT_CONFIG,
+      scopes: [
+        { kind: "project", bankId: "project-bank", tags: [repoTag!], tagsMatch: "any_strict" },
+      ],
+      messages: [{ role: "user", content: "What happened with issue #248?" } as never],
+      cwd: fixture.dir,
+    });
+
+    expect(imported.documents[0]).toMatchObject({
+      rawMessageCount: 4,
+      projectedMessageCount: 3,
+      droppedToolResultCount: 1,
+      keptToolErrorCount: 1,
+    });
+    expect(recall.rendered).toContain("Fix retain queue race for issue #248");
+    expect(recall.rendered).toContain("npm test failed: expected 2 got 1");
+    expect(recall.rendered).toContain("Decision: keep queue-first retain behavior");
+    expect(recall.rendered).toContain("PR #260");
+    expect(recall.rendered).not.toContain("huge source file output");
+    expect(recall.rendered).not.toContain("previous retained fact");
+    expect(recall.rendered).not.toContain("hindsight-recall");
+  });
+});


### PR DESCRIPTION
## Summary

- Add an import-to-recall roundtrip fixture using fake clients.
- Verify curated import keeps durable signal that later recall can render: user task, failed command evidence, assistant decision, PR reference.
- Verify known noise does not survive the roundtrip: successful noisy tool output and recalled memory artifacts.

## Linked issue

- Refs #248

## Scope

Seventh #248 slice: eval-style roundtrip fixture only. No production behavior change.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — CI coverage gate should run if classified.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — not needed unless CI requests it.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — CI routing should decide.
- [ ] package verification requested/passed (release/package changes)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — fake-client fixture only; no live transport changed.

Additional targeted checks:

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run tests/import-recall-roundtrip.test.ts tests/import-quality-fixtures.test.ts tests/recall-quality-fixtures.test.ts`

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

## Risk and rollback

- Risk: Test-only fixture may need adjustment if import/recall output wording changes.
- Rollback/revert path: Revert this PR to remove the roundtrip fixture.

## Follow-ups

- Continue #248 with remaining internal parity/observability slices if appropriate.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
