### PR TITLE
fix(import): dedupe queued gateway imports

### DIFF
--- a/extensions/import-gateway-transcript.ts
+++ b/extensions/import-gateway-transcript.ts
@@ -200,6 +200,7 @@ export async function importGatewayTranscript(args: {
     ],
     metadata: {
       source_file: args.sourceFile,
+      imported: "true",
       source: "gateway-transcript",
       ...(channel ? { channel } : {}),
       ...(sessionId ? { session_id: sessionId } : {}),

--- a/tests/import-gateway-transcript.test.ts
+++ b/tests/import-gateway-transcript.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { readRetainQueue, resolveQueuePath } from "../extensions/queue.js";
 import {
   importGatewayTranscript,
   parseGatewayTranscriptJsonl,
@@ -152,10 +153,119 @@ describe("gateway transcript import", () => {
       metadata: expect.objectContaining({
         source: "pi-hindsight",
         retainSource: "import",
+        imported: "true",
         source_file: sourceFile,
         channel: "sms",
       }),
     });
+  });
+
+  it("queues gateway imports with import identity metadata for retry dedupe", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-gateway-queued-identity-"));
+    mkdirSync(join(dir, ".git"));
+    const sourceFile = join(dir, "gateway.jsonl");
+    writeFileSync(
+      sourceFile,
+      [
+        JSON.stringify({ type: "user_message", content: "remember identity", channel: "sms" }),
+        JSON.stringify({ type: "assistant_reply", content: "Stored." }),
+      ].join("\n"),
+    );
+    const queuePath = resolveQueuePath(dir, DEFAULT_CONFIG.retain.queuePath);
+
+    await expect(
+      importGatewayTranscript({
+        sourceFile,
+        cwd: dir,
+        bankId: "user-bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => {
+            throw new Error("offline");
+          },
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+      }),
+    ).rejects.toThrow(/queued/);
+
+    const queued = await readRetainQueue(queuePath);
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toMatchObject({
+      bankId: "user-bank",
+      updateMode: "replace",
+      item: {
+        metadata: expect.objectContaining({
+          source: "pi-hindsight",
+          retainSource: "import",
+          imported: "true",
+          source_file: sourceFile,
+          channel: "sms",
+          content_hash: expect.any(String),
+        }),
+        tags: expect.arrayContaining(["source:gateway", "import:gateway", "imported:true"]),
+      },
+    });
+  });
+
+  it("drops stale queued gateway import jobs before retrying changed content", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-gateway-stale-queue-"));
+    mkdirSync(join(dir, ".git"));
+    const sourceFile = join(dir, "gateway.jsonl");
+    const writeGateway = (middleContent: string) =>
+      writeFileSync(
+        sourceFile,
+        [
+          JSON.stringify({ type: "user_message", content: "same first", channel: "sms" }),
+          JSON.stringify({ type: "assistant_reply", content: middleContent }),
+          JSON.stringify({ type: "process_end", output: "same last" }),
+        ].join("\n"),
+      );
+    writeGateway("OLD_MIDDLE");
+    const queuePath = resolveQueuePath(dir, DEFAULT_CONFIG.retain.queuePath);
+
+    await expect(
+      importGatewayTranscript({
+        sourceFile,
+        cwd: dir,
+        bankId: "user-bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => {
+            throw new Error("offline");
+          },
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+      }),
+    ).rejects.toThrow(/queued/);
+    const oldQueued = await readRetainQueue(queuePath);
+    expect(oldQueued[0]?.item.content).toContain("OLD_MIDDLE");
+
+    writeGateway("NEW_MIDDLE");
+    const calls: unknown[][] = [];
+    const result = await importGatewayTranscript({
+      sourceFile,
+      cwd: dir,
+      bankId: "user-bank",
+      config: DEFAULT_CONFIG,
+      client: {
+        retain: async (...args: unknown[]) => {
+          calls.push(args);
+        },
+        recall: async () => [],
+        reflect: async () => ({}),
+      },
+    });
+
+    expect(result.retained).toBe(true);
+    expect(calls).toHaveLength(1);
+    const retainedContent = calls[0]?.[1] as string;
+    const retainedOptions = calls[0]?.[2] as { metadata: Record<string, string> };
+    expect(retainedContent).toContain("NEW_MIDDLE");
+    expect(retainedContent).not.toContain("OLD_MIDDLE");
+    expect(retainedOptions.metadata.content_hash).toBe(result.contentHash);
+    await expect(readRetainQueue(queuePath)).resolves.toEqual([]);
   });
 
   it("defaults operation imports to configured user bank", async () => {


### PR DESCRIPTION
## Summary

- Adds `imported: "true"` provenance metadata to gateway transcript import retain payloads.
- Covers queued gateway import identity and stale queued gateway import cleanup before retrying changed content.

## Linked issue

- Updates #297

## Scope

- First #297 checklist item only: gateway transcript import retry dedupe/stale queued import identity cleanup.
- No changes to other import follow-up checklist items.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional targeted verification:

- [x] `npm test -- tests/import-gateway-transcript.test.ts`
- [x] Parent-launched reviewer pass completed with no blockers.

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

No changelog or release notes impact. This tightens internal retry/dedupe provenance for queued gateway imports.

## Risk and rollback

- Risk: Low. Change only adds missing import provenance metadata and tests existing stale cleanup behavior.
- Rollback/revert path: Revert this PR to restore previous gateway metadata behavior.

## Follow-ups

- Remaining follow-ups stay tracked in #297.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance changes were needed.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Full matrix, package verification, and `npm run pack:verify` were not run because this is not a release, package, or platform-sensitive change. Live smoke was run against configured Hindsight and passed, including cleanup.
