### PR TITLE
chore: add PR shepherd workflow

### DIFF
--- a/.pi/agents/pr-shepherd.md
+++ b/.pi/agents/pr-shepherd.md
@@ -1,0 +1,52 @@
+---
+name: pr-shepherd
+description: Own one GitHub PR from an isolated worktree: create/update PR, watch CI/Codex, fix findings, resolve threads, merge, clean up, and report via intercom.
+tools: bash, edit, write, read, grep, find_files, process, schedule_prompt, intercom, todo
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+---
+
+You are pr-shepherd for luxus/pi-hindsight. Own exactly one GitHub PR from one dedicated git worktree.
+
+Mission:
+- Create or finish one focused PR linked to a GitHub issue.
+- Keep the parent/orchestrator unblocked.
+- Report progress and blockers through intercom.
+
+Hard rules:
+- Work only in the cwd/worktree given by the parent. Do not edit the parent worktree.
+- Do not push directly to main. Do not tag releases.
+- Do not bypass hooks or checks. Never use --no-verify.
+- Keep one focused vertical slice per PR. No drive-by refactors.
+- PR must use the repository template completely. No TODO/TBD placeholders.
+- Merge only when CI/checks are green and Codex has commented, reviewed, or given a clear thumbs-up/no-major-issues signal.
+- If Codex leaves findings, fix them, run verification, comment with what changed, and resolve the review thread.
+- If a product/design decision is ambiguous, ask the parent via intercom before changing scope.
+- If checks fail from clear infrastructure flakes, rerun once and report. If failure is code-related, fix it.
+- After merge, sync local main if this worktree has main, report merge SHA/PR/verification, and stop.
+
+Loop:
+1. Confirm issue, branch, cwd, target scope, and base.
+2. Inspect relevant files and current diff.
+3. Implement or finish the focused slice.
+4. Run targeted checks, then required repo checks (`npm run check`; add coverage/tsc/live smoke when memory-path requires it).
+5. Commit with Conventional Commit subject.
+6. Push branch and open/update PR with complete template.
+7. Start CI watcher and poll PR state/Codex.
+8. While waiting, send concise intercom progress updates for state changes only.
+9. For failed checks or Codex findings: inspect, fix, verify, amend or commit logically, push, comment, resolve threads.
+10. When ready: merge via PR, delete branch if allowed, report completion via intercom.
+
+Intercom protocol:
+- Progress update: use `intercom send` to parent if parent name is supplied; include PR URL, state, next wait.
+- Decision/blocker: use `intercom ask` with exact choices and recommendation.
+- Completion: use `intercom ask` or `send` with merged PR, commit/merge SHA, verification, next suggested slice.
+
+Codex thread resolution:
+- Use GitHub GraphQL `resolveReviewThread` for threads you actually fixed or intentionally documented.
+- Do not mark unresolved if you did not address it. Ask parent if rejecting a finding.
+
+Output format:
+- terse final summary: PR URL, merge/fix status, checks, Codex status, parent action needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ Use this loop for each slice:
 11. Comment on and close the issue with delivered behavior, verification, and follow-up issues.
 12. Return to `main`, sync with `origin/main`, and continue with the next slice.
 
+When a maintainer asks for the PR shepherd workflow, create a dedicated git worktree for the slice, launch the `pr-shepherd` project subagent from that worktree, and let the shepherd own the PR through CI, Codex feedback, review-thread resolution, merge, and cleanup reporting. The parent/orchestrator must keep the main worktree clean and only start parallel implementation work when the next slice is independent or explicitly stacked. See `docs/agents/pr-shepherd-workflow.md`.
+
 Keep exactly one implementation slice active at a time unless the user explicitly asks for parallel work. Do not mix unrelated cleanup or drive-by refactors into the current branch. If a review uncovers new work outside the slice, create a follow-up issue and continue after the current PR is complete.
 
 ### Commit and PR discipline for agents
@@ -326,3 +328,7 @@ Triage uses the default five-label vocabulary. See `docs/agents/triage-labels.md
 ### Domain docs
 
 This repo uses a single-context domain documentation layout. See `docs/agents/domain.md`.
+
+### PR shepherd
+
+Use the project `pr-shepherd` subagent for one-worktree, one-PR CI/Codex/merge stewardship when maintainers want parent work to continue during review waits. See `docs/agents/pr-shepherd-workflow.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,8 @@ For each slice:
 11. Comment on and close the issue with delivered behavior, verification, and follow-up issue links.
 12. Return to `main`, sync with `origin/main`, and continue with the next slice.
 
+A maintainer may ask agents to use the PR shepherd workflow for this loop. In that mode, create a dedicated git worktree for the slice, launch the `pr-shepherd` project subagent from that worktree, and let the shepherd own the PR through CI, Codex feedback, review-thread resolution, merge, and cleanup reporting. The parent/orchestrator must keep the main worktree clean and only start parallel implementation work when the next slice is independent or explicitly stacked. See `docs/agents/pr-shepherd-workflow.md`.
+
 Keep one implementation slice active at a time unless a maintainer explicitly asks for parallel work. Do not mix unrelated cleanup, formatting sweeps, or drive-by refactors into the current branch. If review uncovers work outside the slice, create a follow-up issue and continue after the current PR is complete.
 
 ## Commit and PR discipline for agents

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -154,6 +154,7 @@ export default defineConfig({
                 { label: "Issue tracker", slug: "development/agents/issue-tracker" },
                 { label: "Domain docs", slug: "development/agents/domain" },
                 { label: "Triage labels", slug: "development/agents/triage-labels" },
+                { label: "PR shepherd", slug: "development/agents/pr-shepherd-workflow" },
               ],
             },
           ],

--- a/docs-site/src/content/docs/development/agents-root.md
+++ b/docs-site/src/content/docs/development/agents-root.md
@@ -60,6 +60,8 @@ Use this loop for each slice:
 11. Comment on and close the issue with delivered behavior, verification, and follow-up issues.
 12. Return to `main`, sync with `origin/main`, and continue with the next slice.
 
+When a maintainer asks for the PR shepherd workflow, create a dedicated git worktree for the slice, launch the `pr-shepherd` project subagent from that worktree, and let the shepherd own the PR through CI, Codex feedback, review-thread resolution, merge, and cleanup reporting. The parent/orchestrator must keep the main worktree clean and only start parallel implementation work when the next slice is independent or explicitly stacked. See `docs/agents/pr-shepherd-workflow.md`.
+
 Keep exactly one implementation slice active at a time unless the user explicitly asks for parallel work. Do not mix unrelated cleanup or drive-by refactors into the current branch. If a review uncovers new work outside the slice, create a follow-up issue and continue after the current PR is complete.
 
 ### Commit and PR discipline for agents
@@ -328,3 +330,7 @@ Triage uses the default five-label vocabulary. See `docs/agents/triage-labels.md
 ### Domain docs
 
 This repo uses a single-context domain documentation layout. See `docs/agents/domain.md`.
+
+### PR shepherd
+
+Use the project `pr-shepherd` subagent for one-worktree, one-PR CI/Codex/merge stewardship when maintainers want parent work to continue during review waits. See `docs/agents/pr-shepherd-workflow.md`.

--- a/docs-site/src/content/docs/development/agents/pr-shepherd-workflow.md
+++ b/docs-site/src/content/docs/development/agents/pr-shepherd-workflow.md
@@ -1,0 +1,82 @@
+---
+title: PR shepherd workflow
+description: Worktree and subagent workflow for shepherding one PR through CI, Codex, fixes, merge, and cleanup.
+---
+
+Use the `pr-shepherd` project subagent when a PR needs end-to-end CI, Codex, and merge stewardship without blocking the parent agent.
+
+## Roles
+
+- **Parent/orchestrator** selects the issue slice, decides whether parallel work is safe, creates or names the worktree, and launches the shepherd.
+- **PR shepherd** owns exactly one branch and one PR from the supplied worktree.
+- **Codex** remains a required review signal before merge.
+
+## Worktree layout
+
+Create one worktree per active PR:
+
+```bash
+git fetch origin main
+git worktree add ../pi-hindsight-worktrees/pr-263-pr-shepherd -b chore/pr-shepherd-workflow-263 origin/main
+```
+
+Prefer a sibling worktree directory outside the repository so generated files and nested Git metadata do not pollute the main checkout.
+
+## Launch shape
+
+Launch the project agent from the PR worktree:
+
+```ts
+subagent({
+  agent: "pr-shepherd",
+  cwd: "../pi-hindsight-worktrees/pr-263-pr-shepherd",
+  async: true,
+  context: "fresh",
+  task: "Own issue #263. Implement the focused workflow slice, open the PR, watch CI and Codex, fix findings, resolve review threads, merge when ready, and report progress to the parent via intercom.",
+});
+```
+
+If the parent session has a known intercom name, include it in the task so the shepherd can send progress updates and ask blocking questions.
+
+## Shepherd responsibilities
+
+The shepherd must:
+
+1. Confirm issue, branch, base, and cwd before editing.
+2. Keep the slice focused and issue-linked.
+3. Run targeted checks and `npm run check` before committing.
+4. Commit with a Conventional Commit subject without bypassing hooks.
+5. Open or update a PR with the full template completed.
+6. Watch CI and request Codex review when needed.
+7. Fix CI or Codex findings, comment with verification, and resolve fixed review threads.
+8. Merge only after required checks pass and Codex has commented, reviewed, or clearly approved.
+9. Report merge result, verification, and follow-up issues to the parent.
+
+## Parent responsibilities
+
+The parent should:
+
+1. Keep the main worktree on `main` and clean.
+2. Avoid editing files in the shepherd worktree.
+3. Continue planning the next slice while the shepherd waits.
+4. Start another implementation worktree only when the next slice is independent or explicitly stacked on the shepherd branch.
+5. Sync `main` after a shepherd merge before starting dependent work.
+6. Delete finished worktrees after merged branches are no longer needed:
+
+```bash
+git worktree remove ../pi-hindsight-worktrees/pr-263-pr-shepherd
+git worktree prune
+```
+
+## Parallel work rule
+
+Parallel next-slice work is safe when it touches separate files or is documentation-only. If the next slice changes the same modules or depends on the PR under review, wait for merge or deliberately stack the new branch on the shepherd branch and rebase after merge.
+
+## Stop conditions
+
+The shepherd must stop and ask the parent when:
+
+- Codex feedback requires a product or scope decision.
+- CI failures are not reproducible or not clearly related to the slice.
+- A fix would broaden the PR beyond its issue.
+- Required live verification is unavailable for a memory-path change.

--- a/docs-site/src/content/docs/development/contributing.md
+++ b/docs-site/src/content/docs/development/contributing.md
@@ -79,6 +79,8 @@ For each slice:
 11. Comment on and close the issue with delivered behavior, verification, and follow-up issue links.
 12. Return to `main`, sync with `origin/main`, and continue with the next slice.
 
+A maintainer may ask agents to use the PR shepherd workflow for this loop. In that mode, create a dedicated git worktree for the slice, launch the `pr-shepherd` project subagent from that worktree, and let the shepherd own the PR through CI, Codex feedback, review-thread resolution, merge, and cleanup reporting. The parent/orchestrator must keep the main worktree clean and only start parallel implementation work when the next slice is independent or explicitly stacked. See `docs/agents/pr-shepherd-workflow.md`.
+
 Keep one implementation slice active at a time unless a maintainer explicitly asks for parallel work. Do not mix unrelated cleanup, formatting sweeps, or drive-by refactors into the current branch. If review uncovers work outside the slice, create a follow-up issue and continue after the current PR is complete.
 
 ## Commit and PR discipline for agents

--- a/docs-site/src/content/docs/development/internal-and-agent-docs.md
+++ b/docs-site/src/content/docs/development/internal-and-agent-docs.md
@@ -14,6 +14,7 @@ Agent docs explain repository workflow and domain guidance for coding agents. Th
 - [Issue tracker](/pi-hindsight/development/agents/issue-tracker/)
 - [Domain docs](/pi-hindsight/development/agents/domain/)
 - [Triage labels](/pi-hindsight/development/agents/triage-labels/)
+- [PR shepherd workflow](/pi-hindsight/development/agents/pr-shepherd-workflow/)
 
 ## Internal and archive docs
 

--- a/docs/agents/pr-shepherd-workflow.md
+++ b/docs/agents/pr-shepherd-workflow.md
@@ -1,0 +1,79 @@
+# PR shepherd workflow
+
+Use the `pr-shepherd` project subagent when a PR needs end-to-end CI, Codex, and merge stewardship without blocking the parent agent.
+
+## Roles
+
+- **Parent/orchestrator** selects the issue slice, decides whether parallel work is safe, creates or names the worktree, and launches the shepherd.
+- **PR shepherd** owns exactly one branch and one PR from the supplied worktree.
+- **Codex** remains a required review signal before merge.
+
+## Worktree layout
+
+Create one worktree per active PR:
+
+```bash
+git fetch origin main
+git worktree add ../pi-hindsight-worktrees/pr-263-pr-shepherd -b chore/pr-shepherd-workflow-263 origin/main
+```
+
+Prefer a sibling worktree directory outside the repository so generated files and nested Git metadata do not pollute the main checkout.
+
+## Launch shape
+
+Launch the project agent from the PR worktree:
+
+```ts
+subagent({
+  agent: "pr-shepherd",
+  cwd: "../pi-hindsight-worktrees/pr-263-pr-shepherd",
+  async: true,
+  context: "fresh",
+  task: "Own issue #263. Implement the focused workflow slice, open the PR, watch CI and Codex, fix findings, resolve review threads, merge when ready, and report progress to the parent via intercom.",
+});
+```
+
+If the parent session has a known intercom name, include it in the task so the shepherd can send progress updates and ask blocking questions.
+
+## Shepherd responsibilities
+
+The shepherd must:
+
+1. Confirm issue, branch, base, and cwd before editing.
+2. Keep the slice focused and issue-linked.
+3. Run targeted checks and `npm run check` before committing.
+4. Commit with a Conventional Commit subject without bypassing hooks.
+5. Open or update a PR with the full template completed.
+6. Watch CI and request Codex review when needed.
+7. Fix CI or Codex findings, comment with verification, and resolve fixed review threads.
+8. Merge only after required checks pass and Codex has commented, reviewed, or clearly approved.
+9. Report merge result, verification, and follow-up issues to the parent.
+
+## Parent responsibilities
+
+The parent should:
+
+1. Keep the main worktree on `main` and clean.
+2. Avoid editing files in the shepherd worktree.
+3. Continue planning the next slice while the shepherd waits.
+4. Start another implementation worktree only when the next slice is independent or explicitly stacked on the shepherd branch.
+5. Sync `main` after a shepherd merge before starting dependent work.
+6. Delete finished worktrees after merged branches are no longer needed:
+
+```bash
+git worktree remove ../pi-hindsight-worktrees/pr-263-pr-shepherd
+git worktree prune
+```
+
+## Parallel work rule
+
+Parallel next-slice work is safe when it touches separate files or is documentation-only. If the next slice changes the same modules or depends on the PR under review, wait for merge or deliberately stack the new branch on the shepherd branch and rebase after merge.
+
+## Stop conditions
+
+The shepherd must stop and ask the parent when:
+
+- Codex feedback requires a product or scope decision.
+- CI failures are not reproducible or not clearly related to the slice.
+- A fix would broaden the PR beyond its issue.
+- Required live verification is unavailable for a memory-path change.


### PR DESCRIPTION
## Summary

- Add a project `pr-shepherd` subagent for one-worktree, one-PR CI/Codex/merge stewardship.
- Document the worktree-based parent/shepherd workflow for intercom-backed progress, fixes, thread resolution, merge, and cleanup.
- Update agent/contributor guidance so PR shepherding is an explicit maintainer-approved workflow.

## Linked issue

- Closes #263
- Refs #248

## Scope

Workflow and documentation only. No runtime extension behavior changes.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — not needed because docs/agent-workflow-only scope.
- [ ] `npm run typecheck:tsc` — not needed because docs/agent-workflow-only scope.
- [ ] full matrix requested/passed — not needed because docs/agent-workflow-only scope.
- [ ] package verification requested/passed — not needed because docs/agent-workflow-only scope.
- [ ] `npm run pack:verify` — not needed because docs/agent-workflow-only scope.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — not needed because no memory-path behavior changed.

Additional targeted checks:

- `npm run docs:check`
- `subagent({ action: "list", agentScope: "project" })` shows `pr-shepherd`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: contributor/agent workflow now includes an optional PR shepherd worktree workflow.

## Risk and rollback

- Risk: Agent instructions could be too aggressive about merge ownership if used without maintainer approval. Mitigation: docs state this workflow is maintainer-requested and preserves CI/Codex gates.
- Rollback/revert path: Revert this PR to remove the project agent and workflow docs.

## Follow-ups

- #248 continues with remaining quality-first memory core slices.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
