### PR TITLE
fix: revalidate project import cwd during execution

### DIFF
--- a/extensions/import-plan.ts
+++ b/extensions/import-plan.ts
@@ -32,8 +32,14 @@ export function buildImportPlan(args: {
   bankId: string;
   config: ResolvedConfig;
   cwd?: string;
+  requireMatchingCwd?: boolean;
   includeBranches?: ResolvedConfig["import"]["includeBranches"];
 }): ImportPlan {
+  if (args.cwd && args.requireMatchingCwd && !args.parsed.cwd) {
+    throw new Error(
+      `Refusing to import session without cwd; current cwd is ${args.cwd}. Use explicit file import for unscoped sessions.`,
+    );
+  }
   if (args.cwd && args.parsed.cwd && !sameCwd(args.parsed.cwd, args.cwd)) {
     throw new Error(
       `Refusing to import session from cwd ${args.parsed.cwd}; current cwd is ${args.cwd}. Use project-scoped import from the matching repo.`,

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -149,6 +149,7 @@ export async function importProjectSessions(args: {
     imported.push(
       await importPiSession({
         sessionFile,
+        cwd: args.cwd,
         bankId: args.bankId,
         client: args.client,
         config: {

--- a/extensions/import-sessions.ts
+++ b/extensions/import-sessions.ts
@@ -93,6 +93,7 @@ export async function importPiSession(args: {
   client: HindsightLikeClient;
   config: ResolvedConfig;
   dryRun?: boolean;
+  requireMatchingCwd?: boolean;
   includeBranches?: ResolvedConfig["import"]["includeBranches"];
 }): Promise<ImportSessionResult> {
   const text = await readFile(args.sessionFile, "utf8");
@@ -103,6 +104,9 @@ export async function importPiSession(args: {
     bankId: args.bankId,
     config: args.config,
     ...(args.cwd ? { cwd: args.cwd } : {}),
+    ...(args.requireMatchingCwd !== undefined
+      ? { requireMatchingCwd: args.requireMatchingCwd }
+      : {}),
     ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
   });
   const execution = await executeImportPlan({
@@ -150,6 +154,7 @@ export async function importProjectSessions(args: {
       await importPiSession({
         sessionFile,
         cwd: args.cwd,
+        requireMatchingCwd: true,
         bankId: args.bankId,
         client: args.client,
         config: {

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -1917,64 +1917,80 @@ describe("Pi session import", () => {
     expect(result.sessionFiles).toEqual([current, related].sort());
   });
 
-  it("revalidates project cwd during project import execution after discovery", async () => {
-    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
-    const other = mkdtempSync(join(tmpdir(), "pi-hindsight-other-"));
-    const sessionsDir = mkdtempSync(join(tmpdir(), "pi-hindsight-sessions-"));
-    const sessionFile = join(sessionsDir, "current.jsonl");
-    const projectSession = [
-      JSON.stringify({ type: "session", id: "current", cwd: project }),
-      JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "c" } }),
-    ].join("\n");
-    const movedSession = [
-      JSON.stringify({ type: "session", id: "moved", cwd: other }),
-      JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "m" } }),
-    ].join("\n");
-    writeFileSync(sessionFile, projectSession);
+  it.each([
+    {
+      name: "different cwd",
+      replacementSession: (other: string) =>
+        JSON.stringify({ type: "session", id: "moved", cwd: other }),
+      expectedError: /Refusing to import session from cwd/,
+    },
+    {
+      name: "missing cwd",
+      replacementSession: () => JSON.stringify({ type: "session", id: "moved" }),
+      expectedError: /Refusing to import session without cwd/,
+    },
+  ])(
+    "revalidates project cwd during project import execution after discovery: $name",
+    async ({ replacementSession, expectedError }) => {
+      const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+      const other = mkdtempSync(join(tmpdir(), "pi-hindsight-other-"));
+      const sessionsDir = mkdtempSync(join(tmpdir(), "pi-hindsight-sessions-"));
+      const sessionFile = join(sessionsDir, "current.jsonl");
+      const projectSession = [
+        JSON.stringify({ type: "session", id: "current", cwd: project }),
+        JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "c" } }),
+      ].join("\n");
+      const movedSession = [
+        replacementSession(other),
+        JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "m" } }),
+      ].join("\n");
+      writeFileSync(sessionFile, projectSession);
 
-    const fsPromises = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-    let sessionReads = 0;
-    const calls: unknown[][] = [];
+      const fsPromises =
+        await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+      let sessionReads = 0;
+      const calls: unknown[][] = [];
 
-    vi.resetModules();
-    vi.doMock("node:fs/promises", () => ({
-      ...fsPromises,
-      readFile: async (...args: Parameters<typeof fsPromises.readFile>) => {
-        const result = await fsPromises.readFile(...args);
-        if (args[0] === sessionFile && sessionReads++ === 0) {
-          await fsPromises.writeFile(sessionFile, movedSession, "utf8");
-        }
-        return result;
-      },
-    }));
-
-    try {
-      const { importProjectSessions: importProjectSessionsWithSwappedRead } =
-        await import("../extensions/import-sessions.js");
-
-      await expect(
-        importProjectSessionsWithSwappedRead({
-          cwd: project,
-          currentSessionFile: sessionFile,
-          bankId: "bank",
-          config: DEFAULT_CONFIG,
-          client: {
-            retain: async (...args: unknown[]) => {
-              calls.push(args);
-            },
-            recall: async () => [],
-            reflect: async () => ({}),
-          },
-        }),
-      ).rejects.toThrow(/Refusing to import session from cwd/);
-    } finally {
-      vi.doUnmock("node:fs/promises");
       vi.resetModules();
-    }
+      vi.doMock("node:fs/promises", () => ({
+        ...fsPromises,
+        readFile: async (...args: Parameters<typeof fsPromises.readFile>) => {
+          const result = await fsPromises.readFile(...args);
+          if (args[0] === sessionFile && sessionReads++ === 0) {
+            await fsPromises.writeFile(sessionFile, movedSession, "utf8");
+          }
+          return result;
+        },
+      }));
 
-    expect(sessionReads).toBe(2);
-    expect(calls).toHaveLength(0);
-  });
+      try {
+        const { importProjectSessions: importProjectSessionsWithSwappedRead } =
+          await import("../extensions/import-sessions.js");
+
+        await expect(
+          importProjectSessionsWithSwappedRead({
+            cwd: project,
+            currentSessionFile: sessionFile,
+            bankId: "bank",
+            config: DEFAULT_CONFIG,
+            client: {
+              retain: async (...args: unknown[]) => {
+                calls.push(args);
+              },
+              recall: async () => [],
+              reflect: async () => ({}),
+            },
+          }),
+        ).rejects.toThrow(expectedError);
+      } finally {
+        vi.doUnmock("node:fs/promises");
+        vi.resetModules();
+      }
+
+      expect(sessionReads).toBe(2);
+      expect(calls).toHaveLength(0);
+    },
+  );
 
   it("discovers repeated equivalent normalized project cwd paths", async () => {
     const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
@@ -1915,6 +1915,65 @@ describe("Pi session import", () => {
 
     expect(result.scanned).toBe(3);
     expect(result.sessionFiles).toEqual([current, related].sort());
+  });
+
+  it("revalidates project cwd during project import execution after discovery", async () => {
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    const other = mkdtempSync(join(tmpdir(), "pi-hindsight-other-"));
+    const sessionsDir = mkdtempSync(join(tmpdir(), "pi-hindsight-sessions-"));
+    const sessionFile = join(sessionsDir, "current.jsonl");
+    const projectSession = [
+      JSON.stringify({ type: "session", id: "current", cwd: project }),
+      JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "c" } }),
+    ].join("\n");
+    const movedSession = [
+      JSON.stringify({ type: "session", id: "moved", cwd: other }),
+      JSON.stringify({ type: "message", id: "1", message: { role: "user", content: "m" } }),
+    ].join("\n");
+    writeFileSync(sessionFile, projectSession);
+
+    const fsPromises = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    let sessionReads = 0;
+    const calls: unknown[][] = [];
+
+    vi.resetModules();
+    vi.doMock("node:fs/promises", () => ({
+      ...fsPromises,
+      readFile: async (...args: Parameters<typeof fsPromises.readFile>) => {
+        const result = await fsPromises.readFile(...args);
+        if (args[0] === sessionFile && sessionReads++ === 0) {
+          await fsPromises.writeFile(sessionFile, movedSession, "utf8");
+        }
+        return result;
+      },
+    }));
+
+    try {
+      const { importProjectSessions: importProjectSessionsWithSwappedRead } =
+        await import("../extensions/import-sessions.js");
+
+      await expect(
+        importProjectSessionsWithSwappedRead({
+          cwd: project,
+          currentSessionFile: sessionFile,
+          bankId: "bank",
+          config: DEFAULT_CONFIG,
+          client: {
+            retain: async (...args: unknown[]) => {
+              calls.push(args);
+            },
+            recall: async () => [],
+            reflect: async () => ({}),
+          },
+        }),
+      ).rejects.toThrow(/Refusing to import session from cwd/);
+    } finally {
+      vi.doUnmock("node:fs/promises");
+      vi.resetModules();
+    }
+
+    expect(sessionReads).toBe(2);
+    expect(calls).toHaveLength(0);
   });
 
   it("discovers repeated equivalent normalized project cwd paths", async () => {


### PR DESCRIPTION
## Summary

- Re-pass the validated project `cwd` into each discovered `importPiSession` execution.
- Add regression tests that swap a discovered session file to either a different cwd or no cwd between discovery and import and verify execution fails closed before retain.

## Linked issue

- Updates #297

## Scope

- Only covers #297 checklist item: project-session import execution should re-pass `cwd` to `importPiSession` after discovery.
- No other #297 checklist items included.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [x] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not requested; not release/platform-sensitive.
- [x] package verification requested/passed (release/package changes or `ci:package`) — not applicable; no release/package changes.
- [x] `npm run pack:verify` (release/package changes) — not applicable; no release/package changes.
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional targeted verification:

- [x] `npx vitest run tests/import-sessions.test.ts` (38 tests)

Notes:

- First `npm run check` attempt hit one unrelated queue stress timeout in `tests/queue.test.ts`; reran once and passed.
- Parent-launched reviewer reported no blockers before PR; parent-launched Codex-fix re-review also reported no blockers.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Project-scoped historical imports now keep fail-closed cwd validation during execution if a discovered file changes cwd or loses cwd before import.

## Risk and rollback

- Risk: Low. Change forwards an existing validated cwd argument into `buildImportPlan` and enables strict cwd presence for project imports only; deterministic import IDs, manifests, checkpoints, and queue behavior are unchanged.
- Rollback/revert path: Revert this PR to restore prior project import execution behavior.

## Follow-ups

- Remaining follow-ups stay tracked in #297.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. — Not applicable; no guidance changes.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

No ADR conflicts. Live smoke passed against configured Hindsight.