### PR TITLE
fix(import): skip empty curated session imports

### DIFF
--- a/extensions/import-checkpoint.ts
+++ b/extensions/import-checkpoint.ts
@@ -19,6 +19,7 @@ export interface ImportCheckpointDocument {
   chunkIndex?: number;
   messageRange?: { start: number; end: number };
   status: ImportDocumentStatus;
+  skipReason?: "already-imported" | "empty-curated-projection";
   updatedAt: string;
   error?: string;
 }
@@ -92,6 +93,10 @@ function isUpdateMode(value: unknown): value is UpdateMode {
   return value === "append" || value === "replace";
 }
 
+function isSkipReason(value: unknown): value is ImportCheckpointDocument["skipReason"] {
+  return value === "already-imported" || value === "empty-curated-projection";
+}
+
 function isMessageRange(value: unknown): value is { start: number; end: number } {
   return isPlainRecord(value) && typeof value.start === "number" && typeof value.end === "number";
 }
@@ -129,6 +134,7 @@ function isImportCheckpointDocument(value: unknown): value is ImportCheckpointDo
       value.status === "completed" ||
       value.status === "failed" ||
       value.status === "skipped") &&
+    (value.skipReason === undefined || isSkipReason(value.skipReason)) &&
     typeof value.updatedAt === "string" &&
     (value.error === undefined || typeof value.error === "string")
   );

--- a/extensions/import-execution.ts
+++ b/extensions/import-execution.ts
@@ -53,6 +53,7 @@ function checkpointDocument(args: {
     ...(args.document.chunkIndex !== undefined ? { chunkIndex: args.document.chunkIndex } : {}),
     ...(args.document.messageRange ? { messageRange: args.document.messageRange } : {}),
     status: args.status,
+    ...(args.document.skipReason ? { skipReason: args.document.skipReason } : {}),
     updatedAt: args.updatedAt,
     ...(args.error ? { error: args.error } : {}),
   };
@@ -157,7 +158,25 @@ export async function executeImportPlan(args: {
             ...preview.document,
             wouldWrite: false,
             status: canSkip ? ("skipped" as const) : preview.document.status,
+            ...(canSkip ? { skipReason: "already-imported" as const } : {}),
           },
+        });
+        continue;
+      }
+
+      if (preview.document.status === "skipped") {
+        const skippedAt = new Date().toISOString();
+        checkpoint.documents[preview.document.documentId] = checkpointDocument({
+          document: preview.document,
+          status: "skipped",
+          toolResults: importConfig.import.toolResults,
+          updatedAt: skippedAt,
+        });
+        checkpoint.updatedAt = skippedAt;
+        await writeImportCheckpoint(checkpointPath, checkpoint);
+        results.push({
+          ...preview,
+          document: { ...preview.document, wouldWrite: false, status: "skipped" as const },
         });
         continue;
       }
@@ -219,6 +238,7 @@ export async function executeImportPlan(args: {
   if (!args.dryRun && skippedResults.length > 0) {
     const manifest = (await readImportManifestSafe(manifestPath)).manifest;
     const missingSkippedEntries = skippedResults
+      .filter((result) => result.document.skipReason !== "empty-curated-projection")
       .filter((result) => !manifest.imports[result.document.documentId])
       .map((result) => result.manifestEntry);
     if (missingSkippedEntries.length > 0)

--- a/extensions/import-presentation.ts
+++ b/extensions/import-presentation.ts
@@ -18,6 +18,7 @@ export type ImportDocumentSummaryResult = {
     estimatedChunkCount?: number;
     importMode?: "curated" | "raw" | "forensic";
     importQualityProfile?: "compatible" | "strict";
+    skipReason?: "already-imported" | "empty-curated-projection";
   }[];
   malformedLineCount?: number;
 };
@@ -160,12 +161,15 @@ function importDocumentQualitySummary(result: ImportDocumentSummaryResult): stri
   );
   const reasonCounts = formatReasonCounts(summedReasonCounts);
   const topDroppedTools = formatTopDroppedTools(result.documents);
+  const skipReasons = [
+    ...new Set(result.documents.map((document) => document.skipReason).filter(Boolean)),
+  ].join(",");
   const forensicWarning = importModes.includes("forensic")
     ? "; WARNING forensic mode preserves recalled memory blocks for audit-only use"
     : "";
   const qualityDetails = `${keptSignals ? `; keptSignals=${keptSignals}` : ""}${droppedNoise ? `; droppedNoise=${droppedNoise}` : ""}${reasonCounts ? `; reasons=${reasonCounts}` : ""}${topDroppedTools ? `; topDroppedTools=${topDroppedTools}` : ""}`;
-  return rawMessages || droppedToolResults || rawBytes || projectedBytes
-    ? `; mode=${importModes || "unknown"}${importProfiles ? `; profile=${importProfiles}` : ""}; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; keptToolErrors=${keptErrors}; estimatedChunks=${estimatedChunks}; bytes=${projectedBytes}/${rawBytes}${qualityDetails}${forensicWarning}`
+  return rawMessages || droppedToolResults || rawBytes || projectedBytes || skipReasons
+    ? `; mode=${importModes || "unknown"}${importProfiles ? `; profile=${importProfiles}` : ""}; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; keptToolErrors=${keptErrors}; estimatedChunks=${estimatedChunks}; bytes=${projectedBytes}/${rawBytes}${qualityDetails}${skipReasons ? `; skipReasons=${skipReasons}` : ""}${forensicWarning}`
     : "";
 }
 

--- a/extensions/import-retain.ts
+++ b/extensions/import-retain.ts
@@ -57,6 +57,7 @@ export interface ImportDocumentPreview {
   bankId: string;
   wouldWrite: boolean;
   status: "pending" | "queued" | "completed" | "failed" | "skipped";
+  skipReason?: "already-imported" | "empty-curated-projection";
   error?: string;
 }
 
@@ -312,8 +313,14 @@ function buildImportBranch(args: Omit<ImportRetainArgs, "client">): ImportBranch
       tags,
       updateMode,
       bankId: args.bankId,
-      wouldWrite: true,
-      status: "pending" as const,
+      wouldWrite: !(mode === "curated" && projection.messages.length === 0),
+      status:
+        mode === "curated" && projection.messages.length === 0
+          ? ("skipped" as const)
+          : ("pending" as const),
+      ...(mode === "curated" && projection.messages.length === 0
+        ? { skipReason: "empty-curated-projection" as const }
+        : {}),
     };
     const manifestEntry: ImportManifestEntry = {
       documentId,

--- a/tests/import-presentation.test.ts
+++ b/tests/import-presentation.test.ts
@@ -80,6 +80,28 @@ describe("import presentation", () => {
     );
   });
 
+  it("renders skip reasons for skipped empty curated documents", () => {
+    expect(
+      importDocumentSummary({
+        documents: [
+          {
+            updateMode: "replace",
+            status: "skipped",
+            rawMessageCount: 0,
+            projectedMessageCount: 0,
+            rawBytes: 0,
+            projectedBytes: 0,
+            droppedToolResultCount: 0,
+            keptToolErrorCount: 0,
+            estimatedChunkCount: 1,
+            importMode: "curated",
+            skipReason: "empty-curated-projection",
+          },
+        ],
+      }),
+    ).toContain("skipReasons=empty-curated-projection");
+  });
+
   it("aggregates complete dropped-tool totals before slicing preview output", () => {
     const documents = [0, 1].map((chunk) => ({
       updateMode: "replace",

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -184,6 +184,102 @@ describe("Pi session import", () => {
     });
   });
 
+  it("skips curated import documents with zero projected messages after noise filtering", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-empty-curated-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-empty-curated", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "tool1",
+          parentId: null,
+          message: { role: "toolResult", name: "read", content: "successful output only" },
+        }),
+      ].join("\n"),
+    );
+    const retain = vi.fn(async () => undefined);
+
+    const result = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      client: { retain, recall: async () => [], reflect: async () => ({}) },
+    });
+    const checkpoint = await readImportCheckpoint(result.checkpointPath);
+    const manifest = await readImportManifest(result.manifestPath);
+
+    expect(retain).not.toHaveBeenCalled();
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents[0]).toMatchObject({
+      documentId:
+        "pi-import:session-empty-curated:leaf:tool1:turns-12-bytes-80000:curated-turns-v1:chunk-0-0-0",
+      rawMessageCount: 1,
+      messageCount: 1,
+      projectedMessageCount: 0,
+      droppedToolResultCount: 1,
+      importMode: "curated",
+      status: "skipped",
+      skipReason: "empty-curated-projection",
+      wouldWrite: false,
+    });
+    expect(checkpoint?.documents[result.documents[0]!.documentId]).toMatchObject({
+      documentId: result.documents[0]!.documentId,
+      messageCount: 1,
+      importMode: "curated",
+      projectionVersion: "curated-turns-v1",
+      status: "skipped",
+      skipReason: "empty-curated-projection",
+    });
+    expect(manifest.imports).toEqual({});
+  });
+
+  it("preserves explicit raw and forensic empty-source imports", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-empty-raw-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      JSON.stringify({ type: "session", id: "session-empty-source", cwd: dir }),
+    );
+    const rawRetain = vi.fn(async () => undefined);
+    const forensicRetain = vi.fn(async () => undefined);
+
+    const raw = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config: { ...DEFAULT_CONFIG, import: { ...DEFAULT_CONFIG.import, mode: "raw" } },
+      client: { retain: rawRetain, recall: async () => [], reflect: async () => ({}) },
+    });
+    const forensic = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config: { ...DEFAULT_CONFIG, import: { ...DEFAULT_CONFIG.import, mode: "forensic" } },
+      client: { retain: forensicRetain, recall: async () => [], reflect: async () => ({}) },
+    });
+
+    expect(rawRetain).toHaveBeenCalledTimes(1);
+    expect(forensicRetain).toHaveBeenCalledTimes(1);
+    expect(raw.documents[0]).toMatchObject({
+      rawMessageCount: 0,
+      projectedMessageCount: 0,
+      importMode: "raw",
+      status: "completed",
+      wouldWrite: true,
+    });
+    expect(raw.documents[0]).not.toHaveProperty("skipReason");
+    expect(forensic.documents[0]).toMatchObject({
+      rawMessageCount: 0,
+      projectedMessageCount: 0,
+      importMode: "forensic",
+      status: "completed",
+      wouldWrite: true,
+    });
+    expect(forensic.documents[0]).not.toHaveProperty("skipReason");
+  });
+
   it("chunks curated import documents by user turns with deterministic IDs and checkpoint metadata", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-chunks-"));
     mkdirSync(join(dir, ".git"));


### PR DESCRIPTION
## Summary

- Skip curated/default Pi-session import documents when projection/noise filtering leaves zero projected messages.
- Record deterministic skipped checkpoint state with `skipReason=empty-curated-projection` and do not create a manifest import entry for docs never retained.
- Preserve explicit `raw` and `forensic` empty-source imports as intentional retention paths, and render skip reasons in import summaries.

## Linked issue

- Updates #297

## Scope

- Focused on issue #297 fourth slice: empty projected-message handling for curated Pi-session imports.
- Touched import preview/retain metadata, import execution checkpoint/manifest handling, checkpoint validation, presentation summary, and targeted tests.
- Did not change unrelated #297 checklist items or branch/import curation policy beyond empty curated skip behavior.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional verification:

- `npm test -- tests/import-sessions.test.ts tests/import-presentation.test.ts`
- Reviewer pass: `reviewer-297-skip-empty-curated-imports.md`, no blockers.
- Precommit hook ran `npm run check` during commit and passed.
- Note: first `npm run check` attempt hit unrelated `tests/queue.test.ts` stress timeout once; rerun passed, final check passed, and commit hook check passed.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Curated/default Pi-session imports now skip documents with no projected messages instead of retaining empty/noise-only documents. Import summaries can show `skipReasons=empty-curated-projection` for skipped empty curated documents.

## Risk and rollback

- Risk: A curated import that previously retained an empty/noise-only document now records a skipped checkpoint without a manifest entry; users relying on empty curated docs as forensic breadcrumbs should use explicit `raw` or `forensic` mode.
- Rollback/revert path: Revert `fix(import): skip empty curated session imports` to restore prior retain behavior for empty curated projections.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance/source-of-truth/workflow/definition-of-done changes were made, so no docs sync was required.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

No ADR conflicts. Release/package/full-matrix checks were not run because this is a focused import memory-path hardening change, not release/package/platform-sensitive work. Live Hindsight smoke ran against configured `https://h1.luxus.ai` and passed, including import recall and cleanup.
