### PR TITLE
docs: clarify docs check coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,7 +247,7 @@ Before merging or considering a task done, always run:
 npm run check
 ```
 
-`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, validates packaged Markdown links, enforces GitHub Pages base-prefixed docs links, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
+`npm run check` includes `npm run docs:check`, which verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, packaged Markdown links, GitHub Pages base-prefixed docs links, and docs-site build. When iterating only on documentation-site content, run the narrower docs path first:
 
 ```bash
 npm run docs:check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ Run the relevant targeted tests while developing, then run the checks required b
 npm run check
 ```
 
-`npm run check` includes `npm run docs:check`, so the normal fast path builds the documentation site, validates internal documentation routes/sidebar entries, validates packaged Markdown links, enforces GitHub Pages base-prefixed docs links, and checks generated surface-reference docs. When iterating only on documentation-site content, run the narrower docs path first:
+`npm run check` includes `npm run docs:check`, which verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, packaged Markdown links, GitHub Pages base-prefixed docs links, and docs-site build. When iterating only on documentation-site content, run the narrower docs path first:
 
 ```bash
 npm run docs:check

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ npm install
 npm run check
 ```
 
+`npm run check` includes `npm run docs:check`, which verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, packaged Markdown links, GitHub Pages base-prefixed docs links, and docs-site build.
+
 Run Pi with the local extension:
 
 ```bash

--- a/docs-site/src/content/docs/development/development.md
+++ b/docs-site/src/content/docs/development/development.md
@@ -22,6 +22,7 @@ npm run check
 
 This runs:
 
+- docs checks with `docs:check`: generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, packaged Markdown links, GitHub Pages base-prefixed docs links, and docs-site build
 - formatting with `oxfmt`
 - type-aware linting with `oxlint`
 - `tsgo` typecheck

--- a/docs-site/src/content/docs/development/docs-site-publishing.md
+++ b/docs-site/src/content/docs/development/docs-site-publishing.md
@@ -21,7 +21,7 @@ Build and verify the same docs checks used by CI:
 npm run docs:check
 ```
 
-`docs:check` verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, and the Astro/Starlight build.
+`docs:check` verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, packaged Markdown links, GitHub Pages base-prefixed docs links, and docs-site build.
 
 ## GitHub Pages path
 

--- a/docs-site/src/content/docs/development/testing-and-verification.md
+++ b/docs-site/src/content/docs/development/testing-and-verification.md
@@ -23,7 +23,7 @@ For documentation-site changes, run the focused docs check while iterating:
 npm run docs:check
 ```
 
-`docs:check` verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, packaged Markdown links, GitHub Pages base-prefixed docs links, and the Astro/Starlight build. `npm run check` includes `docs:check`, so the normal fast local and PR paths catch docs failures before merge.
+`docs:check` verifies generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, packaged Markdown links, GitHub Pages base-prefixed docs links, and docs-site build. `npm run check` includes `docs:check`, so the normal fast local and PR paths catch docs failures before merge.
 
 For publishing details, see [Docs site publishing](./docs-site-publishing/).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,6 +20,7 @@ npm run check
 
 This runs:
 
+- docs checks with `docs:check`: generated surface-reference freshness, generated code-map freshness, internal docs links/sidebar routes, packaged Markdown links, GitHub Pages base-prefixed docs links, and docs-site build
 - formatting with `oxfmt`
 - type-aware linting with `oxlint`
 - `tsgo` typecheck


### PR DESCRIPTION
## Summary

- Standardizes docs-check descriptions across root docs and docs-site contributor docs.
- Clarifies that `npm run check` includes `docs:check` and lists the docs checks it runs.
- No script/runtime behavior changes.

## Linked issue

- Updates #298

## Scope

- Docs-only first #298 slice: docs-check wording and development setup docs.

## Verification

- [x] `npm run docs:check`
- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped checks: coverage, standalone tsc, full matrix, package verification, pack verification, and live smoke are not required for this docs-only change. `npm run check` includes typecheck and tests.

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

## Risk and rollback

- Risk: Low. Wording could drift if docs-check scripts change later.
- Rollback/revert path: Revert this docs-only commit.

## Follow-ups

- Remaining #298 checklist items stay open.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

AGENTS.md and CONTRIBUTING.md docs-check wording were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Reviewer

Parent-launched project reviewer found no blockers. Reviewer confirmed the duplicated wording is appropriate for separate contributor/docs-site entry points.
