### PR TITLE
feat(import): record checkpoint quality context

### DIFF
--- a/docs-site/src/content/docs/guides/importing-sessions.md
+++ b/docs-site/src/content/docs/guides/importing-sessions.md
@@ -108,7 +108,7 @@ Default paths:
 
 The checkpoint records document delivery state so interrupted imports can resume. When `import.resume` is enabled, completed documents are skipped instead of retained again.
 
-If an import is queued but not delivered because Hindsight is unavailable, the checkpoint records the document as `queued` and the retain queue keeps the job for later flushing.
+If an import is queued but not delivered because Hindsight is unavailable, the checkpoint records the document as `queued` and the retain queue keeps the job for later flushing. Checkpoint run and document entries also record import quality context such as `toolResults` and strict curated `importQualityProfile` when available, so recovery can show which projection policy produced pending, completed, queued, or failed documents.
 
 ## Rebuilding a cleared bank
 

--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -106,7 +106,7 @@ Default paths:
 
 The checkpoint records document delivery state so interrupted imports can resume. When `import.resume` is enabled, completed documents are skipped instead of retained again.
 
-If an import is queued but not delivered because Hindsight is unavailable, the checkpoint records the document as `queued` and the retain queue keeps the job for later flushing.
+If an import is queued but not delivered because Hindsight is unavailable, the checkpoint records the document as `queued` and the retain queue keeps the job for later flushing. Checkpoint run and document entries also record import quality context such as `toolResults` and strict curated `importQualityProfile` when available, so recovery can show which projection policy produced pending, completed, queued, or failed documents.
 
 ## Rebuilding a cleared bank
 

--- a/extensions/import-checkpoint.ts
+++ b/extensions/import-checkpoint.ts
@@ -1,6 +1,8 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
-import type { ImportMode, UpdateMode } from "./types.js";
+import type { ImportMode, ImportQualityProfile, ResolvedConfig, UpdateMode } from "./types.js";
+
+type ImportToolResults = ResolvedConfig["import"]["toolResults"];
 
 export type ImportDocumentStatus = "pending" | "queued" | "completed" | "failed" | "skipped";
 
@@ -10,6 +12,8 @@ export interface ImportCheckpointDocument {
   contentHash: string;
   messageCount: number;
   importMode?: ImportMode;
+  toolResults?: ImportToolResults;
+  importQualityProfile?: ImportQualityProfile;
   projectionVersion?: string;
   importProfile?: string;
   chunkIndex?: number;
@@ -28,6 +32,8 @@ export interface ImportCheckpoint {
   cwd: string;
   includeBranches: "current-only" | "all-leaves";
   importMode?: ImportMode;
+  toolResults?: ImportToolResults;
+  importQualityProfile?: ImportQualityProfile;
   importProfile?: string;
   updateMode: UpdateMode;
   startedAt: string;
@@ -70,6 +76,39 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isImportMode(value: unknown): value is ImportMode {
+  return value === "curated" || value === "raw" || value === "forensic";
+}
+
+function isImportToolResults(value: unknown): value is ImportToolResults {
+  return value === "errors-only" || value === "summary" || value === "content";
+}
+
+function isImportQualityProfile(value: unknown): value is ImportQualityProfile {
+  return value === "compatible" || value === "strict";
+}
+
+function isUpdateMode(value: unknown): value is UpdateMode {
+  return value === "append" || value === "replace";
+}
+
+function isMessageRange(value: unknown): value is { start: number; end: number } {
+  return isPlainRecord(value) && typeof value.start === "number" && typeof value.end === "number";
+}
+
+function hasValidCheckpointRunFields(value: Record<string, unknown>): boolean {
+  return (
+    (value.includeBranches === undefined ||
+      value.includeBranches === "current-only" ||
+      value.includeBranches === "all-leaves") &&
+    (value.importMode === undefined || isImportMode(value.importMode)) &&
+    (value.toolResults === undefined || isImportToolResults(value.toolResults)) &&
+    (value.importQualityProfile === undefined ||
+      isImportQualityProfile(value.importQualityProfile)) &&
+    (value.updateMode === undefined || isUpdateMode(value.updateMode))
+  );
+}
+
 function isImportCheckpointDocument(value: unknown): value is ImportCheckpointDocument {
   if (!isPlainRecord(value)) return false;
   return (
@@ -77,12 +116,21 @@ function isImportCheckpointDocument(value: unknown): value is ImportCheckpointDo
     typeof value.leafId === "string" &&
     typeof value.contentHash === "string" &&
     typeof value.messageCount === "number" &&
+    (value.importMode === undefined || isImportMode(value.importMode)) &&
+    (value.toolResults === undefined || isImportToolResults(value.toolResults)) &&
+    (value.importQualityProfile === undefined ||
+      isImportQualityProfile(value.importQualityProfile)) &&
+    (value.projectionVersion === undefined || typeof value.projectionVersion === "string") &&
+    (value.importProfile === undefined || typeof value.importProfile === "string") &&
+    (value.chunkIndex === undefined || typeof value.chunkIndex === "number") &&
+    (value.messageRange === undefined || isMessageRange(value.messageRange)) &&
     (value.status === "pending" ||
       value.status === "queued" ||
       value.status === "completed" ||
       value.status === "failed" ||
       value.status === "skipped") &&
-    typeof value.updatedAt === "string"
+    typeof value.updatedAt === "string" &&
+    (value.error === undefined || typeof value.error === "string")
   );
 }
 
@@ -90,6 +138,9 @@ export async function readImportCheckpoint(path: string): Promise<ImportCheckpoi
   try {
     const parsed = JSON.parse(await readFile(path, "utf8")) as unknown;
     if (!isPlainRecord(parsed)) throw new Error("import checkpoint must be a JSON object");
+    if (!hasValidCheckpointRunFields(parsed)) {
+      throw new Error("import checkpoint run fields are invalid");
+    }
     const record = parsed as unknown as ImportCheckpoint;
     if (record.documents !== undefined && !isPlainRecord(record.documents)) {
       throw new Error("import checkpoint documents must be a JSON object");
@@ -137,6 +188,8 @@ export function createImportCheckpoint(args: {
   cwd: string;
   includeBranches: "current-only" | "all-leaves";
   importMode?: ImportMode;
+  toolResults?: ImportToolResults;
+  importQualityProfile?: ImportQualityProfile;
   updateMode: UpdateMode;
   now: string;
 }): ImportCheckpoint {
@@ -149,6 +202,8 @@ export function createImportCheckpoint(args: {
     cwd: args.cwd,
     includeBranches: args.includeBranches,
     ...(args.importMode ? { importMode: args.importMode } : {}),
+    ...(args.toolResults ? { toolResults: args.toolResults } : {}),
+    ...(args.importQualityProfile ? { importQualityProfile: args.importQualityProfile } : {}),
     updateMode: args.updateMode,
     startedAt: args.now,
     updatedAt: args.now,

--- a/extensions/import-execution.ts
+++ b/extensions/import-execution.ts
@@ -5,6 +5,8 @@ import {
   readImportCheckpointSafe,
   writeImportCheckpoint,
   type ImportCheckpoint,
+  type ImportCheckpointDocument,
+  type ImportDocumentStatus,
 } from "./import-checkpoint.js";
 import { upsertImportManifestEntries } from "./import-manifest.js";
 import {
@@ -22,6 +24,35 @@ export interface ImportExecutionResult {
   documents: ImportSessionDocumentResult[];
   messageCount: number;
   retained: boolean;
+}
+
+function checkpointDocument(args: {
+  document: ImportDocumentPreview;
+  status: ImportDocumentStatus;
+  toolResults: ImportPlan["importConfig"]["import"]["toolResults"];
+  updatedAt: string;
+  error?: string;
+}): ImportCheckpointDocument {
+  return {
+    documentId: args.document.documentId,
+    leafId: args.document.leafId,
+    contentHash: args.document.contentHash,
+    messageCount: args.document.messageCount,
+    ...(args.document.importMode ? { importMode: args.document.importMode } : {}),
+    toolResults: args.toolResults,
+    ...(args.document.importQualityProfile
+      ? { importQualityProfile: args.document.importQualityProfile }
+      : {}),
+    ...(args.document.projectionVersion
+      ? { projectionVersion: args.document.projectionVersion }
+      : {}),
+    ...(args.document.importProfile ? { importProfile: args.document.importProfile } : {}),
+    ...(args.document.chunkIndex !== undefined ? { chunkIndex: args.document.chunkIndex } : {}),
+    ...(args.document.messageRange ? { messageRange: args.document.messageRange } : {}),
+    status: args.status,
+    updatedAt: args.updatedAt,
+    ...(args.error ? { error: args.error } : {}),
+  };
 }
 
 export async function executeImportPlan(args: {
@@ -59,10 +90,17 @@ export async function executeImportPlan(args: {
           cwd,
           includeBranches,
           importMode: importConfig.import.mode,
+          toolResults: importConfig.import.toolResults,
+          importQualityProfile: importConfig.import.qualityProfile,
           updateMode,
           now,
         });
-  checkpoint = { ...checkpoint, updatedAt: now };
+  checkpoint = {
+    ...checkpoint,
+    updatedAt: now,
+    toolResults: importConfig.import.toolResults,
+    importQualityProfile: importConfig.import.qualityProfile,
+  };
 
   const results = [];
   for (const branch of branches) {
@@ -96,25 +134,12 @@ export async function executeImportPlan(args: {
         continue;
       }
 
-      checkpoint.documents[preview.document.documentId] = {
-        documentId: preview.document.documentId,
-        leafId: preview.document.leafId,
-        contentHash: preview.document.contentHash,
-        messageCount: preview.document.messageCount,
-        ...(preview.document.importMode ? { importMode: preview.document.importMode } : {}),
-        ...(preview.document.projectionVersion
-          ? { projectionVersion: preview.document.projectionVersion }
-          : {}),
-        ...(preview.document.importProfile
-          ? { importProfile: preview.document.importProfile }
-          : {}),
-        ...(preview.document.chunkIndex !== undefined
-          ? { chunkIndex: preview.document.chunkIndex }
-          : {}),
-        ...(preview.document.messageRange ? { messageRange: preview.document.messageRange } : {}),
+      checkpoint.documents[preview.document.documentId] = checkpointDocument({
+        document: preview.document,
         status: "pending",
+        toolResults: importConfig.import.toolResults,
         updatedAt: new Date().toISOString(),
-      };
+      });
       await writeImportCheckpoint(checkpointPath, checkpoint);
 
       try {
@@ -124,27 +149,12 @@ export async function executeImportPlan(args: {
           documentId: preview.document.documentId,
         });
         const completedAt = new Date().toISOString();
-        checkpoint.documents[retained.document.documentId] = {
-          documentId: retained.document.documentId,
-          leafId: retained.document.leafId,
-          contentHash: retained.document.contentHash,
-          messageCount: retained.document.messageCount,
-          ...(retained.document.importMode ? { importMode: retained.document.importMode } : {}),
-          ...(retained.document.projectionVersion
-            ? { projectionVersion: retained.document.projectionVersion }
-            : {}),
-          ...(retained.document.importProfile
-            ? { importProfile: retained.document.importProfile }
-            : {}),
-          ...(retained.document.chunkIndex !== undefined
-            ? { chunkIndex: retained.document.chunkIndex }
-            : {}),
-          ...(retained.document.messageRange
-            ? { messageRange: retained.document.messageRange }
-            : {}),
+        checkpoint.documents[retained.document.documentId] = checkpointDocument({
+          document: retained.document,
           status: "completed",
+          toolResults: importConfig.import.toolResults,
           updatedAt: completedAt,
-        };
+        });
         checkpoint.updatedAt = completedAt;
         await writeImportCheckpoint(checkpointPath, checkpoint);
         results.push({
@@ -155,26 +165,13 @@ export async function executeImportPlan(args: {
         const failedAt = new Date().toISOString();
         const message = redactError(error);
         const status = isImportRetainQueuedError(error) ? "queued" : "failed";
-        checkpoint.documents[preview.document.documentId] = {
-          documentId: preview.document.documentId,
-          leafId: preview.document.leafId,
-          contentHash: preview.document.contentHash,
-          messageCount: preview.document.messageCount,
-          ...(preview.document.importMode ? { importMode: preview.document.importMode } : {}),
-          ...(preview.document.projectionVersion
-            ? { projectionVersion: preview.document.projectionVersion }
-            : {}),
-          ...(preview.document.importProfile
-            ? { importProfile: preview.document.importProfile }
-            : {}),
-          ...(preview.document.chunkIndex !== undefined
-            ? { chunkIndex: preview.document.chunkIndex }
-            : {}),
-          ...(preview.document.messageRange ? { messageRange: preview.document.messageRange } : {}),
+        checkpoint.documents[preview.document.documentId] = checkpointDocument({
+          document: preview.document,
           status,
+          toolResults: importConfig.import.toolResults,
           updatedAt: failedAt,
           error: message,
-        };
+        });
         checkpoint.updatedAt = failedAt;
         await writeImportCheckpoint(checkpointPath, checkpoint);
         results.push({

--- a/tests/import-checkpoint.test.ts
+++ b/tests/import-checkpoint.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { readImportCheckpoint } from "../extensions/import-checkpoint.js";
+
+describe("import checkpoint", () => {
+  it("accepts explicit import quality context allowed values", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-checkpoint-"));
+    const path = join(dir, "checkpoint.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        version: 1,
+        runId: "run",
+        sourceFile: "session.jsonl",
+        bankId: "bank",
+        sessionId: "session",
+        cwd: dir,
+        includeBranches: "current-only",
+        importMode: "curated",
+        toolResults: "content",
+        importQualityProfile: "strict",
+        updateMode: "replace",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        documents: {
+          doc: {
+            documentId: "doc",
+            leafId: "leaf",
+            contentHash: "hash",
+            messageCount: 1,
+            importMode: "curated",
+            toolResults: "summary",
+            importQualityProfile: "compatible",
+            projectionVersion: "curated-turns-v1",
+            importProfile: "turns-12-bytes-80000",
+            chunkIndex: 0,
+            messageRange: { start: 0, end: 0 },
+            status: "pending",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        },
+      }),
+    );
+
+    await expect(readImportCheckpoint(path)).resolves.toMatchObject({
+      toolResults: "content",
+      importQualityProfile: "strict",
+      documents: {
+        doc: {
+          toolResults: "summary",
+          importQualityProfile: "compatible",
+        },
+      },
+    });
+  });
+
+  it("rejects unsupported import quality context values", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-checkpoint-"));
+    const invalidRunPath = join(dir, "invalid-run.json");
+    const invalidDocumentPath = join(dir, "invalid-document.json");
+    const checkpoint = {
+      version: 1,
+      runId: "run",
+      sourceFile: "session.jsonl",
+      bankId: "bank",
+      sessionId: "session",
+      cwd: dir,
+      includeBranches: "current-only",
+      importMode: "curated",
+      toolResults: "summary",
+      importQualityProfile: "strict",
+      updateMode: "replace",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      documents: {
+        doc: {
+          documentId: "doc",
+          leafId: "leaf",
+          contentHash: "hash",
+          messageCount: 1,
+          importMode: "curated",
+          toolResults: "summary",
+          importQualityProfile: "strict",
+          status: "completed",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    };
+    writeFileSync(invalidRunPath, JSON.stringify({ ...checkpoint, toolResults: "all" }));
+    writeFileSync(
+      invalidDocumentPath,
+      JSON.stringify({
+        ...checkpoint,
+        documents: {
+          doc: { ...checkpoint.documents.doc, importQualityProfile: "loose" },
+        },
+      }),
+    );
+
+    await expect(readImportCheckpoint(invalidRunPath)).rejects.toThrow(
+      "import checkpoint run fields are invalid",
+    );
+    await expect(readImportCheckpoint(invalidDocumentPath)).rejects.toThrow(
+      "import checkpoint document doc is invalid",
+    );
+  });
+});

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -216,6 +216,91 @@ describe("Pi session import", () => {
     expect(calls).toHaveLength(2);
   });
 
+  it("records strict curated quality context in pending and completed checkpoints", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-quality-checkpoint-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-quality-checkpoint", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "u1",
+          parentId: null,
+          message: { role: "user", content: "inspect checkpoint quality" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "a1",
+          parentId: "u1",
+          message: { role: "assistant", content: "using tool" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "tool1",
+          parentId: "a1",
+          message: { role: "toolResult", name: "custom-tool", content: "useful short output" },
+        }),
+      ].join("\n"),
+    );
+    const config = {
+      ...DEFAULT_CONFIG,
+      import: {
+        ...DEFAULT_CONFIG.import,
+        qualityProfile: "strict" as const,
+        toolResults: "summary" as const,
+      },
+    };
+    const documentId =
+      "pi-import:session-quality-checkpoint:leaf:tool1:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-2";
+    let pendingCheckpointSeen = false;
+
+    const result = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config,
+      client: {
+        retain: async () => {
+          const checkpoint = await readImportCheckpoint(
+            join(dir, ".pi/hindsight/import-checkpoint.json"),
+          );
+          expect(checkpoint).toMatchObject({
+            importMode: "curated",
+            toolResults: "summary",
+            importQualityProfile: "strict",
+          });
+          expect(checkpoint?.documents[documentId]).toMatchObject({
+            status: "pending",
+            importMode: "curated",
+            toolResults: "summary",
+            importQualityProfile: "strict",
+            projectionVersion: "curated-turns-v1",
+            importProfile: "turns-12-bytes-80000",
+            chunkIndex: 0,
+            messageRange: { start: 0, end: 2 },
+          });
+          pendingCheckpointSeen = true;
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(pendingCheckpointSeen).toBe(true);
+    const completedCheckpoint = await readImportCheckpoint(result.checkpointPath);
+    expect(completedCheckpoint?.documents[documentId]).toMatchObject({
+      status: "completed",
+      toolResults: "summary",
+      importQualityProfile: "strict",
+    });
+    const manifest = await readImportManifest(result.manifestPath);
+    expect(manifest.imports[documentId]).toMatchObject({
+      toolResults: "summary",
+      importQualityProfile: "strict",
+    });
+  });
+
   it("supports raw and forensic import modes as explicit escape hatches", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-mode-"));
     mkdirSync(join(dir, ".git"));
@@ -508,12 +593,20 @@ describe("Pi session import", () => {
         }),
       ].join("\n"),
     );
+    const config = {
+      ...DEFAULT_CONFIG,
+      import: {
+        ...DEFAULT_CONFIG.import,
+        qualityProfile: "strict" as const,
+        toolResults: "content" as const,
+      },
+    };
 
     await expect(
       importPiSession({
         sessionFile,
         bankId: "bank",
-        config: DEFAULT_CONFIG,
+        config,
         client: {
           retain: async () => {
             throw new Error("offline");
@@ -527,20 +620,81 @@ describe("Pi session import", () => {
     const checkpoint = await readImportCheckpoint(
       join(dir, ".pi/hindsight/import-checkpoint.json"),
     );
-    expect(
-      checkpoint?.documents[
-        "pi-import:session-queued:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0"
-      ]?.status,
-    ).toBe("queued");
-    expect(
-      checkpoint?.documents[
-        "pi-import:session-queued:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0"
-      ]?.error,
-    ).toContain("queued");
-    const queue = await readRetainQueue(resolveQueuePath(dir, DEFAULT_CONFIG.retain.queuePath));
-    expect(queue.map((job) => job.documentId)).toEqual([
-      "pi-import:session-queued:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0",
-    ]);
+    const documentId =
+      "pi-import:session-queued:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0";
+    expect(checkpoint).toMatchObject({
+      toolResults: "content",
+      importQualityProfile: "strict",
+    });
+    expect(checkpoint?.documents[documentId]).toMatchObject({
+      status: "queued",
+      toolResults: "content",
+      importQualityProfile: "strict",
+      error: expect.stringContaining("queued"),
+    });
+    const queue = await readRetainQueue(resolveQueuePath(dir, config.retain.queuePath));
+    expect(queue.map((job) => job.documentId)).toEqual([documentId]);
+  });
+
+  it("records strict curated quality context on failed checkpoint documents", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-"));
+    mkdirSync(join(dir, ".git"));
+    mkdirSync(join(dir, ".pi", "hindsight"), { recursive: true });
+    writeFileSync(join(dir, ".pi/hindsight/queue-blocker"), "not a directory");
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-failed", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "failed import" },
+        }),
+      ].join("\n"),
+    );
+    const config = {
+      ...DEFAULT_CONFIG,
+      retain: {
+        ...DEFAULT_CONFIG.retain,
+        queuePath: ".pi/hindsight/queue-blocker/retain-queue.jsonl",
+      },
+      import: {
+        ...DEFAULT_CONFIG.import,
+        qualityProfile: "strict" as const,
+        toolResults: "summary" as const,
+      },
+    };
+
+    await expect(
+      importPiSession({
+        sessionFile,
+        bankId: "bank",
+        config,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+      }),
+    ).rejects.toThrow();
+
+    const documentId =
+      "pi-import:session-failed:leaf:root:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0";
+    const checkpoint = await readImportCheckpoint(
+      join(dir, ".pi/hindsight/import-checkpoint.json"),
+    );
+    expect(checkpoint).toMatchObject({
+      toolResults: "summary",
+      importQualityProfile: "strict",
+    });
+    expect(checkpoint?.documents[documentId]).toMatchObject({
+      status: "failed",
+      toolResults: "summary",
+      importQualityProfile: "strict",
+      error: expect.any(String),
+    });
   });
 
   it("imports all leaves only when includeBranches is all-leaves", async () => {


### PR DESCRIPTION
## Summary

- Record import quality context in Import Checkpoint run and document entries so recovery/debug artifacts show the active `toolResults` policy and curated `importQualityProfile` when documents are pending, completed, queued, or failed.
- Harden Import Checkpoint validation with explicit allowed values for import mode, tool results, quality profile, update mode, status, and optional document metadata.
- Add regression coverage for checkpoint validation and strict curated checkpoint quality context without changing document IDs, content hashes, projection behavior, or resume skip semantics.

## Linked issue

- Closes #271

## Scope

- Added optional `toolResults` and `importQualityProfile` fields to checkpoint run and document types.
- Populated checkpoint document entries for pending, completed, queued, and failed import states from the existing import plan/preview context.
- Refreshed run-level quality context on resumed checkpoint runs while leaving run ID and resume behavior unchanged.
- Documented that checkpoints expose import quality context for recovery.

## Verification

- [x] `npm test -- tests/import-checkpoint.test.ts tests/import-sessions.test.ts`
- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not run because this is not a release or platform-sensitive change.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — not run because package/release files did not change.
- [ ] `npm run pack:verify` (release/package changes) — not run because package/release files did not change.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — local smoke skipped because this only changes checkpoint recovery artifacts/validation/docs/tests and does not change retain delivery, Hindsight transport, bank selection, recall, reflect, document IDs, content hashes, projection, update mode, or resume skip semantics. PR CI may still run the configured integration workflow for import-file changes.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Changelog/release notes should mention that import checkpoints now include quality context for recovery and debugging. Runtime import delivery semantics are unchanged.

## Risk and rollback

- Risk: Low. The change adds optional checkpoint fields and stricter validation for recognized enum values; older checkpoints without these optional fields still read.
- Rollback/revert path: Revert this commit to remove the checkpoint fields, validation additions, docs, and regression tests. Existing import delivery and manifest behavior do not require a data migration.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. This PR does not change that guidance, so no sync edit was required.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Parent-launched repo-local reviewer completed before PR creation. The blocking hygiene finding was fixed by adding `tests/import-checkpoint.test.ts`; the non-blocking run-level refresh suggestion was also addressed. Smoke was skipped locally for artifact-only checkpoint plumbing; CI should remain source of truth for required PR checks.
