### PR TITLE
feat(import): summarize project import quality

### DIFF
--- a/extensions/import-presentation.ts
+++ b/extensions/import-presentation.ts
@@ -37,6 +37,7 @@ export type ImportProjectPresentationResult = {
   documentCount: number;
   messageCount: number;
   malformedLineCount: number;
+  imported?: Array<{ documents: ImportDocumentSummaryResult["documents"] }>;
 };
 
 function sumReasonCounts(
@@ -84,12 +85,7 @@ function formatTopDroppedTools(documents: ImportDocumentSummaryResult["documents
     .join(",");
 }
 
-export function importDocumentSummary(result: ImportDocumentSummaryResult): string {
-  const modes = [...new Set(result.documents.map((document) => document.updateMode))].join(",");
-  const statuses = [...new Set(result.documents.map((document) => document.status))].join(",");
-  const malformed = result.malformedLineCount
-    ? `; malformedLines=${result.malformedLineCount}`
-    : "";
+function importDocumentQualitySummary(result: ImportDocumentSummaryResult): string {
   const rawMessages = result.documents.reduce(
     (count, document) => count + (document.rawMessageCount ?? document.messageCount ?? 0),
     0,
@@ -134,11 +130,18 @@ export function importDocumentSummary(result: ImportDocumentSummaryResult): stri
     ? "; WARNING forensic mode preserves recalled memory blocks for audit-only use"
     : "";
   const qualityDetails = `${reasonCounts ? `; reasons=${reasonCounts}` : ""}${topDroppedTools ? `; topDroppedTools=${topDroppedTools}` : ""}`;
-  const quality =
-    rawMessages || droppedToolResults || rawBytes || projectedBytes
-      ? `; mode=${importModes || "unknown"}${importProfiles ? `; profile=${importProfiles}` : ""}; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; keptToolErrors=${keptErrors}; estimatedChunks=${estimatedChunks}; bytes=${projectedBytes}/${rawBytes}${qualityDetails}${forensicWarning}`
-      : "";
-  return `documents=${result.documents.length}; update=${modes || "n/a"}; status=${statuses || "n/a"}${malformed}${quality}`;
+  return rawMessages || droppedToolResults || rawBytes || projectedBytes
+    ? `; mode=${importModes || "unknown"}${importProfiles ? `; profile=${importProfiles}` : ""}; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; keptToolErrors=${keptErrors}; estimatedChunks=${estimatedChunks}; bytes=${projectedBytes}/${rawBytes}${qualityDetails}${forensicWarning}`
+    : "";
+}
+
+export function importDocumentSummary(result: ImportDocumentSummaryResult): string {
+  const modes = [...new Set(result.documents.map((document) => document.updateMode))].join(",");
+  const statuses = [...new Set(result.documents.map((document) => document.status))].join(",");
+  const malformed = result.malformedLineCount
+    ? `; malformedLines=${result.malformedLineCount}`
+    : "";
+  return `documents=${result.documents.length}; update=${modes || "n/a"}; status=${statuses || "n/a"}${malformed}${importDocumentQualitySummary(result)}`;
 }
 
 export function renderImportSessionMessage(
@@ -160,7 +163,9 @@ export function renderImportSessionMessage(
 }
 
 export function renderProjectImportMessage(result: ImportProjectPresentationResult): string {
-  const summary = `sessions=${result.sessionFiles.length}/${result.scanned}; documents=${result.documentCount}; messages=${result.messageCount}; malformedLines=${result.malformedLineCount}`;
+  const documents = result.imported?.flatMap((session) => session.documents) ?? [];
+  const quality = documents.length ? importDocumentQualitySummary({ documents }) : "";
+  const summary = `sessions=${result.sessionFiles.length}/${result.scanned}; documents=${result.documentCount}; messages=${result.messageCount}; malformedLines=${result.malformedLineCount}${quality}`;
   return result.dryRun
     ? `Project import preview: ${summary}; write=no`
     : `Imported project sessions: ${summary}`;

--- a/tests/import-presentation.test.ts
+++ b/tests/import-presentation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { importDocumentSummary } from "../extensions/import-presentation.js";
+import {
+  importDocumentSummary,
+  renderProjectImportMessage,
+} from "../extensions/import-presentation.js";
 
 describe("import presentation", () => {
   it("renders import quality metrics and forensic warning", () => {
@@ -65,6 +68,78 @@ describe("import presentation", () => {
 
     expect(importDocumentSummary({ documents })).toContain(
       "topDroppedTools=recurring-medium:6,one-off-0-1:1,one-off-1-1:1",
+    );
+  });
+
+  it("aggregates multi-session project import quality metrics in preview and import output", () => {
+    const imported = [
+      {
+        documents: [
+          {
+            updateMode: "replace",
+            status: "pending",
+            rawMessageCount: 4,
+            projectedMessageCount: 2,
+            rawBytes: 1_000,
+            projectedBytes: 200,
+            droppedToolResultCount: 2,
+            keptToolErrorCount: 1,
+            estimatedChunkCount: 1,
+            importMode: "curated" as const,
+            importQualityProfile: "strict" as const,
+            droppedTools: [
+              { name: "read", count: 1, bytes: 500 },
+              { name: "bash", count: 1, bytes: 200 },
+            ],
+            classificationReasonCounts: {
+              "tool-filter-excluded": 2,
+              "assistant-text": 1,
+            },
+          },
+        ],
+      },
+      {
+        documents: [
+          {
+            updateMode: "replace",
+            status: "pending",
+            rawMessageCount: 3,
+            projectedMessageCount: 2,
+            rawBytes: 500,
+            projectedBytes: 300,
+            droppedToolResultCount: 1,
+            keptToolErrorCount: 1,
+            estimatedChunkCount: 2,
+            importMode: "curated" as const,
+            importQualityProfile: "strict" as const,
+            droppedTools: [
+              { name: "read", count: 2, bytes: 100 },
+              { name: "grep", count: 1, bytes: 50 },
+            ],
+            classificationReasonCounts: {
+              "tool-filter-excluded": 1,
+              "tool-error-kept": 1,
+            },
+          },
+        ],
+      },
+    ];
+    const base = {
+      sessionFiles: ["/sessions/a.jsonl", "/sessions/b.jsonl"],
+      scanned: 3,
+      documentCount: 2,
+      messageCount: 7,
+      malformedLineCount: 1,
+      imported,
+    };
+    const quality =
+      "mode=curated; profile=strict; projected=4/7 messages; droppedToolResults=3; keptToolErrors=2; estimatedChunks=3; bytes=500/1500; reasons=tool-filter-excluded:3,assistant-text:1,tool-error-kept:1; topDroppedTools=read:3,bash:1,grep:1";
+
+    expect(renderProjectImportMessage({ ...base, dryRun: true })).toBe(
+      `Project import preview: sessions=2/3; documents=2; messages=7; malformedLines=1; ${quality}; write=no`,
+    );
+    expect(renderProjectImportMessage({ ...base, dryRun: false })).toBe(
+      `Imported project sessions: sessions=2/3; documents=2; messages=7; malformedLines=1; ${quality}`,
     );
   });
 });


### PR DESCRIPTION
## Summary

- Adds project import preview/import quality summary output by aggregating existing per-document import metrics from imported sessions.
- Reuses the single-session import quality vocabulary for mode, profile, projected messages, dropped tool results, kept tool errors, chunk estimates, bytes, reasons, top dropped tools, and forensic warning.
- Adds regression coverage for multi-session project import quality rendering.

## Linked issue

- Closes #269

## Scope

- Focused on presentation/plumbing in `extensions/import-presentation.ts` and regression tests in `tests/import-presentation.test.ts`.
- No import delivery, retain payload, checkpoint, bank, or recall execution semantics changed.
- Docs unchanged because no existing docs documented the exact project import message text.

## Verification

- [x] `npm test -- import-presentation`
- [x] `npm test -- import-presentation commands import-sessions`
- [x] `npm run check`
- [ ] `npm run check:coverage` skipped because this is presentation/plumbing only and execution semantics did not change.
- [ ] `npm run typecheck:tsc` skipped because this is presentation/plumbing only and `npm run check` typecheck passed.
- [ ] full matrix skipped because this is not a release, platform-sensitive, or `ci:full` change.
- [ ] package verification skipped because package/release paths did not change.
- [ ] `npm run pack:verify` skipped because package/release paths did not change.
- [ ] `npm run smoke:hindsight` skipped because this does not change memory-path execution semantics; it only renders already-computed import quality fields.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Project import preview/import notifications now include the same concise quality summary fields already shown for single-session imports.

## Risk and rollback

- Risk: project import messages become longer when quality fields are present.
- Rollback/revert path: revert this PR to return project import output to aggregate counts only; import execution and retained documents are unchanged.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] Not applicable; this does not change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- Repo-local reviewer completed before PR creation with no code-level blockers. Non-blocking note about a stronger optional `imported` guard was left unchanged because project import results are typed and the renderer already omits quality fields when `imported` is absent.
- Codex review requested after PR creation.
