### PR TITLE
feat(import): summarize preview signal noise categories

### DIFF
--- a/docs-site/src/content/docs/reference/import-controls.md
+++ b/docs-site/src/content/docs/reference/import-controls.md
@@ -50,6 +50,8 @@ Pi session dry-runs report items such as:
 - curated projection count
 - dropped non-error tool-result count
 - kept tool-error count
+- kept signal categories (`keptSignals=`), when curated reason counts exist
+- dropped noise categories (`droppedNoise=`), when curated reason counts exist
 - estimated chunk count
 - byte counts
 - target bank

--- a/extensions/import-presentation.ts
+++ b/extensions/import-presentation.ts
@@ -63,6 +63,34 @@ function formatReasonCounts(counts: Record<string, number>): string {
     .join(",");
 }
 
+const KEPT_SIGNAL_REASON_CATEGORIES = [
+  { label: "user", reasons: ["user-text"] },
+  { label: "assistant", reasons: ["assistant-text"] },
+  { label: "tool-errors", reasons: ["tool-error-kept"] },
+  { label: "workflow", reasons: ["message-kept"] },
+] as const;
+
+const DROPPED_NOISE_REASON_CATEGORIES = [
+  { label: "successful-tools", reasons: ["successful-tool-output", "tool-filter-excluded"] },
+  { label: "recalled-memory", reasons: ["recalled-memory"] },
+  { label: "ui/process", reasons: ["ui-noise", "process-noise"] },
+  { label: "oversized/repeated", reasons: ["oversized-output", "repeated-output"] },
+  { label: "empty", reasons: ["tool-result-empty", "empty-projection"] },
+] as const;
+
+function formatReasonCategoryCounts(
+  counts: Record<string, number>,
+  categories: readonly { label: string; reasons: readonly string[] }[],
+): string {
+  return categories
+    .map(({ label, reasons }) => {
+      const count = reasons.reduce((total, reason) => total + (counts[reason] ?? 0), 0);
+      return count > 0 ? `${label}:${count}` : undefined;
+    })
+    .filter((entry): entry is string => Boolean(entry))
+    .join(",");
+}
+
 function formatTopDroppedTools(documents: ImportDocumentSummaryResult["documents"]): string {
   const totals = new Map<string, { count: number; bytes: number }>();
   for (const document of documents) {
@@ -124,12 +152,18 @@ function importDocumentQualitySummary(result: ImportDocumentSummaryResult): stri
         .filter((profile): profile is "strict" => profile === "strict"),
     ),
   ].join(",");
-  const reasonCounts = formatReasonCounts(sumReasonCounts(result.documents));
+  const summedReasonCounts = sumReasonCounts(result.documents);
+  const keptSignals = formatReasonCategoryCounts(summedReasonCounts, KEPT_SIGNAL_REASON_CATEGORIES);
+  const droppedNoise = formatReasonCategoryCounts(
+    summedReasonCounts,
+    DROPPED_NOISE_REASON_CATEGORIES,
+  );
+  const reasonCounts = formatReasonCounts(summedReasonCounts);
   const topDroppedTools = formatTopDroppedTools(result.documents);
   const forensicWarning = importModes.includes("forensic")
     ? "; WARNING forensic mode preserves recalled memory blocks for audit-only use"
     : "";
-  const qualityDetails = `${reasonCounts ? `; reasons=${reasonCounts}` : ""}${topDroppedTools ? `; topDroppedTools=${topDroppedTools}` : ""}`;
+  const qualityDetails = `${keptSignals ? `; keptSignals=${keptSignals}` : ""}${droppedNoise ? `; droppedNoise=${droppedNoise}` : ""}${reasonCounts ? `; reasons=${reasonCounts}` : ""}${topDroppedTools ? `; topDroppedTools=${topDroppedTools}` : ""}`;
   return rawMessages || droppedToolResults || rawBytes || projectedBytes
     ? `; mode=${importModes || "unknown"}${importProfiles ? `; profile=${importProfiles}` : ""}; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; keptToolErrors=${keptErrors}; estimatedChunks=${estimatedChunks}; bytes=${projectedBytes}/${rawBytes}${qualityDetails}${forensicWarning}`
     : "";

--- a/tests/import-presentation.test.ts
+++ b/tests/import-presentation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   importDocumentSummary,
   renderProjectImportMessage,
+  renderImportSessionMessage,
 } from "../extensions/import-presentation.js";
 
 describe("import presentation", () => {
@@ -33,7 +34,49 @@ describe("import presentation", () => {
         ],
       }),
     ).toContain(
-      "mode=forensic; projected=3/5 messages; droppedToolResults=2; keptToolErrors=1; estimatedChunks=1; bytes=400/1000; reasons=tool-filter-excluded:2,assistant-text:1,tool-error-kept:1; topDroppedTools=read:2,grep:1; WARNING forensic mode preserves recalled memory blocks for audit-only use",
+      "mode=forensic; projected=3/5 messages; droppedToolResults=2; keptToolErrors=1; estimatedChunks=1; bytes=400/1000; keptSignals=assistant:1,tool-errors:1; droppedNoise=successful-tools:2; reasons=tool-filter-excluded:2,assistant-text:1,tool-error-kept:1; topDroppedTools=read:2,grep:1; WARNING forensic mode preserves recalled memory blocks for audit-only use",
+    );
+  });
+
+  it("renders concise kept signal and dropped noise categories in single-session previews", () => {
+    expect(
+      renderImportSessionMessage({
+        dryRun: true,
+        messageCount: 21,
+        checkpointPath: "/tmp/checkpoint.json",
+        manifestPath: "/tmp/manifest.json",
+        documents: [
+          {
+            updateMode: "replace",
+            status: "pending",
+            rawMessageCount: 21,
+            projectedMessageCount: 5,
+            rawBytes: 2100,
+            projectedBytes: 500,
+            droppedToolResultCount: 15,
+            keptToolErrorCount: 1,
+            estimatedChunkCount: 1,
+            importMode: "curated",
+            classificationReasonCounts: {
+              "user-text": 2,
+              "assistant-text": 1,
+              "tool-error-kept": 1,
+              "message-kept": 1,
+              "successful-tool-output": 3,
+              "tool-filter-excluded": 2,
+              "recalled-memory": 1,
+              "ui-noise": 2,
+              "process-noise": 1,
+              "oversized-output": 1,
+              "repeated-output": 4,
+              "tool-result-empty": 1,
+              "empty-projection": 1,
+            },
+          },
+        ],
+      }),
+    ).toContain(
+      "keptSignals=user:2,assistant:1,tool-errors:1,workflow:1; droppedNoise=successful-tools:5,recalled-memory:1,ui/process:3,oversized/repeated:5,empty:2; reasons=",
     );
   });
 
@@ -133,7 +176,7 @@ describe("import presentation", () => {
       imported,
     };
     const quality =
-      "mode=curated; profile=strict; projected=4/7 messages; droppedToolResults=3; keptToolErrors=2; estimatedChunks=3; bytes=500/1500; reasons=tool-filter-excluded:3,assistant-text:1,tool-error-kept:1; topDroppedTools=read:3,bash:1,grep:1";
+      "mode=curated; profile=strict; projected=4/7 messages; droppedToolResults=3; keptToolErrors=2; estimatedChunks=3; bytes=500/1500; keptSignals=assistant:1,tool-errors:1; droppedNoise=successful-tools:3; reasons=tool-filter-excluded:3,assistant-text:1,tool-error-kept:1; topDroppedTools=read:3,bash:1,grep:1";
 
     expect(renderProjectImportMessage({ ...base, dryRun: true })).toBe(
       `Project import preview: sessions=2/3; documents=2; messages=7; malformedLines=1; ${quality}; write=no`,


### PR DESCRIPTION
## Summary

- Add deterministic `keptSignals=` and `droppedNoise=` fields to Pi session and project import quality summaries when curated reason counts exist.
- Reuse existing classification reason counts; keep existing `reasons=` and `topDroppedTools=` details for debugging.
- Document the new dry-run metric names in the import controls reference.

## Linked issue

- Closes #273

## Scope

- Presentation-only import preview/import summary update for single-session and project imports.
- No projection/classification behavior changes.
- No retained content, document ID, checkpoint, manifest, API, or queue delivery changes.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (skipped because this is presentation-only; no import execution semantics changed)
- [x] `npm run typecheck:tsc`
- [ ] full matrix requested/passed (not required; not release or platform-sensitive)
- [ ] package verification requested/passed (not required; no package/release path changes)
- [ ] `npm run pack:verify` (not required; no package/release path changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (local smoke skipped because this is presentation-only; no retain/recall/reflect/bank/queue/API behavior changed)
- [x] `npm test -- tests/import-presentation.test.ts`
- [x] Reviewer subagent pass via parent in this worktree: no implementation blockers.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes impact: import previews now show concise kept-signal and dropped-noise category totals when curated reason counts are available.

## Risk and rollback

- Risk: import preview output consumers may see two additional semicolon-delimited fields before `reasons=`.
- Rollback/revert path: revert this PR to remove the added presentation fields and doc bullets; import behavior/data remains unchanged.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] This does not change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done; `AGENTS.md` and `CONTRIBUTING.md` did not need updates.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

No ADR conflicts. Category mapping is presentation-only and derives only from existing curated import classification reason counts.
