### PR TITLE
test(memory): cover queued automatic retain payload

### DIFF
--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -10,6 +10,7 @@ import {
   setSessionMemoryMode,
   setSessionRetainEnabled,
 } from "../extensions/session-memory-meta.js";
+import { liveDocumentId, stableSessionId } from "../extensions/session.js";
 import type { RetainJob } from "../extensions/types.js";
 
 async function waitForCondition(
@@ -1516,6 +1517,74 @@ describe("extension hooks", () => {
     expect(secondContent).toContain("a2");
     expect(secondContent).not.toContain("u1");
     expect(secondContent).not.toContain("a1");
+  });
+
+  it("keeps automatic retain payload stable when queued during outage", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({
+        hindsight: { baseUrl: "http://unused.test" },
+        notifications: { startup: false },
+      }),
+    );
+    const sessionFile = join(cwd, "session-api_key=super-secret-token.jsonl");
+    const { createMemoryLifecycle } = await import("../extensions/memory-lifecycle.js");
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => sessionFile },
+    };
+    const lifecycle = createMemoryLifecycle(cwd);
+    await lifecycle.initialize(ctx);
+    mocked.client.retain.mockClear();
+    mocked.client.retain.mockRejectedValue(new Error("offline TOKEN=queue-secret"));
+
+    const result = await lifecycle.retain(
+      {
+        messages: [
+          { role: "user", content: "Remember API_KEY=content-secret", timestamp: 1 },
+          { role: "assistant", content: "Stored TOKEN=assistant-secret", timestamp: 2 },
+        ],
+      } as any,
+      ctx,
+    );
+
+    expect(result).toMatchObject({ queued: true, sent: 0, remaining: 1 });
+    const queued = await readRetainQueue(resolveQueuePath(cwd, ".pi/hindsight/retain-queue.jsonl"));
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toMatchObject({
+      bankId: expect.stringMatching(/^pi-project-/),
+      documentId: liveDocumentId(sessionFile, cwd),
+      updateMode: "append",
+      retries: 1,
+      lastError: "offline TOKEN=[REDACTED]",
+      item: {
+        context: expect.stringContaining("session-api_key=[REDACTED]"),
+        async: true,
+        metadata: {
+          cwd,
+          imported: "false",
+          pi_session_file: expect.stringContaining("session-api_key=[REDACTED]"),
+        },
+        observationScopes: [["harness:pi"], [expect.stringMatching(/^repo:/)]],
+      },
+    });
+    expect(queued[0]?.item.tags).toEqual(
+      expect.arrayContaining([
+        "source:pi",
+        `session:${stableSessionId(sessionFile, cwd)}`,
+        expect.stringMatching(/^repo:/),
+      ]),
+    );
+    expect(queued[0]?.item.content).toContain("API_KEY=[REDACTED]");
+    expect(queued[0]?.item.content).toContain("TOKEN=[REDACTED]");
+    expect(JSON.stringify(queued[0])).not.toContain("content-secret");
+    expect(JSON.stringify(queued[0])).not.toContain("assistant-secret");
+    expect(JSON.stringify(queued[0])).not.toContain("super-secret");
+    expect(JSON.stringify(queued[0])).not.toContain("queue-secret");
   });
 
   it("uses configured shutdown flush bounds", async () => {


### PR DESCRIPTION
## Summary

- Add direct regression coverage for automatic retain jobs queued during a Hindsight outage.
- Assert queued automatic retain keeps stable live document id, append mode, project tags, provenance metadata, observation scopes, retry state, and redacted content/context/error details.
- Complete the #284 gap found during the #285 final memory creation/import stability audit.

## Linked issue

- Closes #284
- Updates #285

## Scope

- Test-only change in `tests/extension-hooks.test.ts`.
- No runtime behavior, docs, package, release, or config changes.

## Verification

- [x] `npx vitest run tests/extension-hooks.test.ts --maxWorkers=1 --minWorkers=1`
- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not requested; this is a focused test-only memory-path PR.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — not applicable; no package or release changes.
- [ ] `npm run pack:verify` (release/package changes) — not applicable; no package or release changes.
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)
- [x] Reviewer pass: parent-launched reviewer found no blockers and recommended merge for the test-only #284 gap.

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

No changelog or release notes impact; test-only coverage.

## Risk and rollback

- Risk: Low. The change only adds a regression test. Main risk is a brittle assertion against stable queue payload invariants that are intentionally release-critical.
- Rollback/revert path: Revert this PR commit to remove the added test.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] No source-of-truth order, contributor workflow, verification expectation, memory policy, or definition-of-done change; `AGENTS.md` and `CONTRIBUTING.md` updates were not needed.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

#288 covered release-critical import queued payload stability across provenance/content identity, stale cleanup, completed-doc skip cleanup, update-mode/content-hash changes, and queue-lock release. Existing retain durable and golden suites covered explicit queued retain and successful automatic retain stability. This PR closes the remaining direct gap by inspecting automatic retain while queued during outage.
