### PR TITLE
docs: clarify core memory quality non-goals

### DIFF
--- a/docs-site/src/content/docs/concepts/retain-recall-reflect.md
+++ b/docs-site/src/content/docs/concepts/retain-recall-reflect.md
@@ -48,6 +48,29 @@ Use Reflect for:
 
 Do not route all automatic memory behavior through Reflect. Pi Hindsight exposes Reflect as an explicit tool/command path.
 
+## Core quality before admin surfaces
+
+Pi Hindsight's release path is deliberately narrow: make Retain, Recall, Reflect, and Import reliable before adding Hindsight administration or exploration surfaces.
+
+Current priority:
+
+- preserve durable source evidence without summaries
+- keep automatic recall scoped, bounded, and ephemeral
+- keep reflect explicit and memory-grounded
+- make curated imports signal-preserving and low-noise by default
+- expose enough status, receipts, and last-recall visibility to debug the core path safely
+
+Deferred unless a new issue reopens scope:
+
+- audit-log tools
+- webhook tools
+- graph or entity browsers
+- document or memory-unit browsers
+- operation-management tools
+- destructive bank administration UI
+
+These Hindsight features can still inform compatibility work, but they should not displace core memory quality work.
+
 ## Mental models
 
 Mental models are saved Hindsight reflect responses for recurring questions. They are useful for stable project or user context, but they are not replacements for source import material.

--- a/docs-site/src/content/docs/reference/hindsight-api-links.md
+++ b/docs-site/src/content/docs/reference/hindsight-api-links.md
@@ -22,4 +22,14 @@ Pi Hindsight defines repository-specific policy around Hindsight:
 - deterministic import document IDs
 - local diagnostics and setup commands
 
+Pi Hindsight should use newer Hindsight request fields when they improve the core Retain/Recall/Reflect/Import loop. It should not chase every Hindsight administration or exploration API before the core loop is release-ready.
+
+Deferred Hindsight surfaces need a new design issue before implementation:
+
+- audit logs
+- webhooks
+- graph/entity/document browsers
+- memory-unit or operation-management tools
+- destructive bank administration UI
+
 When this documentation conflicts with official Hindsight behavior, follow official Hindsight docs and fix Pi Hindsight documentation or implementation.


### PR DESCRIPTION
## Summary

- Document that the release path prioritizes Retain, Recall, Reflect, and Import quality.
- Clarify that Hindsight admin/exploration surfaces are deferred behind a new design issue.
- Keep official Hindsight docs as the API/behavior source of truth while narrowing Pi Hindsight's current product scope.

## Linked issue

- Refs #248

## Scope

Tenth #248 slice: documentation-only scope clarification for core memory quality and deferred non-goals.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — not needed because docs-only scope.
- [ ] `npm run typecheck:tsc` — not needed because docs-only scope.
- [ ] full matrix requested/passed — not needed because docs-only scope.
- [ ] package verification requested/passed — not needed because docs-only scope.
- [ ] `npm run pack:verify` — not needed because docs-only scope.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — not needed because docs-only scope.

Additional targeted checks:

- `npm run docs:check`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: documentation now states the core-memory quality stance and deferred Hindsight admin/debug surfaces.

## Risk and rollback

- Risk: Low; docs-only clarification could be too narrow if priorities change.
- Rollback/revert path: Revert this PR or replace the deferred-scope wording with a new design decision.

## Follow-ups

- Continue #248 with remaining core-quality slices or return to #233 release-readiness review when backlog is exhausted.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
