### PR TITLE
test(import): relax empty-source import timeout

### DIFF
--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -278,7 +278,7 @@ describe("Pi session import", () => {
       wouldWrite: true,
     });
     expect(forensic.documents[0]).not.toHaveProperty("skipReason");
-  });
+  }, 15_000);
 
   it("chunks curated import documents by user turns with deterministic IDs and checkpoint metadata", async () => {
     const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-chunks-"));


### PR DESCRIPTION
## Summary

- Extends the timeout for the raw/forensic empty-source import regression test.
- Fixes the Windows coverage timeout observed on main after #306.
- No runtime behavior changes.

## Linked issue

- Updates #297

## Scope

- Test-only hotfix for one import regression test that legitimately exceeds the default 5s timeout on Windows coverage.
- No source/runtime behavior changes.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped checks: `typecheck:tsc`, full matrix, package verification, `pack:verify`, and live smoke are not required for this test-only timeout change. PR CI runs coverage/tsc routing.

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

No changelog/release notes impact.

## Risk and rollback

- Risk: Low; test-only timeout relaxation for a Windows/coverage slow path.
- Rollback/revert path: Revert this commit if the test no longer needs extra time.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance changes.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Hotfix opened because the post-#306 `main` Check failed on Windows coverage with `tests/import-sessions.test.ts > preserves explicit raw and forensic empty-source imports` timing out at the default 5s limit.
