### PR TITLE
docs(import): explain import ID namespace rebuilds

### DIFF
--- a/docs-site/src/content/docs/guides/importing-sessions.md
+++ b/docs-site/src/content/docs/guides/importing-sessions.md
@@ -93,6 +93,8 @@ Equivalent path forms are treated as the same project:
 
 Imports use deterministic document IDs based on session and branch leaf identity.
 
+Curated import document IDs also include the derived chunking profile (`turnsPerDocument` and `maxDocumentBytes`), projection namespace, and chunk range. Changing those chunk settings, or changing another input that participates in the document-ID namespace, creates a distinct deterministic set of imported documents. `import.qualityProfile` and successful-tool-result settings change retained content or metadata, but they do not create a separate document-ID namespace.
+
 Historical imports default to deterministic replace semantics so reimporting the same document updates the same Hindsight document instead of appending duplicates.
 
 Live sessions still use stable live-session document IDs with `updateMode: "append"`.
@@ -110,7 +112,7 @@ The checkpoint records document delivery state so interrupted imports can resume
 
 If an import is queued but not delivered because Hindsight is unavailable, the checkpoint records the document as `queued` and the retain queue keeps the job for later flushing. Checkpoint run and document entries also record import quality context such as `toolResults` and strict curated `importQualityProfile` when available, so recovery can show which projection policy produced pending, completed, queued, or failed documents.
 
-## Rebuilding a cleared bank
+## Rebuilds and namespace changes
 
 To rebuild from historical sessions after clearing a Hindsight bank, remove or move:
 
@@ -120,6 +122,8 @@ To rebuild from historical sessions after clearing a Hindsight bank, remove or m
 ```
 
 Then rerun the import. Use `--dry-run` first.
+
+When you intentionally change chunking or another document-ID namespace input, plan the change as a rebuild. Preview first, then decide whether to keep both namespaces or clean up old imported documents in Hindsight. If old retain jobs are still queued, clear or flush the retain queue before reimporting so stale document IDs are not delivered later. Remove or move the import checkpoint and manifest when you want the new namespace to be imported from scratch instead of resumed from prior state.
 
 ## Import modes
 

--- a/docs-site/src/content/docs/reference/import-controls.md
+++ b/docs-site/src/content/docs/reference/import-controls.md
@@ -71,6 +71,8 @@ Gateway dry-runs report items such as:
 
 Historical import writes an Import Manifest and Import Checkpoint so work is inspectable, resumable, and idempotent. Curated document IDs include profile/projection/chunk information. Raw and forensic modes preserve legacy IDs.
 
+Changing the derived chunking profile (`turnsPerDocument` and `maxDocumentBytes`) or another document-ID namespace input creates a different deterministic ID set. Reimporting after such a change writes new imported documents rather than replacing the previous namespace. `import.qualityProfile` and successful-tool-result settings change retained content or metadata, but they do not create a separate document-ID namespace. Treat namespace changes as rebuilds: dry-run first, clean up old imported documents if you do not want both namespaces, and reset relevant checkpoint/manifest or queued retain jobs when stale IDs should not resume.
+
 Curated import has a successful-tool-result policy:
 
 - `errors-only` (default): drop successful tool output and keep failed tool evidence.

--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -91,6 +91,8 @@ Equivalent path forms are treated as the same project:
 
 Imports use deterministic document IDs based on session and branch leaf identity.
 
+Curated import document IDs also include the derived chunking profile (`turnsPerDocument` and `maxDocumentBytes`), projection namespace, and chunk range. Changing those chunk settings, or changing another input that participates in the document-ID namespace, creates a distinct deterministic set of imported documents. `import.qualityProfile` and successful-tool-result settings change retained content or metadata, but they do not create a separate document-ID namespace.
+
 Historical imports default to deterministic replace semantics so reimporting the same document updates the same Hindsight document instead of appending duplicates.
 
 Live sessions still use stable live-session document IDs with `updateMode: "append"`.
@@ -108,7 +110,7 @@ The checkpoint records document delivery state so interrupted imports can resume
 
 If an import is queued but not delivered because Hindsight is unavailable, the checkpoint records the document as `queued` and the retain queue keeps the job for later flushing. Checkpoint run and document entries also record import quality context such as `toolResults` and strict curated `importQualityProfile` when available, so recovery can show which projection policy produced pending, completed, queued, or failed documents.
 
-## Rebuilding a cleared bank
+## Rebuilds and namespace changes
 
 To rebuild from historical sessions after clearing a Hindsight bank, remove or move:
 
@@ -118,6 +120,8 @@ To rebuild from historical sessions after clearing a Hindsight bank, remove or m
 ```
 
 Then rerun the import. Use `--dry-run` first.
+
+When you intentionally change chunking or another document-ID namespace input, plan the change as a rebuild. Preview first, then decide whether to keep both namespaces or clean up old imported documents in Hindsight. If old retain jobs are still queued, clear or flush the retain queue before reimporting so stale document IDs are not delivered later. Remove or move the import checkpoint and manifest when you want the new namespace to be imported from scratch instead of resumed from prior state.
 
 ## Import modes
 


### PR DESCRIPTION
## Summary

- Document that curated import profile, projection namespace, and chunk range participate in deterministic imported document IDs.
- Explain that profile/chunk/namespace changes create a distinct deterministic imported document namespace.
- Add rebuild and cleanup expectations for old Hindsight documents, queued retain jobs, checkpoints, and manifests.

## Linked issue

- Updates #297

## Scope

- Docs-only update for the third focused #297 checklist item.
- No runtime behavior, source code, tests, or generated surface references changed.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional verification:

- [x] `npm run docs:check`

Skipped checks: coverage, `typecheck:tsc`, full matrix, package verification, pack verify, and live smoke are not needed for this docs-only change with no runtime/source behavior changes.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Docs now explain user-facing import rebuild/cleanup expectations for deterministic import document ID namespace changes. No package or runtime release behavior changes.

## Risk and rollback

- Risk: Low. Docs could overstate cleanup expectations or confuse rebuild flow.
- Rollback/revert path: Revert this docs-only commit.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance sync needed; this does not change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Reviewer subagent was not requested because the change is a tiny docs-only diff with no source/runtime changes. Initial `npm run docs:check` failed before dependencies were installed (`tsx: command not found`); `npm ci` fixed the worktree, and `npm run docs:check` then passed. First `npm run check` overlapped with a separate docs build and failed on a missing Astro prerender chunk; rerun after the concurrent docs build completed passed, and the commit hook also reran `npm run check` successfully.
