### PR TITLE
feat: expose advanced recall controls

### DIFF
--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -12,14 +12,23 @@ This reference is generated from the operation catalog and config editing regist
 
 Recall raw memories from Hindsight for this project.
 
-| Parameter        | Type                                        | Required | Description                                                                                   |
-| ---------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `query`          | string                                      | yes      | Natural language memory query                                                                 |
-| `bank`           | string                                      | no       | Optional bank id. Defaults to project bank.                                                   |
-| `queryTimestamp` | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                |
-| `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`      | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
-| `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
+| Parameter               | Type                                        | Required | Description                                                                                                                         |
+| ----------------------- | ------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `query`                 | string                                      | yes      | Natural language memory query                                                                                                       |
+| `bank`                  | string                                      | no       | Optional bank id. Defaults to project bank.                                                                                         |
+| `types`                 | array<world \| experience \| observation>   | no       | Optional Hindsight fact types to retrieve.                                                                                          |
+| `budget`                | low \| mid \| high                          | no       | Optional Hindsight recall budget override for this tool call.                                                                       |
+| `maxTokens`             | integer                                     | no       | Optional Hindsight recall token cap override for this tool call. Use 0 for metadata/source-only recall when supported by Hindsight. |
+| `queryTimestamp`        | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                                                      |
+| `includeChunks`         | boolean                                     | no       | Ask Hindsight to include source chunks when supported.                                                                              |
+| `recallChunksMaxTokens` | integer                                     | no       | Optional token cap for included recall chunks.                                                                                      |
+| `includeSourceFacts`    | boolean                                     | no       | Ask Hindsight to include source facts when supported.                                                                               |
+| `maxSourceFactsTokens`  | integer                                     | no       | Optional token cap for included source facts.                                                                                       |
+| `includeEntities`       | boolean                                     | no       | Ask Hindsight to include entities when supported.                                                                                   |
+| `trace`                 | boolean                                     | no       | Ask Hindsight to include recall trace/debug data.                                                                                   |
+| `tags`                  | array<string>                               | no       | Additional tag filter.                                                                                                              |
+| `tagsMatch`             | any \| all \| any_strict \| all_strict      | no       |                                                                                                                                     |
+| `tagGroups`             | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                       |
 
 ### `hindsight_retain`
 
@@ -213,15 +222,19 @@ Import a gateway/chat transcript JSONL file into the configured user memory bank
 
 Ask Hindsight to synthesize an answer from memory. Use explicitly, not for default recall.
 
-| Parameter        | Type                                        | Required | Description                                                                                   |
-| ---------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `query`          | string                                      | yes      |                                                                                               |
-| `context`        | string                                      | no       |                                                                                               |
-| `bank`           | string                                      | no       |                                                                                               |
-| `responseSchema` | object/map                                  | no       |                                                                                               |
-| `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`      | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
-| `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
+| Parameter          | Type                                        | Required | Description                                                                                   |
+| ------------------ | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `query`            | string                                      | yes      |                                                                                               |
+| `context`          | string                                      | no       |                                                                                               |
+| `bank`             | string                                      | no       |                                                                                               |
+| `budget`           | low \| mid \| high                          | no       | Optional Hindsight reflect budget override for this tool call.                                |
+| `maxTokens`        | integer                                     | no       | Optional Hindsight reflect token cap override for this tool call.                             |
+| `responseSchema`   | object/map                                  | no       |                                                                                               |
+| `includeFacts`     | boolean                                     | no       | Ask Hindsight reflect to include facts when supported.                                        |
+| `includeToolCalls` | boolean                                     | no       | Ask Hindsight reflect to include tool-call trace data when supported.                         |
+| `tags`             | array<string>                               | no       | Additional tag filter.                                                                        |
+| `tagsMatch`        | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
+| `tagGroups`        | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ## Commands
 

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -97,10 +97,10 @@ Additional tools:
 
 Tool notes:
 
-- `hindsight_recall` accepts `queryTimestamp`.
+- `hindsight_recall` accepts `queryTimestamp` plus advanced one-off controls: `types`, `budget`, `maxTokens` (including `0`), `includeChunks`, `recallChunksMaxTokens`, `includeSourceFacts`, `maxSourceFactsTokens`, `includeEntities`, and `trace`.
 - `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp`, `metadata`, `updateMode`, `observationScopes`, and `async`.
 - Caller `metadata` is merged with pi-hindsight provenance, but reserved provenance keys such as `cwd`, `pi_session_file`, `source`, and `retainSource` are set by pi-hindsight and cannot be overridden.
-- `hindsight_reflect` accepts `responseSchema` for structured reflection output.
+- `hindsight_reflect` accepts `responseSchema` for structured reflection output plus `budget`, `maxTokens` (including `0`), `includeFacts`, and `includeToolCalls` when supported by Hindsight.
 - Omit `bank` or pass `project` for the selected project bank.
 - Pass `global` for the configured global bank.
 - `hindsight_retain_global` refuses to write if global memory is disabled or missing a bank ID.

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -8,14 +8,23 @@ This reference is generated from the operation catalog and config editing regist
 
 Recall raw memories from Hindsight for this project.
 
-| Parameter        | Type                                        | Required | Description                                                                                   |
-| ---------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `query`          | string                                      | yes      | Natural language memory query                                                                 |
-| `bank`           | string                                      | no       | Optional bank id. Defaults to project bank.                                                   |
-| `queryTimestamp` | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                |
-| `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`      | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
-| `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
+| Parameter               | Type                                        | Required | Description                                                                                                                         |
+| ----------------------- | ------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `query`                 | string                                      | yes      | Natural language memory query                                                                                                       |
+| `bank`                  | string                                      | no       | Optional bank id. Defaults to project bank.                                                                                         |
+| `types`                 | array<world \| experience \| observation>   | no       | Optional Hindsight fact types to retrieve.                                                                                          |
+| `budget`                | low \| mid \| high                          | no       | Optional Hindsight recall budget override for this tool call.                                                                       |
+| `maxTokens`             | integer                                     | no       | Optional Hindsight recall token cap override for this tool call. Use 0 for metadata/source-only recall when supported by Hindsight. |
+| `queryTimestamp`        | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                                                      |
+| `includeChunks`         | boolean                                     | no       | Ask Hindsight to include source chunks when supported.                                                                              |
+| `recallChunksMaxTokens` | integer                                     | no       | Optional token cap for included recall chunks.                                                                                      |
+| `includeSourceFacts`    | boolean                                     | no       | Ask Hindsight to include source facts when supported.                                                                               |
+| `maxSourceFactsTokens`  | integer                                     | no       | Optional token cap for included source facts.                                                                                       |
+| `includeEntities`       | boolean                                     | no       | Ask Hindsight to include entities when supported.                                                                                   |
+| `trace`                 | boolean                                     | no       | Ask Hindsight to include recall trace/debug data.                                                                                   |
+| `tags`                  | array<string>                               | no       | Additional tag filter.                                                                                                              |
+| `tagsMatch`             | any \| all \| any_strict \| all_strict      | no       |                                                                                                                                     |
+| `tagGroups`             | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                       |
 
 ### `hindsight_retain`
 
@@ -209,15 +218,19 @@ Import a gateway/chat transcript JSONL file into the configured user memory bank
 
 Ask Hindsight to synthesize an answer from memory. Use explicitly, not for default recall.
 
-| Parameter        | Type                                        | Required | Description                                                                                   |
-| ---------------- | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `query`          | string                                      | yes      |                                                                                               |
-| `context`        | string                                      | no       |                                                                                               |
-| `bank`           | string                                      | no       |                                                                                               |
-| `responseSchema` | object/map                                  | no       |                                                                                               |
-| `tags`           | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`      | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
-| `tagGroups`      | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
+| Parameter          | Type                                        | Required | Description                                                                                   |
+| ------------------ | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `query`            | string                                      | yes      |                                                                                               |
+| `context`          | string                                      | no       |                                                                                               |
+| `bank`             | string                                      | no       |                                                                                               |
+| `budget`           | low \| mid \| high                          | no       | Optional Hindsight reflect budget override for this tool call.                                |
+| `maxTokens`        | integer                                     | no       | Optional Hindsight reflect token cap override for this tool call.                             |
+| `responseSchema`   | object/map                                  | no       |                                                                                               |
+| `includeFacts`     | boolean                                     | no       | Ask Hindsight reflect to include facts when supported.                                        |
+| `includeToolCalls` | boolean                                     | no       | Ask Hindsight reflect to include tool-call trace data when supported.                         |
+| `tags`             | array<string>                               | no       | Additional tag filter.                                                                        |
+| `tagsMatch`        | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
+| `tagGroups`        | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ## Commands
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -95,10 +95,10 @@ Additional tools:
 
 Tool notes:
 
-- `hindsight_recall` accepts `queryTimestamp`.
+- `hindsight_recall` accepts `queryTimestamp` plus advanced one-off controls: `types`, `budget`, `maxTokens` (including `0`), `includeChunks`, `recallChunksMaxTokens`, `includeSourceFacts`, `maxSourceFactsTokens`, `includeEntities`, and `trace`.
 - `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp`, `metadata`, `updateMode`, `observationScopes`, and `async`.
 - Caller `metadata` is merged with pi-hindsight provenance, but reserved provenance keys such as `cwd`, `pi_session_file`, `source`, and `retainSource` are set by pi-hindsight and cannot be overridden.
-- `hindsight_reflect` accepts `responseSchema` for structured reflection output.
+- `hindsight_reflect` accepts `responseSchema` for structured reflection output plus `budget`, `maxTokens` (including `0`), `includeFacts`, and `includeToolCalls` when supported by Hindsight.
 - Omit `bank` or pass `project` for the selected project bank.
 - Pass `global` for the configured global bank.
 - `hindsight_retain_global` refuses to write if global memory is disabled or missing a bank ID.

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -77,7 +77,10 @@ export function reflectRequestBody(
   options: {
     context?: string;
     budget?: string;
+    maxTokens?: number;
     responseSchema?: unknown;
+    includeFacts?: boolean;
+    includeToolCalls?: boolean;
     factTypes?: Array<"world" | "experience" | "observation">;
     excludeMentalModels?: boolean;
     excludeMentalModelIds?: string[];
@@ -90,7 +93,20 @@ export function reflectRequestBody(
     query,
     ...(options.context ? { context: options.context } : {}),
     budget: options.budget ?? "low",
+    ...(options.maxTokens !== undefined ? { max_tokens: options.maxTokens } : {}),
     ...(options.responseSchema ? { response_schema: options.responseSchema } : {}),
+    ...(options.includeFacts !== undefined || options.includeToolCalls !== undefined
+      ? {
+          include: {
+            ...(options.includeFacts !== undefined
+              ? { facts: options.includeFacts ? {} : null }
+              : {}),
+            ...(options.includeToolCalls !== undefined
+              ? { tool_calls: options.includeToolCalls ? {} : null }
+              : {}),
+          },
+        }
+      : {}),
     ...(options.factTypes ? { fact_types: options.factTypes } : {}),
     ...(options.excludeMentalModels !== undefined
       ? { exclude_mental_models: options.excludeMentalModels }

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -53,8 +53,12 @@ async function reflect(
   },
   signal: AbortSignal,
 ): Promise<unknown> {
-  if (!args.options?.responseSchema)
-    return args.raw.reflect(args.bankId, args.query, { ...args.options, signal });
+  const needsRestShim =
+    args.options?.responseSchema ||
+    args.options?.maxTokens !== undefined ||
+    args.options?.includeFacts !== undefined ||
+    args.options?.includeToolCalls !== undefined;
+  if (!needsRestShim) return args.raw.reflect(args.bankId, args.query, { ...args.options, signal });
   const response = await args.rest.request(encodeBankPath(args.bankId, "/reflect"), {
     method: "POST",
     signal,

--- a/extensions/memory-recall-operations.ts
+++ b/extensions/memory-recall-operations.ts
@@ -7,6 +7,8 @@ import { getEffectiveSessionMemoryMode, readSessionMemoryMeta } from "./session-
 import type { HindsightTagGroup, ResolvedConfig, TagsMatch } from "./types.js";
 
 interface ExplicitRecallFilters {
+  budget?: import("./types.js").Budget;
+  maxTokens?: number;
   queryTimestamp?: string;
   types?: string[];
   trace?: boolean;
@@ -23,6 +25,8 @@ interface ExplicitRecallFilters {
 }
 
 interface ExplicitReflectFilters extends Omit<ExplicitRecallFilters, "queryTimestamp" | "types"> {
+  includeFacts?: boolean;
+  includeToolCalls?: boolean;
   factTypes?: Array<"world" | "experience" | "observation">;
   excludeMentalModels?: boolean;
   excludeMentalModelIds?: string[];
@@ -76,8 +80,8 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
       });
       const scopeTags = recallTagsForBank(cwd, config, deps.getProjectBankId(), bankId);
       const result = await deps.getClient().recall(bankId, query, {
-        budget: config.recall.budget,
-        maxTokens: config.recall.maxTokens,
+        budget: filters.budget ?? config.recall.budget,
+        maxTokens: filters.maxTokens ?? config.recall.maxTokens,
         ...(filters.queryTimestamp || config.recall.queryTimestamp
           ? { queryTimestamp: filters.queryTimestamp ?? config.recall.queryTimestamp }
           : {}),
@@ -120,8 +124,13 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
       const scopeTags = recallTagsForBank(cwd, config, deps.getProjectBankId(), bankId);
       const result = await deps.getClient().reflect(bankId, query, {
         ...(context ? { context } : {}),
-        budget: config.recall.budget,
+        budget: filters.budget ?? config.recall.budget,
+        ...(filters.maxTokens !== undefined ? { maxTokens: filters.maxTokens } : {}),
         ...(responseSchema ? { responseSchema } : {}),
+        ...(filters.includeFacts !== undefined ? { includeFacts: filters.includeFacts } : {}),
+        ...(filters.includeToolCalls !== undefined
+          ? { includeToolCalls: filters.includeToolCalls }
+          : {}),
         ...(filters.factTypes ? { factTypes: filters.factTypes } : {}),
         ...(filters.excludeMentalModels !== undefined
           ? { excludeMentalModels: filters.excludeMentalModels }

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -35,6 +35,14 @@ const tagMatchSchema = Type.Union([
   Type.Literal("all_strict"),
 ]);
 
+const budgetSchema = Type.Union([Type.Literal("low"), Type.Literal("mid"), Type.Literal("high")]);
+
+const recallTypeSchema = Type.Union([
+  Type.Literal("world"),
+  Type.Literal("experience"),
+  Type.Literal("observation"),
+]);
+
 const tagGroupJsonSchema = {
   $id: "HindsightTagGroup",
   anyOf: [
@@ -170,8 +178,50 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         bank: Type.Optional(
           Type.String({ description: "Optional bank id. Defaults to project bank." }),
         ),
+        types: Type.Optional(
+          Type.Array(recallTypeSchema, {
+            description: "Optional Hindsight fact types to retrieve.",
+          }),
+        ),
+        budget: Type.Optional(
+          Type.Unsafe<import("./types.js").Budget>({
+            ...budgetSchema,
+            description: "Optional Hindsight recall budget override for this tool call.",
+          }),
+        ),
+        maxTokens: Type.Optional(
+          Type.Integer({
+            minimum: 0,
+            description:
+              "Optional Hindsight recall token cap override for this tool call. Use 0 for metadata/source-only recall when supported by Hindsight.",
+          }),
+        ),
         queryTimestamp: Type.Optional(
           Type.String({ description: "Optional ISO timestamp for time-scoped recall." }),
+        ),
+        includeChunks: Type.Optional(
+          Type.Boolean({ description: "Ask Hindsight to include source chunks when supported." }),
+        ),
+        recallChunksMaxTokens: Type.Optional(
+          Type.Integer({
+            minimum: 0,
+            description: "Optional token cap for included recall chunks.",
+          }),
+        ),
+        includeSourceFacts: Type.Optional(
+          Type.Boolean({ description: "Ask Hindsight to include source facts when supported." }),
+        ),
+        maxSourceFactsTokens: Type.Optional(
+          Type.Integer({
+            minimum: 0,
+            description: "Optional token cap for included source facts.",
+          }),
+        ),
+        includeEntities: Type.Optional(
+          Type.Boolean({ description: "Ask Hindsight to include entities when supported." }),
+        ),
+        trace: Type.Optional(
+          Type.Boolean({ description: "Ask Hindsight to include recall trace/debug data." }),
         ),
         tags: Type.Optional(Type.Array(Type.String(), { description: "Additional tag filter." })),
         tagsMatch: Type.Optional(tagMatchSchema),
@@ -188,7 +238,24 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           params.bank,
           sessionFile,
           {
+            ...(params.types ? { types: params.types } : {}),
+            ...(params.budget ? { budget: params.budget } : {}),
+            ...(params.maxTokens !== undefined ? { maxTokens: params.maxTokens } : {}),
             ...(params.queryTimestamp ? { queryTimestamp: params.queryTimestamp } : {}),
+            ...(params.includeChunks !== undefined ? { includeChunks: params.includeChunks } : {}),
+            ...(params.recallChunksMaxTokens !== undefined
+              ? { maxChunkTokens: params.recallChunksMaxTokens }
+              : {}),
+            ...(params.includeSourceFacts !== undefined
+              ? { includeSourceFacts: params.includeSourceFacts }
+              : {}),
+            ...(params.maxSourceFactsTokens !== undefined
+              ? { maxSourceFactsTokens: params.maxSourceFactsTokens }
+              : {}),
+            ...(params.includeEntities !== undefined
+              ? { includeEntities: params.includeEntities }
+              : {}),
+            ...(params.trace !== undefined ? { trace: params.trace } : {}),
             ...(params.tags ? { tags: params.tags } : {}),
             ...(params.tagsMatch ? { tagsMatch: params.tagsMatch } : {}),
             ...(params.tagGroups
@@ -645,7 +712,27 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         query: Type.String(),
         context: Type.Optional(Type.String()),
         bank: Type.Optional(Type.String()),
+        budget: Type.Optional(
+          Type.Unsafe<import("./types.js").Budget>({
+            ...budgetSchema,
+            description: "Optional Hindsight reflect budget override for this tool call.",
+          }),
+        ),
+        maxTokens: Type.Optional(
+          Type.Integer({
+            minimum: 0,
+            description: "Optional Hindsight reflect token cap override for this tool call.",
+          }),
+        ),
         responseSchema: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+        includeFacts: Type.Optional(
+          Type.Boolean({ description: "Ask Hindsight reflect to include facts when supported." }),
+        ),
+        includeToolCalls: Type.Optional(
+          Type.Boolean({
+            description: "Ask Hindsight reflect to include tool-call trace data when supported.",
+          }),
+        ),
         tags: Type.Optional(Type.Array(Type.String(), { description: "Additional tag filter." })),
         tagsMatch: Type.Optional(tagMatchSchema),
         tagGroups: tagGroupsSchema(
@@ -661,6 +748,12 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           params.bank,
           params.responseSchema,
           {
+            ...(params.budget ? { budget: params.budget } : {}),
+            ...(params.maxTokens !== undefined ? { maxTokens: params.maxTokens } : {}),
+            ...(params.includeFacts !== undefined ? { includeFacts: params.includeFacts } : {}),
+            ...(params.includeToolCalls !== undefined
+              ? { includeToolCalls: params.includeToolCalls }
+              : {}),
             ...(params.tags ? { tags: params.tags } : {}),
             ...(params.tagsMatch ? { tagsMatch: params.tagsMatch } : {}),
             ...(params.tagGroups

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -327,7 +327,10 @@ export interface HindsightLikeClient {
     options?: {
       context?: string;
       budget?: Budget;
+      maxTokens?: number;
       responseSchema?: Record<string, unknown>;
+      includeFacts?: boolean;
+      includeToolCalls?: boolean;
       factTypes?: Array<"world" | "experience" | "observation">;
       excludeMentalModels?: boolean;
       excludeMentalModelIds?: string[];

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -229,7 +229,10 @@ describe("Hindsight client adapter integration", () => {
     });
     const reflection = await client.reflect("test-bank", "query", {
       budget: "low",
+      maxTokens: 0,
       responseSchema: { type: "object", properties: { answer: { type: "string" } } },
+      includeFacts: true,
+      includeToolCalls: false,
       tagGroups: [{ tags: ["source:pi"], match: "any_strict" }],
     });
     const templateDryRun = await client.importBankTemplate?.(
@@ -395,7 +398,9 @@ describe("Hindsight client adapter integration", () => {
     expect(requests[5]?.body).toMatchObject({
       query: "query",
       budget: "low",
+      max_tokens: 0,
       response_schema: { type: "object", properties: { answer: { type: "string" } } },
+      include: { facts: {}, tool_calls: null },
       tag_groups: [{ tags: ["source:pi"], match: "any_strict" }],
     });
     expect(requests[6]?.body).toEqual({

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -27,7 +27,10 @@ describe("Hindsight REST transport helpers", () => {
       reflectRequestBody("query", {
         context: "ctx",
         budget: "mid",
+        maxTokens: 0,
         responseSchema: { type: "object" },
+        includeFacts: true,
+        includeToolCalls: false,
         tags: ["source:pi"],
         tagsMatch: "any_strict",
       }),
@@ -35,7 +38,9 @@ describe("Hindsight REST transport helpers", () => {
       query: "query",
       context: "ctx",
       budget: "mid",
+      max_tokens: 0,
       response_schema: { type: "object" },
+      include: { facts: {}, tool_calls: null },
       tags: ["source:pi"],
       tags_match: "any_strict",
     });

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -7,6 +7,8 @@ import { createOperationCatalog } from "../extensions/operation-catalog.js";
 import type { HindsightLikeClient, ResolvedConfig } from "../extensions/types.js";
 
 type RetainOptions = Parameters<HindsightLikeClient["retain"]>[2];
+type RecallOptions = Parameters<HindsightLikeClient["recall"]>[2];
+type ReflectOptions = Parameters<HindsightLikeClient["reflect"]>[2];
 
 type JsonSchema = {
   type?: string;
@@ -15,6 +17,7 @@ type JsonSchema = {
   items?: JsonSchema;
   anyOf?: JsonSchema[];
   const?: unknown;
+  minimum?: number;
 };
 
 function client(): HindsightLikeClient {
@@ -147,6 +150,7 @@ describe("operation catalog", () => {
       getConfig: () => DEFAULT_CONFIG,
       getProjectBankId: () => "project-bank",
     });
+
     const tool = requireTool(catalog, "hindsight_retain");
 
     await tool.execute(
@@ -177,6 +181,129 @@ describe("operation catalog", () => {
         expect.stringMatching(/^repo:/),
         expect.stringMatching(/^session:/),
       ]),
+    );
+  });
+
+  it("exposes and maps advanced explicit recall controls", async () => {
+    const recall = vi.fn(async (_bankId: string, _query: string, _options?: RecallOptions) => ({
+      ok: true,
+    }));
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-catalog-"));
+    const catalog = createOperationCatalog({
+      getClient: () => ({ ...client(), recall }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+    const tool = requireTool(catalog, "hindsight_recall");
+    const properties = (tool.parameters as JsonSchema).properties ?? {};
+
+    expect(properties.types?.items?.anyOf?.map((schema) => schema.const)).toEqual([
+      "world",
+      "experience",
+      "observation",
+    ]);
+    expect(properties.budget?.anyOf?.map((schema) => schema.const)).toEqual(["low", "mid", "high"]);
+    expect(properties.maxTokens?.type).toBe("integer");
+    expect(properties.maxTokens?.minimum).toBe(0);
+    expect(properties.includeChunks?.type).toBe("boolean");
+    expect(properties.recallChunksMaxTokens?.type).toBe("integer");
+    expect(properties.includeSourceFacts?.type).toBe("boolean");
+    expect(properties.maxSourceFactsTokens?.type).toBe("integer");
+    expect(properties.includeEntities?.type).toBe("boolean");
+    expect(properties.trace?.type).toBe("boolean");
+
+    await tool.execute(
+      "call",
+      {
+        query: "find source context",
+        types: ["world", "observation"],
+        budget: "high",
+        maxTokens: 0,
+        includeChunks: true,
+        recallChunksMaxTokens: 512,
+        includeSourceFacts: true,
+        maxSourceFactsTokens: 256,
+        includeEntities: true,
+        trace: true,
+        tags: ["caller:tag"],
+      },
+      new AbortController().signal,
+      () => undefined,
+      { cwd, sessionManager: {} } as never,
+    );
+
+    expect(recall).toHaveBeenCalledWith(
+      "project-bank",
+      "find source context",
+      expect.objectContaining({
+        types: ["world", "observation"],
+        budget: "high",
+        maxTokens: 0,
+        includeChunks: true,
+        maxChunkTokens: 512,
+        includeSourceFacts: true,
+        maxSourceFactsTokens: 256,
+        includeEntities: true,
+        trace: true,
+        tagGroups: expect.arrayContaining([
+          expect.objectContaining({
+            tags: expect.arrayContaining([expect.stringMatching(/^repo:/)]),
+          }),
+          { tags: ["caller:tag"], match: "any_strict" },
+        ]),
+      }),
+    );
+  });
+
+  it("exposes and maps low-risk explicit reflect controls", async () => {
+    const reflect = vi.fn(async (_bankId: string, _query: string, _options?: ReflectOptions) => ({
+      ok: true,
+    }));
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-catalog-"));
+    const catalog = createOperationCatalog({
+      getClient: () => ({ ...client(), reflect }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+    const tool = requireTool(catalog, "hindsight_reflect");
+    const properties = (tool.parameters as JsonSchema).properties ?? {};
+
+    expect(properties.budget?.anyOf?.map((schema) => schema.const)).toEqual(["low", "mid", "high"]);
+    expect(properties.maxTokens?.type).toBe("integer");
+    expect(properties.maxTokens?.minimum).toBe(0);
+    expect(properties.includeFacts?.type).toBe("boolean");
+    expect(properties.includeToolCalls?.type).toBe("boolean");
+
+    await tool.execute(
+      "call",
+      {
+        query: "synthesize",
+        budget: "mid",
+        maxTokens: 0,
+        includeFacts: true,
+        includeToolCalls: true,
+        tags: ["caller:tag"],
+      },
+      new AbortController().signal,
+      () => undefined,
+      { cwd, sessionManager: {} } as never,
+    );
+
+    expect(reflect).toHaveBeenCalledWith(
+      "project-bank",
+      "synthesize",
+      expect.objectContaining({
+        budget: "mid",
+        maxTokens: 0,
+        includeFacts: true,
+        includeToolCalls: true,
+        tagGroups: expect.arrayContaining([
+          expect.objectContaining({
+            tags: expect.arrayContaining([expect.stringMatching(/^repo:/)]),
+          }),
+          { tags: ["caller:tag"], match: "any_strict" },
+        ]),
+      }),
     );
   });
 


### PR DESCRIPTION
## Summary

- Adds advanced explicit `hindsight_recall` parameters for Hindsight-supported controls: fact `types`, `budget`, `maxTokens` including `0`, source chunks/facts/entities include flags, and `trace`.
- Maps explicit recall controls through the shared memory operation path while leaving automatic recall defaults and scope tag injection unchanged.
- Adds low-risk explicit `hindsight_reflect` controls for `budget`, `maxTokens`, `includeFacts`, and `includeToolCalls`, with REST shim mapping for fields not covered by the high-level SDK call.
- Updates generated surface reference and tools docs.

## Linked issue

- Updates #235

## Scope

- Focused on explicit tool schemas and request mapping for advanced recall controls already present in current Hindsight client/OpenAPI types.
- Includes reflect controls only where they share the same operation path and map cleanly to current OpenAPI fields.
- Does not change automatic context recall defaults, retention behavior, bank selection, or import behavior.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional verification:

- `npm test -- operation-catalog client-rest client-integration`
- `npm run typecheck`
- Reviewer pass completed by parent-launched reviewer; blocking budget enum finding fixed.
- `npm run smoke:hindsight` first configured-server attempt failed on strict import recall visibility after 20 attempts; reran once per flake policy and passed with `cleanup_ok` for bank `pi-hindsight-smoke-1778164567980`.

Skipped checks:

- Full matrix not requested because this is not release verification or platform-sensitive behavior.
- Package verification and `npm run pack:verify` not run because package/release path did not change.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Explicit tools now expose advanced one-off recall and reflect parameters. Include in changelog/release notes as a user-visible tool surface improvement.

## Risk and rollback

- Risk: Incorrect explicit parameter mapping could send unsupported Hindsight payload fields or weaken scoped recall isolation.
- Rollback/revert path: Revert this PR to remove the new explicit schema fields and mapping; automatic recall defaults remain unchanged by this slice.

## Follow-ups

- #235 remains open for additional older-release parity, including finer reflect trace/include controls if needed beyond `includeFacts` and `includeToolCalls`.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance sync required; this PR changes tool behavior/docs only.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- Automatic recall defaults and scoped tag injection are preserved; tests assert caller tags are AND-ed with project scope tag groups.
- Reviewer finding fixed: `budget` schema now uses Hindsight-supported `low | mid | high`, not unsupported `medium`.
- The initial live smoke failure was an import recall visibility flake; one rerun passed.