### PR TITLE
fix: harden queue lock race retries on Windows

### DIFF
--- a/extensions/queue-lock.ts
+++ b/extensions/queue-lock.ts
@@ -78,7 +78,8 @@ async function isOwnerlessLockDirectoryStale(lockPath: string): Promise<boolean>
   try {
     const info = await stat(lockPath);
     return Date.now() - info.mtimeMs > RETAIN_QUEUE_LOCK.staleMs;
-  } catch {
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
     return true;
   }
 }
@@ -96,6 +97,11 @@ async function isQueueLockStale(lockPath: string, owner: QueueLockOwner): Promis
 async function removeLockIfOwned(lockPath: string, token: string): Promise<void> {
   const owner = await readQueueLockOwner(lockPath);
   if (owner?.token === token) await removeDirectory(lockPath);
+}
+
+export function isQueueLockRaceError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "EEXIST" || code === "EPERM" || code === "ENOTEMPTY" || code === "EBUSY";
 }
 
 function staleClaimPath(lockPath: string): string {
@@ -174,8 +180,9 @@ async function acquireFileLock(path: string): Promise<() => Promise<void>> {
         await removeLockIfOwned(lockPath, token);
       };
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      if (await removeLockIfStillStale(lockPath)) continue;
+      const code = (error as NodeJS.ErrnoException).code;
+      if (!isQueueLockRaceError(error)) throw error;
+      if (code === "EEXIST" && (await removeLockIfStillStale(lockPath))) continue;
       if (Date.now() - started > RETAIN_QUEUE_LOCK.timeoutMs)
         throw new Error(`Timed out waiting for retain queue lock ${lockPath}`);
       await sleep(RETAIN_QUEUE_LOCK.retryMs);

--- a/tests/queue-lock.test.ts
+++ b/tests/queue-lock.test.ts
@@ -1,0 +1,119 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("queue lock acquisition", () => {
+  afterEach(() => {
+    vi.doUnmock("node:fs/promises");
+    vi.resetModules();
+  });
+
+  it("fails closed after deadline when lock mkdir keeps returning EPERM", async () => {
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-lock-")), "q.jsonl");
+    const lockPath = `${path}.lock`;
+    let lockMkdirAttempts = 0;
+
+    vi.doMock("node:fs/promises", () => ({
+      ...actualFs,
+      mkdir: async (target: string, options?: Parameters<typeof actualFs.mkdir>[1]) => {
+        if (target === lockPath) {
+          lockMkdirAttempts += 1;
+          throw Object.assign(new Error("persistent lock permission failure"), { code: "EPERM" });
+        }
+        return actualFs.mkdir(target, options);
+      },
+    }));
+
+    const { RETAIN_QUEUE_LOCK, withQueueLock } = await import("../extensions/queue-lock.js");
+    const originalRetryMs = RETAIN_QUEUE_LOCK.retryMs;
+    const originalTimeoutMs = RETAIN_QUEUE_LOCK.timeoutMs;
+    RETAIN_QUEUE_LOCK.retryMs = 1;
+    RETAIN_QUEUE_LOCK.timeoutMs = 5;
+    try {
+      await expect(withQueueLock(path, async () => "unexpected")).rejects.toThrow(
+        /Timed out waiting for retain queue lock/,
+      );
+    } finally {
+      RETAIN_QUEUE_LOCK.retryMs = originalRetryMs;
+      RETAIN_QUEUE_LOCK.timeoutMs = originalTimeoutMs;
+    }
+
+    expect(lockMkdirAttempts).toBeGreaterThanOrEqual(1);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("does not run stale cleanup after transient Windows mkdir EPERM contention", async () => {
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-lock-")), "q.jsonl");
+    const lockPath = `${path}.lock`;
+    mkdirSync(lockPath, { recursive: true });
+    writeFileSync(
+      join(lockPath, "owner"),
+      JSON.stringify({ pid: 123, acquiredAt: new Date().toISOString() }),
+    );
+
+    vi.doMock("node:fs/promises", () => ({
+      ...actualFs,
+      mkdir: async (target: string, options?: Parameters<typeof actualFs.mkdir>[1]) => {
+        if (target === lockPath) {
+          throw Object.assign(new Error("transient Windows lock contention"), { code: "EPERM" });
+        }
+        return actualFs.mkdir(target, options);
+      },
+    }));
+
+    const { RETAIN_QUEUE_LOCK, withQueueLock } = await import("../extensions/queue-lock.js");
+    const originalRetryMs = RETAIN_QUEUE_LOCK.retryMs;
+    const originalTimeoutMs = RETAIN_QUEUE_LOCK.timeoutMs;
+    RETAIN_QUEUE_LOCK.retryMs = 1;
+    RETAIN_QUEUE_LOCK.timeoutMs = 5;
+    try {
+      await expect(withQueueLock(path, async () => "unexpected")).rejects.toThrow(
+        /Timed out waiting for retain queue lock/,
+      );
+    } finally {
+      RETAIN_QUEUE_LOCK.retryMs = originalRetryMs;
+      RETAIN_QUEUE_LOCK.timeoutMs = originalTimeoutMs;
+    }
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(existsSync(join(lockPath, "owner"))).toBe(true);
+  });
+
+  it("retries transient Windows mkdir EPERM errors at the lock-directory seam", async () => {
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-lock-")), "q.jsonl");
+    const lockPath = `${path}.lock`;
+    let lockMkdirAttempts = 0;
+
+    vi.doMock("node:fs/promises", () => ({
+      ...actualFs,
+      mkdir: async (target: string, options?: Parameters<typeof actualFs.mkdir>[1]) => {
+        if (target === lockPath) {
+          lockMkdirAttempts += 1;
+          if (lockMkdirAttempts === 1) {
+            throw Object.assign(new Error("transient Windows lock race"), { code: "EPERM" });
+          }
+        }
+        return actualFs.mkdir(target, options);
+      },
+    }));
+
+    const { RETAIN_QUEUE_LOCK, withQueueLock } = await import("../extensions/queue-lock.js");
+    const originalRetryMs = RETAIN_QUEUE_LOCK.retryMs;
+    const originalTimeoutMs = RETAIN_QUEUE_LOCK.timeoutMs;
+    RETAIN_QUEUE_LOCK.retryMs = 1;
+    RETAIN_QUEUE_LOCK.timeoutMs = 100;
+    try {
+      await withQueueLock(path, async () => "ok");
+    } finally {
+      RETAIN_QUEUE_LOCK.retryMs = originalRetryMs;
+      RETAIN_QUEUE_LOCK.timeoutMs = originalTimeoutMs;
+    }
+
+    expect(lockMkdirAttempts).toBe(2);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
+import { isQueueLockRaceError } from "../extensions/queue-lock.js";
 import {
   enqueueRetainJob,
   flushRetainQueue,
@@ -71,6 +72,23 @@ async function createQueueWithJob(id = "1"): Promise<string> {
 }
 
 describe("retain queue", () => {
+  it("classifies Windows lock-directory race errors as retryable contention", () => {
+    expect(isQueueLockRaceError(Object.assign(new Error("exists"), { code: "EEXIST" }))).toBe(true);
+    expect(
+      isQueueLockRaceError(Object.assign(new Error("transient eperm"), { code: "EPERM" })),
+    ).toBe(true);
+    expect(isQueueLockRaceError(Object.assign(new Error("busy"), { code: "EBUSY" }))).toBe(true);
+    expect(isQueueLockRaceError(Object.assign(new Error("not empty"), { code: "ENOTEMPTY" }))).toBe(
+      true,
+    );
+    expect(isQueueLockRaceError(Object.assign(new Error("missing"), { code: "ENOENT" }))).toBe(
+      false,
+    );
+    expect(
+      isQueueLockRaceError(Object.assign(new Error("access denied"), { code: "EACCES" })),
+    ).toBe(false);
+  });
+
   it("checks stale locks from owner acquiredAt instead of waiter age", () => {
     const now = Date.parse("2026-04-27T12:00:00.000Z");
     expect(


### PR DESCRIPTION
## Summary

- Harden retain queue lock acquisition so Windows-style transient lock directory `mkdir` errors (`EPERM`, `EBUSY`, `ENOTEMPTY`) are treated as bounded lock contention.
- Preserve stale-lock cleanup and fail closed on persistent lock `EPERM` by timing out instead of spinning forever.
- Add queue-lock seam regression tests for transient `EPERM` recovery and persistent `EPERM` timeout.

## Linked issue

- Closes #311

## Scope

- Queue lock acquisition and targeted queue-lock tests only.
- No retain payload, recall, reflect, bank, import, transport, package, or docs behavior changed.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Targeted verification:

- `npm test -- tests/queue-lock.test.ts tests/queue.test.ts`
- Pre-commit hook reran `npm run check` before commit.

Skipped verification:

- Full matrix not requested locally; GitHub CI covers PR platform checks.
- Package verification not applicable; package/release path untouched.
- Live Hindsight smoke not applicable; change is local filesystem queue-lock hardening and does not touch Hindsight API payloads, transport, bank selection, recall formatting, or runtime smoke path.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

This fixes Windows retain queue lock flakiness under concurrent enqueue stress. Changelog-worthy bug fix.

## Risk and rollback

- Risk: Persistent Windows `EPERM` on lock directory creation now reports the existing queue lock timeout error rather than the original filesystem error; non-retryable codes still throw immediately.
- Rollback/revert path: Revert this PR to restore prior lock acquisition behavior.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance changes were made, so documentation sync is not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Reviewer pass completed before PR. Finding to add `tests/queue-lock.test.ts` was fixed before push. No ADR conflicts found.
