### PR TITLE
chore: tune PR CI and shepherd workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 - [ ] `npm run check`
 - [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
 - [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
-- [ ] full matrix requested/passed (runtime, queue/import, package/release, workflow changes, or `ci:full`)
+- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
 - [ ] package verification requested/passed (release/package changes or `ci:package`)
 - [ ] `npm run pack:verify` (release/package changes)
 - [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,6 +46,8 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           FULL_INPUT: ${{ inputs.full || 'true' }}
           LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || '' }}
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
         run: |
           set -euo pipefail
 
@@ -56,6 +58,10 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$FULL_INPUT" = "false" ]; then
             :
           elif [ "$EVENT_NAME" != "pull_request" ]; then
+            coverage=true
+            full_matrix=true
+            package_check=true
+          elif [ "$PR_AUTHOR" = "github-actions[bot]" ] && [[ "$PR_TITLE" == chore*": release"* ]]; then
             coverage=true
             full_matrix=true
             package_check=true
@@ -74,11 +80,6 @@ jobs:
               case "$path" in
                 extensions/*|tests/*|scripts/*|package.json|package-lock.json|tsconfig.json|vitest.config.ts|.release-please-config.json|.release-please-manifest.json)
                   coverage=true
-                  ;;
-              esac
-              case "$path" in
-                extensions/client*|extensions/queue*|extensions/retain*|extensions/import*|extensions/memory-lifecycle*|extensions/memory-*operations.ts|extensions/bank*|extensions/config*|extensions/commands.ts|extensions/tools.ts|extensions/index.ts|scripts/smoke-*|scripts/verify-release.mjs|scripts/install-smoke.mjs|package.json|package-lock.json|.release-please-config.json|.release-please-manifest.json|.github/workflows/*)
-                  full_matrix=true
                   ;;
               esac
               case "$path" in

--- a/.pi/agents/pr-shepherd.md
+++ b/.pi/agents/pr-shepherd.md
@@ -1,7 +1,7 @@
 ---
 name: pr-shepherd
 description: Own one GitHub PR from an isolated worktree: create/update PR, watch CI/Codex, fix findings, resolve threads, merge, clean up, and report via intercom.
-tools: bash, edit, write, read, grep, find_files, process, schedule_prompt, intercom, todo
+tools: bash, edit, write, read, grep, find_files, process, schedule_prompt, intercom, todo, subagent
 systemPromptMode: replace
 inheritProjectContext: true
 inheritSkills: false
@@ -25,6 +25,9 @@ Hard rules:
 - If Codex leaves findings, fix them, run verification, comment with what changed, and resolve the review thread.
 - If a product/design decision is ambiguous, ask the parent via intercom before changing scope.
 - If checks fail from clear infrastructure flakes, rerun once and report. If failure is code-related, fix it.
+- Waiting for CI, Codex, or review is not completion. Do not finish while the PR is merely open and waiting.
+- Terminal states are only: PR merged; PR closed by parent; explicit blocker requiring parent decision; unrecoverable auth/infra issue after one retry.
+- Before opening the PR or before final push for non-trivial diffs, launch a `reviewer` subagent in this same worktree for an evidence-backed review. Fix accepted findings before PR creation or clearly document deferrals in the PR.
 - After merge, sync local main if this worktree has main, report merge SHA/PR/verification, and stop.
 
 Loop:
@@ -32,12 +35,13 @@ Loop:
 2. Inspect relevant files and current diff.
 3. Implement or finish the focused slice.
 4. Run targeted checks, then required repo checks (`npm run check`; add coverage/tsc/live smoke when memory-path requires it).
-5. Commit with Conventional Commit subject.
-6. Push branch and open/update PR with complete template.
-7. Start CI watcher and poll PR state/Codex.
-8. While waiting, send concise intercom progress updates for state changes only.
-9. For failed checks or Codex findings: inspect, fix, verify, amend or commit logically, push, comment, resolve threads.
-10. When ready: merge via PR, delete branch if allowed, report completion via intercom.
+5. Run a `reviewer` subagent for non-trivial diffs; fix accepted findings and re-run relevant checks.
+6. Commit with Conventional Commit subject.
+7. Push branch and open/update PR with complete template.
+8. Start CI watcher and poll PR state/Codex until a terminal state. Use process or interval schedules as needed, and remove interval schedules before stopping.
+9. While waiting, send concise intercom progress updates for state changes only. Do not exit just because the PR is waiting.
+10. For failed checks or Codex findings: inspect, fix, verify, amend or commit logically, push, comment, resolve threads.
+11. When ready: merge via PR, delete branch if allowed, report completion via intercom.
 
 Intercom protocol:
 - Progress update: use `intercom send` to parent if parent name is supplied; include PR URL, state, next wait.

--- a/.pi/agents/reviewer.md
+++ b/.pi/agents/reviewer.md
@@ -1,0 +1,25 @@
+---
+name: reviewer
+description: Evidence-backed reviewer for pi-hindsight PR diffs, plans, and issue validation. Use before non-trivial PR creation or final push.
+tools: bash, read, grep, find_files
+systemPromptMode: replace
+inheritProjectContext: true
+inheritSkills: false
+defaultContext: fresh
+---
+
+You are reviewer for luxus/pi-hindsight. Review proposed changes against the linked GitHub issue, `AGENTS.md`, `CONTRIBUTING.md`, and project memory rules.
+
+Rules:
+- Do not modify files.
+- Inspect the diff against `main` unless the parent gives a narrower target.
+- Prefer concrete evidence with file paths and line references.
+- Separate blockers from non-blocking findings.
+- Do not request speculative refactors outside the issue scope.
+- Verify docs, tests, CI routing, and PR-template implications when relevant.
+
+Output:
+- Blockers: findings that should stop merge.
+- Non-blocking findings: useful improvements or risks.
+- Verification notes: checks inspected or recommended.
+- Merge recommendation: merge / merge after fixes / do not merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ npm run check:coverage
 npm run typecheck:tsc
 ```
 
-GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix. Package/release changes and `ci:package` also run package verification. Manual `workflow_dispatch` can run the full matrix for any PR.
+GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Memory-path changes run live smoke when configured. The full Ubuntu/macOS/Windows matrix is reserved for release PRs/release verification, manual workflow dispatch, non-PR events, or PRs explicitly labeled `ci:full`. Package/release changes and `ci:package` also run package verification.
 
 If release or package dependencies changed, also run:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ npm run check:coverage
 npm run typecheck:tsc
 ```
 
-GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix. Package/release changes and `ci:package` also run package verification. Manual `workflow_dispatch` can run the full matrix for any PR.
+GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Memory-path changes run live smoke when configured. The full Ubuntu/macOS/Windows matrix is reserved for release PRs/release verification, manual workflow dispatch, non-PR events, or PRs explicitly labeled `ci:full`. Package/release changes and `ci:package` also run package verification.
 
 For release-path or packaging changes, also run:
 
@@ -194,7 +194,7 @@ Before opening or marking a PR ready:
 - [ ] I ran `npm run check`.
 - [ ] I ran `npm run check:coverage` when touching source, tests, or critical paths.
 - [ ] I ran `npm run typecheck:tsc` when touching source or critical paths.
-- [ ] I requested or confirmed full matrix when touching runtime-sensitive paths, queue/import/memory paths, package/release code, workflows, or platform-sensitive behavior.
+- [ ] I requested or confirmed full matrix when preparing release verification, using `ci:full`, or changing platform-sensitive behavior that needs macOS/Windows proof.
 - [ ] I ran `npm run audit:signatures` when touching release/package dependencies.
 - [ ] I ran `npm run smoke:hindsight` or confirmed a configured `Hindsight Integration` pass when memory-path behavior changed; if unavailable, I documented the limitation.
 

--- a/docs-site/src/content/docs/development/agents-root.md
+++ b/docs-site/src/content/docs/development/agents-root.md
@@ -262,7 +262,7 @@ npm run check:coverage
 npm run typecheck:tsc
 ```
 
-GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix. Package/release changes and `ci:package` also run package verification. Manual `workflow_dispatch` can run the full matrix for any PR.
+GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Memory-path changes run live smoke when configured. The full Ubuntu/macOS/Windows matrix is reserved for release PRs/release verification, manual workflow dispatch, non-PR events, or PRs explicitly labeled `ci:full`. Package/release changes and `ci:package` also run package verification.
 
 If release or package dependencies changed, also run:
 

--- a/docs-site/src/content/docs/development/agents/pr-shepherd-workflow.md
+++ b/docs-site/src/content/docs/development/agents/pr-shepherd-workflow.md
@@ -9,6 +9,7 @@ Use the `pr-shepherd` project subagent when a PR needs end-to-end CI, Codex, and
 
 - **Parent/orchestrator** selects the issue slice, decides whether parallel work is safe, creates or names the worktree, and launches the shepherd.
 - **PR shepherd** owns exactly one branch and one PR from the supplied worktree.
+- **Reviewer** is the project agent defined at `.pi/agents/reviewer.md`; the shepherd launches it for non-trivial diffs before PR creation or final push.
 - **Codex** remains a required review signal before merge.
 
 ## Worktree layout
@@ -45,12 +46,14 @@ The shepherd must:
 1. Confirm issue, branch, base, and cwd before editing.
 2. Keep the slice focused and issue-linked.
 3. Run targeted checks and `npm run check` before committing.
-4. Commit with a Conventional Commit subject without bypassing hooks.
-5. Open or update a PR with the full template completed.
-6. Watch CI and request Codex review when needed.
-7. Fix CI or Codex findings, comment with verification, and resolve fixed review threads.
-8. Merge only after required checks pass and Codex has commented, reviewed, or clearly approved.
-9. Report merge result, verification, and follow-up issues to the parent.
+4. Launch a `reviewer` subagent for non-trivial diffs before PR creation or final push, then fix accepted findings.
+5. Commit with a Conventional Commit subject without bypassing hooks.
+6. Open or update a PR with the full template completed.
+7. Watch CI and request Codex review when needed.
+8. Stay alive while the PR is open and merely waiting for CI, Codex, or review. Waiting is not completion.
+9. Fix CI or Codex findings, comment with verification, and resolve fixed review threads.
+10. Merge only after required checks pass and Codex has commented, reviewed, or clearly approved.
+11. Report merge result, verification, and follow-up issues to the parent.
 
 ## Parent responsibilities
 
@@ -71,6 +74,17 @@ git worktree prune
 ## Parallel work rule
 
 Parallel next-slice work is safe when it touches separate files or is documentation-only. If the next slice changes the same modules or depends on the PR under review, wait for merge or deliberately stack the new branch on the shepherd branch and rebase after merge.
+
+## Terminal states
+
+The shepherd may finish only when one of these is true:
+
+- The PR is merged and completion was reported to the parent.
+- The parent explicitly closed or cancelled the PR.
+- A blocker requires a parent decision.
+- An unrecoverable authentication or infrastructure issue remains after one retry.
+
+Waiting for CI, Codex, or review is not a terminal state.
 
 ## Stop conditions
 

--- a/docs-site/src/content/docs/development/ci-routing.md
+++ b/docs-site/src/content/docs/development/ci-routing.md
@@ -14,7 +14,9 @@ Source, tests, critical paths, or explicit `ci:coverage` work runs coverage and 
 
 ## Full matrix
 
-Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix.
+Normal pull requests do not run macOS/Windows matrix lanes by default. Runtime-sensitive paths, queue/import/memory-path changes, and source/test changes use Ubuntu fast checks plus coverage/compiler fallback and live smoke when applicable.
+
+Run the full Ubuntu/macOS/Windows matrix for release PRs/release verification, manual `workflow_dispatch`, non-PR events, or PRs explicitly labeled `ci:full`.
 
 ## Package verification
 

--- a/docs-site/src/content/docs/development/contributing.md
+++ b/docs-site/src/content/docs/development/contributing.md
@@ -130,7 +130,7 @@ npm run check:coverage
 npm run typecheck:tsc
 ```
 
-GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Runtime-sensitive paths, queue/import/memory-path changes, package/release changes, workflow changes, and `ci:full` run the full Ubuntu/macOS/Windows matrix. Package/release changes and `ci:package` also run package verification. Manual `workflow_dispatch` can run the full matrix for any PR.
+GitHub PR CI is tiered. Low-impact docs/TUI changes run the fast Ubuntu check by default. Source, tests, critical paths, and `ci:coverage` run coverage and the TypeScript compiler fallback. Memory-path changes run live smoke when configured. The full Ubuntu/macOS/Windows matrix is reserved for release PRs/release verification, manual workflow dispatch, non-PR events, or PRs explicitly labeled `ci:full`. Package/release changes and `ci:package` also run package verification.
 
 For release-path or packaging changes, also run:
 
@@ -196,7 +196,7 @@ Before opening or marking a PR ready:
 - [ ] I ran `npm run check`.
 - [ ] I ran `npm run check:coverage` when touching source, tests, or critical paths.
 - [ ] I ran `npm run typecheck:tsc` when touching source or critical paths.
-- [ ] I requested or confirmed full matrix when touching runtime-sensitive paths, queue/import/memory paths, package/release code, workflows, or platform-sensitive behavior.
+- [ ] I requested or confirmed full matrix when preparing release verification, using `ci:full`, or changing platform-sensitive behavior that needs macOS/Windows proof.
 - [ ] I ran `npm run audit:signatures` when touching release/package dependencies.
 - [ ] I ran `npm run smoke:hindsight` or confirmed a configured `Hindsight Integration` pass when memory-path behavior changed; if unavailable, I documented the limitation.
 

--- a/docs-site/src/content/docs/internal/post-mvp-roadmap.md
+++ b/docs-site/src/content/docs/internal/post-mvp-roadmap.md
@@ -210,7 +210,7 @@ After the MVP hardening pass and global review loop, a second small-PR hardening
 
 Completed outcomes:
 
-- Cross-platform CI now runs normal checks on Ubuntu, macOS, and Windows.
+- Cross-platform CI remains available through release verification, manual dispatch, and `ci:full`; normal PR checks prioritize Ubuntu plus targeted gates.
 - Dependency review, Dependabot, npm audit signatures, trusted publishing, and GitHub default CodeQL cover the supply-chain/release path.
 - The release workflow publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC and no npm token in the workflow.
 - Live smoke covers the official Hindsight client, extension Adapter, memory operations service, import flow, GitHub step summary output, and successful temporary-bank cleanup.

--- a/docs/agents/pr-shepherd-workflow.md
+++ b/docs/agents/pr-shepherd-workflow.md
@@ -6,6 +6,7 @@ Use the `pr-shepherd` project subagent when a PR needs end-to-end CI, Codex, and
 
 - **Parent/orchestrator** selects the issue slice, decides whether parallel work is safe, creates or names the worktree, and launches the shepherd.
 - **PR shepherd** owns exactly one branch and one PR from the supplied worktree.
+- **Reviewer** is the project agent defined at `.pi/agents/reviewer.md`; the shepherd launches it for non-trivial diffs before PR creation or final push.
 - **Codex** remains a required review signal before merge.
 
 ## Worktree layout
@@ -42,12 +43,14 @@ The shepherd must:
 1. Confirm issue, branch, base, and cwd before editing.
 2. Keep the slice focused and issue-linked.
 3. Run targeted checks and `npm run check` before committing.
-4. Commit with a Conventional Commit subject without bypassing hooks.
-5. Open or update a PR with the full template completed.
-6. Watch CI and request Codex review when needed.
-7. Fix CI or Codex findings, comment with verification, and resolve fixed review threads.
-8. Merge only after required checks pass and Codex has commented, reviewed, or clearly approved.
-9. Report merge result, verification, and follow-up issues to the parent.
+4. Launch a `reviewer` subagent for non-trivial diffs before PR creation or final push, then fix accepted findings.
+5. Commit with a Conventional Commit subject without bypassing hooks.
+6. Open or update a PR with the full template completed.
+7. Watch CI and request Codex review when needed.
+8. Stay alive while the PR is open and merely waiting for CI, Codex, or review. Waiting is not completion.
+9. Fix CI or Codex findings, comment with verification, and resolve fixed review threads.
+10. Merge only after required checks pass and Codex has commented, reviewed, or clearly approved.
+11. Report merge result, verification, and follow-up issues to the parent.
 
 ## Parent responsibilities
 
@@ -68,6 +71,17 @@ git worktree prune
 ## Parallel work rule
 
 Parallel next-slice work is safe when it touches separate files or is documentation-only. If the next slice changes the same modules or depends on the PR under review, wait for merge or deliberately stack the new branch on the shepherd branch and rebase after merge.
+
+## Terminal states
+
+The shepherd may finish only when one of these is true:
+
+- The PR is merged and completion was reported to the parent.
+- The parent explicitly closed or cancelled the PR.
+- A blocker requires a parent decision.
+- An unrecoverable authentication or infrastructure issue remains after one retry.
+
+Waiting for CI, Codex, or review is not a terminal state.
 
 ## Stop conditions
 

--- a/docs/post-mvp-roadmap.md
+++ b/docs/post-mvp-roadmap.md
@@ -208,7 +208,7 @@ After the MVP hardening pass and global review loop, a second small-PR hardening
 
 Completed outcomes:
 
-- Cross-platform CI now runs normal checks on Ubuntu, macOS, and Windows.
+- Cross-platform CI remains available through release verification, manual dispatch, and `ci:full`; normal PR checks prioritize Ubuntu plus targeted gates.
 - Dependency review, Dependabot, npm audit signatures, trusted publishing, and GitHub default CodeQL cover the supply-chain/release path.
 - The release workflow publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC and no npm token in the workflow.
 - Live smoke covers the official Hindsight client, extension Adapter, memory operations service, import flow, GitHub step summary output, and successful temporary-bank cleanup.


### PR DESCRIPTION
## Summary

- Stop routing ordinary PRs to the macOS/Windows full matrix by default; reserve full matrix for release verification, non-PR events, manual dispatch, or `ci:full`.
- Keep targeted PR gates: fast Ubuntu check, coverage/compiler fallback when classified, live smoke for memory-path, package verification for package/release paths.
- Update `pr-shepherd` so it runs a reviewer subagent for non-trivial diffs and cannot finish while a PR is only waiting for CI/Codex.
- Sync AGENTS, CONTRIBUTING, PR template, and docs-site workflow docs.

## Linked issue

- Closes #267
- Refs #248

## Scope

Workflow and agent-guidance change only. No extension runtime behavior changes.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — not needed because no source/test/runtime behavior changed.
- [ ] `npm run typecheck:tsc` — not needed because no source/runtime behavior changed.
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not needed because this PR intentionally changes PR routing and release PR/manual workflow still provide matrix proof.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — not needed because no package/release artifact changed.
- [ ] `npm run pack:verify` — not needed because no package/release artifact changed.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — not needed because no memory-path behavior changed.

Additional targeted checks:

- `npm run docs:check`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: contributor workflow changes PR CI routing and PR shepherd behavior.

## Risk and rollback

- Risk: macOS/Windows regressions may be caught later than ordinary PR time. Mitigation: full matrix remains available for release, manual dispatch, non-PR events, and `ci:full` labels.
- Risk: PR shepherd may run longer. Mitigation: terminal states and intercom blocker rules are explicit.
- Rollback/revert path: Revert this PR to restore previous PR matrix routing and shepherd behavior.

## Follow-ups

- #248 continues with release hardening/import-quality slices.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
