### PR TITLE
test(memory): add golden retain/import stability fixtures

### DIFF
--- a/tests/golden-memory-stability.test.ts
+++ b/tests/golden-memory-stability.test.ts
@@ -1,0 +1,375 @@
+import { mkdirSync, writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { createMemoryOperations } from "../extensions/memory-operation-service.js";
+import { createRetainTurnPolicy } from "../extensions/memory-lifecycle-retain.js";
+import type { RuntimeSnapshot } from "../extensions/memory-lifecycle-runtime.js";
+import { readImportCheckpoint } from "../extensions/import-checkpoint.js";
+import { readImportManifest } from "../extensions/import-manifest.js";
+import { readRetainQueue, resolveQueuePath } from "../extensions/queue.js";
+import { liveDocumentId, stableSessionId } from "../extensions/session.js";
+import type { HindsightLikeClient, ResolvedConfig } from "../extensions/types.js";
+
+type RetainOptions = NonNullable<Parameters<HindsightLikeClient["retain"]>[2]>;
+
+interface RetainWrite {
+  bankId: string;
+  content: string;
+  options: RetainOptions;
+}
+
+function makeCwd(prefix: string): string {
+  const cwd = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(cwd, ".git"));
+  return cwd;
+}
+
+function writePiSession(
+  path: string,
+  cwd: string,
+  sessionId: string,
+  messages: Array<{
+    id: string;
+    parentId?: string | null;
+    role: string;
+    content: string;
+  }>,
+): void {
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({ type: "session", id: sessionId, cwd }),
+      ...messages.map((message, index) =>
+        JSON.stringify({
+          type: "message",
+          id: message.id,
+          parentId: message.parentId ?? (index === 0 ? null : messages[index - 1]?.id),
+          message: { role: message.role, content: message.content },
+        }),
+      ),
+    ].join("\n"),
+  );
+}
+
+function createMemoryStore(args: { failWrites?: number } = {}) {
+  let failuresRemaining = args.failWrites ?? 0;
+  const attempts: RetainWrite[] = [];
+  const writes: RetainWrite[] = [];
+  const logicalDocuments = new Map<string, RetainWrite>();
+  const client: HindsightLikeClient = {
+    retain: async (bankId, content, options = {}) => {
+      const write = { bankId, content, options };
+      attempts.push(write);
+      if (failuresRemaining > 0) {
+        failuresRemaining -= 1;
+        throw new Error("offline");
+      }
+      const documentId = options.documentId ?? `generated:${attempts.length}`;
+      logicalDocuments.set(`${bankId}:${documentId}`, write);
+      writes.push(write);
+    },
+    recall: async () => [],
+    reflect: async () => ({}),
+  };
+  return { client, attempts, writes, logicalDocuments };
+}
+
+function operations(args: {
+  client: HindsightLikeClient;
+  config?: ResolvedConfig;
+  projectBankId?: string;
+}) {
+  const config = args.config ?? DEFAULT_CONFIG;
+  return createMemoryOperations({
+    getClient: () => args.client,
+    getConfig: () => config,
+    getProjectBankId: () => args.projectBankId ?? "project-bank",
+  });
+}
+
+function expectProjectTags(tags: string[] | undefined, cwd: string, sessionId: string): void {
+  expect(tags).toEqual(
+    expect.arrayContaining(["source:pi", `session:${sessionId}`, expect.stringMatching(/^repo:/)]),
+  );
+  expect(tags?.filter((tag) => tag.startsWith("repo:"))).toHaveLength(1);
+  expect(tags?.filter((tag) => tag === `session:${sessionId}`)).toHaveLength(1);
+  expect(tags?.join("\n")).not.toContain(cwd);
+}
+
+describe("golden memory stability", () => {
+  it("keeps explicit retain document identity, update mode, tags, and provenance stable across repeats and restarts", async () => {
+    const cwd = makeCwd("pi-hindsight-golden-explicit-");
+    const sessionFile = join(cwd, "session.jsonl");
+    const store = createMemoryStore();
+    const memory = operations({ client: store.client });
+    const args = {
+      cwd,
+      sessionFile,
+      content: "remember stable explicit fact",
+      context: "user requested explicit retention",
+      tags: ["kind:golden"],
+      metadata: { source_id: "explicit-fixture" },
+    };
+
+    const first = await memory.retainExplicit(args);
+    const afterRestart = operations({ client: store.client });
+    const second = await afterRestart.retainExplicit({ ...args });
+
+    expect(second.documentId).toBe(first.documentId);
+    expect(first.updateMode).toBe("replace");
+    expect(second.updateMode).toBe("replace");
+    expect(store.logicalDocuments.size).toBe(1);
+    expect(store.writes.map((write) => write.options.documentId)).toEqual([
+      first.documentId,
+      first.documentId,
+    ]);
+
+    const options = store.writes[0]?.options;
+    expect(options).toMatchObject({
+      documentId: first.documentId,
+      updateMode: "replace",
+      context: "user requested explicit retention",
+      metadata: {
+        cwd,
+        pi_session_file: sessionFile,
+        source: "pi-hindsight",
+        retainSource: "tool",
+        source_id: "explicit-fixture",
+      },
+    });
+    expectProjectTags(options?.tags, cwd, stableSessionId(sessionFile, cwd));
+    expect(options?.tags).toContain("kind:golden");
+
+    await memory.retainExplicit({ ...args, documentId: "manual-explicit-doc" });
+    expect(store.logicalDocuments.size).toBe(2);
+    expect(store.logicalDocuments.has("project-bank:manual-explicit-doc")).toBe(true);
+  });
+
+  it("keeps automatic retain on one live document and restart cursor prevents duplicate logical documents", async () => {
+    const cwd = makeCwd("pi-hindsight-golden-auto-");
+    const sessionFile = join(cwd, "session.jsonl");
+    const store = createMemoryStore();
+    const statuses: string[] = [];
+    const runtime: RuntimeSnapshot = {
+      cwd,
+      sessionFile,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+    };
+    const event = {
+      messages: [
+        { id: "u1", role: "user", content: "remember stable auto fact", timestamp: 1 },
+        { id: "a1", role: "assistant", content: "stable auto fact retained", timestamp: 2 },
+      ],
+    } as unknown as AgentEndEvent;
+    const newPolicy = () =>
+      createRetainTurnPolicy({
+        getConfig: () => DEFAULT_CONFIG,
+        getClient: () => store.client,
+        getProjectBankId: () => "project-bank",
+        getCapabilities: () => undefined,
+        setMemoryStatus: (_runtime, activity) => statuses.push(activity),
+        notify: () => undefined,
+      });
+
+    const first = await newPolicy().retain(event, runtime);
+    const second = await newPolicy().retain({ ...event }, runtime);
+
+    expect(first).toMatchObject({ queued: true, sent: 1, remaining: 0 });
+    expect(second).toMatchObject({ queued: false, sent: 0, remaining: 0 });
+    expect(store.writes).toHaveLength(1);
+    expect(store.logicalDocuments.size).toBe(1);
+
+    const options = store.writes[0]?.options;
+    expect(options).toMatchObject({
+      documentId: liveDocumentId(sessionFile, cwd),
+      updateMode: "append",
+      metadata: { cwd, imported: "false", pi_session_file: sessionFile },
+    });
+    expectProjectTags(options?.tags, cwd, stableSessionId(sessionFile, cwd));
+    await expect(
+      readRetainQueue(resolveQueuePath(cwd, DEFAULT_CONFIG.retain.queuePath)),
+    ).resolves.toEqual([]);
+    expect(statuses).toContain("retained");
+  });
+
+  it("resumes and reimports single-session imports with deterministic IDs, tags, provenance, manifest, and checkpoint", async () => {
+    const cwd = makeCwd("pi-hindsight-golden-import-one-");
+    const sessionFile = join(cwd, "session.jsonl");
+    writePiSession(sessionFile, cwd, "single-session-stability", [
+      { id: "user-1", role: "user", content: "import stable memory" },
+      { id: "assistant-1", role: "assistant", content: "stable imported memory" },
+    ]);
+    const documentId =
+      "pi-import:single-session-stability:leaf:assistant-1:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1";
+    const store = createMemoryStore({ failWrites: 1 });
+
+    await expect(
+      operations({ client: store.client }).importSession({ sessionFile, cwd }),
+    ).rejects.toThrow(/queued/);
+    const queuedCheckpoint = await readImportCheckpoint(
+      join(cwd, ".pi/hindsight/import-checkpoint.json"),
+    );
+    expect(queuedCheckpoint?.updateMode).toBe("replace");
+    expect(queuedCheckpoint?.documents[documentId]).toMatchObject({
+      documentId,
+      status: "queued",
+      contentHash: expect.any(String),
+    });
+
+    const resumed = await operations({ client: store.client }).importSession({ sessionFile, cwd });
+    const reimported = await operations({ client: store.client }).importSession({
+      sessionFile,
+      cwd,
+    });
+
+    expect(resumed.documents.map((document) => document.documentId)).toEqual([documentId]);
+    expect(reimported.documents).toEqual([
+      expect.objectContaining({ documentId, status: "skipped", wouldWrite: false }),
+    ]);
+    expect(store.writes).toHaveLength(1);
+    expect(store.logicalDocuments.size).toBe(1);
+    await expect(
+      readRetainQueue(resolveQueuePath(cwd, DEFAULT_CONFIG.retain.queuePath)),
+    ).resolves.toEqual([]);
+
+    const options = store.writes[0]?.options;
+    expect(options).toMatchObject({
+      documentId,
+      updateMode: "replace",
+      metadata: {
+        pi_session_file: sessionFile,
+        imported: "true",
+        cwd,
+        session_id: "single-session-stability",
+        branch_leaf_id: "assistant-1",
+        import_mode: "curated",
+        content_hash: resumed.documents[0]?.contentHash,
+        include_branches: "current-only",
+        tool_results: "errors-only",
+      },
+    });
+    expect(options?.tags).toEqual(
+      expect.arrayContaining([
+        "source:pi",
+        "import:historical",
+        "imported:true",
+        "session:single-session-stability",
+        "branch:assistant-1",
+        `document:${documentId}`,
+        expect.stringMatching(/^repo:/),
+      ]),
+    );
+
+    const completedCheckpoint = await readImportCheckpoint(resumed.checkpointPath);
+    const manifest = await readImportManifest(resumed.manifestPath);
+    expect(completedCheckpoint?.runId).toBe(resumed.runId);
+    expect(completedCheckpoint?.documents[documentId]).toMatchObject({
+      documentId,
+      status: "completed",
+      contentHash: resumed.documents[0]?.contentHash,
+      messageCount: 2,
+      importMode: "curated",
+      projectionVersion: "curated-turns-v1",
+      importProfile: "turns-12-bytes-80000",
+    });
+    expect(manifest.imports[documentId]).toMatchObject({
+      documentId,
+      bankId: "project-bank",
+      sourceFile: sessionFile,
+      contentHash: resumed.documents[0]?.contentHash,
+      messageCount: 2,
+      leafId: "assistant-1",
+      sessionId: "single-session-stability",
+      cwd,
+      includeBranches: "current-only",
+      updateMode: "replace",
+    });
+    expect(Object.keys(manifest.imports)).toEqual([documentId]);
+  });
+
+  it("reimports project sessions without duplicate logical documents and keeps per-file checkpoints aligned to manifest", async () => {
+    const cwd = makeCwd("pi-hindsight-golden-project-");
+    const sessionsDir = mkdtempSync(join(tmpdir(), "pi-hindsight-golden-project-sessions-"));
+    const firstSession = join(sessionsDir, "first.jsonl");
+    const secondSession = join(sessionsDir, "second.jsonl");
+    writePiSession(firstSession, cwd, "project-session-one", [
+      { id: "one-u", role: "user", content: "project import one" },
+      { id: "one-a", role: "assistant", content: "project import one stable" },
+    ]);
+    writePiSession(secondSession, cwd, "project-session-two", [
+      { id: "two-u", role: "user", content: "project import two" },
+    ]);
+    const expected = [
+      "pi-import:project-session-one:leaf:one-a:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-1",
+      "pi-import:project-session-two:leaf:two-u:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0",
+    ];
+    const store = createMemoryStore();
+    const memory = operations({ client: store.client });
+
+    const first = await memory.importProjectSessions({ cwd, searchDir: sessionsDir });
+    const second = await operations({ client: store.client }).importProjectSessions({
+      cwd,
+      searchDir: sessionsDir,
+    });
+
+    expect(
+      first.imported.flatMap((item) => item.documents.map((document) => document.documentId)),
+    ).toEqual(expected);
+    expect(
+      second.imported.flatMap((item) => item.documents.map((document) => document.status)),
+    ).toEqual(["skipped", "skipped"]);
+    expect(store.writes.map((write) => write.options.documentId)).toEqual(expected);
+    expect(store.logicalDocuments.size).toBe(2);
+    expect(new Set(first.imported.map((item) => item.checkpointPath)).size).toBe(2);
+
+    const manifest = await readImportManifest(first.imported[0]!.manifestPath);
+    expect(Object.keys(manifest.imports).sort()).toEqual([...expected].sort());
+    for (const [index, result] of first.imported.entries()) {
+      const document = result.documents[0]!;
+      const options = store.writes[index]!.options;
+      expect(options).toMatchObject({
+        documentId: document.documentId,
+        updateMode: "replace",
+        metadata: expect.objectContaining({
+          pi_session_file: result.sessionFile,
+          imported: "true",
+          cwd,
+          session_id: index === 0 ? "project-session-one" : "project-session-two",
+          branch_leaf_id: index === 0 ? "one-a" : "two-u",
+          content_hash: document.contentHash,
+        }),
+      });
+      const sessionId = index === 0 ? "project-session-one" : "project-session-two";
+      const branchId = index === 0 ? "one-a" : "two-u";
+      expect(options.tags).toEqual(
+        expect.arrayContaining([
+          "source:pi",
+          "import:historical",
+          "imported:true",
+          `session:${sessionId}`,
+          `branch:${branchId}`,
+          `document:${document.documentId}`,
+          expect.stringMatching(/^repo:/),
+        ]),
+      );
+
+      const checkpoint = await readImportCheckpoint(result.checkpointPath);
+      expect(checkpoint?.documents[document.documentId]).toMatchObject({
+        documentId: document.documentId,
+        status: "completed",
+        contentHash: document.contentHash,
+        messageCount: document.messageCount,
+      });
+      expect(manifest.imports[document.documentId]).toMatchObject({
+        documentId: document.documentId,
+        sourceFile: result.sessionFile,
+        contentHash: document.contentHash,
+        messageCount: document.messageCount,
+        updateMode: "replace",
+      });
+    }
+  });
+});

--- a/tests/import-recall-roundtrip.test.ts
+++ b/tests/import-recall-roundtrip.test.ts
@@ -1,75 +1,346 @@
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { createMemoryOperations } from "../extensions/memory-operation-service.js";
+import { createRetainTurnPolicy } from "../extensions/memory-lifecycle-retain.js";
+import type { RuntimeSnapshot } from "../extensions/memory-lifecycle-runtime.js";
 import { importPiSession } from "../extensions/import-sessions.js";
 import { recallForContext } from "../extensions/recall.js";
-import type { HindsightLikeClient } from "../extensions/types.js";
+import { liveDocumentId, stableSessionId } from "../extensions/session.js";
+import type { HindsightLikeClient, ResolvedConfig, TagsMatch } from "../extensions/types.js";
 import {
   assistantMessage,
-  captureRetainClient,
-  parsedRetainedMessages,
+  processStatusNoise,
+  progressNoise,
   recalledMemoryBlock,
   toolResult,
   userMessage,
   writePiTranscriptFixture,
 } from "./helpers/memory-quality-fixtures.js";
 
+type RetainOptions = NonNullable<Parameters<HindsightLikeClient["retain"]>[2]>;
+type RecallOptions = NonNullable<Parameters<HindsightLikeClient["recall"]>[2]>;
+
+interface RetainedMemory {
+  bankId: string;
+  content: string;
+  options: RetainOptions;
+}
+
+interface RecallCall {
+  bankId: string;
+  query: string;
+  options: RecallOptions;
+}
+
+function makeCwd(prefix: string): string {
+  const cwd = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(cwd, ".git"));
+  return cwd;
+}
+
 function textField(value: unknown): string {
   return typeof value === "string" ? value : JSON.stringify(value ?? "");
 }
 
-function recallClientFromImportedMessages(retained: {
-  options: unknown;
-  content: string;
-}): HindsightLikeClient {
-  const options = retained.options as { tags?: string[] };
-  const messages = parsedRetainedMessages(retained.content);
-  return {
-    retain: async () => undefined,
-    reflect: async () => ({}),
-    recall: async (_bankId, _query, recallOptions) => {
-      const tags = options.tags ?? [];
-      const requestedTags = recallOptions?.tags ?? [];
-      const matchesScope =
-        requestedTags.length === 0 || requestedTags.some((tag) => tags.includes(tag));
-      if (!matchesScope) return [];
-      return messages.map((message) => ({
-        text: `${textField(message.role)}: ${textField(message.content)}`,
-        tags,
-      }));
-    },
-  };
+function contentLine(message: Record<string, unknown>): string {
+  return `${textField(message.role)}: ${textField(message.content)}`;
 }
 
-describe("import to recall roundtrip quality", () => {
-  it("preserves durable signal through curated import and recall while excluding known noise", async () => {
-    const fixture = writePiTranscriptFixture("roundtrip-quality", [
-      userMessage("u1", "Fix retain queue race for issue #248."),
-      toolResult("read1", "read", "huge source file output should not survive roundtrip"),
-      toolResult("bash1", "bash", "npm test failed: expected 2 got 1", { isError: true }),
-      assistantMessage(
-        "a1",
-        "Decision: keep queue-first retain behavior; PR #260 will add regression coverage.",
-      ),
-      recalledMemoryBlock("r1"),
+function retainedContentText(content: string): string {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (Array.isArray(parsed)) return parsed.map((message) => contentLine(message)).join("\n");
+    const record = parsed as { messages?: Record<string, unknown>[] };
+    if (Array.isArray(record.messages)) return record.messages.map(contentLine).join("\n");
+  } catch {
+    return content;
+  }
+  return content;
+}
+
+function matchTags(requested: string[], tags: string[], match: TagsMatch | undefined): boolean {
+  const mode = match ?? "any_strict";
+  if (mode === "all" || mode === "all_strict") return requested.every((tag) => tags.includes(tag));
+  return requested.some((tag) => tags.includes(tag));
+}
+
+function tagGroupMatches(group: unknown, tags: string[]): boolean {
+  const record = group as { tags?: unknown; match?: unknown };
+  if (!Array.isArray(record.tags)) return false;
+  return matchTags(
+    record.tags.filter((tag): tag is string => typeof tag === "string"),
+    tags,
+    typeof record.match === "string" ? (record.match as TagsMatch) : undefined,
+  );
+}
+
+function recallRequestMatches(options: RecallOptions | undefined, tags: string[]): boolean {
+  if (!options) return true;
+  if (Array.isArray(options.tagGroups) && options.tagGroups.length > 0) {
+    return options.tagGroups.every((group) => tagGroupMatches(group, tags));
+  }
+  if (Array.isArray(options.tags) && options.tags.length > 0) {
+    return matchTags(options.tags, tags, options.tagsMatch);
+  }
+  return true;
+}
+
+function createRoundtripMemoryClient() {
+  const retained: RetainedMemory[] = [];
+  const recallCalls: RecallCall[] = [];
+  const client: HindsightLikeClient = {
+    retain: async (bankId, content, options = {}) => {
+      retained.push({ bankId, content, options });
+    },
+    recall: async (bankId, query, options = {}) => {
+      recallCalls.push({ bankId, query, options });
+      return retained
+        .filter((memory) => memory.bankId === bankId)
+        .filter((memory) => recallRequestMatches(options, memory.options.tags ?? []))
+        .map((memory) => ({
+          text: retainedContentText(memory.content),
+          tags: memory.options.tags,
+          metadata: memory.options.metadata,
+        }));
+    },
+    reflect: async () => ({}),
+  };
+  return { client, retained, recallCalls };
+}
+
+function createOperations(client: HindsightLikeClient, config: ResolvedConfig = DEFAULT_CONFIG) {
+  return createMemoryOperations({
+    getClient: () => client,
+    getConfig: () => config,
+    getProjectBankId: () => "project-bank",
+  });
+}
+
+function repoTag(tags: string[] | undefined): string {
+  const tag = tags?.find((candidate) => candidate.startsWith("repo:"));
+  expect(tag).toBeDefined();
+  return tag!;
+}
+
+describe("retain/import to recall roundtrip quality", () => {
+  it("roundtrips explicit global retain with advanced options, provenance, and strict global recall tags", async () => {
+    const cwd = makeCwd("pi-hindsight-explicit-roundtrip-");
+    const sessionFile = join(cwd, "session.jsonl");
+    const store = createRoundtripMemoryClient();
+    const config = {
+      ...DEFAULT_CONFIG,
+      banks: {
+        ...DEFAULT_CONFIG.banks,
+        user: { ...DEFAULT_CONFIG.banks.user, enabled: true, bankId: "global-bank" },
+      },
+    };
+    const memory = createOperations(store.client, config);
+
+    await memory.retainExplicit({
+      cwd,
+      sessionFile,
+      bank: "global",
+      content: "User prefers compact review handoffs with verification listed first.",
+      context: "Manual user preference retain from explicit tool call.",
+      tags: ["topic:preferences"],
+      metadata: { source_id: "explicit-roundtrip", source: "caller-overridden" },
+      documentId: "explicit-roundtrip-doc",
+      updateMode: "append",
+      timestamp: "2026-05-06T12:00:00.000Z",
+      entities: [{ text: "review handoffs", type: "preference" }],
+      observationScopes: [["source:pi", "topic:preferences"]],
+      async: false,
+    });
+
+    const recalled = await memory.recall(
+      cwd,
+      "How should reviews be handed off?",
+      "global",
+      sessionFile,
+      {
+        tags: ["topic:preferences"],
+        tagsMatch: "all_strict",
+        includeChunks: true,
+      },
+    );
+
+    expect(recalled.bankId).toBe("global-bank");
+    expect(store.retained).toHaveLength(1);
+    expect(store.retained[0]!.options).toMatchObject({
+      documentId: "explicit-roundtrip-doc",
+      updateMode: "append",
+      context: "Manual user preference retain from explicit tool call.",
+      timestamp: "2026-05-06T12:00:00.000Z",
+      async: false,
+      entities: [{ text: "review handoffs", type: "preference" }],
+      observationScopes: [["source:pi", "topic:preferences"]],
+      metadata: {
+        source: "pi-hindsight",
+        retainSource: "tool",
+        source_id: "explicit-roundtrip",
+        cwd,
+        pi_session_file: sessionFile,
+      },
+    });
+    expect(store.retained[0]!.options.tags).toEqual(
+      expect.arrayContaining([
+        "source:pi",
+        "topic:preferences",
+        `session:${stableSessionId(sessionFile, cwd)}`,
+        expect.stringMatching(/^repo:/),
+      ]),
+    );
+    expect(store.recallCalls[0]).toMatchObject({
+      bankId: "global-bank",
+      options: {
+        includeChunks: true,
+        tagGroups: [
+          { tags: ["source:pi"], match: "any_strict" },
+          { tags: ["topic:preferences"], match: "all_strict" },
+        ],
+      },
+    });
+    expect(store.recallCalls[0]!.options).not.toHaveProperty("tags");
+    expect(recalled.result).toEqual([
+      expect.objectContaining({
+        text: expect.stringContaining("compact review handoffs"),
+        tags: expect.arrayContaining(["source:pi", "topic:preferences"]),
+      }),
     ]);
-    const importClient = captureRetainClient();
+  });
+
+  it("roundtrips automatic retain while excluding injected recall blocks and noisy successful tools", async () => {
+    const cwd = makeCwd("pi-hindsight-auto-roundtrip-");
+    const sessionFile = join(cwd, "session.jsonl");
+    const store = createRoundtripMemoryClient();
+    const runtime: RuntimeSnapshot = {
+      cwd,
+      sessionFile,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+    };
+    const event = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: "Keep issue #282 recall roundtrip coverage test-only.",
+          timestamp: 1,
+        },
+        {
+          id: "r1",
+          role: "assistant",
+          customType: "hindsight-recall",
+          content: "<hindsight-memory>previous retained fact must not return</hindsight-memory>",
+          timestamp: 2,
+        },
+        {
+          id: "read1",
+          role: "toolResult",
+          toolName: "read",
+          content: "huge successful read output should not survive automatic retain",
+          isError: false,
+          timestamp: 3,
+        },
+        {
+          id: "bash1",
+          role: "toolResult",
+          toolName: "bash",
+          content: "npm run check failed once with expected 2 got 1",
+          isError: true,
+          timestamp: 4,
+        },
+        {
+          id: "a1",
+          role: "assistant",
+          content: "Decision: automatic retain roundtrip should recall issue #282 verification.",
+          timestamp: 5,
+        },
+      ],
+    } as unknown as AgentEndEvent;
+    const policy = createRetainTurnPolicy({
+      getConfig: () => DEFAULT_CONFIG,
+      getClient: () => store.client,
+      getProjectBankId: () => "project-bank",
+      getCapabilities: () => undefined,
+      setMemoryStatus: () => undefined,
+      notify: () => undefined,
+    });
+
+    await policy.retain(event, runtime);
+    const retained = store.retained[0]!;
+    const tag = repoTag(retained.options.tags);
+    const recall = await recallForContext({
+      client: store.client,
+      config: DEFAULT_CONFIG,
+      scopes: [{ kind: "project", bankId: "project-bank", tags: [tag], tagsMatch: "any_strict" }],
+      messages: [
+        { role: "user", content: "What did issue #282 automatic retain decide?" } as never,
+      ],
+      cwd,
+    });
+
+    expect(retained.options).toMatchObject({
+      documentId: liveDocumentId(sessionFile, cwd),
+      updateMode: "append",
+      metadata: { cwd, imported: "false", pi_session_file: sessionFile },
+    });
+    expect(retained.options.tags).toEqual(
+      expect.arrayContaining(["source:pi", `session:${stableSessionId(sessionFile, cwd)}`, tag]),
+    );
+    expect(store.recallCalls[0]).toMatchObject({
+      bankId: "project-bank",
+      options: { tags: [tag], tagsMatch: "any_strict" },
+    });
+    expect(recall.rendered).toContain("Keep issue #282 recall roundtrip coverage test-only");
+    expect(recall.rendered).toContain("npm run check failed once");
+    expect(recall.rendered).toContain("automatic retain roundtrip should recall issue #282");
+    expect(recall.rendered).not.toContain("previous retained fact");
+    expect(recall.rendered).not.toContain("huge successful read output");
+  });
+
+  it("roundtrips strict curated import through project recall while excluding recall and process noise", async () => {
+    const fixture = writePiTranscriptFixture(
+      "roundtrip-quality",
+      [
+        userMessage("u1", "Fix retain queue race for issue #248."),
+        toolResult("read1", "read", "huge source file output should not survive roundtrip"),
+        toolResult("bash1", "bash", "npm test failed: expected 2 got 1", { isError: true }),
+        assistantMessage(
+          "a1",
+          "Decision: keep queue-first retain behavior; PR #260 will add regression coverage.",
+        ),
+        recalledMemoryBlock("r1"),
+      ],
+      [
+        processStatusNoise("proc1", "Process 'npm-check' completed successfully"),
+        progressNoise(
+          "last1",
+          "last-recall.json contained <hindsight-memory>previous retained fact</hindsight-memory>",
+        ),
+      ],
+    );
+    const store = createRoundtripMemoryClient();
+    const strictConfig = {
+      ...DEFAULT_CONFIG,
+      import: { ...DEFAULT_CONFIG.import, qualityProfile: "strict" as const },
+    };
 
     const imported = await importPiSession({
       sessionFile: fixture.sessionFile,
       bankId: "project-bank",
-      config: DEFAULT_CONFIG,
-      client: importClient,
+      config: strictConfig,
+      client: store.client,
     });
-    const retained = importClient.retained[0]!;
-    const importedTags = (retained.options as { tags?: string[] }).tags ?? [];
-    const repoTag = importedTags.find((tag) => tag.startsWith("repo:"));
-    expect(repoTag).toBeDefined();
+    const retained = store.retained[0]!;
+    const tag = repoTag(retained.options.tags);
     const recall = await recallForContext({
-      client: recallClientFromImportedMessages(retained),
-      config: DEFAULT_CONFIG,
-      scopes: [
-        { kind: "project", bankId: "project-bank", tags: [repoTag!], tagsMatch: "any_strict" },
-      ],
+      client: store.client,
+      config: strictConfig,
+      scopes: [{ kind: "project", bankId: "project-bank", tags: [tag], tagsMatch: "any_strict" }],
       messages: [{ role: "user", content: "What happened with issue #248?" } as never],
       cwd: fixture.dir,
     });
@@ -79,6 +350,21 @@ describe("import to recall roundtrip quality", () => {
       projectedMessageCount: 3,
       droppedToolResultCount: 1,
       keptToolErrorCount: 1,
+      importQualityProfile: "strict",
+    });
+    expect(retained.options).toMatchObject({
+      updateMode: "replace",
+      tags: expect.arrayContaining(["source:pi", "imported:true", "import:historical", tag]),
+      metadata: expect.objectContaining({
+        imported: "true",
+        import_mode: "curated",
+        import_quality_profile: "strict",
+        tool_results: "errors-only",
+      }),
+    });
+    expect(store.recallCalls[0]).toMatchObject({
+      bankId: "project-bank",
+      options: { tags: [tag], tagsMatch: "any_strict" },
     });
     expect(recall.rendered).toContain("Fix retain queue race for issue #248");
     expect(recall.rendered).toContain("npm test failed: expected 2 got 1");
@@ -87,5 +373,7 @@ describe("import to recall roundtrip quality", () => {
     expect(recall.rendered).not.toContain("huge source file output");
     expect(recall.rendered).not.toContain("previous retained fact");
     expect(recall.rendered).not.toContain("hindsight-recall");
+    expect(recall.rendered).not.toContain("last-recall.json");
+    expect(recall.rendered).not.toContain("Process 'npm-check' completed successfully");
   });
 });


### PR DESCRIPTION
## Summary

- Add golden stability fixtures for explicit Retain, automatic Retain, single-session import, and project session import.
- Expand retain/import-to-Recall roundtrip tests for explicit global Retain, automatic Retain, and strict curated import.
- Keep scope test-only; no Hindsight API/admin surfaces and no runtime behavior changes.

## Linked issue

- Closes #280
- Closes #282

## Scope

- Assert stable document IDs, update modes, tags, provenance metadata, and logical document identity across repeats, restarts, retries, resume, and reimport.
- Assert import manifest and checkpoint consistency for resumed/reimported single-session and project imports.
- Assert recalled-memory blocks, sidecar/status chatter, and noisy successful tool outputs do not become recallable source truth.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (test-only memory-path fixtures; run for confidence)
- [x] `npm run typecheck:tsc` (test-only memory-path fixtures; run for confidence)
- [ ] full matrix requested/passed (not run because this is a test-only, platform-neutral slice)
- [ ] package verification requested/passed (not run because package/release path did not change)
- [ ] `npm run pack:verify` (not run because package/release path did not change)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (not run because diff is test-only and changes no memory-path runtime behavior)
- [x] `npx vitest run tests/golden-memory-stability.test.ts tests/import-recall-roundtrip.test.ts tests/import-sessions.test.ts tests/retain.test.ts tests/retain-job-builder.test.ts tests/retain-cursor.test.ts tests/retain-durable.test.ts tests/memory-operations.test.ts tests/recall-quality-fixtures.test.ts`
- [x] Reviewer pass requested by parent twice; no blockers.

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

No changelog or release notes impact; tests only.

## Risk and rollback

- Risk: Golden fixtures intentionally couple to stable import document ID/profile defaults, so future intentional default changes may need fixture updates.
- Rollback/revert path: Revert this commit to remove the added test coverage without changing runtime behavior.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. No guidance change in this PR.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Test-only scope. Smoke not run because no runtime memory-path behavior changed; fake clients assert retained/imported tags/options and recall filters.
