### PR TITLE
feat(tools): add Hindsight admin inspection tools

### DIFF
--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -34,36 +34,38 @@ Recall raw memories from Hindsight for this project.
 
 Retain explicit raw content in Hindsight. Use for durable facts or decisions.
 
-| Parameter           | Type                 | Required | Description                                                                                                                                                            |
-| ------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `content`           | string               | yes      | Raw content to retain, not summary if source content is available.                                                                                                     |
-| `context`           | string               | yes      | Source context for this memory.                                                                                                                                        |
-| `bank`              | string               | no       | Optional bank id. Defaults to project bank.                                                                                                                            |
-| `tags`              | array<string>        | no       |                                                                                                                                                                        |
-| `entities`          | array<object>        | no       | Optional Hindsight entities to associate with this retained content.                                                                                                   |
-| `documentId`        | string               | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                    |
-| `timestamp`         | string               | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                           |
-| `metadata`          | object/map           | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden. |
-| `updateMode`        | append \| replace    | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                          |
-| `observationScopes` | array<array<string>> | no       | Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.                           |
-| `async`             | boolean              | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                    |
+| Parameter           | Type                                                            | Required | Description                                                                                                                                                                                     |
+| ------------------- | --------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`           | string                                                          | yes      | Raw content to retain, not summary if source content is available.                                                                                                                              |
+| `context`           | string                                                          | yes      | Source context for this memory.                                                                                                                                                                 |
+| `bank`              | string                                                          | no       | Optional bank id. Defaults to project bank.                                                                                                                                                     |
+| `tags`              | array<string>                                                   | no       |                                                                                                                                                                                                 |
+| `entities`          | array<object>                                                   | no       | Optional Hindsight entities to associate with this retained content.                                                                                                                            |
+| `documentId`        | string                                                          | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                                             |
+| `timestamp`         | string                                                          | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                                                    |
+| `metadata`          | object/map                                                      | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden.                          |
+| `updateMode`        | append \| replace                                               | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                                                   |
+| `observationScopes` | per_tag \| combined \| all_combinations \| array<array<string>> | no       | Optional Hindsight observation scopes. Use per_tag, combined, all_combinations, or explicit string groups. When provided, overrides configured default observation scopes for this retain call. |
+| `documentTags`      | array<string>                                                   | no       | Optional Hindsight document_tags for this retained document when supported.                                                                                                                     |
+| `async`             | boolean                                                         | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                                             |
 
 ### `hindsight_retain_global`
 
 Retain explicit durable user memory in the configured user bank. Use for stable user identity, preferences, and cross-project workflows only.
 
-| Parameter           | Type                 | Required | Description                                                                                                                                                            |
-| ------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `content`           | string               | yes      | Raw memory content to retain.                                                                                                                                          |
-| `context`           | string               | yes      | Why this memory is durable user context.                                                                                                                               |
-| `tags`              | array<string>        | no       |                                                                                                                                                                        |
-| `entities`          | array<object>        | no       | Optional Hindsight entities to associate with this retained content.                                                                                                   |
-| `documentId`        | string               | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                    |
-| `timestamp`         | string               | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                           |
-| `metadata`          | object/map           | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden. |
-| `updateMode`        | append \| replace    | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                          |
-| `observationScopes` | array<array<string>> | no       | Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.                           |
-| `async`             | boolean              | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                    |
+| Parameter           | Type                                                            | Required | Description                                                                                                                                                                                     |
+| ------------------- | --------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`           | string                                                          | yes      | Raw memory content to retain.                                                                                                                                                                   |
+| `context`           | string                                                          | yes      | Why this memory is durable user context.                                                                                                                                                        |
+| `tags`              | array<string>                                                   | no       |                                                                                                                                                                                                 |
+| `entities`          | array<object>                                                   | no       | Optional Hindsight entities to associate with this retained content.                                                                                                                            |
+| `documentId`        | string                                                          | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                                             |
+| `timestamp`         | string                                                          | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                                                    |
+| `metadata`          | object/map                                                      | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden.                          |
+| `updateMode`        | append \| replace                                               | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                                                   |
+| `observationScopes` | per_tag \| combined \| all_combinations \| array<array<string>> | no       | Optional Hindsight observation scopes. Use per_tag, combined, all_combinations, or explicit string groups. When provided, overrides configured default observation scopes for this retain call. |
+| `documentTags`      | array<string>                                                   | no       | Optional Hindsight document_tags for this retained document when supported.                                                                                                                     |
+| `async`             | boolean                                                         | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                                             |
 
 ### `hindsight_retain_receipts`
 
@@ -91,6 +93,85 @@ Delete a specific Hindsight document and all memories extracted from it. Destruc
 | `bank`       | string  | yes      | Bank ID containing the document.              |
 | `documentId` | string  | yes      | Exact Hindsight document ID to delete.        |
 | `confirm`    | boolean | yes      | Must be true to confirm destructive deletion. |
+
+### `hindsight_list_operations`
+
+List Hindsight async operations for a bank with supported server filters.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+| `status`   | string | no       | Optional operation status filter.           |
+| `taskType` | string | no       | Optional task type filter.                  |
+| `limit`    | number | no       | Maximum operations to return.               |
+| `offset`   | number | no       | Pagination offset.                          |
+
+### `hindsight_cancel_operation`
+
+Cancel a pending Hindsight async operation. Requires confirm=true.
+
+| Parameter     | Type   | Required | Description                                             |
+| ------------- | ------ | -------- | ------------------------------------------------------- |
+| `operationId` | string | yes      | Hindsight operation ID.                                 |
+| `bank`        | string | no       | Optional bank id. Defaults to project bank.             |
+| `confirm`     | true   | yes      | Required destructive-action confirmation. Must be true. |
+
+### `hindsight_retry_operation`
+
+Retry a failed or cancelled Hindsight async operation.
+
+| Parameter     | Type   | Required | Description                                 |
+| ------------- | ------ | -------- | ------------------------------------------- |
+| `operationId` | string | yes      | Hindsight operation ID.                     |
+| `bank`        | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_list_memories`
+
+List raw Hindsight memory units for inspection.
+
+| Parameter | Type   | Required | Description                                 |
+| --------- | ------ | -------- | ------------------------------------------- |
+| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+| `type`    | string | no       | Optional memory type filter.                |
+| `q`       | string | no       | Optional text query filter.                 |
+| `limit`   | number | no       | Maximum memories to return.                 |
+| `offset`  | number | no       | Pagination offset.                          |
+
+### `hindsight_get_memory`
+
+Fetch a raw Hindsight memory unit by ID.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `memoryId` | string | yes      | Hindsight memory ID.                        |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_get_chunk`
+
+Fetch a raw Hindsight source chunk by chunk ID.
+
+| Parameter | Type   | Required | Description         |
+| --------- | ------ | -------- | ------------------- |
+| `chunkId` | string | yes      | Hindsight chunk ID. |
+
+### `hindsight_get_memory_history`
+
+Fetch Hindsight memory history by memory ID when server supports it.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `memoryId` | string | yes      | Hindsight memory ID.                        |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_delete_memory_observations`
+
+Delete observations for one Hindsight memory. Destructive; requires exact memory ID and confirm=true.
+
+| Parameter  | Type   | Required | Description                                             |
+| ---------- | ------ | -------- | ------------------------------------------------------- |
+| `memoryId` | string | yes      | Hindsight memory ID.                                    |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank.             |
+| `confirm`  | true   | yes      | Required destructive-action confirmation. Must be true. |
 
 ### `hindsight_configure`
 

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -94,17 +94,30 @@ Additional tools:
 - `hindsight_route_memory`
 - `hindsight_retain_receipts`
 - `hindsight_delete_document`
+- `hindsight_list_operations`
+- `hindsight_cancel_operation`
+- `hindsight_retry_operation`
+- `hindsight_list_memories`
+- `hindsight_get_memory`
+- `hindsight_get_chunk`
+- `hindsight_get_memory_history`
+- `hindsight_delete_memory_observations`
 
 Tool notes:
 
 - `hindsight_recall` accepts `queryTimestamp` plus advanced one-off controls: `types`, `budget`, `maxTokens` (including `0`), `includeChunks`, `recallChunksMaxTokens`, `includeSourceFacts`, `maxSourceFactsTokens`, `includeEntities`, and `trace`.
-- `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp`, `metadata`, `updateMode`, `observationScopes`, and `async`.
+- `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp` (including literal `unset`), `metadata`, `updateMode`, `observationScopes`, `documentTags`, and `async`. `observationScopes` accepts `per_tag`, `combined`, `all_combinations`, or explicit string groups. Hindsight supports `documentTags` for compatibility, but upstream marks it deprecated; prefer normal `tags` unless document-level interop requires it.
+- For `updateMode: "append"`, use a stable `documentId` when continuing a known document. If omitted, pi-hindsight still uses its deterministic explicit-retain document ID; repeated calls only append together when content/context/session produce the same ID.
+- Async retain responses include Hindsight operation IDs when the server returns them; use `hindsight_list_operations`, `hindsight_cancel_operation`, and `hindsight_retry_operation` to inspect or manage those jobs.
 - Caller `metadata` is merged with pi-hindsight provenance, but reserved provenance keys such as `cwd`, `pi_session_file`, `source`, and `retainSource` are set by pi-hindsight and cannot be overridden.
 - `hindsight_reflect` accepts `responseSchema` for structured reflection output plus `budget`, `maxTokens` (including `0`), `includeFacts`, and `includeToolCalls` when supported by Hindsight.
 - Omit `bank` or pass `project` for the selected project bank.
 - Pass `global` for the configured global bank.
 - `hindsight_retain_global` refuses to write if global memory is disabled or missing a bank ID.
 - `hindsight_delete_document` requires exact bank, exact document ID, and `confirm: true`.
+- `hindsight_cancel_operation` requires exact operation ID and `confirm: true`; it is intended for pending operations.
+- `hindsight_delete_memory_observations` requires exact memory ID and `confirm: true`. Bank-wide memory clear/delete-all is intentionally not exposed.
+- Memory inspection tools use current documented REST endpoints: list memory units, fetch a memory, fetch a chunk by ID, fetch memory history when the server supports it, and delete observations for one memory when supported.
 
 ## Receipts and deletion
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -30,36 +30,38 @@ Recall raw memories from Hindsight for this project.
 
 Retain explicit raw content in Hindsight. Use for durable facts or decisions.
 
-| Parameter           | Type                 | Required | Description                                                                                                                                                            |
-| ------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `content`           | string               | yes      | Raw content to retain, not summary if source content is available.                                                                                                     |
-| `context`           | string               | yes      | Source context for this memory.                                                                                                                                        |
-| `bank`              | string               | no       | Optional bank id. Defaults to project bank.                                                                                                                            |
-| `tags`              | array<string>        | no       |                                                                                                                                                                        |
-| `entities`          | array<object>        | no       | Optional Hindsight entities to associate with this retained content.                                                                                                   |
-| `documentId`        | string               | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                    |
-| `timestamp`         | string               | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                           |
-| `metadata`          | object/map           | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden. |
-| `updateMode`        | append \| replace    | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                          |
-| `observationScopes` | array<array<string>> | no       | Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.                           |
-| `async`             | boolean              | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                    |
+| Parameter           | Type                                                            | Required | Description                                                                                                                                                                                     |
+| ------------------- | --------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`           | string                                                          | yes      | Raw content to retain, not summary if source content is available.                                                                                                                              |
+| `context`           | string                                                          | yes      | Source context for this memory.                                                                                                                                                                 |
+| `bank`              | string                                                          | no       | Optional bank id. Defaults to project bank.                                                                                                                                                     |
+| `tags`              | array<string>                                                   | no       |                                                                                                                                                                                                 |
+| `entities`          | array<object>                                                   | no       | Optional Hindsight entities to associate with this retained content.                                                                                                                            |
+| `documentId`        | string                                                          | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                                             |
+| `timestamp`         | string                                                          | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                                                    |
+| `metadata`          | object/map                                                      | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden.                          |
+| `updateMode`        | append \| replace                                               | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                                                   |
+| `observationScopes` | per_tag \| combined \| all_combinations \| array<array<string>> | no       | Optional Hindsight observation scopes. Use per_tag, combined, all_combinations, or explicit string groups. When provided, overrides configured default observation scopes for this retain call. |
+| `documentTags`      | array<string>                                                   | no       | Optional Hindsight document_tags for this retained document when supported.                                                                                                                     |
+| `async`             | boolean                                                         | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                                             |
 
 ### `hindsight_retain_global`
 
 Retain explicit durable user memory in the configured user bank. Use for stable user identity, preferences, and cross-project workflows only.
 
-| Parameter           | Type                 | Required | Description                                                                                                                                                            |
-| ------------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `content`           | string               | yes      | Raw memory content to retain.                                                                                                                                          |
-| `context`           | string               | yes      | Why this memory is durable user context.                                                                                                                               |
-| `tags`              | array<string>        | no       |                                                                                                                                                                        |
-| `entities`          | array<object>        | no       | Optional Hindsight entities to associate with this retained content.                                                                                                   |
-| `documentId`        | string               | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                    |
-| `timestamp`         | string               | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                           |
-| `metadata`          | object/map           | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden. |
-| `updateMode`        | append \| replace    | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                          |
-| `observationScopes` | array<array<string>> | no       | Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.                           |
-| `async`             | boolean              | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                    |
+| Parameter           | Type                                                            | Required | Description                                                                                                                                                                                     |
+| ------------------- | --------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `content`           | string                                                          | yes      | Raw memory content to retain.                                                                                                                                                                   |
+| `context`           | string                                                          | yes      | Why this memory is durable user context.                                                                                                                                                        |
+| `tags`              | array<string>                                                   | no       |                                                                                                                                                                                                 |
+| `entities`          | array<object>                                                   | no       | Optional Hindsight entities to associate with this retained content.                                                                                                                            |
+| `documentId`        | string                                                          | no       | Optional Hindsight document ID. Defaults to the existing deterministic explicit retain document ID.                                                                                             |
+| `timestamp`         | string                                                          | no       | Optional Hindsight timestamp string, including ISO-ish strings or literal unset, passed through as provided.                                                                                    |
+| `metadata`          | object/map                                                      | no       | Optional caller metadata string map. Reserved provenance keys such as cwd, pi_session_file, source, and retainSource are set by pi-hindsight and cannot be overridden.                          |
+| `updateMode`        | append \| replace                                               | no       | Optional Hindsight update mode for this explicit retain call.                                                                                                                                   |
+| `observationScopes` | per_tag \| combined \| all_combinations \| array<array<string>> | no       | Optional Hindsight observation scopes. Use per_tag, combined, all_combinations, or explicit string groups. When provided, overrides configured default observation scopes for this retain call. |
+| `documentTags`      | array<string>                                                   | no       | Optional Hindsight document_tags for this retained document when supported.                                                                                                                     |
+| `async`             | boolean                                                         | no       | Optional Hindsight async extraction flag for this retain call. Defaults to configured retain.async.                                                                                             |
 
 ### `hindsight_retain_receipts`
 
@@ -87,6 +89,85 @@ Delete a specific Hindsight document and all memories extracted from it. Destruc
 | `bank`       | string  | yes      | Bank ID containing the document.              |
 | `documentId` | string  | yes      | Exact Hindsight document ID to delete.        |
 | `confirm`    | boolean | yes      | Must be true to confirm destructive deletion. |
+
+### `hindsight_list_operations`
+
+List Hindsight async operations for a bank with supported server filters.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+| `status`   | string | no       | Optional operation status filter.           |
+| `taskType` | string | no       | Optional task type filter.                  |
+| `limit`    | number | no       | Maximum operations to return.               |
+| `offset`   | number | no       | Pagination offset.                          |
+
+### `hindsight_cancel_operation`
+
+Cancel a pending Hindsight async operation. Requires confirm=true.
+
+| Parameter     | Type   | Required | Description                                             |
+| ------------- | ------ | -------- | ------------------------------------------------------- |
+| `operationId` | string | yes      | Hindsight operation ID.                                 |
+| `bank`        | string | no       | Optional bank id. Defaults to project bank.             |
+| `confirm`     | true   | yes      | Required destructive-action confirmation. Must be true. |
+
+### `hindsight_retry_operation`
+
+Retry a failed or cancelled Hindsight async operation.
+
+| Parameter     | Type   | Required | Description                                 |
+| ------------- | ------ | -------- | ------------------------------------------- |
+| `operationId` | string | yes      | Hindsight operation ID.                     |
+| `bank`        | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_list_memories`
+
+List raw Hindsight memory units for inspection.
+
+| Parameter | Type   | Required | Description                                 |
+| --------- | ------ | -------- | ------------------------------------------- |
+| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+| `type`    | string | no       | Optional memory type filter.                |
+| `q`       | string | no       | Optional text query filter.                 |
+| `limit`   | number | no       | Maximum memories to return.                 |
+| `offset`  | number | no       | Pagination offset.                          |
+
+### `hindsight_get_memory`
+
+Fetch a raw Hindsight memory unit by ID.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `memoryId` | string | yes      | Hindsight memory ID.                        |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_get_chunk`
+
+Fetch a raw Hindsight source chunk by chunk ID.
+
+| Parameter | Type   | Required | Description         |
+| --------- | ------ | -------- | ------------------- |
+| `chunkId` | string | yes      | Hindsight chunk ID. |
+
+### `hindsight_get_memory_history`
+
+Fetch Hindsight memory history by memory ID when server supports it.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `memoryId` | string | yes      | Hindsight memory ID.                        |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_delete_memory_observations`
+
+Delete observations for one Hindsight memory. Destructive; requires exact memory ID and confirm=true.
+
+| Parameter  | Type   | Required | Description                                             |
+| ---------- | ------ | -------- | ------------------------------------------------------- |
+| `memoryId` | string | yes      | Hindsight memory ID.                                    |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank.             |
+| `confirm`  | true   | yes      | Required destructive-action confirmation. Must be true. |
 
 ### `hindsight_configure`
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -92,17 +92,30 @@ Additional tools:
 - `hindsight_route_memory`
 - `hindsight_retain_receipts`
 - `hindsight_delete_document`
+- `hindsight_list_operations`
+- `hindsight_cancel_operation`
+- `hindsight_retry_operation`
+- `hindsight_list_memories`
+- `hindsight_get_memory`
+- `hindsight_get_chunk`
+- `hindsight_get_memory_history`
+- `hindsight_delete_memory_observations`
 
 Tool notes:
 
 - `hindsight_recall` accepts `queryTimestamp` plus advanced one-off controls: `types`, `budget`, `maxTokens` (including `0`), `includeChunks`, `recallChunksMaxTokens`, `includeSourceFacts`, `maxSourceFactsTokens`, `includeEntities`, and `trace`.
-- `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp`, `metadata`, `updateMode`, `observationScopes`, and `async`.
+- `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp` (including literal `unset`), `metadata`, `updateMode`, `observationScopes`, `documentTags`, and `async`. `observationScopes` accepts `per_tag`, `combined`, `all_combinations`, or explicit string groups. Hindsight supports `documentTags` for compatibility, but upstream marks it deprecated; prefer normal `tags` unless document-level interop requires it.
+- For `updateMode: "append"`, use a stable `documentId` when continuing a known document. If omitted, pi-hindsight still uses its deterministic explicit-retain document ID; repeated calls only append together when content/context/session produce the same ID.
+- Async retain responses include Hindsight operation IDs when the server returns them; use `hindsight_list_operations`, `hindsight_cancel_operation`, and `hindsight_retry_operation` to inspect or manage those jobs.
 - Caller `metadata` is merged with pi-hindsight provenance, but reserved provenance keys such as `cwd`, `pi_session_file`, `source`, and `retainSource` are set by pi-hindsight and cannot be overridden.
 - `hindsight_reflect` accepts `responseSchema` for structured reflection output plus `budget`, `maxTokens` (including `0`), `includeFacts`, and `includeToolCalls` when supported by Hindsight.
 - Omit `bank` or pass `project` for the selected project bank.
 - Pass `global` for the configured global bank.
 - `hindsight_retain_global` refuses to write if global memory is disabled or missing a bank ID.
 - `hindsight_delete_document` requires exact bank, exact document ID, and `confirm: true`.
+- `hindsight_cancel_operation` requires exact operation ID and `confirm: true`; it is intended for pending operations.
+- `hindsight_delete_memory_observations` requires exact memory ID and `confirm: true`. Bank-wide memory clear/delete-all is intentionally not exposed.
+- Memory inspection tools use current documented REST endpoints: list memory units, fetch a memory, fetch a chunk by ID, fetch memory history when the server supports it, and delete observations for one memory when supported.
 
 ## Receipts and deletion
 

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -2,8 +2,10 @@ import type {
   CreateDirectiveRequest,
   CreateMentalModelRequest,
   GetMentalModelOptions,
+  ListMemoriesOptions,
   ListDirectivesOptions,
   ListMentalModelsOptions,
+  ListOperationsOptions,
   ResolvedConfig,
   UpdateDirectiveRequest,
   UpdateMentalModelRequest,
@@ -127,6 +129,55 @@ function appendQuery(path: string, params: URLSearchParams): string {
 
 export function encodeBankPath(bankId: string, suffix: string): string {
   return `/v1/default/banks/${encodeURIComponent(bankId)}${suffix}`;
+}
+
+export function chunkItemPath(chunkId: string): string {
+  return `/v1/default/chunks/${encodeURIComponent(chunkId)}`;
+}
+
+export function operationsCollectionPath(
+  bankId: string,
+  options: ListOperationsOptions = {},
+): string {
+  const params = new URLSearchParams();
+  if (options.status) params.set("status", options.status);
+  if (options.taskType) params.set("type", options.taskType);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  return appendQuery(encodeBankPath(bankId, "/operations"), params);
+}
+
+export function operationItemPath(bankId: string, operationId: string): string {
+  return `${encodeBankPath(bankId, "/operations")}/${encodeURIComponent(operationId)}`;
+}
+
+export function operationCancelPath(bankId: string, operationId: string): string {
+  return operationItemPath(bankId, operationId);
+}
+
+export function operationRetryPath(bankId: string, operationId: string): string {
+  return `${operationItemPath(bankId, operationId)}/retry`;
+}
+
+export function memoriesCollectionPath(bankId: string, options: ListMemoriesOptions = {}): string {
+  const params = new URLSearchParams();
+  if (options.type) params.set("type", options.type);
+  if (options.q) params.set("q", options.q);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  return appendQuery(encodeBankPath(bankId, "/memories/list"), params);
+}
+
+export function memoryItemPath(bankId: string, memoryId: string): string {
+  return `${encodeBankPath(bankId, "/memories")}/${encodeURIComponent(memoryId)}`;
+}
+
+export function memoryHistoryPath(bankId: string, memoryId: string): string {
+  return `${memoryItemPath(bankId, memoryId)}/history`;
+}
+
+export function memoryObservationsPath(bankId: string, memoryId: string): string {
+  return `${memoryItemPath(bankId, memoryId)}/observations`;
 }
 
 export function bankConfigPath(bankId: string): string {

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -8,16 +8,24 @@ import {
   bankTemplateExportPath,
   bankTemplateImportPath,
   bankTemplateSchemaPath,
+  chunkItemPath,
   createDirectiveRequestBody,
   createHindsightRestTransport,
   createMentalModelRequestBody,
   directiveItemPath,
   directivesCollectionPath,
   encodeBankPath,
+  memoriesCollectionPath,
+  memoryHistoryPath,
+  memoryItemPath,
+  memoryObservationsPath,
   mentalModelCollectionPath,
   mentalModelHistoryPath,
   mentalModelItemPath,
   mentalModelRefreshPath,
+  operationCancelPath,
+  operationRetryPath,
+  operationsCollectionPath,
   reflectRequestBody,
   updateBankConfigRequestBody,
   updateDirectiveRequestBody,
@@ -81,11 +89,11 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
         "hindsight retain",
         timeoutMs,
         (signal) =>
-          raw.retainBatch(
-            bankId,
-            [retainBatchItem(content, options)],
-            options?.async !== undefined ? { async: options.async, signal } : { signal },
-          ),
+          raw.retainBatch(bankId, [retainBatchItem(content, options)], {
+            ...(options?.async !== undefined ? { async: options.async } : {}),
+            ...(options?.documentTags ? { documentTags: options.documentTags } : {}),
+            signal,
+          }),
         options?.signal,
       ),
     retainBatch: (...args) =>
@@ -245,6 +253,38 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
     refreshMentalModel: (bankId, mentalModelId) =>
       withTimeout("hindsight refreshMentalModel", timeoutMs, (signal) =>
         rest.request(mentalModelRefreshPath(bankId, mentalModelId), { method: "POST", signal }),
+      ),
+    listOperations: (bankId, options) =>
+      withTimeout("hindsight listOperations", timeoutMs, (signal) =>
+        rest.request(operationsCollectionPath(bankId, options), { signal }),
+      ),
+    cancelOperation: (bankId, operationId) =>
+      withTimeout("hindsight cancelOperation", timeoutMs, (signal) =>
+        rest.request(operationCancelPath(bankId, operationId), { method: "DELETE", signal }),
+      ),
+    retryOperation: (bankId, operationId) =>
+      withTimeout("hindsight retryOperation", timeoutMs, (signal) =>
+        rest.request(operationRetryPath(bankId, operationId), { method: "POST", signal }),
+      ),
+    listMemories: (bankId, options) =>
+      withTimeout("hindsight listMemories", timeoutMs, (signal) =>
+        rest.request(memoriesCollectionPath(bankId, options), { signal }),
+      ),
+    getMemory: (bankId, memoryId) =>
+      withTimeout("hindsight getMemory", timeoutMs, (signal) =>
+        rest.request(memoryItemPath(bankId, memoryId), { signal }),
+      ),
+    getChunk: (chunkId) =>
+      withTimeout("hindsight getChunk", timeoutMs, (signal) =>
+        rest.request(chunkItemPath(chunkId), { signal }),
+      ),
+    getMemoryHistory: (bankId, memoryId) =>
+      withTimeout("hindsight getMemoryHistory", timeoutMs, (signal) =>
+        rest.request(memoryHistoryPath(bankId, memoryId), { signal }),
+      ),
+    deleteMemoryObservations: (bankId, memoryId) =>
+      withTimeout("hindsight deleteMemoryObservations", timeoutMs, (signal) =>
+        rest.request(memoryObservationsPath(bankId, memoryId), { method: "DELETE", signal }),
       ),
   };
 }

--- a/extensions/memory-admin-operations.ts
+++ b/extensions/memory-admin-operations.ts
@@ -1,0 +1,86 @@
+import { resolveOperationBank } from "./bank-selection.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+import type { ListMemoriesOptions, ListOperationsOptions } from "./types.js";
+
+function unsupported(name: string): Error {
+  return new Error(`Hindsight client does not support ${name}.`);
+}
+
+function bankFor(deps: MemoryOperationsDeps, bank: string | undefined): string {
+  const config = deps.getConfig();
+  return resolveOperationBank({
+    requestedBank: bank,
+    config,
+    projectBankId: deps.getProjectBankId(),
+  });
+}
+
+export function createAdminOperations(deps: MemoryOperationsDeps) {
+  return {
+    async listOperations(args: { bank?: string; options?: ListOperationsOptions }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.listOperations) throw unsupported("listOperations");
+      const result = await client.listOperations(bankId, args.options);
+      return { bankId, result };
+    },
+
+    async cancelOperation(args: { bank?: string; operationId: string; confirm: true }) {
+      if (!args.confirm) throw new Error("Set confirm=true to cancel this Hindsight operation.");
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.cancelOperation) throw unsupported("cancelOperation");
+      const result = await client.cancelOperation(bankId, args.operationId);
+      return { bankId, operationId: args.operationId, result };
+    },
+
+    async retryOperation(args: { bank?: string; operationId: string }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.retryOperation) throw unsupported("retryOperation");
+      const result = await client.retryOperation(bankId, args.operationId);
+      return { bankId, operationId: args.operationId, result };
+    },
+
+    async listMemories(args: { bank?: string; options?: ListMemoriesOptions }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.listMemories) throw unsupported("listMemories");
+      const result = await client.listMemories(bankId, args.options);
+      return { bankId, result };
+    },
+
+    async getMemory(args: { bank?: string; memoryId: string }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getMemory) throw unsupported("getMemory");
+      const result = await client.getMemory(bankId, args.memoryId);
+      return { bankId, memoryId: args.memoryId, result };
+    },
+
+    async getChunk(args: { chunkId: string }) {
+      const client = deps.getClient();
+      if (!client.getChunk) throw unsupported("getChunk");
+      const result = await client.getChunk(args.chunkId);
+      return { chunkId: args.chunkId, result };
+    },
+
+    async getMemoryHistory(args: { bank?: string; memoryId: string }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getMemoryHistory) throw unsupported("getMemoryHistory");
+      const result = await client.getMemoryHistory(bankId, args.memoryId);
+      return { bankId, memoryId: args.memoryId, result };
+    },
+
+    async deleteMemoryObservations(args: { bank?: string; memoryId: string; confirm: true }) {
+      if (!args.confirm)
+        throw new Error("Set confirm=true to delete observations for this Hindsight memory.");
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.deleteMemoryObservations) throw unsupported("deleteMemoryObservations");
+      const result = await client.deleteMemoryObservations(bankId, args.memoryId);
+      return { bankId, memoryId: args.memoryId, result };
+    },
+  };
+}

--- a/extensions/memory-operation-service.ts
+++ b/extensions/memory-operation-service.ts
@@ -6,6 +6,7 @@ import {
 } from "./import-operations.js";
 import { createBankConfigOperations } from "./bank-config-operations.js";
 import { createBankTemplateOperations } from "./bank-template-operations.js";
+import { createAdminOperations } from "./memory-admin-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
 import { createDirectiveOperations } from "./memory-directive-operations.js";
 import { createDocumentOperations } from "./memory-document-operations.js";
@@ -63,6 +64,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createBankTemplateOperations(deps),
     ...createDirectiveOperations(deps),
     ...createMentalModelOperations(deps),
+    ...createAdminOperations(deps),
     ...createImportOperations(deps),
     ...createSessionOperations(),
   };

--- a/extensions/memory-retain-operations.ts
+++ b/extensions/memory-retain-operations.ts
@@ -7,7 +7,7 @@ import { expandObservationScopes } from "./observation-scopes.js";
 import { retainDurably } from "./retain-durable.js";
 import { appendRetainReceipt, listRetainReceipts } from "./retain-receipts.js";
 import { getEffectiveSessionMemoryMode, readSessionMemoryMeta } from "./session-memory-meta.js";
-import type { ResolvedConfig, UpdateMode } from "./types.js";
+import type { HindsightObservationScopes, ResolvedConfig, UpdateMode } from "./types.js";
 
 const RESERVED_EXPLICIT_RETAIN_METADATA_KEYS = new Set([
   "cwd",
@@ -40,7 +40,8 @@ export function createRetainOperations(deps: MemoryOperationsDeps) {
       timestamp?: string;
       metadata?: Record<string, string>;
       updateMode?: UpdateMode;
-      observationScopes?: string[][];
+      observationScopes?: HindsightObservationScopes;
+      documentTags?: string[];
       async?: boolean;
     }) {
       const meta = await readSessionMemoryMeta(args.cwd, args.sessionFile);
@@ -90,7 +91,8 @@ export function createRetainOperations(deps: MemoryOperationsDeps) {
         },
         ...(args.timestamp ? { timestamp: args.timestamp } : {}),
         source: "tool",
-        ...(observationScopes.length ? { observationScopes } : {}),
+        ...(hasObservationScopes(observationScopes) ? { observationScopes } : {}),
+        ...(args.documentTags?.length ? { documentTags: args.documentTags } : {}),
         ...(args.entities?.length ? { entities: args.entities } : {}),
         ...(args.async !== undefined ? { async: args.async } : {}),
         ...(capabilities ? { capabilities } : {}),
@@ -120,4 +122,8 @@ export function createRetainOperations(deps: MemoryOperationsDeps) {
       return flushRetain(cwd, deps.getConfig(), deps.getClient());
     },
   };
+}
+
+function hasObservationScopes(scopes: HindsightObservationScopes): boolean {
+  return typeof scopes === "string" ? scopes.length > 0 : scopes.length > 0;
 }

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -18,7 +18,11 @@ import {
   getBankTemplateSchemaToolResponse,
   getDirectiveToolResponse,
   importToolResponse,
+  jsonToolResponse,
   listDirectivesToolResponse,
+  listMemoriesToolResponse,
+  listOperationsToolResponse,
+  operationToolResponse,
   resetBankConfigToolResponse,
   retainReceiptListToolResponse,
   retainToolResponse,
@@ -91,6 +95,17 @@ const retainUpdateModeSchema = Type.Union([Type.Literal("append"), Type.Literal(
   description: "Optional Hindsight update mode for this explicit retain call.",
 });
 
+const observationScopesSchema = Type.Unsafe<import("./types.js").HindsightObservationScopes>({
+  ...Type.Union([
+    Type.Literal("per_tag"),
+    Type.Literal("combined"),
+    Type.Literal("all_combinations"),
+    Type.Array(Type.Array(Type.String())),
+  ]),
+  description:
+    "Optional Hindsight observation scopes. Use per_tag, combined, all_combinations, or explicit string groups. When provided, overrides configured default observation scopes for this retain call.",
+});
+
 function explicitRetainOptionParameters() {
   return {
     documentId: Type.Optional(
@@ -112,10 +127,10 @@ function explicitRetainOptionParameters() {
       }),
     ),
     updateMode: Type.Optional(retainUpdateModeSchema),
-    observationScopes: Type.Optional(
-      Type.Array(Type.Array(Type.String()), {
-        description:
-          "Optional Hindsight observation scopes as string groups. When provided, overrides configured default observation scopes for this retain call.",
+    observationScopes: Type.Optional(observationScopesSchema),
+    documentTags: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Optional Hindsight document_tags for this retained document when supported.",
       }),
     ),
     async: Type.Optional(
@@ -132,7 +147,8 @@ type ExplicitRetainOptionParams = {
   timestamp?: string;
   metadata?: Record<string, string>;
   updateMode?: import("./types.js").UpdateMode;
-  observationScopes?: string[][];
+  observationScopes?: import("./types.js").HindsightObservationScopes;
+  documentTags?: string[];
   async?: boolean;
 };
 
@@ -145,6 +161,7 @@ function explicitRetainOptions(params: ExplicitRetainOptionParams) {
     ...(params.observationScopes !== undefined
       ? { observationScopes: params.observationScopes }
       : {}),
+    ...(params.documentTags !== undefined ? { documentTags: params.documentTags } : {}),
     ...(params.async !== undefined ? { async: params.async } : {}),
   };
 }
@@ -392,6 +409,179 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           documentId: params.documentId,
         });
         return deleteDocumentToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_list_operations",
+      label: "Hindsight List Operations",
+      description: "List Hindsight async operations for a bank with supported server filters.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        status: Type.Optional(Type.String({ description: "Optional operation status filter." })),
+        taskType: Type.Optional(Type.String({ description: "Optional task type filter." })),
+        limit: Type.Optional(Type.Number({ description: "Maximum operations to return." })),
+        offset: Type.Optional(Type.Number({ description: "Pagination offset." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.listOperations({
+          ...(params.bank ? { bank: params.bank } : {}),
+          options: {
+            ...(params.status
+              ? { status: params.status as import("./types.js").OperationStatus }
+              : {}),
+            ...(params.taskType ? { taskType: params.taskType } : {}),
+            ...(params.limit !== undefined ? { limit: params.limit } : {}),
+            ...(params.offset !== undefined ? { offset: params.offset } : {}),
+          },
+        });
+        return listOperationsToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_cancel_operation",
+      label: "Hindsight Cancel Operation",
+      description: "Cancel a pending Hindsight async operation. Requires confirm=true.",
+      parameters: Type.Object({
+        operationId: Type.String({ description: "Hindsight operation ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        confirm: Type.Literal(true, {
+          description: "Required destructive-action confirmation. Must be true.",
+        }),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.cancelOperation({
+          operationId: params.operationId,
+          ...(params.bank ? { bank: params.bank } : {}),
+          confirm: params.confirm,
+        });
+        return operationToolResponse("Cancelled", result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_retry_operation",
+      label: "Hindsight Retry Operation",
+      description: "Retry a failed or cancelled Hindsight async operation.",
+      parameters: Type.Object({
+        operationId: Type.String({ description: "Hindsight operation ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.retryOperation({
+          operationId: params.operationId,
+          ...(params.bank ? { bank: params.bank } : {}),
+        });
+        return operationToolResponse("Retried", result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_list_memories",
+      label: "Hindsight List Memories",
+      description: "List raw Hindsight memory units for inspection.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        type: Type.Optional(Type.String({ description: "Optional memory type filter." })),
+        q: Type.Optional(Type.String({ description: "Optional text query filter." })),
+        limit: Type.Optional(Type.Number({ description: "Maximum memories to return." })),
+        offset: Type.Optional(Type.Number({ description: "Pagination offset." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.listMemories({
+          ...(params.bank ? { bank: params.bank } : {}),
+          options: {
+            ...(params.type ? { type: params.type } : {}),
+            ...(params.q ? { q: params.q } : {}),
+            ...(params.limit !== undefined ? { limit: params.limit } : {}),
+            ...(params.offset !== undefined ? { offset: params.offset } : {}),
+          },
+        });
+        return listMemoriesToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_memory",
+      label: "Hindsight Get Memory",
+      description: "Fetch a raw Hindsight memory unit by ID.",
+      parameters: Type.Object({
+        memoryId: Type.String({ description: "Hindsight memory ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getMemory({
+          memoryId: params.memoryId,
+          ...(params.bank ? { bank: params.bank } : {}),
+        });
+        return jsonToolResponse(`Memory ${params.memoryId} in ${result.bankId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_chunk",
+      label: "Hindsight Get Chunk",
+      description: "Fetch a raw Hindsight source chunk by chunk ID.",
+      parameters: Type.Object({
+        chunkId: Type.String({ description: "Hindsight chunk ID." }),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getChunk({ chunkId: params.chunkId });
+        return jsonToolResponse(`Chunk ${params.chunkId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_memory_history",
+      label: "Hindsight Get Memory History",
+      description: "Fetch Hindsight memory history by memory ID when server supports it.",
+      parameters: Type.Object({
+        memoryId: Type.String({ description: "Hindsight memory ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getMemoryHistory({
+          memoryId: params.memoryId,
+          ...(params.bank ? { bank: params.bank } : {}),
+        });
+        return jsonToolResponse(`Memory history ${params.memoryId} in ${result.bankId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_delete_memory_observations",
+      label: "Hindsight Delete Memory Observations",
+      description:
+        "Delete observations for one Hindsight memory. Destructive; requires exact memory ID and confirm=true.",
+      parameters: Type.Object({
+        memoryId: Type.String({ description: "Hindsight memory ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        confirm: Type.Literal(true, {
+          description: "Required destructive-action confirmation. Must be true.",
+        }),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.deleteMemoryObservations({
+          memoryId: params.memoryId,
+          ...(params.bank ? { bank: params.bank } : {}),
+          confirm: params.confirm,
+        });
+        return jsonToolResponse(`Deleted observations for memory ${params.memoryId}.`, result);
       },
     }),
     defineCatalogTool({

--- a/extensions/queue-delivery.ts
+++ b/extensions/queue-delivery.ts
@@ -39,11 +39,42 @@ export function retainOptionsForJob(job: RetainJob) {
     ...(job.item.entities?.length ? { entities: job.item.entities } : {}),
     ...(job.item.tags ? { tags: job.item.tags } : {}),
     ...(job.item.observationScopes ? { observationScopes: job.item.observationScopes } : {}),
+    ...(job.item.documentTags ? { documentTags: job.item.documentTags } : {}),
     documentId: job.documentId,
     updateMode: job.updateMode,
   };
 }
 
-export async function deliverRetainJob(client: HindsightLikeClient, job: RetainJob): Promise<void> {
-  await client.retain(job.bankId, job.item.content, retainOptionsForJob(job));
+export function operationIdsFromResponse(response: unknown): string[] {
+  if (!response || typeof response !== "object") return [];
+  const record = response as Record<string, unknown>;
+  const candidates = [record.operation_id, record.operationId, record.id];
+  const operationIds = candidates.filter(
+    (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
+  );
+  const nested = record.operations;
+  if (Array.isArray(nested)) {
+    for (const item of nested) {
+      if (typeof item === "string") operationIds.push(item);
+      else if (item && typeof item === "object") {
+        const id =
+          (item as Record<string, unknown>).id ?? (item as Record<string, unknown>).operation_id;
+        if (typeof id === "string") operationIds.push(id);
+      }
+    }
+  }
+  const operationIdsArray = record.operation_ids ?? record.operationIds;
+  if (Array.isArray(operationIdsArray)) {
+    for (const item of operationIdsArray) {
+      if (typeof item === "string" && item.length > 0) operationIds.push(item);
+    }
+  }
+  return [...new Set(operationIds)];
+}
+
+export async function deliverRetainJob(
+  client: HindsightLikeClient,
+  job: RetainJob,
+): Promise<unknown> {
+  return client.retain(job.bankId, job.item.content, retainOptionsForJob(job));
 }

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 import type { HindsightLikeClient, RetainJob } from "./types.js";
-import { deliverRetainJob, redactQueueError } from "./queue-delivery.js";
+import { deliverRetainJob, operationIdsFromResponse, redactQueueError } from "./queue-delivery.js";
 import { JsonlQueueStore, type JsonlQueueFileSummary } from "./jsonl-queue-store.js";
 import {
   RETAIN_QUEUE_LOCK,
@@ -116,6 +116,7 @@ export interface FlushRetainQueueResult {
   remaining: number;
   deadLettered: number;
   malformed: number;
+  operationIds?: string[];
 }
 
 function isRetainJob(value: unknown): value is RetainJob {
@@ -178,6 +179,7 @@ export async function flushRetainQueue(
     const jobs = parsed.jobs;
     const remaining: RetainJob[] = [];
     const deadLetteredJobs: RetainJob[] = [];
+    const operationIds: string[] = [];
     let sent = 0;
     for (const [index, job] of jobs.entries()) {
       if (index >= maxJobs || Date.now() - started >= maxElapsedMs) {
@@ -185,7 +187,8 @@ export async function flushRetainQueue(
         break;
       }
       try {
-        await deliverRetainJob(client, job);
+        const response = await deliverRetainJob(client, job);
+        operationIds.push(...operationIdsFromResponse(response));
         sent += 1;
       } catch (error) {
         const errorMessage = redactQueueError(error);
@@ -218,6 +221,7 @@ export async function flushRetainQueue(
       remaining: remaining.length,
       deadLettered: appendedDeadLetterJobs,
       malformed: parsed.malformedLines.length,
+      ...(operationIds.length ? { operationIds: [...new Set(operationIds)] } : {}),
     };
   });
 }

--- a/extensions/retain-durable.ts
+++ b/extensions/retain-durable.ts
@@ -1,6 +1,7 @@
 import type {
   HindsightCapabilities,
   HindsightLikeClient,
+  HindsightObservationScopes,
   ResolvedConfig,
   RetainJob,
   UpdateMode,
@@ -23,7 +24,8 @@ export interface RetainDurablyArgs {
   metadata?: Record<string, string>;
   source: DurableRetainSource;
   timestamp?: string;
-  observationScopes?: string[][];
+  observationScopes?: HindsightObservationScopes;
+  documentTags?: string[];
   entities?: RetainJob["item"]["entities"];
   async?: boolean;
   capabilities?: HindsightCapabilities;
@@ -38,6 +40,7 @@ export interface RetainDurablyResult {
   documentId: string;
   queueJobId: string;
   updateMode: UpdateMode;
+  operationIds?: string[];
 }
 
 export function buildDurableRetainJob(args: Omit<RetainDurablyArgs, "client">): RetainJob {

--- a/extensions/retain-job-builder.ts
+++ b/extensions/retain-job-builder.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from "node:crypto";
-import type { HindsightCapabilities, ResolvedConfig, RetainJob, UpdateMode } from "./types.js";
+import type {
+  HindsightCapabilities,
+  HindsightObservationScopes,
+  ResolvedConfig,
+  RetainJob,
+  UpdateMode,
+} from "./types.js";
 import { redactSecrets } from "./sanitize.js";
 import { resolveRetainDocumentTarget } from "./capabilities.js";
 
@@ -13,7 +19,8 @@ export interface RetainJobBuildArgs {
   updateMode: UpdateMode;
   metadata?: Record<string, string>;
   timestamp?: string;
-  observationScopes?: string[][];
+  observationScopes?: HindsightObservationScopes;
+  documentTags?: string[];
   entities?: RetainJob["item"]["entities"];
   capabilities?: HindsightCapabilities;
   async?: boolean;
@@ -58,6 +65,7 @@ export function buildRetainJob(args: RetainJobBuildArgs): RetainJob {
       tags: args.tags,
       ...(metadata ? { metadata } : {}),
       ...(args.observationScopes?.length ? { observationScopes: args.observationScopes } : {}),
+      ...(args.documentTags?.length ? { documentTags: args.documentTags } : {}),
     },
     retries: 0,
   };

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -31,6 +31,13 @@ export type ExportBankTemplateToolResult = Awaited<
 export type GetBankConfigToolResult = Awaited<ReturnType<MemoryOperations["getBankConfig"]>>;
 export type ResetBankConfigToolResult = Awaited<ReturnType<MemoryOperations["resetBankConfig"]>>;
 export type RetainReceiptListResult = Awaited<ReturnType<MemoryOperations["listRetainReceipts"]>>;
+export type ListOperationsToolResult = Awaited<ReturnType<MemoryOperations["listOperations"]>>;
+export type OperationToolResult =
+  | Awaited<ReturnType<MemoryOperations["cancelOperation"]>>
+  | Awaited<ReturnType<MemoryOperations["retryOperation"]>>;
+export type ListMemoriesToolResult = Awaited<ReturnType<MemoryOperations["listMemories"]>>;
+export type MemoryToolResult = Awaited<ReturnType<MemoryOperations["getMemory"]>>;
+export type ChunkToolResult = Awaited<ReturnType<MemoryOperations["getChunk"]>>;
 
 export function retainToolResponse(result: RetainToolResult): ToolTextResponse<RetainToolResult> {
   const deadLetterStatus = result.deadLettered
@@ -40,7 +47,10 @@ export function retainToolResponse(result: RetainToolResult): ToolTextResponse<R
     result.remaining > 0
       ? `Queued for ${result.bankId}; ${result.remaining} job${result.remaining === 1 ? "" : "s"} pending.${deadLetterStatus}`
       : `Retained in ${result.bankId} as ${result.documentId}.${deadLetterStatus}`;
-  return { content: [{ type: "text", text }], details: result };
+  const operationText = result.operationIds?.length
+    ? ` Operation IDs: ${result.operationIds.join(", ")}.`
+    : "";
+  return { content: [{ type: "text", text: `${text}${operationText}` }], details: result };
 }
 
 export function routeMemoryToolResponse(
@@ -221,6 +231,135 @@ export function deleteDirectiveToolResponse(
         ].join("\n"),
       },
     ],
+    details: result,
+  };
+}
+
+function objectItems(result: unknown): unknown[] {
+  if (!result || typeof result !== "object" || Array.isArray(result)) return [];
+  const record = result as Record<string, unknown>;
+  if (Array.isArray(record.items)) return record.items;
+  if (Array.isArray(record.memories)) return record.memories;
+  if (Array.isArray(record.operations)) return record.operations;
+  return [];
+}
+
+function textField(record: Record<string, unknown>, keys: string[], fallback = "unknown"): string {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return fallback;
+}
+
+function numberField(record: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number") return value;
+    if (Array.isArray(value)) return value.length;
+  }
+  return undefined;
+}
+
+function payloadSummary(value: unknown): string {
+  if (!value || typeof value !== "object") return "payload unavailable";
+  const record = value as Record<string, unknown>;
+  const payload = record.payload ?? record.request ?? record.input;
+  if (!payload || typeof payload !== "object") return "payload unavailable";
+  return (
+    Object.keys(payload as Record<string, unknown>)
+      .slice(0, 8)
+      .join(", ") || "payload empty"
+  );
+}
+
+function operationLabel(value: unknown): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return JSON.stringify(value);
+  const record = value as Record<string, unknown>;
+  const documentIds = record.document_ids ?? record.documentIds ?? record.document_id;
+  const docs = Array.isArray(documentIds)
+    ? documentIds.join(",")
+    : typeof documentIds === "string"
+      ? documentIds
+      : "unknown";
+  const items = numberField(record, ["items_count", "itemsCount", "item_count", "items"]);
+  const error = textField(record, ["error", "error_message", "message"], "none");
+  const created = textField(record, ["created_at", "createdAt"], "unknown-created");
+  const updated = textField(
+    record,
+    ["updated_at", "updatedAt", "completed_at", "completedAt"],
+    "unknown-updated",
+  );
+  return `${textField(record, ["id", "operation_id", "operationId"])} · ${textField(record, ["status"])} · ${textField(record, ["task_type", "taskType", "type"])} · docs=${docs} · items=${items ?? "unknown"} · error=${error} · ${created}→${updated} · ${payloadSummary(value)}`;
+}
+
+export function listOperationsToolResponse(
+  result: ListOperationsToolResult,
+): ToolTextResponse<ListOperationsToolResult> {
+  const items = objectItems(result.result);
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `Operations in ${result.bankId}: ${items.length}`,
+          ...items.map(operationLabel),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function operationToolResponse(
+  verb: "Cancelled" | "Retried",
+  result: OperationToolResult,
+): ToolTextResponse<OperationToolResult> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          `${verb} operation ${result.operationId} in ${result.bankId}.`,
+          operationLabel(result.result),
+          JSON.stringify(result.result, null, 2),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+function memoryLabel(value: unknown): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return JSON.stringify(value);
+  const record = value as Record<string, unknown>;
+  const text = textField(record, ["content", "text", "summary"], "").slice(0, 120);
+  return `${textField(record, ["id", "memory_id", "memoryId"])} · ${textField(record, ["type", "fact_type", "factType"])} · ${text}`;
+}
+
+export function listMemoriesToolResponse(
+  result: ListMemoriesToolResult,
+): ToolTextResponse<ListMemoriesToolResult> {
+  const items = objectItems(result.result);
+  return {
+    content: [
+      {
+        type: "text",
+        text: [`Memories in ${result.bankId}: ${items.length}`, ...items.map(memoryLabel)].join(
+          "\n",
+        ),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function jsonToolResponse<T extends { result: unknown }>(
+  heading: string,
+  result: T,
+): ToolTextResponse<T> {
+  return {
+    content: [{ type: "text", text: [heading, JSON.stringify(result.result, null, 2)].join("\n") }],
     details: result,
   };
 }

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -19,6 +19,8 @@ export type HindsightTagGroup =
   | TagGroupNotInput;
 export type MentalModelDetail = "metadata" | "content" | "full";
 export type MentalModelTagsMatch = "any" | "all" | "exact";
+export type OperationStatus = "pending" | "processing" | "completed" | "failed" | "cancelled";
+export type HindsightObservationScopes = "per_tag" | "combined" | "all_combinations" | string[][];
 export type StatusStyle = "off" | "text" | "emoji" | "nerdfont";
 export type StatusDetail = "minimal" | "project" | "activity" | "verbose";
 export type RecallRole = "user" | "assistant" | "tool" | "system";
@@ -181,7 +183,8 @@ export interface RetainJob {
     async?: boolean;
     tags?: string[];
     metadata?: Record<string, string>;
-    observationScopes?: string[][];
+    observationScopes?: HindsightObservationScopes;
+    documentTags?: string[];
     entities?: HindsightEntityInput[];
   };
   retries: number;
@@ -263,6 +266,20 @@ export interface GetMentalModelOptions {
   detail?: MentalModelDetail;
 }
 
+export interface ListOperationsOptions {
+  status?: OperationStatus;
+  taskType?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ListMemoriesOptions {
+  type?: string;
+  q?: string;
+  limit?: number;
+  offset?: number;
+}
+
 export interface HindsightLikeClient {
   retain(
     bankId: string,
@@ -272,11 +289,12 @@ export interface HindsightLikeClient {
       context?: string;
       metadata?: Record<string, string>;
       documentId?: string;
+      documentTags?: string[];
       async?: boolean;
       entities?: HindsightEntityInput[];
       tags?: string[];
       updateMode?: UpdateMode;
-      observationScopes?: string[][];
+      observationScopes?: HindsightObservationScopes;
       signal?: AbortSignal;
     },
   ): Promise<unknown>;
@@ -290,7 +308,7 @@ export interface HindsightLikeClient {
       document_id?: string;
       entities?: Array<{ text: string; type?: string }>;
       tags?: string[];
-      observation_scopes?: string[][];
+      observation_scopes?: HindsightObservationScopes;
       update_mode?: UpdateMode;
     }>,
     options?: {
@@ -389,4 +407,12 @@ export interface HindsightLikeClient {
   deleteMentalModel?(bankId: string, mentalModelId: string): Promise<unknown>;
   getMentalModelHistory?(bankId: string, mentalModelId: string): Promise<unknown>;
   refreshMentalModel?(bankId: string, mentalModelId: string): Promise<unknown>;
+  listOperations?(bankId: string, options?: ListOperationsOptions): Promise<unknown>;
+  cancelOperation?(bankId: string, operationId: string): Promise<unknown>;
+  retryOperation?(bankId: string, operationId: string): Promise<unknown>;
+  listMemories?(bankId: string, options?: ListMemoriesOptions): Promise<unknown>;
+  getMemory?(bankId: string, memoryId: string): Promise<unknown>;
+  getChunk?(chunkId: string): Promise<unknown>;
+  getMemoryHistory?(bankId: string, memoryId: string): Promise<unknown>;
+  deleteMemoryObservations?(bankId: string, memoryId: string): Promise<unknown>;
 }

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assertHealthResponse,
   assertReflectResponse,
@@ -6,7 +6,9 @@ import {
   bankTemplateExportPath,
   bankTemplateImportPath,
   bankTemplateSchemaPath,
+  chunkItemPath,
   createDirectiveRequestBody,
+  createHindsightRestTransport,
   createMentalModelRequestBody,
   directiveItemPath,
   directivesCollectionPath,
@@ -15,6 +17,14 @@ import {
   mentalModelHistoryPath,
   mentalModelItemPath,
   mentalModelRefreshPath,
+  memoriesCollectionPath,
+  memoryHistoryPath,
+  memoryItemPath,
+  memoryObservationsPath,
+  operationCancelPath,
+  operationItemPath,
+  operationRetryPath,
+  operationsCollectionPath,
   reflectRequestBody,
   updateBankConfigRequestBody,
   updateDirectiveRequestBody,
@@ -22,6 +32,10 @@ import {
 } from "../extensions/client-rest.js";
 
 describe("Hindsight REST transport helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("maps reflect response schema options to Hindsight REST request shape", () => {
     expect(
       reflectRequestBody("query", {
@@ -92,6 +106,39 @@ describe("Hindsight REST transport helpers", () => {
       content: null,
       is_active: true,
     });
+  });
+
+  it("maps operation and memory inspection paths", () => {
+    expect(
+      operationsCollectionPath("bank/id", {
+        status: "failed",
+        taskType: "retain",
+        limit: 25,
+        offset: 50,
+      }),
+    ).toBe("/v1/default/banks/bank%2Fid/operations?status=failed&type=retain&limit=25&offset=50");
+    expect(operationItemPath("bank/id", "op/id")).toBe(
+      "/v1/default/banks/bank%2Fid/operations/op%2Fid",
+    );
+    expect(operationCancelPath("bank/id", "op/id")).toBe(
+      "/v1/default/banks/bank%2Fid/operations/op%2Fid",
+    );
+    expect(operationRetryPath("bank/id", "op/id")).toBe(
+      "/v1/default/banks/bank%2Fid/operations/op%2Fid/retry",
+    );
+    expect(
+      memoriesCollectionPath("bank/id", { type: "observation", q: "needle", limit: 5, offset: 2 }),
+    ).toBe("/v1/default/banks/bank%2Fid/memories/list?type=observation&q=needle&limit=5&offset=2");
+    expect(memoryItemPath("bank/id", "mem/id")).toBe(
+      "/v1/default/banks/bank%2Fid/memories/mem%2Fid",
+    );
+    expect(memoryHistoryPath("bank/id", "mem/id")).toBe(
+      "/v1/default/banks/bank%2Fid/memories/mem%2Fid/history",
+    );
+    expect(memoryObservationsPath("bank/id", "mem/id")).toBe(
+      "/v1/default/banks/bank%2Fid/memories/mem%2Fid/observations",
+    );
+    expect(chunkItemPath("chunk/id")).toBe("/v1/default/chunks/chunk%2Fid");
   });
 
   it("maps mental model paths and query options to Hindsight REST shape", () => {
@@ -169,5 +216,25 @@ describe("Hindsight REST transport helpers", () => {
     expect(assertHealthResponse("ok")).toEqual({});
     expect(assertReflectResponse({ text: "answer" })).toEqual({ text: "answer" });
     expect(() => assertReflectResponse(null)).toThrow("non-object response");
+  });
+
+  it("preserves REST status and body for admin-tool error presentation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({ detail: "operation is not pending" }),
+      })),
+    );
+    const transport = createHindsightRestTransport({
+      hindsight: { baseUrl: "http://hindsight.test/", apiKey: "secret", timeoutMs: 1000 },
+    } as never);
+
+    await expect(transport.request("/v1/default/banks/bank/operations/op")).rejects.toMatchObject({
+      status: 409,
+      body: { detail: "operation is not pending" },
+      message: 'Hindsight request failed with status 409: {"detail":"operation is not pending"}',
+    });
   });
 });

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -34,6 +34,14 @@ function client(): HindsightLikeClient {
     updateDirective: async () => ({ id: "directive", name: "Rule", content: "Updated." }),
     deleteDirective: async () => ({ deleted: true }),
     exportBankTemplate: async () => ({ version: "1" }),
+    listOperations: async () => ({ items: [] }),
+    cancelOperation: async () => ({ status: "cancelled" }),
+    retryOperation: async () => ({ status: "pending" }),
+    listMemories: async () => ({ items: [] }),
+    getMemory: async () => ({ id: "memory" }),
+    getChunk: async () => ({ id: "chunk" }),
+    getMemoryHistory: async () => ({ items: [] }),
+    deleteMemoryObservations: async () => ({ deleted: true }),
   };
 }
 
@@ -67,7 +75,13 @@ describe("operation catalog", () => {
       "append",
       "replace",
     ]);
-    expect(properties.observationScopes?.items?.items?.type).toBe("string");
+    expect(properties.observationScopes?.anyOf?.some((entry) => entry.const === "per_tag")).toBe(
+      true,
+    );
+    expect(properties.observationScopes?.anyOf?.some((entry) => entry.const === "combined")).toBe(
+      true,
+    );
+    expect(properties.documentTags?.items?.type).toBe("string");
     expect(properties.async?.type).toBe("boolean");
 
     await tool.execute(
@@ -88,7 +102,8 @@ describe("operation catalog", () => {
           caller: "kept",
         },
         updateMode: "append",
-        observationScopes: [["repo:manual"], ["bank:manual"]],
+        observationScopes: "per_tag",
+        documentTags: ["doc:manual"],
         async: false,
       },
       new AbortController().signal,
@@ -111,7 +126,8 @@ describe("operation catalog", () => {
           caller: "kept",
         },
         updateMode: "append",
-        observationScopes: [["repo:manual"], ["bank:manual"]],
+        observationScopes: "per_tag",
+        documentTags: ["doc:manual"],
         async: false,
         entities: [{ text: "Alice", type: "person" }],
       }),
@@ -370,6 +386,134 @@ describe("operation catalog", () => {
       (requireTool(catalog, "hindsight_delete_directive").parameters as JsonSchema).properties
         ?.confirm?.const,
     ).toBe(true);
+    expect(
+      (requireTool(catalog, "hindsight_cancel_operation").parameters as JsonSchema).properties
+        ?.confirm?.const,
+    ).toBe(true);
+    expect(
+      (requireTool(catalog, "hindsight_delete_memory_observations").parameters as JsonSchema)
+        .properties?.confirm?.const,
+    ).toBe(true);
+  });
+
+  it("maps operation and memory inspection tools to client calls", async () => {
+    const calls: unknown[] = [];
+    const catalog = createOperationCatalog({
+      getClient: () => ({
+        ...client(),
+        listOperations: async (bank, options) => {
+          calls.push({ method: "listOperations", bank, options });
+          return { items: [{ id: "op-1", status: "failed", task_type: "retain" }] };
+        },
+        cancelOperation: async (bank, operationId) => {
+          calls.push({ method: "cancelOperation", bank, operationId });
+          return { id: operationId, status: "cancelled" };
+        },
+        retryOperation: async (bank, operationId) => {
+          calls.push({ method: "retryOperation", bank, operationId });
+          return { id: operationId, status: "pending" };
+        },
+        listMemories: async (bank, options) => {
+          calls.push({ method: "listMemories", bank, options });
+          return { items: [{ id: "mem-1", type: "observation" }] };
+        },
+        getMemory: async (bank, memoryId) => {
+          calls.push({ method: "getMemory", bank, memoryId });
+          return { id: memoryId };
+        },
+        getChunk: async (chunkId) => {
+          calls.push({ method: "getChunk", chunkId });
+          return { id: chunkId };
+        },
+        getMemoryHistory: async (bank, memoryId) => {
+          calls.push({ method: "getMemoryHistory", bank, memoryId });
+          return { items: [] };
+        },
+        deleteMemoryObservations: async (bank, memoryId) => {
+          calls.push({ method: "deleteMemoryObservations", bank, memoryId });
+          return { deleted: true };
+        },
+      }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+    const ctx = { cwd: "/repo", sessionManager: {} } as never;
+
+    await requireTool(catalog, "hindsight_list_operations").execute(
+      "call",
+      { status: "failed", taskType: "retain", limit: 2, offset: 1 },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_cancel_operation").execute(
+      "call",
+      { operationId: "op-1", confirm: true },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_retry_operation").execute(
+      "call",
+      { operationId: "op-1" },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_list_memories").execute(
+      "call",
+      { type: "observation", q: "needle", limit: 3, offset: 0 },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_get_memory").execute(
+      "call",
+      { memoryId: "mem-1" },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_get_chunk").execute(
+      "call",
+      { chunkId: "chunk-1" },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_get_memory_history").execute(
+      "call",
+      { memoryId: "mem-1" },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_delete_memory_observations").execute(
+      "call",
+      { memoryId: "mem-1", confirm: true },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+
+    expect(calls).toEqual([
+      {
+        method: "listOperations",
+        bank: "project-bank",
+        options: { status: "failed", taskType: "retain", limit: 2, offset: 1 },
+      },
+      { method: "cancelOperation", bank: "project-bank", operationId: "op-1" },
+      { method: "retryOperation", bank: "project-bank", operationId: "op-1" },
+      {
+        method: "listMemories",
+        bank: "project-bank",
+        options: { type: "observation", q: "needle", limit: 3, offset: 0 },
+      },
+      { method: "getMemory", bank: "project-bank", memoryId: "mem-1" },
+      { method: "getChunk", chunkId: "chunk-1" },
+      { method: "getMemoryHistory", bank: "project-bank", memoryId: "mem-1" },
+      { method: "deleteMemoryObservations", bank: "project-bank", memoryId: "mem-1" },
+    ]);
   });
 
   it("passes nullable directive updates through the public tool surface", async () => {
@@ -409,6 +553,14 @@ describe("operation catalog", () => {
       "hindsight_retain_receipts",
       "hindsight_route_memory",
       "hindsight_delete_document",
+      "hindsight_list_operations",
+      "hindsight_cancel_operation",
+      "hindsight_retry_operation",
+      "hindsight_list_memories",
+      "hindsight_get_memory",
+      "hindsight_get_chunk",
+      "hindsight_get_memory_history",
+      "hindsight_delete_memory_observations",
       "hindsight_configure",
       "hindsight_get_bank_config",
       "hindsight_reset_bank_config",

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -25,7 +25,7 @@ import {
   summarizeRetainQueue,
   writeRetainQueue,
 } from "../extensions/queue.js";
-import { retainOptionsForJob } from "../extensions/queue-delivery.js";
+import { operationIdsFromResponse, retainOptionsForJob } from "../extensions/queue-delivery.js";
 import type { RetainJob } from "../extensions/types.js";
 
 const job: RetainJob = {
@@ -111,6 +111,7 @@ describe("retain queue", () => {
           metadata: { source: "test" },
           entities: [{ text: "entity", type: "thing" }],
           observationScopes: [["repo:abc"]],
+          documentTags: ["doc:test"],
         },
       }),
     ).toMatchObject({
@@ -121,9 +122,23 @@ describe("retain queue", () => {
       entities: [{ text: "entity", type: "thing" }],
       tags: ["source:pi"],
       observationScopes: [["repo:abc"]],
+      documentTags: ["doc:test"],
       documentId: "doc",
       updateMode: "append",
     });
+  });
+
+  it("extracts async operation IDs from retain responses", () => {
+    expect(operationIdsFromResponse(undefined)).toEqual([]);
+    expect(operationIdsFromResponse({ operation_id: "op-1", operationId: "op-1" })).toEqual([
+      "op-1",
+    ]);
+    expect(
+      operationIdsFromResponse({
+        operations: ["op-2", { id: "op-3" }, { operation_id: "op-4" }],
+        operation_ids: ["op-5"],
+      }),
+    ).toEqual(["op-2", "op-3", "op-4", "op-5"]);
   });
 
   it("persists and flushes jobs", async () => {
@@ -134,11 +149,13 @@ describe("retain queue", () => {
     const result = await flushRetainQueue(path, {
       retain: async (...args: unknown[]) => {
         calls.push(args);
+        return { operation_id: "op-retain" };
       },
       recall: async () => [],
       reflect: async () => ({}),
     });
     expect(result.sent).toBe(1);
+    expect(result.operationIds).toEqual(["op-retain"]);
     expect(await readRetainQueue(path)).toHaveLength(0);
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject(["b", "raw", { async: true }]);

--- a/tests/tool-presenters.test.ts
+++ b/tests/tool-presenters.test.ts
@@ -5,7 +5,10 @@ import {
   exportBankTemplateToolResponse,
   getBankTemplateSchemaToolResponse,
   getDirectiveToolResponse,
+  listMemoriesToolResponse,
   listDirectivesToolResponse,
+  listOperationsToolResponse,
+  operationToolResponse,
   updateDirectiveToolResponse,
 } from "../extensions/tool-presenters.js";
 
@@ -47,6 +50,47 @@ describe("tool presenters", () => {
         result: { deleted: true },
       }).content[0]?.text,
     ).toContain("Deleted directive directive-2 in bank.");
+  });
+
+  it("presents operation and memory inspection summaries", () => {
+    const operations = listOperationsToolResponse({
+      bankId: "bank",
+      result: {
+        items: [
+          {
+            id: "op-1",
+            status: "failed",
+            task_type: "retain",
+            document_ids: ["doc-1"],
+            items_count: 2,
+            error: "boom",
+            created_at: "2026-05-07T00:00:00Z",
+            updated_at: "2026-05-07T00:01:00Z",
+            payload: { document_id: "doc-1", update_mode: "append" },
+          },
+        ],
+      },
+    });
+    expect(operations.content[0]?.text).toContain("Operations in bank: 1");
+    expect(operations.content[0]?.text).toContain(
+      "op-1 · failed · retain · docs=doc-1 · items=2 · error=boom",
+    );
+    expect(operations.content[0]?.text).toContain("document_id, update_mode");
+
+    expect(
+      operationToolResponse("Cancelled", {
+        bankId: "bank",
+        operationId: "op-1",
+        result: { id: "op-1", status: "cancelled" },
+      }).content[0]?.text,
+    ).toContain("Cancelled operation op-1 in bank.");
+
+    const memories = listMemoriesToolResponse({
+      bankId: "bank",
+      result: { items: [{ id: "mem-1", type: "observation", content: "Exact fact" }] },
+    });
+    expect(memories.content[0]?.text).toContain("Memories in bank: 1");
+    expect(memories.content[0]?.text).toContain("mem-1 · observation · Exact fact");
   });
 
   it("presents saved bank template export paths", () => {


### PR DESCRIPTION
## Summary

- Add Hindsight admin tools for operation listing/cancel/retry and memory/chunk inspection.
- Extend explicit retain parity with supported Hindsight options: document ID, literal `unset` timestamp pass-through, metadata, update mode, observation scopes, document tags, async retain, and surfaced async operation IDs.
- Document safe destructive boundaries and generated tool surface changes.

## Linked issue

- Closes #237
- Closes #239
- Closes #241

## Scope

- Adds REST shim helpers for current documented Hindsight operations, memory, chunk, and memory-history endpoints where the package wrapper has no high-level helper.
- Adds confirm-guarded cancel/delete-observation tools; does not add bank-wide clear/delete-all.
- Keeps automatic recall/retain behavior unchanged except shared retain queue/client plumbing can carry explicit-only document tags and async operation IDs.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional verification:

- `npm test -- tests/client-rest.test.ts tests/operation-catalog.test.ts tests/tool-presenters.test.ts`
- `npm test -- tests/client-rest.test.ts tests/queue.test.ts`
- `npm test -- tests/operation-catalog.test.ts tests/queue.test.ts`
- Reviewer pass requested by parent; blockers fixed before PR.

Skipped checks:

- Full matrix/package verification/pack verify: not a release, package, or platform-sensitive change.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds user-visible Hindsight tools for admin inspection, operation management, memory/chunk inspection, and richer explicit retain options.

## Risk and rollback

- Risk: Admin inspection tools expose raw Hindsight memory/chunk payloads in tool results; cancel and delete-observation tools are destructive if called with exact IDs and `confirm: true`.
- Rollback/revert path: Revert this PR to remove the new tools, REST helpers, and retain-option plumbing. Existing automatic recall/retain paths should return to prior behavior.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No contributor guidance changes were made.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

OpenAPI/current client support notes:

- Operation `taskType` tool filter maps to the documented REST `type` query parameter.
- Cancel uses documented `DELETE /v1/default/banks/{bank_id}/operations/{operation_id}`.
- Memory observation delete is scoped to one memory and requires `confirm: true`.
- Bank-wide clear/delete-all is intentionally not exposed.
- `documentTags` is supported for compatibility but deprecated upstream; docs recommend normal `tags` unless document-level interop needs it.
