### PR TITLE
docs: document import status labels

### DIFF
--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -12,7 +12,7 @@ For generated details of registered tools and editable config fields, see [Gener
 /hindsight
 ```
 
-Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Press `m` to open the read-only mental model list/detail view; use the Hindsight web interface for create, edit, refresh, or delete.
+Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. Status activity can distinguish recall, retain, and import work, including `importing`, `imported`, `import-queued`, and `import-failed`. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Press `m` to open the read-only mental model list/detail view; use the Hindsight web interface for create, edit, refresh, or delete.
 
 ## Setup and config
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -10,7 +10,7 @@ For a generated reference of registered tools, commands, and editable config fie
 /hindsight
 ```
 
-Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Press `m` to open the read-only mental model list/detail view; use the Hindsight web interface for create, edit, refresh, or delete.
+Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. Status activity can distinguish recall, retain, and import work, including `importing`, `imported`, `import-queued`, and `import-failed`. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Press `m` to open the read-only mental model list/detail view; use the Hindsight web interface for create, edit, refresh, or delete.
 
 ## Setup and config
 


### PR DESCRIPTION
## Summary

- Document import-specific status activity labels in the tools and commands reference.
- Keep packaged docs and docs-site content aligned.

## Linked issue

- Refs #248

## Scope

Twelfth #248 slice: docs-only follow-up for import status labels added in PR #261.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — not needed because docs-only scope.
- [ ] `npm run typecheck:tsc` — not needed because docs-only scope.
- [ ] full matrix requested/passed — not needed because docs-only scope.
- [ ] package verification requested/passed — not needed because docs-only scope.
- [ ] `npm run pack:verify` — not needed because docs-only scope.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — not needed because docs-only scope.

Additional targeted checks:

- `npm run docs:check`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: status documentation now lists import-specific activity labels.

## Risk and rollback

- Risk: Low; docs-only wording change.
- Rollback/revert path: Revert this PR.

## Follow-ups

- Continue #248 for any remaining core-quality backlog.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
