### PR TITLE
feat: add import status activity labels

### DIFF
--- a/extensions/status.ts
+++ b/extensions/status.ts
@@ -12,7 +12,11 @@ export type HindsightActivity =
   | "retaining"
   | "retained"
   | "retain-queued"
-  | "retain-failed";
+  | "retain-failed"
+  | "importing"
+  | "imported"
+  | "import-queued"
+  | "import-failed";
 
 export interface HindsightStatusState {
   projectBankId: string;
@@ -62,6 +66,14 @@ export function formatHindsightActivity(
       return queueRemaining !== undefined ? `queued:${queueRemaining}` : "queued";
     case "retain-failed":
       return "retain-failed";
+    case "importing":
+      return "importing";
+    case "imported":
+      return queueRemaining ? `imported+queued:${queueRemaining}` : "imported";
+    case "import-queued":
+      return queueRemaining !== undefined ? `import-queued:${queueRemaining}` : "import-queued";
+    case "import-failed":
+      return "import-failed";
     default:
       return "idle";
   }
@@ -76,6 +88,8 @@ function prefix(style: StatusStyle, activity: HindsightActivity): string {
     if (activity.includes("failed") || activity === "offline") return "󰧑";
     if (activity === "recalling" || activity === "recalled") return "󰑓";
     if (activity === "retaining" || activity === "retained") return "󰆓";
+    if (activity === "importing" || activity === "imported" || activity === "import-queued")
+      return "󰋺";
     return "󰍛";
   }
   return "mem";

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -58,6 +58,41 @@ describe("formatHindsightStatus", () => {
     ).toBe("🧠 recalling");
   });
 
+  it("shows import activity labels without implying retain success", () => {
+    const config = {
+      ...DEFAULT_CONFIG,
+      status: {
+        style: "text" as const,
+        detail: "activity" as const,
+        maxLength: 40,
+        showActivity: true,
+      },
+    };
+    expect(
+      formatHindsightStatus(config, {
+        cwd: "/repo",
+        projectBankId: "bank",
+        activity: "importing",
+      }),
+    ).toBe("mem:importing");
+    expect(
+      formatHindsightStatus(config, {
+        cwd: "/repo",
+        projectBankId: "bank",
+        activity: "imported",
+        queueRemaining: 2,
+      }),
+    ).toBe("mem:imported+queued:2");
+    expect(
+      formatHindsightStatus(config, {
+        cwd: "/repo",
+        projectBankId: "bank",
+        activity: "import-queued",
+        queueRemaining: 3,
+      }),
+    ).toBe("mem:import-queued:3");
+  });
+
   it("uses connected and offline health labels", () => {
     const config = {
       ...DEFAULT_CONFIG,
@@ -76,7 +111,7 @@ describe("formatHindsightStatus", () => {
     ).toBe("🤯 offline");
   });
 
-  it("uses brain explosion for failed emoji status", () => {
+  it("uses error prefixes for failed emoji and nerdfont status", () => {
     const config = {
       ...DEFAULT_CONFIG,
       status: {
@@ -93,6 +128,23 @@ describe("formatHindsightStatus", () => {
         activity: "recall-failed",
       }),
     ).toBe("🤯 recall-failed");
+
+    const nerdfontConfig = {
+      ...DEFAULT_CONFIG,
+      status: {
+        style: "nerdfont" as const,
+        detail: "activity" as const,
+        maxLength: 40,
+        showActivity: true,
+      },
+    };
+    expect(
+      formatHindsightStatus(nerdfontConfig, {
+        cwd: "/repo",
+        projectBankId: "bank",
+        activity: "import-failed",
+      }),
+    ).toBe("󰧑 import-failed");
   });
 
   it("uses idle text instead of implying verified connectivity", () => {


### PR DESCRIPTION
## Summary

- Add import-specific status activity labels for importing, imported, queued import delivery, and import failure states.
- Keep retained vs imported status language separate so queued import delivery does not imply automatic retain success.
- Add status formatter coverage for import activity and queued import delivery counts.

## Linked issue

- Refs #248

## Scope

Eleventh #248 slice: status activity vocabulary only. No import delivery behavior changes.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — CI coverage gate should run if classified.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — not run locally because primary typecheck and CI routing cover this small status slice.
- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`) — CI routing should decide.
- [ ] package verification requested/passed (release/package changes)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — not needed because this only formats local status labels.

Additional targeted checks:

- `npm run typecheck`
- `npm test -- --run tests/status.test.ts tests/diagnostics.test.ts`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: status output can now represent import-specific activity states distinctly from retain activity.

## Risk and rollback

- Risk: Low; only status formatting vocabulary is extended.
- Rollback/revert path: Revert this PR to restore previous status labels.

## Follow-ups

- #248 will continue with any later slice that wires import commands to these activity states if live status updates during long imports are needed.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

