### PR TITLE
fix(release): align release-please tags

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "release-type": "node",
       "package-name": "@luxusai/pi-hindsight",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false
     }
   }
 }

--- a/docs-site/src/content/docs/development/release.md
+++ b/docs-site/src/content/docs/development/release.md
@@ -4,7 +4,7 @@ title: "Release"
 
 Release automation uses [`release-please`](https://github.com/googleapis/release-please) to turn Conventional Commits on `main` into a release PR. The release PR updates `package.json`, `package-lock.json`, `.release-please-manifest.json`, and `CHANGELOG.md`.
 
-After the release PR merges, release-please creates the tag and GitHub release. The existing `Release` workflow then verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
+After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. The existing `Release` workflow then verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
 
 ## Release checks
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,7 +2,7 @@
 
 Release automation uses [`release-please`](https://github.com/googleapis/release-please) to turn Conventional Commits on `main` into a release PR. The release PR updates `package.json`, `package-lock.json`, `.release-please-manifest.json`, and `CHANGELOG.md`.
 
-After the release PR merges, release-please creates the tag and GitHub release. The existing `Release` workflow then verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
+After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. The existing `Release` workflow then verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
 
 ## Release checks
 

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -6,10 +6,13 @@ const version = pkg.version;
 if (!version) throw new Error("package.json missing version");
 
 const refName = process.env.GITHUB_REF_NAME;
-if (refName?.startsWith("v")) {
-  const tagVersion = refName.slice(1);
-  if (tagVersion !== version) {
-    throw new Error(`Release tag ${refName} does not match package.json version ${version}`);
+const refType = process.env.GITHUB_REF_TYPE;
+const expectedTag = `v${version}`;
+if (refName && (refType === "tag" || refName.startsWith("v"))) {
+  if (refName !== expectedTag) {
+    throw new Error(
+      `Release tag ${refName} does not match package.json version ${version} (expected ${expectedTag})`,
+    );
   }
 }
 
@@ -20,7 +23,7 @@ function escapeRegExp(value) {
 const changelog = await readFile("CHANGELOG.md", "utf8");
 const escapedVersion = escapeRegExp(version);
 const versionHeading = new RegExp(
-  `^## (?:\\[${escapedVersion}\\]|${escapedVersion})(?:\\s|$|\\])`,
+  `^## (?:${escapedVersion}|\\[${escapedVersion}\\](?:\\([^\\r\\n)]*\\))?)(?:\\s|$)`,
   "m",
 );
 if (!versionHeading.test(changelog)) {

--- a/tests/verify-release.test.mjs
+++ b/tests/verify-release.test.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { execFile } from "node:child_process";
@@ -7,7 +7,9 @@ import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 const script = resolve("scripts/verify-release.mjs");
-const testEnv = { ...process.env, GITHUB_REF_NAME: "" };
+const releasePleaseConfig = resolve(".release-please-config.json");
+const releaseWorkflow = resolve(".github/workflows/release.yml");
+const testEnv = { ...process.env, GITHUB_REF_NAME: "", GITHUB_REF_TYPE: "" };
 
 async function repo(version, changelog) {
   const dir = await mkdtemp(join(tmpdir(), "verify-release-"));
@@ -24,10 +26,32 @@ describe("verify-release", () => {
     });
   });
 
+  it("accepts release-please linked changelog version heading", async () => {
+    const cwd = await repo(
+      "1.2.3",
+      "## [1.2.3](https://github.com/luxus/pi-hindsight/compare/pi-hindsight-v1.2.2...pi-hindsight-v1.2.3) (2026-01-01)\n",
+    );
+    await expect(execFileAsync("node", [script], { cwd, env: testEnv })).resolves.toMatchObject({
+      stdout: expect.stringContaining('"version":"1.2.3"'),
+    });
+  });
+
   it("rejects substring changelog version heading", async () => {
     const cwd = await repo("1.2.3", "## [11.2.3] - 2026-01-01\n");
     await expect(execFileAsync("node", [script], { cwd, env: testEnv })).rejects.toMatchObject({
       stderr: expect.stringContaining("CHANGELOG.md missing release heading for 1.2.3"),
+    });
+  });
+
+  it("accepts matching v tag version", async () => {
+    const cwd = await repo("1.2.3", "## [1.2.3] - 2026-01-01\n");
+    await expect(
+      execFileAsync("node", [script], {
+        cwd,
+        env: { ...testEnv, GITHUB_REF_NAME: "v1.2.3", GITHUB_REF_TYPE: "tag" },
+      }),
+    ).resolves.toMatchObject({
+      stdout: expect.stringContaining('"refName":"v1.2.3"'),
     });
   });
 
@@ -40,5 +64,27 @@ describe("verify-release", () => {
         "Release tag v1.2.4 does not match package.json version 1.2.3",
       ),
     });
+  });
+
+  it("rejects release-please component tag namespace for tag refs", async () => {
+    const cwd = await repo("1.2.3", "## [1.2.3] - 2026-01-01\n");
+    await expect(
+      execFileAsync("node", [script], {
+        cwd,
+        env: { ...testEnv, GITHUB_REF_NAME: "pi-hindsight-v1.2.3", GITHUB_REF_TYPE: "tag" },
+      }),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("expected v1.2.3"),
+    });
+  });
+
+  it("keeps release-please tag namespace aligned with release workflow", async () => {
+    const config = JSON.parse(await readFile(releasePleaseConfig, "utf8"));
+    const workflow = await readFile(releaseWorkflow, "utf8");
+
+    expect(config.packages["."]["package-name"]).toBe("@luxusai/pi-hindsight");
+    expect(config.packages["."]["include-component-in-tag"]).toBe(false);
+    expect(workflow).toContain('- "v*.*.*"');
+    expect(workflow).not.toContain("pi-hindsight-v");
   });
 });


### PR DESCRIPTION
## Summary

- Configure release-please to keep generated tags in the `vX.Y.Z` namespace used by the release workflow.
- Update release verification to accept release-please linked changelog headings and require exact `v${package.json.version}` tag refs.
- Add release verification tests and sync release docs for the tag namespace decision.

## Linked issue

- Closes #290

## Scope

- `.release-please-config.json` tag namespace setting.
- `scripts/verify-release.mjs` changelog heading and tag validation.
- `tests/verify-release.test.mjs` coverage for linked headings, matching/mismatched tags, and config/workflow alignment.
- Release docs in root docs and docs site.
- No memory-path runtime behavior changes.

## Verification

- [x] `npx vitest run tests/verify-release.test.mjs`
- [x] `npm run check`
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [x] full matrix not required for this focused release verification fix; package CI requested with `ci:package`.
- [x] package verification requested/passed locally; `ci:package` label will request package CI.
- [x] `npm run pack:verify`
- [x] `npm run smoke:hindsight` not run because no memory-path behavior changed.
- [x] `npm run audit:signatures`
- [x] Temporary combined #212 + #290 state: `npm run pack:verify` passed for the release PR `0.2.0` state.
- [x] Reviewer pass completed: `/tmp/pr-290-review.md`, no blockers.

## Release impact

Check exactly one:

- [ ] No release impact
- [ ] User-visible change
- [x] Package/release path change

This changes release automation/verification only. It should make release-please produce `vX.Y.Z` tags that match the existing release workflow and make `pack:verify` accept release-please linked changelog headings.

## Risk and rollback

- Risk: release-please tag namespace behavior could differ from expectations if upstream config semantics change; tests now guard repo config/workflow alignment and verify exact tag behavior.
- Rollback/revert path: revert this PR to restore previous release-please config and verification behavior.

## Follow-ups

- Refresh release PR #212 after this lands so generated changelog compare links move from `pi-hindsight-v*` to `v*`.
- Prove release-please-created `v*.*.*` tags trigger the separate `Release` workflow before final release, or keep that tracked under #291/#233.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable: this only updates release docs and release verification behavior.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Reviewer non-blocking findings are documented in Follow-ups. Live smoke is not needed because this PR only changes release/package verification and documentation.
