### PR TITLE
feat: add internal recall reflect option parity

### DIFF
--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -78,6 +78,9 @@ export function reflectRequestBody(
     context?: string;
     budget?: string;
     responseSchema?: unknown;
+    factTypes?: Array<"world" | "experience" | "observation">;
+    excludeMentalModels?: boolean;
+    excludeMentalModelIds?: string[];
     tags?: string[];
     tagsMatch?: string;
     tagGroups?: unknown[];
@@ -88,6 +91,13 @@ export function reflectRequestBody(
     ...(options.context ? { context: options.context } : {}),
     budget: options.budget ?? "low",
     ...(options.responseSchema ? { response_schema: options.responseSchema } : {}),
+    ...(options.factTypes ? { fact_types: options.factTypes } : {}),
+    ...(options.excludeMentalModels !== undefined
+      ? { exclude_mental_models: options.excludeMentalModels }
+      : {}),
+    ...(options.excludeMentalModelIds
+      ? { exclude_mental_model_ids: options.excludeMentalModelIds }
+      : {}),
     ...(options.tagGroups ? { tag_groups: options.tagGroups } : {}),
     ...(options.tagGroups ? {} : options.tags ? { tags: options.tags } : {}),
     ...(options.tagGroups ? {} : options.tagsMatch ? { tags_match: options.tagsMatch } : {}),

--- a/extensions/memory-recall-operations.ts
+++ b/extensions/memory-recall-operations.ts
@@ -8,10 +8,24 @@ import type { HindsightTagGroup, ResolvedConfig, TagsMatch } from "./types.js";
 
 interface ExplicitRecallFilters {
   queryTimestamp?: string;
+  types?: string[];
+  trace?: boolean;
+  includeEntities?: boolean;
+  maxEntityTokens?: number;
+  includeChunks?: boolean;
+  maxChunkTokens?: number;
+  includeSourceFacts?: boolean;
+  maxSourceFactsTokens?: number;
   tags?: string[];
   tagsMatch?: TagsMatch;
   tagGroups?: HindsightTagGroup[];
   signal?: AbortSignal;
+}
+
+interface ExplicitReflectFilters extends Omit<ExplicitRecallFilters, "queryTimestamp" | "types"> {
+  factTypes?: Array<"world" | "experience" | "observation">;
+  excludeMentalModels?: boolean;
+  excludeMentalModelIds?: string[];
 }
 
 function recallTagsForBank(
@@ -67,6 +81,22 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
         ...(filters.queryTimestamp || config.recall.queryTimestamp
           ? { queryTimestamp: filters.queryTimestamp ?? config.recall.queryTimestamp }
           : {}),
+        ...(filters.types ? { types: filters.types } : {}),
+        ...(filters.trace !== undefined ? { trace: filters.trace } : {}),
+        ...(filters.includeEntities !== undefined
+          ? { includeEntities: filters.includeEntities }
+          : {}),
+        ...(filters.maxEntityTokens !== undefined
+          ? { maxEntityTokens: filters.maxEntityTokens }
+          : {}),
+        ...(filters.includeChunks !== undefined ? { includeChunks: filters.includeChunks } : {}),
+        ...(filters.maxChunkTokens !== undefined ? { maxChunkTokens: filters.maxChunkTokens } : {}),
+        ...(filters.includeSourceFacts !== undefined
+          ? { includeSourceFacts: filters.includeSourceFacts }
+          : {}),
+        ...(filters.maxSourceFactsTokens !== undefined
+          ? { maxSourceFactsTokens: filters.maxSourceFactsTokens }
+          : {}),
         ...scopedTagFilterOptions(scopeTags, filters),
         ...(filters.signal ? { signal: filters.signal } : {}),
       });
@@ -79,7 +109,7 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
       context?: string,
       bank?: string,
       responseSchema?: Record<string, unknown>,
-      filters: Omit<ExplicitRecallFilters, "queryTimestamp"> = {},
+      filters: ExplicitReflectFilters = {},
     ) {
       const config = deps.getConfig();
       const bankId = resolveOperationBank({
@@ -92,6 +122,13 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
         ...(context ? { context } : {}),
         budget: config.recall.budget,
         ...(responseSchema ? { responseSchema } : {}),
+        ...(filters.factTypes ? { factTypes: filters.factTypes } : {}),
+        ...(filters.excludeMentalModels !== undefined
+          ? { excludeMentalModels: filters.excludeMentalModels }
+          : {}),
+        ...(filters.excludeMentalModelIds
+          ? { excludeMentalModelIds: filters.excludeMentalModelIds }
+          : {}),
         ...scopedTagFilterOptions(scopeTags, filters),
         ...(filters.signal ? { signal: filters.signal } : {}),
       });

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -306,6 +306,13 @@ export interface HindsightLikeClient {
       maxTokens?: number;
       budget?: Budget;
       queryTimestamp?: string;
+      trace?: boolean;
+      includeEntities?: boolean;
+      maxEntityTokens?: number;
+      includeChunks?: boolean;
+      maxChunkTokens?: number;
+      includeSourceFacts?: boolean;
+      maxSourceFactsTokens?: number;
       tags?: string[];
       tagsMatch?: TagsMatch;
       tagGroups?: HindsightTagGroup[];
@@ -319,6 +326,9 @@ export interface HindsightLikeClient {
       context?: string;
       budget?: Budget;
       responseSchema?: Record<string, unknown>;
+      factTypes?: Array<"world" | "experience" | "observation">;
+      excludeMentalModels?: boolean;
+      excludeMentalModelIds?: string[];
       tags?: string[];
       tagsMatch?: TagsMatch;
       tagGroups?: HindsightTagGroup[];

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -105,6 +105,14 @@ describe("memory operations", () => {
 
     await operations.recall(cwd, "query", undefined, undefined, {
       queryTimestamp: "2024-02-01T00:00:00Z",
+      types: ["observation"],
+      trace: true,
+      includeEntities: false,
+      maxEntityTokens: 128,
+      includeChunks: true,
+      maxChunkTokens: 512,
+      includeSourceFacts: true,
+      maxSourceFactsTokens: 1024,
     });
     await operations.retainExplicit({
       cwd,
@@ -122,6 +130,9 @@ describe("memory operations", () => {
         properties: { answer: { type: "string" } },
       },
       {
+        factTypes: ["observation"],
+        excludeMentalModels: true,
+        excludeMentalModelIds: ["model:stale"],
         tags: ["topic:hindsight"],
         tagsMatch: "all_strict",
         tagGroups: [{ tags: ["kind:decision"], match: "any_strict" }],
@@ -130,12 +141,23 @@ describe("memory operations", () => {
 
     expect(calls.find((call) => call.method === "recall")?.options).toMatchObject({
       queryTimestamp: "2024-02-01T00:00:00Z",
+      types: ["observation"],
+      trace: true,
+      includeEntities: false,
+      maxEntityTokens: 128,
+      includeChunks: true,
+      maxChunkTokens: 512,
+      includeSourceFacts: true,
+      maxSourceFactsTokens: 1024,
     });
     expect(calls.find((call) => call.method === "retain")?.options).toMatchObject({
       entities: [{ text: "Alice", type: "person" }],
     });
     expect(calls.find((call) => call.method === "reflect")?.options).toMatchObject({
       responseSchema: { type: "object", properties: { answer: { type: "string" } } },
+      factTypes: ["observation"],
+      excludeMentalModels: true,
+      excludeMentalModelIds: ["model:stale"],
       tagGroups: [
         { tags: [expect.stringMatching(/^repo:/)], match: "any_strict" },
         { tags: ["topic:hindsight"], match: "all_strict" },


### PR DESCRIPTION
## Summary

- Add internal recall option parity for trace, entity, chunk, and source-fact options.
- Add internal reflect option parity for fact types and mental-model exclusions.
- Preserve scope-tag isolation by still composing Pi scope tags/tag groups around all advanced recall/reflect options.
- Map reflect parity fields through the REST fallback request body.

## Linked issue

- Refs #248

## Scope

Eighth #248 slice: internal recall/reflect option parity plumbing only. No new public tool families.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — CI coverage gate should run if classified.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — not needed unless CI requests it.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — CI routing should decide.
- [ ] package verification requested/passed (release/package changes)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — no new live transport endpoint; live smoke expected if CI classifies memory-path.

Additional targeted checks:

- `npm run typecheck`
- `npm test -- --run tests/memory-operations.test.ts tests/client-integration.test.ts tests/client-rest.test.ts`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: internal recall/reflect request mapping now supports more Hindsight-compatible options while keeping public tool scope unchanged.

## Risk and rollback

- Risk: Advanced internal options are passed only when explicitly provided; default behavior remains unchanged.
- Rollback/revert path: Revert this PR to remove the new option fields and REST mapping.

## Follow-ups

- Continue #248 with any remaining retain parity/observability or docs decisions.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
