### PR TITLE
feat(retain): expose explicit retain options

### DIFF
--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -18,31 +18,43 @@ Recall raw memories from Hindsight for this project.
 | `bank`           | string                                      | no       | Optional bank id. Defaults to project bank.                                                   |
 | `queryTimestamp` | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                |
 | `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`      | string \| string \| string \| string        | no       |                                                                                               |
+| `tagsMatch`      | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
 | `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ### `hindsight_retain`
 
 Retain explicit raw content in Hindsight. Use for durable facts or decisions.
 
-| Parameter  | Type          | Required | Description                                                        |
-| ---------- | ------------- | -------- | ------------------------------------------------------------------ |
-| `content`  | string        | yes      | Raw content to retain, not summary if source content is available. |
-| `context`  | string        | yes      | Source context for this memory.                                    |
-| `bank`     | string        | no       | Optional bank id. Defaults to project bank.                        |
-| `tags`     | array<string> | no       |                                                                    |
-| `entities` | array<object> | no       |                                                                    |
+| Parameter           | Type                 | Required | Description                                                                                                                                                            |
+| ------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`           | string               | yes      | Raw content to retain, not summary if source content is available.                                                                                                     |
+| `context`           | string               | yes      | Source context for this memory.                                                                                                                                        |
+| `bank`              | string               | no       | Optional bank id. Defaults to project bank.                                                                                                                            |
+| `tags`              | array<string>        | no       |                                                                                                                                                                        |
+| `entities`          | array<object>        | no       | Optional Hindsight entities to associate with this retained content.                                                                                                   |
+| `documentId`        | string               | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                    |
+| `timestamp`         | string               | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                           |
+| `metadata`          | object/map           | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden. |
+| `updateMode`        | append \| replace    | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                          |
+| `observationScopes` | array<array<string>> | no       | Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.                           |
+| `async`             | boolean              | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                    |
 
 ### `hindsight_retain_global`
 
 Retain explicit durable user memory in the configured user bank. Use for stable user identity, preferences, and cross-project workflows only.
 
-| Parameter  | Type          | Required | Description                              |
-| ---------- | ------------- | -------- | ---------------------------------------- |
-| `content`  | string        | yes      | Raw memory content to retain.            |
-| `context`  | string        | yes      | Why this memory is durable user context. |
-| `tags`     | array<string> | no       |                                          |
-| `entities` | array<object> | no       |                                          |
+| Parameter           | Type                 | Required | Description                                                                                                                                                            |
+| ------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`           | string               | yes      | Raw memory content to retain.                                                                                                                                          |
+| `context`           | string               | yes      | Why this memory is durable user context.                                                                                                                               |
+| `tags`              | array<string>        | no       |                                                                                                                                                                        |
+| `entities`          | array<object>        | no       | Optional Hindsight entities to associate with this retained content.                                                                                                   |
+| `documentId`        | string               | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                    |
+| `timestamp`         | string               | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                           |
+| `metadata`          | object/map           | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden. |
+| `updateMode`        | append \| replace    | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                          |
+| `observationScopes` | array<array<string>> | no       | Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.                           |
+| `async`             | boolean              | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                    |
 
 ### `hindsight_retain_receipts`
 
@@ -104,14 +116,14 @@ Reset Hindsight bank config overrides for a selected bank.
 
 List bank-owned Hindsight directives (hard reflect rules).
 
-| Parameter    | Type                       | Required | Description                                 |
-| ------------ | -------------------------- | -------- | ------------------------------------------- |
-| `bank`       | string                     | no       | Optional bank id. Defaults to project bank. |
-| `tags`       | array<string>              | no       | Optional tag filter.                        |
-| `tagsMatch`  | string \| string \| string | no       |                                             |
-| `activeOnly` | boolean                    | no       | Only return active directives.              |
-| `limit`      | number                     | no       | Maximum directives to return.               |
-| `offset`     | number                     | no       | Pagination offset.                          |
+| Parameter    | Type                | Required | Description                                 |
+| ------------ | ------------------- | -------- | ------------------------------------------- |
+| `bank`       | string              | no       | Optional bank id. Defaults to project bank. |
+| `tags`       | array<string>       | no       | Optional tag filter.                        |
+| `tagsMatch`  | any \| all \| exact | no       |                                             |
+| `activeOnly` | boolean             | no       | Only return active directives.              |
+| `limit`      | number              | no       | Maximum directives to return.               |
+| `offset`     | number              | no       | Pagination offset.                          |
 
 ### `hindsight_get_directive`
 
@@ -204,9 +216,9 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 | `query`          | string                                      | yes      |                                                                                               |
 | `context`        | string                                      | no       |                                                                                               |
 | `bank`           | string                                      | no       |                                                                                               |
-| `responseSchema` | object                                      | no       |                                                                                               |
+| `responseSchema` | object/map                                  | no       |                                                                                               |
 | `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`      | string \| string \| string \| string        | no       |                                                                                               |
+| `tagsMatch`      | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
 | `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ## Commands

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -98,7 +98,8 @@ Additional tools:
 Tool notes:
 
 - `hindsight_recall` accepts `queryTimestamp`.
-- `hindsight_retain` accepts `entities`.
+- `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp`, `metadata`, `updateMode`, `observationScopes`, and `async`.
+- Caller `metadata` is merged with pi-hindsight provenance, but reserved provenance keys such as `cwd`, `pi_session_file`, `source`, and `retainSource` are set by pi-hindsight and cannot be overridden.
 - `hindsight_reflect` accepts `responseSchema` for structured reflection output.
 - Omit `bank` or pass `project` for the selected project bank.
 - Pass `global` for the configured global bank.

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -14,31 +14,43 @@ Recall raw memories from Hindsight for this project.
 | `bank`           | string                                      | no       | Optional bank id. Defaults to project bank.                                                   |
 | `queryTimestamp` | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                |
 | `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`      | string \| string \| string \| string        | no       |                                                                                               |
+| `tagsMatch`      | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
 | `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ### `hindsight_retain`
 
 Retain explicit raw content in Hindsight. Use for durable facts or decisions.
 
-| Parameter  | Type          | Required | Description                                                        |
-| ---------- | ------------- | -------- | ------------------------------------------------------------------ |
-| `content`  | string        | yes      | Raw content to retain, not summary if source content is available. |
-| `context`  | string        | yes      | Source context for this memory.                                    |
-| `bank`     | string        | no       | Optional bank id. Defaults to project bank.                        |
-| `tags`     | array<string> | no       |                                                                    |
-| `entities` | array<object> | no       |                                                                    |
+| Parameter           | Type                 | Required | Description                                                                                                                                                            |
+| ------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`           | string               | yes      | Raw content to retain, not summary if source content is available.                                                                                                     |
+| `context`           | string               | yes      | Source context for this memory.                                                                                                                                        |
+| `bank`              | string               | no       | Optional bank id. Defaults to project bank.                                                                                                                            |
+| `tags`              | array<string>        | no       |                                                                                                                                                                        |
+| `entities`          | array<object>        | no       | Optional Hindsight entities to associate with this retained content.                                                                                                   |
+| `documentId`        | string               | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                    |
+| `timestamp`         | string               | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                           |
+| `metadata`          | object/map           | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden. |
+| `updateMode`        | append \| replace    | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                          |
+| `observationScopes` | array<array<string>> | no       | Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.                           |
+| `async`             | boolean              | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                    |
 
 ### `hindsight_retain_global`
 
 Retain explicit durable user memory in the configured user bank. Use for stable user identity, preferences, and cross-project workflows only.
 
-| Parameter  | Type          | Required | Description                              |
-| ---------- | ------------- | -------- | ---------------------------------------- |
-| `content`  | string        | yes      | Raw memory content to retain.            |
-| `context`  | string        | yes      | Why this memory is durable user context. |
-| `tags`     | array<string> | no       |                                          |
-| `entities` | array<object> | no       |                                          |
+| Parameter           | Type                 | Required | Description                                                                                                                                                            |
+| ------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`           | string               | yes      | Raw memory content to retain.                                                                                                                                          |
+| `context`           | string               | yes      | Why this memory is durable user context.                                                                                                                               |
+| `tags`              | array<string>        | no       |                                                                                                                                                                        |
+| `entities`          | array<object>        | no       | Optional Hindsight entities to associate with this retained content.                                                                                                   |
+| `documentId`        | string               | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                    |
+| `timestamp`         | string               | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                           |
+| `metadata`          | object/map           | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden. |
+| `updateMode`        | append \| replace    | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                          |
+| `observationScopes` | array<array<string>> | no       | Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.                           |
+| `async`             | boolean              | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                    |
 
 ### `hindsight_retain_receipts`
 
@@ -100,14 +112,14 @@ Reset Hindsight bank config overrides for a selected bank.
 
 List bank-owned Hindsight directives (hard reflect rules).
 
-| Parameter    | Type                       | Required | Description                                 |
-| ------------ | -------------------------- | -------- | ------------------------------------------- |
-| `bank`       | string                     | no       | Optional bank id. Defaults to project bank. |
-| `tags`       | array<string>              | no       | Optional tag filter.                        |
-| `tagsMatch`  | string \| string \| string | no       |                                             |
-| `activeOnly` | boolean                    | no       | Only return active directives.              |
-| `limit`      | number                     | no       | Maximum directives to return.               |
-| `offset`     | number                     | no       | Pagination offset.                          |
+| Parameter    | Type                | Required | Description                                 |
+| ------------ | ------------------- | -------- | ------------------------------------------- |
+| `bank`       | string              | no       | Optional bank id. Defaults to project bank. |
+| `tags`       | array<string>       | no       | Optional tag filter.                        |
+| `tagsMatch`  | any \| all \| exact | no       |                                             |
+| `activeOnly` | boolean             | no       | Only return active directives.              |
+| `limit`      | number              | no       | Maximum directives to return.               |
+| `offset`     | number              | no       | Pagination offset.                          |
 
 ### `hindsight_get_directive`
 
@@ -200,9 +212,9 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 | `query`          | string                                      | yes      |                                                                                               |
 | `context`        | string                                      | no       |                                                                                               |
 | `bank`           | string                                      | no       |                                                                                               |
-| `responseSchema` | object                                      | no       |                                                                                               |
+| `responseSchema` | object/map                                  | no       |                                                                                               |
 | `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`      | string \| string \| string \| string        | no       |                                                                                               |
+| `tagsMatch`      | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
 | `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ## Commands

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -96,7 +96,8 @@ Additional tools:
 Tool notes:
 
 - `hindsight_recall` accepts `queryTimestamp`.
-- `hindsight_retain` accepts `entities`.
+- `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp`, `metadata`, `updateMode`, `observationScopes`, and `async`.
+- Caller `metadata` is merged with pi-hindsight provenance, but reserved provenance keys such as `cwd`, `pi_session_file`, `source`, and `retainSource` are set by pi-hindsight and cannot be overridden.
 - `hindsight_reflect` accepts `responseSchema` for structured reflection output.
 - Omit `bank` or pass `project` for the selected project bank.
 - Pass `global` for the configured global bank.

--- a/extensions/memory-retain-operations.ts
+++ b/extensions/memory-retain-operations.ts
@@ -9,6 +9,23 @@ import { appendRetainReceipt, listRetainReceipts } from "./retain-receipts.js";
 import { getEffectiveSessionMemoryMode, readSessionMemoryMeta } from "./session-memory-meta.js";
 import type { ResolvedConfig, UpdateMode } from "./types.js";
 
+const RESERVED_EXPLICIT_RETAIN_METADATA_KEYS = new Set([
+  "cwd",
+  "pi_session_file",
+  "source",
+  "retainSource",
+]);
+
+function callerMetadata(
+  metadata: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!metadata) return undefined;
+  const entries = Object.entries(metadata).filter(
+    ([key]) => !RESERVED_EXPLICIT_RETAIN_METADATA_KEYS.has(key),
+  );
+  return entries.length ? Object.fromEntries(entries) : undefined;
+}
+
 export function createRetainOperations(deps: MemoryOperationsDeps) {
   return {
     async retainExplicit(args: {
@@ -67,7 +84,7 @@ export function createRetainOperations(deps: MemoryOperationsDeps) {
             context: args.context,
           }),
         metadata: {
-          ...args.metadata,
+          ...callerMetadata(args.metadata),
           cwd: args.cwd,
           ...(args.sessionFile ? { pi_session_file: args.sessionFile } : {}),
         },

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -74,6 +74,73 @@ function tagGroupsSchema(description: string) {
   return Type.Optional(Type.Array(tagGroupSchema, { description }));
 }
 
+const retainEntitySchema = Type.Object({
+  text: Type.String({ description: "Entity text to associate with the retained content." }),
+  type: Type.Optional(Type.String({ description: "Optional entity type." })),
+});
+
+const retainUpdateModeSchema = Type.Union([Type.Literal("append"), Type.Literal("replace")], {
+  description: "Optional Hindsight update mode for this explicit retain call.",
+});
+
+function explicitRetainOptionParameters() {
+  return {
+    documentId: Type.Optional(
+      Type.String({
+        description:
+          "Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.",
+      }),
+    ),
+    timestamp: Type.Optional(
+      Type.String({
+        description:
+          "Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.",
+      }),
+    ),
+    metadata: Type.Optional(
+      Type.Record(Type.String(), Type.String(), {
+        description:
+          "Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden.",
+      }),
+    ),
+    updateMode: Type.Optional(retainUpdateModeSchema),
+    observationScopes: Type.Optional(
+      Type.Array(Type.Array(Type.String()), {
+        description:
+          "Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.",
+      }),
+    ),
+    async: Type.Optional(
+      Type.Boolean({
+        description:
+          "Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.",
+      }),
+    ),
+  };
+}
+
+type ExplicitRetainOptionParams = {
+  documentId?: string;
+  timestamp?: string;
+  metadata?: Record<string, string>;
+  updateMode?: import("./types.js").UpdateMode;
+  observationScopes?: string[][];
+  async?: boolean;
+};
+
+function explicitRetainOptions(params: ExplicitRetainOptionParams) {
+  return {
+    ...(params.documentId !== undefined ? { documentId: params.documentId } : {}),
+    ...(params.timestamp !== undefined ? { timestamp: params.timestamp } : {}),
+    ...(params.metadata !== undefined ? { metadata: params.metadata } : {}),
+    ...(params.updateMode !== undefined ? { updateMode: params.updateMode } : {}),
+    ...(params.observationScopes !== undefined
+      ? { observationScopes: params.observationScopes }
+      : {}),
+    ...(params.async !== undefined ? { async: params.async } : {}),
+  };
+}
+
 function defineCatalogTool<TParams extends ToolDefinition["parameters"], TDetails = unknown>(
   tool: ToolDefinition<TParams, TDetails>,
 ): ToolOperation {
@@ -150,13 +217,11 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         ),
         tags: Type.Optional(Type.Array(Type.String())),
         entities: Type.Optional(
-          Type.Array(
-            Type.Object({
-              text: Type.String(),
-              type: Type.Optional(Type.String()),
-            }),
-          ),
+          Type.Array(retainEntitySchema, {
+            description: "Optional Hindsight entities to associate with this retained content.",
+          }),
         ),
+        ...explicitRetainOptionParameters(),
       }),
       async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
@@ -169,6 +234,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           ...(params.bank ? { bank: params.bank } : {}),
           ...(params.tags ? { tags: params.tags } : {}),
           ...(params.entities ? { entities: params.entities } : {}),
+          ...explicitRetainOptions(params),
         });
         return retainToolResponse(result);
       },
@@ -183,13 +249,11 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         context: Type.String({ description: "Why this memory is durable user context." }),
         tags: Type.Optional(Type.Array(Type.String())),
         entities: Type.Optional(
-          Type.Array(
-            Type.Object({
-              text: Type.String(),
-              type: Type.Optional(Type.String()),
-            }),
-          ),
+          Type.Array(retainEntitySchema, {
+            description: "Optional Hindsight entities to associate with this retained content.",
+          }),
         ),
+        ...explicitRetainOptionParameters(),
       }),
       async execute(_id, params, _signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
@@ -202,6 +266,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           ...(sessionFile ? { sessionFile } : {}),
           ...(params.tags ? { tags: params.tags } : {}),
           ...(params.entities ? { entities: params.entities } : {}),
+          ...explicitRetainOptions(params),
         });
         return retainToolResponse(result);
       },

--- a/extensions/retain-job-builder.ts
+++ b/extensions/retain-job-builder.ts
@@ -19,8 +19,20 @@ export interface RetainJobBuildArgs {
   async?: boolean;
 }
 
+function sanitizedMetadata(
+  metadata: Record<string, string> | undefined,
+  redact: boolean,
+): Record<string, string> | undefined {
+  if (!metadata) return undefined;
+  if (!redact) return metadata;
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => [key, redactSecrets(value)]),
+  );
+}
+
 export function buildRetainJob(args: RetainJobBuildArgs): RetainJob {
   const content = args.config.retain.redactSecrets ? redactSecrets(args.content) : args.content;
+  const metadata = sanitizedMetadata(args.metadata, args.config.retain.redactSecrets);
   const target = resolveRetainDocumentTarget({
     config: args.config,
     ...(args.capabilities ? { capabilities: args.capabilities } : {}),
@@ -42,7 +54,7 @@ export function buildRetainJob(args: RetainJobBuildArgs): RetainJob {
         ? { entities: [...args.config.retain.entities, ...(args.entities ?? [])] }
         : {}),
       tags: args.tags,
-      ...(args.metadata ? { metadata: args.metadata } : {}),
+      ...(metadata ? { metadata } : {}),
       ...(args.observationScopes?.length ? { observationScopes: args.observationScopes } : {}),
     },
     retries: 0,

--- a/scripts/generate-surface-reference.ts
+++ b/scripts/generate-surface-reference.ts
@@ -27,6 +27,8 @@ type JsonSchema = {
   items?: JsonSchema;
   anyOf?: JsonSchema[];
   enum?: unknown[];
+  const?: unknown;
+  patternProperties?: Record<string, JsonSchema>;
   additionalProperties?: JsonSchema | boolean;
 };
 
@@ -55,8 +57,10 @@ function table(headers: string[], rows: string[][]): string[] {
 function schemaType(schema: JsonSchema | undefined): string {
   if (!schema) return "unknown";
   if (schema.enum) return schema.enum.map(String).join(" | ");
+  if (schema.const !== undefined) return String(schema.const);
   if (schema.type === "array") return `array<${schemaType(schema.items)}>`;
-  if (schema.type === "object" && schema.additionalProperties) return "object/map";
+  if (schema.type === "object" && (schema.additionalProperties || schema.patternProperties))
+    return "object/map";
   if (schema.type) return schema.type;
   if (schema.anyOf?.length) return schema.anyOf.map(schemaType).join(" | ");
   return "unknown";

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -171,6 +171,10 @@ describe("memory operations", () => {
       async: true,
       entities: [{ text: "Alice", type: "person" }],
     });
+    const retainOptions = calls.find((call) => call.method === "retain")?.options as {
+      metadata?: Record<string, string>;
+    };
+    expect(retainOptions.metadata).not.toHaveProperty("pi_session_file");
     expect(calls.find((call) => call.method === "reflect")?.options).toMatchObject({
       responseSchema: { type: "object", properties: { answer: { type: "string" } } },
       factTypes: ["observation"],

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -1,7 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { createOperationCatalog } from "../extensions/operation-catalog.js";
-import type { HindsightLikeClient } from "../extensions/types.js";
+import type { HindsightLikeClient, ResolvedConfig } from "../extensions/types.js";
+
+type RetainOptions = Parameters<HindsightLikeClient["retain"]>[2];
+
+type JsonSchema = {
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  patternProperties?: Record<string, JsonSchema>;
+  items?: JsonSchema;
+  anyOf?: JsonSchema[];
+  const?: unknown;
+};
 
 function client(): HindsightLikeClient {
   return {
@@ -20,7 +34,200 @@ function client(): HindsightLikeClient {
   };
 }
 
+function retainMock() {
+  return vi.fn(async (_bankId: string, _content: string, _options?: RetainOptions) => undefined);
+}
+
+function requireTool(catalog: ReturnType<typeof createOperationCatalog>, name: string) {
+  const tool = catalog.tools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`Missing ${name} tool`);
+  return tool;
+}
+
 describe("operation catalog", () => {
+  it("exposes and maps advanced explicit retain options on the project retain tool", async () => {
+    const retain = retainMock();
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-catalog-"));
+    const sessionFile = join(cwd, "session.jsonl");
+    const catalog = createOperationCatalog({
+      getClient: () => ({ ...client(), retain }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+    const tool = requireTool(catalog, "hindsight_retain");
+    const properties = (tool.parameters as JsonSchema).properties ?? {};
+
+    expect(properties.documentId?.type).toBe("string");
+    expect(properties.timestamp?.type).toBe("string");
+    expect(properties.metadata?.patternProperties?.["^.*$"]?.type).toBe("string");
+    expect(properties.updateMode?.anyOf?.map((schema) => schema.const)).toEqual([
+      "append",
+      "replace",
+    ]);
+    expect(properties.observationScopes?.items?.items?.type).toBe("string");
+    expect(properties.async?.type).toBe("boolean");
+
+    await tool.execute(
+      "call",
+      {
+        content: "Remember exact decision",
+        context: "unit test retain tool",
+        bank: "target-bank",
+        tags: ["decision:test"],
+        entities: [{ text: "Alice", type: "person" }],
+        documentId: "manual-doc",
+        timestamp: "unset",
+        metadata: {
+          cwd: "wrong-cwd",
+          pi_session_file: "wrong-session",
+          source: "wrong-source",
+          retainSource: "wrong-retain-source",
+          caller: "kept",
+        },
+        updateMode: "append",
+        observationScopes: [["repo:manual"], ["bank:manual"]],
+        async: false,
+      },
+      new AbortController().signal,
+      () => undefined,
+      { cwd, sessionManager: { getSessionFile: () => sessionFile } } as never,
+    );
+
+    expect(retain).toHaveBeenCalledWith(
+      "target-bank",
+      "Remember exact decision",
+      expect.objectContaining({
+        context: "unit test retain tool",
+        documentId: "manual-doc",
+        timestamp: "unset",
+        metadata: {
+          cwd,
+          pi_session_file: sessionFile,
+          source: "pi-hindsight",
+          retainSource: "tool",
+          caller: "kept",
+        },
+        updateMode: "append",
+        observationScopes: [["repo:manual"], ["bank:manual"]],
+        async: false,
+        entities: [{ text: "Alice", type: "person" }],
+      }),
+    );
+
+    retain.mockClear();
+    await tool.execute(
+      "call",
+      {
+        content: "Append using deterministic explicit document ID",
+        context: "unit test append default document ID",
+        updateMode: "append",
+      },
+      new AbortController().signal,
+      () => undefined,
+      { cwd, sessionManager: { getSessionFile: () => sessionFile } } as never,
+    );
+
+    expect(retain).toHaveBeenCalledWith(
+      "project-bank",
+      "Append using deterministic explicit document ID",
+      expect.objectContaining({
+        context: "unit test append default document ID",
+        documentId: expect.stringMatching(/^pi-explicit:/),
+        updateMode: "append",
+      }),
+    );
+  });
+
+  it("keeps simple retain defaults unchanged when advanced tool options are omitted", async () => {
+    const retain = retainMock();
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-catalog-"));
+    const sessionFile = join(cwd, "session.jsonl");
+    const catalog = createOperationCatalog({
+      getClient: () => ({ ...client(), retain }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+    const tool = requireTool(catalog, "hindsight_retain");
+
+    await tool.execute(
+      "call",
+      { content: "Remember simple default", context: "unit test retain defaults" },
+      new AbortController().signal,
+      () => undefined,
+      { cwd, sessionManager: { getSessionFile: () => sessionFile } } as never,
+    );
+
+    const options = retain.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(options).toMatchObject({
+      context: "unit test retain defaults",
+      updateMode: "replace",
+      async: true,
+      metadata: {
+        cwd,
+        pi_session_file: sessionFile,
+        source: "pi-hindsight",
+        retainSource: "tool",
+      },
+      observationScopes: [["harness:pi"], [expect.stringMatching(/^repo:/)]],
+    });
+    expect(options.documentId).toEqual(expect.stringMatching(/^pi-explicit:/));
+    expect(options.tags).toEqual(
+      expect.arrayContaining([
+        "source:pi",
+        expect.stringMatching(/^repo:/),
+        expect.stringMatching(/^session:/),
+      ]),
+    );
+  });
+
+  it("maps advanced explicit retain options on the global retain tool", async () => {
+    const retain = retainMock();
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-catalog-"));
+    const config: ResolvedConfig = {
+      ...DEFAULT_CONFIG,
+      banks: {
+        ...DEFAULT_CONFIG.banks,
+        user: { ...DEFAULT_CONFIG.banks.user, enabled: true, bankId: "global-bank" },
+      },
+    };
+    const catalog = createOperationCatalog({
+      getClient: () => ({ ...client(), retain }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    });
+    const tool = requireTool(catalog, "hindsight_retain_global");
+
+    await tool.execute(
+      "call",
+      {
+        content: "Remember global preference",
+        context: "unit test global retain tool",
+        documentId: "global-doc",
+        timestamp: "2026-05-06T00:00:00Z",
+        metadata: { caller: "kept", source: "wrong-source", retainSource: "wrong-retain" },
+        updateMode: "append",
+        observationScopes: [["user:manual"]],
+        async: false,
+      },
+      new AbortController().signal,
+      () => undefined,
+      { cwd, sessionManager: {} } as never,
+    );
+
+    expect(retain).toHaveBeenCalledWith(
+      "global-bank",
+      "Remember global preference",
+      expect.objectContaining({
+        documentId: "global-doc",
+        timestamp: "2026-05-06T00:00:00Z",
+        metadata: { cwd, source: "pi-hindsight", retainSource: "tool", caller: "kept" },
+        updateMode: "append",
+        observationScopes: [["user:manual"]],
+        async: false,
+      }),
+    );
+  });
+
   it("passes nullable directive updates through the public tool surface", async () => {
     const updateDirective = vi.fn(async () => ({ id: "directive", content: "Updated" }));
     const catalog = createOperationCatalog({

--- a/tests/retain-durable.test.ts
+++ b/tests/retain-durable.test.ts
@@ -85,6 +85,40 @@ describe("durable explicit retain", () => {
     expect(queued[0]?.item.tags).toEqual(expect.arrayContaining(["source:pi", "decision:test"]));
   });
 
+  it("redacts explicit retain metadata when secret redaction is enabled", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
+    const config = testConfig();
+    const operations = createMemoryOperations({
+      getClient: () =>
+        client(async () => {
+          throw new Error("down");
+        }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    });
+
+    await operations.retainExplicit({
+      cwd,
+      content: "Durable fact",
+      context: "unit test explicit retain",
+      metadata: {
+        source_url: "https://example.test/callback?token=super-secret&ok=true",
+        api_key: "sk-abcdefghijklmnopqrstuvwxyz",
+      },
+    });
+
+    const queued = await readRetainQueue(resolveQueuePath(cwd, config.retain.queuePath));
+    expect(queued[0]?.item.metadata).toMatchObject({
+      source_url: "https://example.test/callback?token=[REDACTED]",
+      api_key: "[REDACTED_API_KEY]",
+      cwd,
+      source: "pi-hindsight",
+      retainSource: "tool",
+    });
+    expect(JSON.stringify(queued[0]?.item.metadata)).not.toContain("super-secret");
+    expect(JSON.stringify(queued[0]?.item.metadata)).not.toContain("abcdefghijklmnopqrstuvwxyz");
+  });
+
   it("passes configured observation scopes for explicit retain", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
     const config: ResolvedConfig = {


### PR DESCRIPTION
## Summary

- Exposes advanced explicit retain options on `hindsight_retain` and `hindsight_retain_global` without adding new tool families.
- Maps `documentId`, `timestamp`, `metadata`, `updateMode`, `observationScopes`, and `async` through existing explicit retain execution.
- Keeps simple retain defaults unchanged and documents caller metadata provenance protection.

## Linked issue

- Closes #277

## Scope

- Adds optional public parameters only to existing explicit retain tool schemas.
- Reuses existing `retainExplicit` behavior so default document IDs, queueing, automatic retain, and append/replace defaults are unchanged unless caller passes options.
- Updates generated surface reference and tools docs for source-controlled public parameter docs.
- Adds operation-catalog tests for schema exposure, project/global mapping, reserved provenance override protection, simple defaults, and append without explicit `documentId`.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not needed; not release/platform-sensitive.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — not needed; no package/release path change.
- [ ] `npm run pack:verify` (release/package changes) — not needed; no package/release path change.
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional targeted/local proof:

- `npm test -- tests/operation-catalog.test.ts tests/memory-operations.test.ts tests/retain-durable.test.ts`
- `npm run lint`
- `npm test -- tests/operation-catalog.test.ts`
- Local `npm run smoke:hindsight` used configured `https://h1.luxus.ai` and passed through `success` plus `cleanup_ok`. Evidence included `operations_retain_ok` with document ID `pi-explicit:acb55567aad8575e:b010791cf42f3075`, `operations_recall_ok`, `operations_reflect_ok`, `import_recall_ok`, and `cleanup_ok` for temporary bank `pi-hindsight-smoke-1778093037032`.
- Precommit hook also ran `npm run check` during commit and passed.
- Parent-launched repo-local reviewer completed with no blockers; cheap findings fixed.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Explicit retain tool users can now pass Hindsight retain options directly through existing retain tools. Mention in release notes as an added tool-surface capability.

## Risk and rollback

- Risk: callers can now override per-call explicit retain options, so malformed caller values could cause Hindsight retain failures for that explicit call.
- Rollback/revert path: revert this PR to remove the public parameter exposure and restore the previous narrow retain tool surface. Existing defaults remain unchanged, so no migration rollback is required.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable: no such guidance changed.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

No ADR conflicts. CI live-smoke may not route this operation-catalog-only memory-path change, so local configured `npm run smoke:hindsight` evidence is included above.
