### PR TITLE
fix(retain): redact retain context

### DIFF
--- a/extensions/retain-job-builder.ts
+++ b/extensions/retain-job-builder.ts
@@ -31,8 +31,10 @@ function sanitizedMetadata(
 }
 
 export function buildRetainJob(args: RetainJobBuildArgs): RetainJob {
-  const content = args.config.retain.redactSecrets ? redactSecrets(args.content) : args.content;
-  const metadata = sanitizedMetadata(args.metadata, args.config.retain.redactSecrets);
+  const redact = args.config.retain.redactSecrets;
+  const content = redact ? redactSecrets(args.content) : args.content;
+  const context = redact ? redactSecrets(args.context) : args.context;
+  const metadata = sanitizedMetadata(args.metadata, redact);
   const target = resolveRetainDocumentTarget({
     config: args.config,
     ...(args.capabilities ? { capabilities: args.capabilities } : {}),
@@ -47,7 +49,7 @@ export function buildRetainJob(args: RetainJobBuildArgs): RetainJob {
     updateMode: target.updateMode,
     item: {
       content,
-      context: args.context,
+      context,
       timestamp: args.timestamp ?? new Date().toISOString(),
       async: args.async ?? args.config.retain.async,
       ...((args.entities?.length ?? args.config.retain.entities.length)

--- a/tests/retain-job-builder.test.ts
+++ b/tests/retain-job-builder.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { buildRetainJob, type RetainJobBuildArgs } from "../extensions/retain-job-builder.js";
+
+function retainJobArgs(overrides: Partial<RetainJobBuildArgs> = {}): RetainJobBuildArgs {
+  return {
+    config: DEFAULT_CONFIG,
+    bankId: "bank",
+    content: "safe content",
+    context: "safe context",
+    tags: ["source:pi"],
+    documentId: "pi-session:test",
+    updateMode: "append",
+    ...overrides,
+  };
+}
+
+describe("retain job builder redaction", () => {
+  it("redacts content and context when secret redaction is enabled", () => {
+    const job = buildRetainJob(
+      retainJobArgs({
+        content: "content API_KEY=content-secret",
+        context: "context https://example.test/callback?token=context-secret&ok=true",
+      }),
+    );
+
+    expect(job.item.content).toContain("API_KEY=[REDACTED]");
+    expect(job.item.content).not.toContain("content-secret");
+    expect(job.item.context).toContain("token=[REDACTED]");
+    expect(job.item.context).not.toContain("context-secret");
+  });
+
+  it("preserves unredacted context when secret redaction is disabled", () => {
+    const job = buildRetainJob(
+      retainJobArgs({
+        config: {
+          ...DEFAULT_CONFIG,
+          retain: { ...DEFAULT_CONFIG.retain, redactSecrets: false },
+        },
+        content: "content API_KEY=content-secret",
+        context: "context API_KEY=context-secret",
+      }),
+    );
+
+    expect(job.item.content).toContain("API_KEY=content-secret");
+    expect(job.item.context).toContain("API_KEY=context-secret");
+  });
+
+  it("keeps metadata redaction intact", () => {
+    const job = buildRetainJob(
+      retainJobArgs({
+        metadata: {
+          source_url: "https://example.test/callback?token=metadata-secret&ok=true",
+          api_key: "sk-abcdefghijklmnopqrstuvwxyz",
+        },
+      }),
+    );
+
+    expect(job.item.metadata).toMatchObject({
+      source_url: "https://example.test/callback?token=[REDACTED]",
+      api_key: "[REDACTED_API_KEY]",
+    });
+    expect(JSON.stringify(job.item.metadata)).not.toContain("metadata-secret");
+    expect(JSON.stringify(job.item.metadata)).not.toContain("abcdefghijklmnopqrstuvwxyz");
+  });
+});


### PR DESCRIPTION
## Summary

- Redacts retain job `context` with `redactSecrets` when `retain.redactSecrets` is enabled.
- Keeps context unchanged when secret redaction is disabled.
- Adds regression coverage for content, context, and metadata redaction behavior.

## Linked issue

- Closes #279

## Scope

- Focused retain job builder slice only: content/context/metadata redaction behavior inside `buildRetainJob`.
- No tag, document ID, queue delivery, import projection, API, or config changes.
- No docs changes needed because this aligns implementation with existing redaction policy.

## Verification

- [x] `npm test -- tests/retain-job-builder.test.ts tests/retain-durable.test.ts tests/retain.test.ts` passed locally.
- [x] `npm run check` passed locally.
- [x] `npm run check:coverage` passed locally; coverage summary: all files 94.31% statements, 79.7% branches, 97.04% functions, 94.31% lines.
- [x] `npm run typecheck:tsc` passed locally.
- [ ] full matrix requested/passed (not run because this is not a release, release verification, manual dispatch, platform-sensitive change, or `ci:full` slice).
- [ ] package verification requested/passed (not run because package and release paths were not changed).
- [ ] `npm run pack:verify` (not run because package and release paths were not changed).
- [x] `npm run smoke:hindsight` passed locally against `https://h1.luxus.ai`; retain, recall, reflect, adapter, operations, import, and cleanup steps succeeded.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Retain context now honors the existing `retain.redactSecrets` safety setting before memory creation, so release notes should mention the redaction fix. There is no package or release-path impact.

## Risk and rollback

- Risk: Low. The change applies the existing sanitizer to one additional retain field only when `retain.redactSecrets` is enabled. Disabled behavior remains covered by regression tests.
- Rollback/revert path: Revert commit `4ce1612` to restore prior context handling while keeping queue, import, API, and config behavior unchanged.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] No source-of-truth order, contributor workflow, verification expectation, memory policy, or definition-of-done guidance changed; `AGENTS.md` and `CONTRIBUTING.md` did not need updates.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Parent launched the required repo-local reviewer because this child session cannot launch subagents. Reviewer found no code blockers and confirmed the focused diff. No ADR conflicts, live-smoke limitations, or follow-up issues.
