### PR TITLE
feat(diagnostics): show import quality context

### DIFF
--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -190,6 +190,26 @@ export function formatDebugReport(args: DebugReportArgs): string {
               leafId: args.latestImport.leafId,
               sessionId: args.latestImport.sessionId,
               contentHash: args.latestImport.contentHash,
+              ...(args.latestImport.importMode ? { importMode: args.latestImport.importMode } : {}),
+              ...(args.latestImport.toolResults
+                ? { toolResults: args.latestImport.toolResults }
+                : {}),
+              ...(args.latestImport.importQualityProfile
+                ? { importQualityProfile: args.latestImport.importQualityProfile }
+                : {}),
+              ...(args.latestImport.projectionVersion
+                ? { projectionVersion: args.latestImport.projectionVersion }
+                : {}),
+              ...(args.latestImport.importProfile
+                ? { importProfile: args.latestImport.importProfile }
+                : {}),
+              ...(args.latestImport.chunkIndex !== undefined
+                ? { chunkIndex: args.latestImport.chunkIndex }
+                : {}),
+              ...(args.latestImport.messageRange
+                ? { messageRange: args.latestImport.messageRange }
+                : {}),
+              ...(args.latestImport.updateMode ? { updateMode: args.latestImport.updateMode } : {}),
             }
           : null,
       },

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -6,6 +6,24 @@ import {
   observationScopeDiagnostics,
   safeConfig,
 } from "../extensions/diagnostics.js";
+import type { ImportManifestEntry } from "../extensions/import-manifest.js";
+
+function latestImport(overrides: Partial<ImportManifestEntry> = {}): ImportManifestEntry {
+  return {
+    documentId: "doc-1",
+    bankId: "bank",
+    sourceFile: "/tmp/session.jsonl",
+    importedAt: "2026-05-06T12:00:00.000Z",
+    contentHash: "sha256:abc",
+    messageCount: 3,
+    leafId: "leaf-1",
+    sessionId: "session-1",
+    cwd: "/repo",
+    includeBranches: "current-only",
+    updateMode: "append",
+    ...overrides,
+  };
+}
 
 describe("diagnostics", () => {
   it("explains automatic bank selection and override", () => {
@@ -246,5 +264,69 @@ describe("diagnostics", () => {
 
     expect(report.queue.deadLetterMalformedLines).toBe(1);
     expect(report.queue.action).toContain("Inspect queue files");
+  });
+
+  it("includes latest import quality context when manifest fields are present", () => {
+    const report = JSON.parse(
+      formatDebugReport({
+        cwd: process.cwd(),
+        projectBankId: "bank",
+        config: DEFAULT_CONFIG,
+        queueLength: 0,
+        latestImport: latestImport({
+          importMode: "curated",
+          toolResults: "summary",
+          importQualityProfile: "strict",
+          projectionVersion: "curated-turns-v1",
+          importProfile: "turns-12-bytes-80000",
+          chunkIndex: 0,
+          messageRange: { start: 4, end: 8 },
+          updateMode: "replace",
+        }),
+      }),
+    ) as Record<string, any>;
+
+    expect(report.imports.latest).toEqual({
+      documentId: "doc-1",
+      sourceFile: "/tmp/session.jsonl",
+      importedAt: "2026-05-06T12:00:00.000Z",
+      messageCount: 3,
+      leafId: "leaf-1",
+      sessionId: "session-1",
+      contentHash: "sha256:abc",
+      importMode: "curated",
+      toolResults: "summary",
+      importQualityProfile: "strict",
+      projectionVersion: "curated-turns-v1",
+      importProfile: "turns-12-bytes-80000",
+      chunkIndex: 0,
+      messageRange: { start: 4, end: 8 },
+      updateMode: "replace",
+    });
+  });
+
+  it("omits absent latest import quality fields", () => {
+    const importWithoutQualityContext = latestImport() as Partial<ImportManifestEntry>;
+    delete importWithoutQualityContext.updateMode;
+
+    const report = JSON.parse(
+      formatDebugReport({
+        cwd: process.cwd(),
+        projectBankId: "bank",
+        config: DEFAULT_CONFIG,
+        queueLength: 0,
+        latestImport: importWithoutQualityContext as ImportManifestEntry,
+      }),
+    ) as Record<string, any>;
+
+    expect(report.imports.latest).toEqual({
+      documentId: "doc-1",
+      sourceFile: "/tmp/session.jsonl",
+      importedAt: "2026-05-06T12:00:00.000Z",
+      messageCount: 3,
+      leafId: "leaf-1",
+      sessionId: "session-1",
+      contentHash: "sha256:abc",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add existing Import Manifest quality context to `/hindsight` diagnostics JSON at `imports.latest` when fields are present.
- Preserve existing latest-import fields and omit absent optional fields.
- Add diagnostics regression tests for present quality context and legacy/absent context.

## Linked issue

- Closes #275

## Scope

- Diagnostics presentation only in `formatDebugReport(...).imports.latest`.
- Regression coverage in `tests/diagnostics.test.ts`.
- No manifest write, Import Checkpoint, import execution, projection, Retain, Document ID, Hindsight API, or Retain Queue behavior changes.
- No docs update because no exact diagnostics latest-import field reference exists.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional verification:

- [x] `npm test -- tests/diagnostics.test.ts`
- [x] Parent-launched reviewer pass completed; accepted finding to assert `chunkIndex: 0` was applied.

Skipped check rationale:

- `npm run check:coverage` skipped because this slice only changes diagnostics JSON presentation and adds targeted regression tests; no execution semantics changed.
- `npm run typecheck:tsc` skipped because this slice does not change critical/runtime semantics; `npm run check` typecheck passed.
- `npm run smoke:hindsight` skipped because no memory-path behavior changed; diagnostics only reads existing manifest fields.
- Full matrix, package verification, and `npm run pack:verify` skipped because no release, package, or platform-sensitive behavior changed.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Diagnostics output now shows latest Import Manifest quality context when available, so release notes can mention improved import observability.

## Risk and rollback

- Risk: Low. Change only adds optional fields to diagnostics JSON when already present on the Import Manifest entry.
- Rollback/revert path: Revert this PR to remove the added diagnostics fields and regression tests.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- No ADR conflicts found.
- Docs unchanged because only general diagnostics docs exist; no exact latest-import field list exists.
- Coverage, TypeScript compiler fallback, and live smoke were skipped for the reasons above.
