### PR TITLE
feat(tools): add bank exploration tools

### DIFF
--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -94,6 +94,105 @@ Delete a specific Hindsight document and all memories extracted from it. Destruc
 | `documentId` | string  | yes      | Exact Hindsight document ID to delete.        |
 | `confirm`    | boolean | yes      | Must be true to confirm destructive deletion. |
 
+### `hindsight_list_documents`
+
+List Hindsight documents for compact inspection with supported filters.
+
+| Parameter   | Type                                   | Required | Description                                 |
+| ----------- | -------------------------------------- | -------- | ------------------------------------------- |
+| `bank`      | string                                 | no       | Optional bank id. Defaults to project bank. |
+| `q`         | string                                 | no       | Optional text query filter.                 |
+| `tags`      | array<string>                          | no       | Optional tag filter.                        |
+| `tagsMatch` | any \| all \| any_strict \| all_strict | no       |                                             |
+| `limit`     | number                                 | no       | Maximum documents to return.                |
+| `offset`    | number                                 | no       | Pagination offset.                          |
+
+### `hindsight_get_document`
+
+Fetch one Hindsight document by ID for inspection.
+
+| Parameter    | Type   | Required | Description                                 |
+| ------------ | ------ | -------- | ------------------------------------------- |
+| `documentId` | string | yes      | Exact Hindsight document ID.                |
+| `bank`       | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_update_document_tags`
+
+Replace document tags for one Hindsight document. Requires confirm=true.
+
+| Parameter    | Type          | Required | Description                                   |
+| ------------ | ------------- | -------- | --------------------------------------------- |
+| `documentId` | string        | yes      | Exact Hindsight document ID.                  |
+| `tags`       | array<string> | yes      | Replacement tag set.                          |
+| `bank`       | string        | no       | Optional bank id. Defaults to project bank.   |
+| `confirm`    | true          | yes      | Required mutation confirmation. Must be true. |
+
+### `hindsight_list_entities`
+
+List Hindsight entities for compact inspection.
+
+| Parameter | Type   | Required | Description                                 |
+| --------- | ------ | -------- | ------------------------------------------- |
+| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+| `limit`   | number | no       | Maximum entities to return.                 |
+| `offset`  | number | no       | Pagination offset.                          |
+
+### `hindsight_get_entity`
+
+Fetch one Hindsight entity by ID.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `entityId` | string | yes      | Hindsight entity ID.                        |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_regenerate_entity`
+
+Regenerate observations for one Hindsight entity. Expensive mutation; requires confirm=true.
+
+| Parameter  | Type   | Required | Description                                   |
+| ---------- | ------ | -------- | --------------------------------------------- |
+| `entityId` | string | yes      | Hindsight entity ID.                          |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank.   |
+| `confirm`  | true   | yes      | Required mutation confirmation. Must be true. |
+
+### `hindsight_get_graph`
+
+Explore Hindsight graph with supported filters.
+
+| Parameter    | Type                                   | Required | Description                                                                        |
+| ------------ | -------------------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `bank`       | string                                 | no       | Optional bank id. Defaults to project bank.                                        |
+| `type`       | world \| experience \| opinion         | no       | Optional graph fact type filter. Hindsight supports world, experience, or opinion. |
+| `q`          | string                                 | no       | Optional text query filter.                                                        |
+| `limit`      | number                                 | no       | Maximum graph items to return.                                                     |
+| `tags`       | array<string>                          | no       | Optional tag filter.                                                               |
+| `tagsMatch`  | any \| all \| any_strict \| all_strict | no       |                                                                                    |
+| `documentId` | string                                 | no       | Optional document ID filter.                                                       |
+| `chunkId`    | string                                 | no       | Optional chunk ID filter.                                                          |
+
+### `hindsight_get_entity_graph`
+
+Fetch Hindsight entity graph summary when server supports it.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+| `limit`    | number | no       | Maximum graph items to return.              |
+| `minCount` | number | no       | Minimum entity count filter.                |
+
+### `hindsight_list_tags`
+
+List Hindsight tags for compact inspection.
+
+| Parameter | Type                      | Required | Description                                 |
+| --------- | ------------------------- | -------- | ------------------------------------------- |
+| `bank`    | string                    | no       | Optional bank id. Defaults to project bank. |
+| `q`       | string                    | no       | Optional tag text filter.                   |
+| `source`  | memories \| mental_models | no       |                                             |
+| `limit`   | number                    | no       | Maximum tags to return.                     |
+| `offset`  | number                    | no       | Pagination offset.                          |
+
 ### `hindsight_list_operations`
 
 List Hindsight async operations for a bank with supported server filters.
@@ -193,6 +292,52 @@ Read resolved Hindsight bank config and override counts for a selected bank.
 | Parameter | Type   | Required | Description                                 |
 | --------- | ------ | -------- | ------------------------------------------- |
 | `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_get_bank_profile`
+
+Read Hindsight bank profile/background/disposition.
+
+| Parameter | Type   | Required | Description                                 |
+| --------- | ------ | -------- | ------------------------------------------- |
+| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_update_bank_profile`
+
+Patch supported Hindsight bank profile fields. Requires confirm=true.
+
+| Parameter             | Type           | Required | Description                                         |
+| --------------------- | -------------- | -------- | --------------------------------------------------- |
+| `bank`                | string         | no       | Optional bank id. Defaults to project bank.         |
+| `name`                | string \| null | no       |                                                     |
+| `mission`             | string \| null | no       |                                                     |
+| `background`          | string \| null | no       |                                                     |
+| `reflectMission`      | string \| null | no       |                                                     |
+| `retainMission`       | string \| null | no       |                                                     |
+| `observationsMission` | string \| null | no       |                                                     |
+| `confirm`             | true           | yes      | Required admin mutation confirmation. Must be true. |
+
+### `hindsight_update_bank_disposition`
+
+Update bank disposition traits. Requires confirm=true.
+
+| Parameter    | Type    | Required | Description                                         |
+| ------------ | ------- | -------- | --------------------------------------------------- |
+| `bank`       | string  | no       | Optional bank id. Defaults to project bank.         |
+| `skepticism` | integer | yes      |                                                     |
+| `literalism` | integer | yes      |                                                     |
+| `empathy`    | integer | yes      |                                                     |
+| `confirm`    | true    | yes      | Required admin mutation confirmation. Must be true. |
+
+### `hindsight_add_bank_background`
+
+Append bank background. Optional disposition update; requires confirm=true.
+
+| Parameter           | Type    | Required | Description                                          |
+| ------------------- | ------- | -------- | ---------------------------------------------------- |
+| `bank`              | string  | no       | Optional bank id. Defaults to project bank.          |
+| `content`           | string  | yes      | Background text to append.                           |
+| `updateDisposition` | boolean | no       | Ask Hindsight to update disposition from background. |
+| `confirm`           | true    | yes      | Required admin mutation confirmation. Must be true.  |
 
 ### `hindsight_reset_bank_config`
 

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -2,7 +2,7 @@
 title: "Tools and commands"
 ---
 
-For generated details of registered tools and editable config fields, see [Generated surface reference](/pi-hindsight/reference/surface-reference/). For related concepts, see [Retain, Recall, and Reflect](/pi-hindsight/concepts/retain-recall-reflect/) and [Memory Banks](/pi-hindsight/concepts/memory-banks/).
+For generated details of registered tools and editable config fields, see [Generated surface reference](/pi-hindsight/reference/surface-reference/).
 
 `/hindsight` is the main control center. Commands are convenience shortcuts and escape hatches for advanced workflows.
 
@@ -80,6 +80,10 @@ Additional tools:
 
 - `hindsight_configure`
 - `hindsight_get_bank_config`
+- `hindsight_get_bank_profile`
+- `hindsight_update_bank_profile`
+- `hindsight_update_bank_disposition`
+- `hindsight_add_bank_background`
 - `hindsight_reset_bank_config`
 - `hindsight_list_directives`
 - `hindsight_get_directive`
@@ -94,6 +98,15 @@ Additional tools:
 - `hindsight_route_memory`
 - `hindsight_retain_receipts`
 - `hindsight_delete_document`
+- `hindsight_list_documents`
+- `hindsight_get_document`
+- `hindsight_update_document_tags`
+- `hindsight_list_entities`
+- `hindsight_get_entity`
+- `hindsight_regenerate_entity`
+- `hindsight_get_graph`
+- `hindsight_get_entity_graph`
+- `hindsight_list_tags`
 - `hindsight_list_operations`
 - `hindsight_cancel_operation`
 - `hindsight_retry_operation`
@@ -115,6 +128,9 @@ Tool notes:
 - Pass `global` for the configured global bank.
 - `hindsight_retain_global` refuses to write if global memory is disabled or missing a bank ID.
 - `hindsight_delete_document` requires exact bank, exact document ID, and `confirm: true`.
+- Document/entity/graph/tag inspection tools present compact IDs, tags, metadata/provenance keys, timestamps, and counts when Hindsight returns them. They do not print giant source payloads by default beyond bounded JSON detail.
+- `hindsight_update_document_tags`, `hindsight_regenerate_entity`, `hindsight_update_bank_profile`, `hindsight_update_bank_disposition`, and `hindsight_add_bank_background` are admin mutations and require `confirm: true`.
+- Bank profile/background/disposition tools only call current supported Hindsight endpoints. They do not expose bank-wide destructive operations. Roll back profile/disposition/background changes by reapplying the previous values from the returned `before` profile or the Hindsight web UI.
 - `hindsight_cancel_operation` requires exact operation ID and `confirm: true`; it is intended for pending operations.
 - `hindsight_delete_memory_observations` requires exact memory ID and `confirm: true`. Bank-wide memory clear/delete-all is intentionally not exposed.
 - Memory inspection tools use current documented REST endpoints: list memory units, fetch a memory, fetch a chunk by ID, fetch memory history when the server supports it, and delete observations for one memory when supported.

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -90,6 +90,105 @@ Delete a specific Hindsight document and all memories extracted from it. Destruc
 | `documentId` | string  | yes      | Exact Hindsight document ID to delete.        |
 | `confirm`    | boolean | yes      | Must be true to confirm destructive deletion. |
 
+### `hindsight_list_documents`
+
+List Hindsight documents for compact inspection with supported filters.
+
+| Parameter   | Type                                   | Required | Description                                 |
+| ----------- | -------------------------------------- | -------- | ------------------------------------------- |
+| `bank`      | string                                 | no       | Optional bank id. Defaults to project bank. |
+| `q`         | string                                 | no       | Optional text query filter.                 |
+| `tags`      | array<string>                          | no       | Optional tag filter.                        |
+| `tagsMatch` | any \| all \| any_strict \| all_strict | no       |                                             |
+| `limit`     | number                                 | no       | Maximum documents to return.                |
+| `offset`    | number                                 | no       | Pagination offset.                          |
+
+### `hindsight_get_document`
+
+Fetch one Hindsight document by ID for inspection.
+
+| Parameter    | Type   | Required | Description                                 |
+| ------------ | ------ | -------- | ------------------------------------------- |
+| `documentId` | string | yes      | Exact Hindsight document ID.                |
+| `bank`       | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_update_document_tags`
+
+Replace document tags for one Hindsight document. Requires confirm=true.
+
+| Parameter    | Type          | Required | Description                                   |
+| ------------ | ------------- | -------- | --------------------------------------------- |
+| `documentId` | string        | yes      | Exact Hindsight document ID.                  |
+| `tags`       | array<string> | yes      | Replacement tag set.                          |
+| `bank`       | string        | no       | Optional bank id. Defaults to project bank.   |
+| `confirm`    | true          | yes      | Required mutation confirmation. Must be true. |
+
+### `hindsight_list_entities`
+
+List Hindsight entities for compact inspection.
+
+| Parameter | Type   | Required | Description                                 |
+| --------- | ------ | -------- | ------------------------------------------- |
+| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+| `limit`   | number | no       | Maximum entities to return.                 |
+| `offset`  | number | no       | Pagination offset.                          |
+
+### `hindsight_get_entity`
+
+Fetch one Hindsight entity by ID.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `entityId` | string | yes      | Hindsight entity ID.                        |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_regenerate_entity`
+
+Regenerate observations for one Hindsight entity. Expensive mutation; requires confirm=true.
+
+| Parameter  | Type   | Required | Description                                   |
+| ---------- | ------ | -------- | --------------------------------------------- |
+| `entityId` | string | yes      | Hindsight entity ID.                          |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank.   |
+| `confirm`  | true   | yes      | Required mutation confirmation. Must be true. |
+
+### `hindsight_get_graph`
+
+Explore Hindsight graph with supported filters.
+
+| Parameter    | Type                                   | Required | Description                                                                        |
+| ------------ | -------------------------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `bank`       | string                                 | no       | Optional bank id. Defaults to project bank.                                        |
+| `type`       | world \| experience \| opinion         | no       | Optional graph fact type filter. Hindsight supports world, experience, or opinion. |
+| `q`          | string                                 | no       | Optional text query filter.                                                        |
+| `limit`      | number                                 | no       | Maximum graph items to return.                                                     |
+| `tags`       | array<string>                          | no       | Optional tag filter.                                                               |
+| `tagsMatch`  | any \| all \| any_strict \| all_strict | no       |                                                                                    |
+| `documentId` | string                                 | no       | Optional document ID filter.                                                       |
+| `chunkId`    | string                                 | no       | Optional chunk ID filter.                                                          |
+
+### `hindsight_get_entity_graph`
+
+Fetch Hindsight entity graph summary when server supports it.
+
+| Parameter  | Type   | Required | Description                                 |
+| ---------- | ------ | -------- | ------------------------------------------- |
+| `bank`     | string | no       | Optional bank id. Defaults to project bank. |
+| `limit`    | number | no       | Maximum graph items to return.              |
+| `minCount` | number | no       | Minimum entity count filter.                |
+
+### `hindsight_list_tags`
+
+List Hindsight tags for compact inspection.
+
+| Parameter | Type                      | Required | Description                                 |
+| --------- | ------------------------- | -------- | ------------------------------------------- |
+| `bank`    | string                    | no       | Optional bank id. Defaults to project bank. |
+| `q`       | string                    | no       | Optional tag text filter.                   |
+| `source`  | memories \| mental_models | no       |                                             |
+| `limit`   | number                    | no       | Maximum tags to return.                     |
+| `offset`  | number                    | no       | Pagination offset.                          |
+
 ### `hindsight_list_operations`
 
 List Hindsight async operations for a bank with supported server filters.
@@ -189,6 +288,52 @@ Read resolved Hindsight bank config and override counts for a selected bank.
 | Parameter | Type   | Required | Description                                 |
 | --------- | ------ | -------- | ------------------------------------------- |
 | `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_get_bank_profile`
+
+Read Hindsight bank profile/background/disposition.
+
+| Parameter | Type   | Required | Description                                 |
+| --------- | ------ | -------- | ------------------------------------------- |
+| `bank`    | string | no       | Optional bank id. Defaults to project bank. |
+
+### `hindsight_update_bank_profile`
+
+Patch supported Hindsight bank profile fields. Requires confirm=true.
+
+| Parameter             | Type           | Required | Description                                         |
+| --------------------- | -------------- | -------- | --------------------------------------------------- |
+| `bank`                | string         | no       | Optional bank id. Defaults to project bank.         |
+| `name`                | string \| null | no       |                                                     |
+| `mission`             | string \| null | no       |                                                     |
+| `background`          | string \| null | no       |                                                     |
+| `reflectMission`      | string \| null | no       |                                                     |
+| `retainMission`       | string \| null | no       |                                                     |
+| `observationsMission` | string \| null | no       |                                                     |
+| `confirm`             | true           | yes      | Required admin mutation confirmation. Must be true. |
+
+### `hindsight_update_bank_disposition`
+
+Update bank disposition traits. Requires confirm=true.
+
+| Parameter    | Type    | Required | Description                                         |
+| ------------ | ------- | -------- | --------------------------------------------------- |
+| `bank`       | string  | no       | Optional bank id. Defaults to project bank.         |
+| `skepticism` | integer | yes      |                                                     |
+| `literalism` | integer | yes      |                                                     |
+| `empathy`    | integer | yes      |                                                     |
+| `confirm`    | true    | yes      | Required admin mutation confirmation. Must be true. |
+
+### `hindsight_add_bank_background`
+
+Append bank background. Optional disposition update; requires confirm=true.
+
+| Parameter           | Type    | Required | Description                                          |
+| ------------------- | ------- | -------- | ---------------------------------------------------- |
+| `bank`              | string  | no       | Optional bank id. Defaults to project bank.          |
+| `content`           | string  | yes      | Background text to append.                           |
+| `updateDisposition` | boolean | no       | Ask Hindsight to update disposition from background. |
+| `confirm`           | true    | yes      | Required admin mutation confirmation. Must be true.  |
 
 ### `hindsight_reset_bank_config`
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -32,7 +32,7 @@ The `hindsight_configure` tool can write config from agents. Prefer `/hindsight`
 /hindsight:import-project-sessions
 ```
 
-Use dry-run before non-dry-run imports. See [`importing-sessions.md`](importing-sessions.md).
+Use dry-run before non-dry-run imports. See [`import-controls.md`](import-controls.md) and [`importing-sessions.md`](importing-sessions.md).
 
 ## Queue and snapshots
 
@@ -78,6 +78,10 @@ Additional tools:
 
 - `hindsight_configure`
 - `hindsight_get_bank_config`
+- `hindsight_get_bank_profile`
+- `hindsight_update_bank_profile`
+- `hindsight_update_bank_disposition`
+- `hindsight_add_bank_background`
 - `hindsight_reset_bank_config`
 - `hindsight_list_directives`
 - `hindsight_get_directive`
@@ -92,6 +96,15 @@ Additional tools:
 - `hindsight_route_memory`
 - `hindsight_retain_receipts`
 - `hindsight_delete_document`
+- `hindsight_list_documents`
+- `hindsight_get_document`
+- `hindsight_update_document_tags`
+- `hindsight_list_entities`
+- `hindsight_get_entity`
+- `hindsight_regenerate_entity`
+- `hindsight_get_graph`
+- `hindsight_get_entity_graph`
+- `hindsight_list_tags`
 - `hindsight_list_operations`
 - `hindsight_cancel_operation`
 - `hindsight_retry_operation`
@@ -113,6 +126,9 @@ Tool notes:
 - Pass `global` for the configured global bank.
 - `hindsight_retain_global` refuses to write if global memory is disabled or missing a bank ID.
 - `hindsight_delete_document` requires exact bank, exact document ID, and `confirm: true`.
+- Document/entity/graph/tag inspection tools present compact IDs, tags, metadata/provenance keys, timestamps, and counts when Hindsight returns them. They do not print giant source payloads by default beyond bounded JSON detail.
+- `hindsight_update_document_tags`, `hindsight_regenerate_entity`, `hindsight_update_bank_profile`, `hindsight_update_bank_disposition`, and `hindsight_add_bank_background` are admin mutations and require `confirm: true`.
+- Bank profile/background/disposition tools only call current supported Hindsight endpoints. They do not expose bank-wide destructive operations. Roll back profile/disposition/background changes by reapplying the previous values from the returned `before` profile or the Hindsight web UI.
 - `hindsight_cancel_operation` requires exact operation ID and `confirm: true`; it is intended for pending operations.
 - `hindsight_delete_memory_observations` requires exact memory ID and `confirm: true`. Bank-wide memory clear/delete-all is intentionally not exposed.
 - Memory inspection tools use current documented REST endpoints: list memory units, fetch a memory, fetch a chunk by ID, fetch memory history when the server supports it, and delete observations for one memory when supported.

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -1,13 +1,20 @@
 import type {
   CreateDirectiveRequest,
   CreateMentalModelRequest,
+  GetEntityGraphOptions,
+  GetGraphOptions,
   GetMentalModelOptions,
+  ListDocumentsOptions,
+  ListEntitiesOptions,
   ListMemoriesOptions,
   ListDirectivesOptions,
   ListMentalModelsOptions,
   ListOperationsOptions,
+  ListTagsOptions,
   ResolvedConfig,
+  UpdateBankProfileRequest,
   UpdateDirectiveRequest,
+  UpdateDocumentRequest,
   UpdateMentalModelRequest,
 } from "./types.js";
 
@@ -180,8 +187,97 @@ export function memoryObservationsPath(bankId: string, memoryId: string): string
   return `${memoryItemPath(bankId, memoryId)}/observations`;
 }
 
+export function documentsCollectionPath(
+  bankId: string,
+  options: ListDocumentsOptions = {},
+): string {
+  const params = new URLSearchParams();
+  if (options.q) params.set("q", options.q);
+  for (const tag of options.tags ?? []) params.append("tags", tag);
+  if (options.tagsMatch) params.set("tags_match", options.tagsMatch);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  return appendQuery(encodeBankPath(bankId, "/documents"), params);
+}
+
+export function documentItemPath(bankId: string, documentId: string): string {
+  return `${encodeBankPath(bankId, "/documents")}/${encodeURIComponent(documentId)}`;
+}
+
+export function updateDocumentRequestBody(request: UpdateDocumentRequest): Record<string, unknown> {
+  return {
+    ...(request.tags !== undefined ? { tags: request.tags } : {}),
+  };
+}
+
+export function entitiesCollectionPath(bankId: string, options: ListEntitiesOptions = {}): string {
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  return appendQuery(encodeBankPath(bankId, "/entities"), params);
+}
+
+export function entityItemPath(bankId: string, entityId: string): string {
+  return `${encodeBankPath(bankId, "/entities")}/${encodeURIComponent(entityId)}`;
+}
+
+export function entityRegeneratePath(bankId: string, entityId: string): string {
+  return `${entityItemPath(bankId, entityId)}/regenerate`;
+}
+
+export function graphPath(bankId: string, options: GetGraphOptions = {}): string {
+  const params = new URLSearchParams();
+  if (options.type) params.set("type", options.type);
+  if (options.q) params.set("q", options.q);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  for (const tag of options.tags ?? []) params.append("tags", tag);
+  if (options.tagsMatch) params.set("tags_match", options.tagsMatch);
+  if (options.documentId) params.set("document_id", options.documentId);
+  if (options.chunkId) params.set("chunk_id", options.chunkId);
+  return appendQuery(encodeBankPath(bankId, "/graph"), params);
+}
+
+export function entityGraphPath(bankId: string, options: GetEntityGraphOptions = {}): string {
+  const params = new URLSearchParams();
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.minCount !== undefined) params.set("min_count", String(options.minCount));
+  return appendQuery(encodeBankPath(bankId, "/entities/graph"), params);
+}
+
+export function tagsCollectionPath(bankId: string, options: ListTagsOptions = {}): string {
+  const params = new URLSearchParams();
+  if (options.q) params.set("q", options.q);
+  if (options.source) params.set("source", options.source);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.offset !== undefined) params.set("offset", String(options.offset));
+  return appendQuery(encodeBankPath(bankId, "/tags"), params);
+}
+
 export function bankConfigPath(bankId: string): string {
   return encodeBankPath(bankId, "/config");
+}
+
+export function bankProfilePath(bankId: string): string {
+  return encodeBankPath(bankId, "/profile");
+}
+
+export function bankBackgroundPath(bankId: string): string {
+  return encodeBankPath(bankId, "/background");
+}
+
+export function updateBankProfileRequestBody(
+  request: UpdateBankProfileRequest,
+): Record<string, unknown> {
+  return {
+    ...(request.name !== undefined ? { name: request.name } : {}),
+    ...(request.mission !== undefined ? { mission: request.mission } : {}),
+    ...(request.background !== undefined ? { background: request.background } : {}),
+    ...(request.reflectMission !== undefined ? { reflect_mission: request.reflectMission } : {}),
+    ...(request.retainMission !== undefined ? { retain_mission: request.retainMission } : {}),
+    ...(request.observationsMission !== undefined
+      ? { observations_mission: request.observationsMission }
+      : {}),
+  };
 }
 
 export function directivesCollectionPath(

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -5,6 +5,8 @@ import {
   assertHealthResponse,
   assertReflectResponse,
   bankConfigPath,
+  bankBackgroundPath,
+  bankProfilePath,
   bankTemplateExportPath,
   bankTemplateImportPath,
   bankTemplateSchemaPath,
@@ -12,9 +14,16 @@ import {
   createDirectiveRequestBody,
   createHindsightRestTransport,
   createMentalModelRequestBody,
+  documentItemPath,
+  documentsCollectionPath,
   directiveItemPath,
   directivesCollectionPath,
   encodeBankPath,
+  entitiesCollectionPath,
+  entityGraphPath,
+  entityItemPath,
+  entityRegeneratePath,
+  graphPath,
   memoriesCollectionPath,
   memoryHistoryPath,
   memoryItemPath,
@@ -27,8 +36,11 @@ import {
   operationRetryPath,
   operationsCollectionPath,
   reflectRequestBody,
+  tagsCollectionPath,
   updateBankConfigRequestBody,
+  updateBankProfileRequestBody,
   updateDirectiveRequestBody,
+  updateDocumentRequestBody,
   updateMentalModelRequestBody,
 } from "./client-rest.js";
 import { withTimeout } from "./timeout.js";
@@ -141,6 +153,35 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
       withTimeout("hindsight getBankConfig", timeoutMs, (signal) =>
         rest.request(bankConfigPath(bankId), { signal }),
       ),
+    updateBankProfile: (bankId, request) =>
+      withTimeout("hindsight updateBankProfile", timeoutMs, (signal) =>
+        rest.request(encodeBankPath(bankId, ""), {
+          method: "PATCH",
+          signal,
+          body: JSON.stringify(updateBankProfileRequestBody(request)),
+        }),
+      ),
+    updateBankDisposition: (bankId, disposition) =>
+      withTimeout("hindsight updateBankDisposition", timeoutMs, (signal) =>
+        rest.request(bankProfilePath(bankId), {
+          method: "PUT",
+          signal,
+          body: JSON.stringify({ disposition }),
+        }),
+      ),
+    addBankBackground: (bankId, request) =>
+      withTimeout("hindsight addBankBackground", timeoutMs, (signal) =>
+        rest.request(bankBackgroundPath(bankId), {
+          method: "POST",
+          signal,
+          body: JSON.stringify({
+            content: request.content,
+            ...(request.updateDisposition !== undefined
+              ? { update_disposition: request.updateDisposition }
+              : {}),
+          }),
+        }),
+      ),
     updateBankConfig: (bankId, updates) =>
       withTimeout("hindsight updateBankConfig", timeoutMs, (signal) =>
         rest.request(bankConfigPath(bankId), {
@@ -157,12 +198,49 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
       withTimeout("hindsight health", timeoutMs, async (signal) =>
         assertHealthResponse(await rest.request("/health", { signal })),
       ),
+    listDocuments: (bankId, options) =>
+      withTimeout("hindsight listDocuments", timeoutMs, (signal) =>
+        rest.request(documentsCollectionPath(bankId, options), { signal }),
+      ),
+    getDocument: (bankId, documentId) =>
+      withTimeout("hindsight getDocument", timeoutMs, (signal) =>
+        rest.request(documentItemPath(bankId, documentId), { signal }),
+      ),
+    updateDocument: (bankId, documentId, request) =>
+      withTimeout("hindsight updateDocument", timeoutMs, (signal) =>
+        rest.request(documentItemPath(bankId, documentId), {
+          method: "PATCH",
+          signal,
+          body: JSON.stringify(updateDocumentRequestBody(request)),
+        }),
+      ),
     deleteDocument: (bankId, documentId) =>
       withTimeout("hindsight deleteDocument", timeoutMs, (signal) =>
-        rest.request(`${encodeBankPath(bankId, "/documents")}/${encodeURIComponent(documentId)}`, {
-          method: "DELETE",
-          signal,
-        }),
+        rest.request(documentItemPath(bankId, documentId), { method: "DELETE", signal }),
+      ),
+    listEntities: (bankId, options) =>
+      withTimeout("hindsight listEntities", timeoutMs, (signal) =>
+        rest.request(entitiesCollectionPath(bankId, options), { signal }),
+      ),
+    getEntity: (bankId, entityId) =>
+      withTimeout("hindsight getEntity", timeoutMs, (signal) =>
+        rest.request(entityItemPath(bankId, entityId), { signal }),
+      ),
+    regenerateEntity: (bankId, entityId) =>
+      withTimeout("hindsight regenerateEntity", timeoutMs, (signal) =>
+        rest.request(entityRegeneratePath(bankId, entityId), { method: "POST", signal }),
+      ),
+    getGraph: (bankId, options) =>
+      withTimeout("hindsight getGraph", timeoutMs, (signal) =>
+        rest.request(graphPath(bankId, options), { signal }),
+      ),
+    getEntityGraph: (bankId, options) =>
+      withTimeout("hindsight getEntityGraph", timeoutMs, (signal) =>
+        rest.request(entityGraphPath(bankId, options), { signal }),
+      ),
+    listTags: (bankId, options) =>
+      withTimeout("hindsight listTags", timeoutMs, (signal) =>
+        rest.request(tagsCollectionPath(bankId, options), { signal }),
       ),
     // The installed high-level SDK does not export bank-template helpers. Its generated
     // import helper also exposes no typed body because the server endpoint accepts raw JSON.

--- a/extensions/memory-bank-profile-operations.ts
+++ b/extensions/memory-bank-profile-operations.ts
@@ -1,0 +1,88 @@
+import { resolveOperationBank } from "./bank-selection.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+import type {
+  AddBankBackgroundRequest,
+  DispositionTraits,
+  UpdateBankProfileRequest,
+} from "./types.js";
+
+function unsupported(name: string): Error {
+  return new Error(`Hindsight client does not support ${name}.`);
+}
+
+function bankFor(deps: MemoryOperationsDeps, bank: string | undefined): string {
+  return resolveOperationBank({
+    requestedBank: bank,
+    config: deps.getConfig(),
+    projectBankId: deps.getProjectBankId(),
+  });
+}
+
+function validateDisposition(disposition: DispositionTraits): void {
+  for (const [key, value] of Object.entries(disposition)) {
+    if (!Number.isInteger(value) || value < 1 || value > 5)
+      throw new Error(`Disposition ${key} must be an integer from 1 to 5.`);
+  }
+}
+
+function hasProfileUpdates(request: UpdateBankProfileRequest): boolean {
+  return Object.values(request).some((value) => value !== undefined);
+}
+
+export function createBankProfileOperations(deps: MemoryOperationsDeps) {
+  return {
+    async getBankProfile(args: { bank?: string } = {}) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getBankProfile) throw unsupported("getBankProfile");
+      const result = await client.getBankProfile(bankId);
+      return { bankId, result };
+    },
+
+    async updateBankProfile(args: {
+      bank?: string;
+      request: UpdateBankProfileRequest;
+      confirm: true;
+    }) {
+      if (!args.confirm) throw new Error("Set confirm=true to update Hindsight bank profile.");
+      if (!hasProfileUpdates(args.request))
+        throw new Error("At least one profile field is required.");
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.updateBankProfile) throw unsupported("updateBankProfile");
+      const before = client.getBankProfile ? await client.getBankProfile(bankId) : undefined;
+      const result = await client.updateBankProfile(bankId, args.request);
+      return { bankId, before, result };
+    },
+
+    async updateBankDisposition(args: {
+      bank?: string;
+      disposition: DispositionTraits;
+      confirm: true;
+    }) {
+      if (!args.confirm) throw new Error("Set confirm=true to update Hindsight bank disposition.");
+      validateDisposition(args.disposition);
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.updateBankDisposition) throw unsupported("updateBankDisposition");
+      const before = client.getBankProfile ? await client.getBankProfile(bankId) : undefined;
+      const result = await client.updateBankDisposition(bankId, args.disposition);
+      return { bankId, before, result };
+    },
+
+    async addBankBackground(args: {
+      bank?: string;
+      request: AddBankBackgroundRequest;
+      confirm: true;
+    }) {
+      if (!args.confirm) throw new Error("Set confirm=true to append Hindsight bank background.");
+      if (!args.request.content.trim()) throw new Error("Background content is required.");
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.addBankBackground) throw unsupported("addBankBackground");
+      const before = client.getBankProfile ? await client.getBankProfile(bankId) : undefined;
+      const result = await client.addBankBackground(bankId, args.request);
+      return { bankId, before, result };
+    },
+  };
+}

--- a/extensions/memory-exploration-operations.ts
+++ b/extensions/memory-exploration-operations.ts
@@ -1,0 +1,106 @@
+import { resolveOperationBank } from "./bank-selection.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+import type {
+  GetEntityGraphOptions,
+  GetGraphOptions,
+  ListDocumentsOptions,
+  ListEntitiesOptions,
+  ListTagsOptions,
+  UpdateDocumentRequest,
+} from "./types.js";
+
+function unsupported(name: string): Error {
+  return new Error(`Hindsight client does not support ${name}.`);
+}
+
+function bankFor(deps: MemoryOperationsDeps, bank: string | undefined): string {
+  return resolveOperationBank({
+    requestedBank: bank,
+    config: deps.getConfig(),
+    projectBankId: deps.getProjectBankId(),
+  });
+}
+
+export function createExplorationOperations(deps: MemoryOperationsDeps) {
+  return {
+    async listDocuments(args: { bank?: string; options?: ListDocumentsOptions }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.listDocuments) throw unsupported("listDocuments");
+      const result = await client.listDocuments(bankId, args.options);
+      return { bankId, result };
+    },
+
+    async getDocument(args: { bank?: string; documentId: string }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getDocument) throw unsupported("getDocument");
+      const result = await client.getDocument(bankId, args.documentId);
+      return { bankId, documentId: args.documentId, result };
+    },
+
+    async updateDocumentTags(args: {
+      bank?: string;
+      documentId: string;
+      request: UpdateDocumentRequest;
+      confirm: true;
+    }) {
+      if (!args.confirm) throw new Error("Set confirm=true to update Hindsight document tags.");
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.updateDocument) throw unsupported("updateDocument");
+      const result = await client.updateDocument(bankId, args.documentId, args.request);
+      return { bankId, documentId: args.documentId, result };
+    },
+
+    async listEntities(args: { bank?: string; options?: ListEntitiesOptions }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.listEntities) throw unsupported("listEntities");
+      const result = await client.listEntities(bankId, args.options);
+      return { bankId, result };
+    },
+
+    async getEntity(args: { bank?: string; entityId: string }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getEntity) throw unsupported("getEntity");
+      const result = await client.getEntity(bankId, args.entityId);
+      return { bankId, entityId: args.entityId, result };
+    },
+
+    async regenerateEntity(args: { bank?: string; entityId: string; confirm: true }) {
+      if (!args.confirm)
+        throw new Error("Set confirm=true to regenerate Hindsight entity observations.");
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.regenerateEntity) throw unsupported("regenerateEntity");
+      const result = await client.regenerateEntity(bankId, args.entityId);
+      return { bankId, entityId: args.entityId, result };
+    },
+
+    async getGraph(args: { bank?: string; options?: GetGraphOptions }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getGraph) throw unsupported("getGraph");
+      const result = await client.getGraph(bankId, args.options);
+      return { bankId, result };
+    },
+
+    async getEntityGraph(args: { bank?: string; options?: GetEntityGraphOptions }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.getEntityGraph) throw unsupported("getEntityGraph");
+      const result = await client.getEntityGraph(bankId, args.options);
+      return { bankId, result };
+    },
+
+    async listTags(args: { bank?: string; options?: ListTagsOptions }) {
+      const bankId = bankFor(deps, args.bank);
+      const client = deps.getClient();
+      if (!client.listTags) throw unsupported("listTags");
+      const result = await client.listTags(bankId, args.options);
+      return { bankId, result };
+    },
+  };
+}

--- a/extensions/memory-operation-service.ts
+++ b/extensions/memory-operation-service.ts
@@ -5,11 +5,13 @@ import {
   importMemorySession,
 } from "./import-operations.js";
 import { createBankConfigOperations } from "./bank-config-operations.js";
+import { createBankProfileOperations } from "./memory-bank-profile-operations.js";
 import { createBankTemplateOperations } from "./bank-template-operations.js";
 import { createAdminOperations } from "./memory-admin-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
 import { createDirectiveOperations } from "./memory-directive-operations.js";
 import { createDocumentOperations } from "./memory-document-operations.js";
+import { createExplorationOperations } from "./memory-exploration-operations.js";
 import { createMentalModelOperations } from "./memory-mental-model-operations.js";
 import { createRecallOperations } from "./memory-recall-operations.js";
 import { createRetainOperations } from "./memory-retain-operations.js";
@@ -58,9 +60,11 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createRecallOperations(deps),
     ...createRetainOperations(deps),
     ...createDocumentOperations(deps),
+    ...createExplorationOperations(deps),
     ...createRoutingOperations(deps),
     ...createConfigOperations(deps),
     ...createBankConfigOperations(deps),
+    ...createBankProfileOperations(deps),
     ...createBankTemplateOperations(deps),
     ...createDirectiveOperations(deps),
     ...createMentalModelOperations(deps),

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -9,19 +9,26 @@ import { getSessionFile } from "./session.js";
 import { runHindsightSetupTui } from "./setup-tui.js";
 import {
   configureToolResponse,
+  bankProfileToolResponse,
   createDirectiveToolResponse,
   deleteDirectiveToolResponse,
   deleteDocumentToolResponse,
+  documentToolResponse,
+  entityToolResponse,
   exportBankTemplateToolResponse,
   gatewayImportToolResponse,
   getBankConfigToolResponse,
   getBankTemplateSchemaToolResponse,
   getDirectiveToolResponse,
+  graphToolResponse,
   importToolResponse,
   jsonToolResponse,
   listDirectivesToolResponse,
+  listDocumentsToolResponse,
+  listEntitiesToolResponse,
   listMemoriesToolResponse,
   listOperationsToolResponse,
+  listTagsToolResponse,
   operationToolResponse,
   resetBankConfigToolResponse,
   retainReceiptListToolResponse,
@@ -412,6 +419,235 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       },
     }),
     defineCatalogTool({
+      name: "hindsight_list_documents",
+      label: "Hindsight List Documents",
+      description: "List Hindsight documents for compact inspection with supported filters.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        q: Type.Optional(Type.String({ description: "Optional text query filter." })),
+        tags: Type.Optional(Type.Array(Type.String(), { description: "Optional tag filter." })),
+        tagsMatch: Type.Optional(tagMatchSchema),
+        limit: Type.Optional(Type.Number({ description: "Maximum documents to return." })),
+        offset: Type.Optional(Type.Number({ description: "Pagination offset." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.listDocuments({
+          ...(params.bank ? { bank: params.bank } : {}),
+          options: {
+            ...(params.q ? { q: params.q } : {}),
+            ...(params.tags ? { tags: params.tags } : {}),
+            ...(params.tagsMatch ? { tagsMatch: params.tagsMatch } : {}),
+            ...(params.limit !== undefined ? { limit: params.limit } : {}),
+            ...(params.offset !== undefined ? { offset: params.offset } : {}),
+          },
+        });
+        return listDocumentsToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_document",
+      label: "Hindsight Get Document",
+      description: "Fetch one Hindsight document by ID for inspection.",
+      parameters: Type.Object({
+        documentId: Type.String({ description: "Exact Hindsight document ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getDocument({
+          documentId: params.documentId,
+          ...(params.bank ? { bank: params.bank } : {}),
+        });
+        return documentToolResponse(`Document ${params.documentId} in ${result.bankId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_update_document_tags",
+      label: "Hindsight Update Document Tags",
+      description: "Replace document tags for one Hindsight document. Requires confirm=true.",
+      parameters: Type.Object({
+        documentId: Type.String({ description: "Exact Hindsight document ID." }),
+        tags: Type.Array(Type.String(), { description: "Replacement tag set." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        confirm: Type.Literal(true, {
+          description: "Required mutation confirmation. Must be true.",
+        }),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.updateDocumentTags({
+          documentId: params.documentId,
+          request: { tags: params.tags },
+          ...(params.bank ? { bank: params.bank } : {}),
+          confirm: params.confirm,
+        });
+        return documentToolResponse(`Updated document ${params.documentId} tags.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_list_entities",
+      label: "Hindsight List Entities",
+      description: "List Hindsight entities for compact inspection.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        limit: Type.Optional(Type.Number({ description: "Maximum entities to return." })),
+        offset: Type.Optional(Type.Number({ description: "Pagination offset." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.listEntities({
+          ...(params.bank ? { bank: params.bank } : {}),
+          options: {
+            ...(params.limit !== undefined ? { limit: params.limit } : {}),
+            ...(params.offset !== undefined ? { offset: params.offset } : {}),
+          },
+        });
+        return listEntitiesToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_entity",
+      label: "Hindsight Get Entity",
+      description: "Fetch one Hindsight entity by ID.",
+      parameters: Type.Object({
+        entityId: Type.String({ description: "Hindsight entity ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getEntity({
+          entityId: params.entityId,
+          ...(params.bank ? { bank: params.bank } : {}),
+        });
+        return entityToolResponse(`Entity ${params.entityId} in ${result.bankId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_regenerate_entity",
+      label: "Hindsight Regenerate Entity",
+      description:
+        "Regenerate observations for one Hindsight entity. Expensive mutation; requires confirm=true.",
+      parameters: Type.Object({
+        entityId: Type.String({ description: "Hindsight entity ID." }),
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        confirm: Type.Literal(true, {
+          description: "Required mutation confirmation. Must be true.",
+        }),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.regenerateEntity({
+          entityId: params.entityId,
+          ...(params.bank ? { bank: params.bank } : {}),
+          confirm: params.confirm,
+        });
+        return entityToolResponse(`Regenerated entity ${params.entityId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_graph",
+      label: "Hindsight Get Graph",
+      description: "Explore Hindsight graph with supported filters.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        type: Type.Optional(
+          Type.Union([Type.Literal("world"), Type.Literal("experience"), Type.Literal("opinion")], {
+            description:
+              "Optional graph fact type filter. Hindsight supports world, experience, or opinion.",
+          }),
+        ),
+        q: Type.Optional(Type.String({ description: "Optional text query filter." })),
+        limit: Type.Optional(Type.Number({ description: "Maximum graph items to return." })),
+        tags: Type.Optional(Type.Array(Type.String(), { description: "Optional tag filter." })),
+        tagsMatch: Type.Optional(tagMatchSchema),
+        documentId: Type.Optional(Type.String({ description: "Optional document ID filter." })),
+        chunkId: Type.Optional(Type.String({ description: "Optional chunk ID filter." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getGraph({
+          ...(params.bank ? { bank: params.bank } : {}),
+          options: {
+            ...(params.type ? { type: params.type } : {}),
+            ...(params.q ? { q: params.q } : {}),
+            ...(params.limit !== undefined ? { limit: params.limit } : {}),
+            ...(params.tags ? { tags: params.tags } : {}),
+            ...(params.tagsMatch ? { tagsMatch: params.tagsMatch } : {}),
+            ...(params.documentId ? { documentId: params.documentId } : {}),
+            ...(params.chunkId ? { chunkId: params.chunkId } : {}),
+          },
+        });
+        return graphToolResponse(`Graph in ${result.bankId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_entity_graph",
+      label: "Hindsight Get Entity Graph",
+      description: "Fetch Hindsight entity graph summary when server supports it.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        limit: Type.Optional(Type.Number({ description: "Maximum graph items to return." })),
+        minCount: Type.Optional(Type.Number({ description: "Minimum entity count filter." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getEntityGraph({
+          ...(params.bank ? { bank: params.bank } : {}),
+          options: {
+            ...(params.limit !== undefined ? { limit: params.limit } : {}),
+            ...(params.minCount !== undefined ? { minCount: params.minCount } : {}),
+          },
+        });
+        return graphToolResponse(`Entity graph in ${result.bankId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_list_tags",
+      label: "Hindsight List Tags",
+      description: "List Hindsight tags for compact inspection.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        q: Type.Optional(Type.String({ description: "Optional tag text filter." })),
+        source: Type.Optional(
+          Type.Union([Type.Literal("memories"), Type.Literal("mental_models")]),
+        ),
+        limit: Type.Optional(Type.Number({ description: "Maximum tags to return." })),
+        offset: Type.Optional(Type.Number({ description: "Pagination offset." })),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.listTags({
+          ...(params.bank ? { bank: params.bank } : {}),
+          options: {
+            ...(params.q ? { q: params.q } : {}),
+            ...(params.source ? { source: params.source } : {}),
+            ...(params.limit !== undefined ? { limit: params.limit } : {}),
+            ...(params.offset !== undefined ? { offset: params.offset } : {}),
+          },
+        });
+        return listTagsToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
       name: "hindsight_list_operations",
       label: "Hindsight List Operations",
       description: "List Hindsight async operations for a bank with supported server filters.",
@@ -630,6 +866,120 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         useCwd(ctx.cwd);
         const result = await operations.getBankConfig(params.bank ? { bank: params.bank } : {});
         return getBankConfigToolResponse(result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_get_bank_profile",
+      label: "Hindsight Get Bank Profile",
+      description: "Read Hindsight bank profile/background/disposition.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.getBankProfile(params.bank ? { bank: params.bank } : {});
+        return bankProfileToolResponse(`Bank profile ${result.bankId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_update_bank_profile",
+      label: "Hindsight Update Bank Profile",
+      description: "Patch supported Hindsight bank profile fields. Requires confirm=true.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        name: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        mission: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        background: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        reflectMission: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        retainMission: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        observationsMission: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+        confirm: Type.Literal(true, {
+          description: "Required admin mutation confirmation. Must be true.",
+        }),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.updateBankProfile({
+          ...(params.bank ? { bank: params.bank } : {}),
+          request: {
+            ...(params.name !== undefined ? { name: params.name } : {}),
+            ...(params.mission !== undefined ? { mission: params.mission } : {}),
+            ...(params.background !== undefined ? { background: params.background } : {}),
+            ...(params.reflectMission !== undefined
+              ? { reflectMission: params.reflectMission }
+              : {}),
+            ...(params.retainMission !== undefined ? { retainMission: params.retainMission } : {}),
+            ...(params.observationsMission !== undefined
+              ? { observationsMission: params.observationsMission }
+              : {}),
+          },
+          confirm: params.confirm,
+        });
+        return bankProfileToolResponse(`Updated bank profile ${result.bankId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_update_bank_disposition",
+      label: "Hindsight Update Bank Disposition",
+      description: "Update bank disposition traits. Requires confirm=true.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        skepticism: Type.Integer({ minimum: 1, maximum: 5 }),
+        literalism: Type.Integer({ minimum: 1, maximum: 5 }),
+        empathy: Type.Integer({ minimum: 1, maximum: 5 }),
+        confirm: Type.Literal(true, {
+          description: "Required admin mutation confirmation. Must be true.",
+        }),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.updateBankDisposition({
+          ...(params.bank ? { bank: params.bank } : {}),
+          disposition: {
+            skepticism: params.skepticism,
+            literalism: params.literalism,
+            empathy: params.empathy,
+          },
+          confirm: params.confirm,
+        });
+        return bankProfileToolResponse(`Updated bank disposition ${result.bankId}.`, result);
+      },
+    }),
+    defineCatalogTool({
+      name: "hindsight_add_bank_background",
+      label: "Hindsight Add Bank Background",
+      description: "Append bank background. Optional disposition update; requires confirm=true.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        content: Type.String({ description: "Background text to append." }),
+        updateDisposition: Type.Optional(
+          Type.Boolean({ description: "Ask Hindsight to update disposition from background." }),
+        ),
+        confirm: Type.Literal(true, {
+          description: "Required admin mutation confirmation. Must be true.",
+        }),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.addBankBackground({
+          ...(params.bank ? { bank: params.bank } : {}),
+          request: {
+            content: params.content,
+            ...(params.updateDisposition !== undefined
+              ? { updateDisposition: params.updateDisposition }
+              : {}),
+          },
+          confirm: params.confirm,
+        });
+        return bankProfileToolResponse(`Added bank background ${result.bankId}.`, result);
       },
     }),
     defineCatalogTool({

--- a/extensions/tool-presenters.ts
+++ b/extensions/tool-presenters.ts
@@ -38,6 +38,27 @@ export type OperationToolResult =
 export type ListMemoriesToolResult = Awaited<ReturnType<MemoryOperations["listMemories"]>>;
 export type MemoryToolResult = Awaited<ReturnType<MemoryOperations["getMemory"]>>;
 export type ChunkToolResult = Awaited<ReturnType<MemoryOperations["getChunk"]>>;
+export type ListDocumentsToolResult = Awaited<ReturnType<MemoryOperations["listDocuments"]>>;
+export type DocumentToolResult = Awaited<ReturnType<MemoryOperations["getDocument"]>>;
+export type UpdateDocumentTagsToolResult = Awaited<
+  ReturnType<MemoryOperations["updateDocumentTags"]>
+>;
+export type ListEntitiesToolResult = Awaited<ReturnType<MemoryOperations["listEntities"]>>;
+export type EntityToolResult = Awaited<ReturnType<MemoryOperations["getEntity"]>>;
+export type RegenerateEntityToolResult = Awaited<ReturnType<MemoryOperations["regenerateEntity"]>>;
+export type GraphToolResult = Awaited<ReturnType<MemoryOperations["getGraph"]>>;
+export type EntityGraphToolResult = Awaited<ReturnType<MemoryOperations["getEntityGraph"]>>;
+export type ListTagsToolResult = Awaited<ReturnType<MemoryOperations["listTags"]>>;
+export type BankProfileToolResult = Awaited<ReturnType<MemoryOperations["getBankProfile"]>>;
+export type UpdateBankProfileToolResult = Awaited<
+  ReturnType<MemoryOperations["updateBankProfile"]>
+>;
+export type UpdateBankDispositionToolResult = Awaited<
+  ReturnType<MemoryOperations["updateBankDisposition"]>
+>;
+export type AddBankBackgroundToolResult = Awaited<
+  ReturnType<MemoryOperations["addBankBackground"]>
+>;
 
 export function retainToolResponse(result: RetainToolResult): ToolTextResponse<RetainToolResult> {
   const deadLetterStatus = result.deadLettered
@@ -337,6 +358,72 @@ function memoryLabel(value: unknown): string {
   return `${textField(record, ["id", "memory_id", "memoryId"])} · ${textField(record, ["type", "fact_type", "factType"])} · ${text}`;
 }
 
+function arrayField(record: Record<string, unknown>, keys: string[]): string[] {
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) return value.map(String);
+  }
+  return [];
+}
+
+function nestedRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value && typeof value === "object" && !Array.isArray(value))
+    return value as Record<string, unknown>;
+  return undefined;
+}
+
+function documentLabel(value: unknown): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return JSON.stringify(value);
+  const record = value as Record<string, unknown>;
+  const metadata =
+    nestedRecord(record.document_metadata) ??
+    nestedRecord(record.documentMetadata) ??
+    nestedRecord(record.metadata) ??
+    nestedRecord(record.provenance);
+  const metadataKeys = metadata ? Object.keys(metadata).slice(0, 6).join(",") : "none";
+  const tags = arrayField(record, ["tags", "document_tags", "documentTags"]);
+  const counts = [
+    numberField(record, ["item_count", "itemCount", "items", "chunks"]),
+    numberField(record, [
+      "memory_unit_count",
+      "memoryUnitCount",
+      "memory_count",
+      "memoryCount",
+      "memories",
+    ]),
+  ];
+  return `${textField(record, ["id", "document_id", "documentId"])} · tags=${tags.join(",") || "none"} · metadata=${metadataKeys} · items=${counts[0] ?? "?"} · memories=${counts[1] ?? "?"} · ${textField(record, ["created_at", "createdAt"], "unknown-created")}→${textField(record, ["updated_at", "updatedAt"], "unknown-updated")}`;
+}
+
+function entityLabel(value: unknown): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return JSON.stringify(value);
+  const record = value as Record<string, unknown>;
+  return `${textField(record, ["id", "entity_id", "entityId"])} · ${textField(record, ["canonical_name", "canonicalName", "text", "name", "label"])} · ${textField(record, ["type", "entity_type", "entityType"])} · count=${numberField(record, ["mention_count", "mentionCount", "count", "memory_count", "memories"]) ?? "?"}`;
+}
+
+function graphSummary(result: unknown): string[] {
+  if (!result || typeof result !== "object" || Array.isArray(result))
+    return [JSON.stringify(result)];
+  const record = result as Record<string, unknown>;
+  const nodes = Array.isArray(record.nodes)
+    ? record.nodes.length
+    : numberField(record, ["node_count", "nodeCount"]);
+  const edges = Array.isArray(record.edges)
+    ? record.edges.length
+    : numberField(record, ["edge_count", "edgeCount"]);
+  return [
+    `nodes=${nodes ?? "?"}; edges=${edges ?? "?"}`,
+    JSON.stringify(result, null, 2).slice(0, 4000),
+  ];
+}
+
+function tagLabel(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return JSON.stringify(value);
+  const record = value as Record<string, unknown>;
+  return `${textField(record, ["tag", "name", "id"])} · count=${numberField(record, ["count", "memory_count", "document_count"]) ?? "?"}`;
+}
+
 export function listMemoriesToolResponse(
   result: ListMemoriesToolResult,
 ): ToolTextResponse<ListMemoriesToolResult> {
@@ -348,6 +435,127 @@ export function listMemoriesToolResponse(
         text: [`Memories in ${result.bankId}: ${items.length}`, ...items.map(memoryLabel)].join(
           "\n",
         ),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function listDocumentsToolResponse(
+  result: ListDocumentsToolResult,
+): ToolTextResponse<ListDocumentsToolResult> {
+  const items = objectItems(result.result);
+  return {
+    content: [
+      {
+        type: "text",
+        text: [`Documents in ${result.bankId}: ${items.length}`, ...items.map(documentLabel)].join(
+          "\n",
+        ),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function documentToolResponse(
+  heading: string,
+  result: DocumentToolResult | UpdateDocumentTagsToolResult,
+): ToolTextResponse<DocumentToolResult | UpdateDocumentTagsToolResult> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          heading,
+          documentLabel(result.result),
+          JSON.stringify(result.result, null, 2).slice(0, 4000),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function listEntitiesToolResponse(
+  result: ListEntitiesToolResult,
+): ToolTextResponse<ListEntitiesToolResult> {
+  const items = objectItems(result.result);
+  return {
+    content: [
+      {
+        type: "text",
+        text: [`Entities in ${result.bankId}: ${items.length}`, ...items.map(entityLabel)].join(
+          "\n",
+        ),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function entityToolResponse(
+  heading: string,
+  result: EntityToolResult | RegenerateEntityToolResult,
+): ToolTextResponse<EntityToolResult | RegenerateEntityToolResult> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          heading,
+          entityLabel(result.result),
+          JSON.stringify(result.result, null, 2).slice(0, 4000),
+        ].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function graphToolResponse(
+  heading: string,
+  result: GraphToolResult | EntityGraphToolResult,
+): ToolTextResponse<GraphToolResult | EntityGraphToolResult> {
+  return {
+    content: [{ type: "text", text: [heading, ...graphSummary(result.result)].join("\n") }],
+    details: result,
+  };
+}
+
+export function listTagsToolResponse(
+  result: ListTagsToolResult,
+): ToolTextResponse<ListTagsToolResult> {
+  const items = objectItems(result.result);
+  return {
+    content: [
+      {
+        type: "text",
+        text: [`Tags in ${result.bankId}: ${items.length}`, ...items.map(tagLabel)].join("\n"),
+      },
+    ],
+    details: result,
+  };
+}
+
+export function bankProfileToolResponse(
+  heading: string,
+  result:
+    | BankProfileToolResult
+    | UpdateBankProfileToolResult
+    | UpdateBankDispositionToolResult
+    | AddBankBackgroundToolResult,
+): ToolTextResponse<
+  | BankProfileToolResult
+  | UpdateBankProfileToolResult
+  | UpdateBankDispositionToolResult
+  | AddBankBackgroundToolResult
+> {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [heading, JSON.stringify(result.result, null, 2).slice(0, 4000)].join("\n"),
       },
     ],
     details: result,

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -20,6 +20,9 @@ export type HindsightTagGroup =
 export type MentalModelDetail = "metadata" | "content" | "full";
 export type MentalModelTagsMatch = "any" | "all" | "exact";
 export type OperationStatus = "pending" | "processing" | "completed" | "failed" | "cancelled";
+export type GraphFactType = "world" | "experience" | "opinion";
+export type DocumentTagsMatch = "any" | "all" | "any_strict" | "all_strict";
+export type TagSource = "memories" | "mental_models";
 export type HindsightObservationScopes = "per_tag" | "combined" | "all_combinations" | string[][];
 export type StatusStyle = "off" | "text" | "emoji" | "nerdfont";
 export type StatusDetail = "minimal" | "project" | "activity" | "verbose";
@@ -280,6 +283,65 @@ export interface ListMemoriesOptions {
   offset?: number;
 }
 
+export interface ListDocumentsOptions {
+  q?: string;
+  tags?: string[];
+  tagsMatch?: DocumentTagsMatch;
+  limit?: number;
+  offset?: number;
+}
+
+export interface UpdateDocumentRequest {
+  tags?: string[] | null;
+}
+
+export interface ListEntitiesOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export interface GetGraphOptions {
+  type?: string;
+  q?: string;
+  limit?: number;
+  tags?: string[];
+  tagsMatch?: string;
+  documentId?: string;
+  chunkId?: string;
+}
+
+export interface GetEntityGraphOptions {
+  limit?: number;
+  minCount?: number;
+}
+
+export interface ListTagsOptions {
+  q?: string;
+  source?: TagSource;
+  limit?: number;
+  offset?: number;
+}
+
+export interface DispositionTraits {
+  skepticism: number;
+  literalism: number;
+  empathy: number;
+}
+
+export interface UpdateBankProfileRequest {
+  name?: string | null;
+  mission?: string | null;
+  background?: string | null;
+  reflectMission?: string | null;
+  retainMission?: string | null;
+  observationsMission?: string | null;
+}
+
+export interface AddBankBackgroundRequest {
+  content: string;
+  updateDisposition?: boolean;
+}
+
 export interface HindsightLikeClient {
   retain(
     bankId: string,
@@ -375,7 +437,23 @@ export interface HindsightLikeClient {
   updateBankConfig?(bankId: string, updates: Record<string, unknown>): Promise<unknown>;
   resetBankConfig?(bankId: string): Promise<unknown>;
   health?(): Promise<unknown>;
+  listDocuments?(bankId: string, options?: ListDocumentsOptions): Promise<unknown>;
+  getDocument?(bankId: string, documentId: string): Promise<unknown>;
+  updateDocument?(
+    bankId: string,
+    documentId: string,
+    request: UpdateDocumentRequest,
+  ): Promise<unknown>;
   deleteDocument?(bankId: string, documentId: string): Promise<unknown>;
+  listEntities?(bankId: string, options?: ListEntitiesOptions): Promise<unknown>;
+  getEntity?(bankId: string, entityId: string): Promise<unknown>;
+  regenerateEntity?(bankId: string, entityId: string): Promise<unknown>;
+  getGraph?(bankId: string, options?: GetGraphOptions): Promise<unknown>;
+  getEntityGraph?(bankId: string, options?: GetEntityGraphOptions): Promise<unknown>;
+  listTags?(bankId: string, options?: ListTagsOptions): Promise<unknown>;
+  updateBankProfile?(bankId: string, request: UpdateBankProfileRequest): Promise<unknown>;
+  updateBankDisposition?(bankId: string, disposition: DispositionTraits): Promise<unknown>;
+  addBankBackground?(bankId: string, request: AddBankBackgroundRequest): Promise<unknown>;
   importBankTemplate?(
     bankId: string,
     manifest: BankTemplateManifest,

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -136,6 +136,74 @@ describe("Hindsight client adapter integration", () => {
       if (
         req.method === "GET" &&
         req.url ===
+          "/v1/default/banks/test-bank/documents?q=session&tags=source%3Api&tags_match=all&limit=5&offset=1"
+      ) {
+        sendJson(res, 200, { items: [{ id: "doc-1", tags: ["source:pi"] }] });
+        return;
+      }
+      if (req.method === "GET" && req.url === "/v1/default/banks/test-bank/documents/doc-1") {
+        sendJson(res, 200, { id: "doc-1", content: "doc" });
+        return;
+      }
+      if (req.method === "PATCH" && req.url === "/v1/default/banks/test-bank/documents/doc-1") {
+        sendJson(res, 200, { id: "doc-1", tags: ["updated"] });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url === "/v1/default/banks/test-bank/entities?limit=5&offset=1"
+      ) {
+        sendJson(res, 200, { items: [{ id: "entity-1", text: "Alice" }] });
+        return;
+      }
+      if (req.method === "GET" && req.url === "/v1/default/banks/test-bank/entities/entity-1") {
+        sendJson(res, 200, { id: "entity-1", text: "Alice" });
+        return;
+      }
+      if (
+        req.method === "POST" &&
+        req.url === "/v1/default/banks/test-bank/entities/entity-1/regenerate"
+      ) {
+        sendJson(res, 202, { operation_id: "entity-op" });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url ===
+          "/v1/default/banks/test-bank/graph?type=world&q=alice&limit=7&tags=source%3Api&tags_match=any&document_id=doc-1&chunk_id=chunk-1"
+      ) {
+        sendJson(res, 200, { nodes: [{ id: "entity-1" }], edges: [] });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url === "/v1/default/banks/test-bank/entities/graph?limit=4&min_count=2"
+      ) {
+        sendJson(res, 200, { nodes: [{ id: "entity-1" }] });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url === "/v1/default/banks/test-bank/tags?q=source&source=memories&limit=5&offset=2"
+      ) {
+        sendJson(res, 200, { items: [{ tag: "source:pi" }] });
+        return;
+      }
+      if (req.method === "PATCH" && req.url === "/v1/default/banks/test-bank") {
+        sendJson(res, 200, { bank_id: "test-bank", name: "Updated" });
+        return;
+      }
+      if (req.method === "PUT" && req.url === "/v1/default/banks/test-bank/profile") {
+        sendJson(res, 200, { disposition: { skepticism: 1, literalism: 2, empathy: 3 } });
+        return;
+      }
+      if (req.method === "POST" && req.url === "/v1/default/banks/test-bank/background") {
+        sendJson(res, 200, { updated: true });
+        return;
+      }
+      if (
+        req.method === "GET" &&
+        req.url ===
           "/v1/default/banks/test-bank/mental-models?tags=source%3Api&tags_match=all&detail=metadata&limit=10&offset=2"
       ) {
         sendJson(res, 200, { items: [{ id: "model-1", name: "Model" }] });
@@ -267,6 +335,49 @@ describe("Hindsight client adapter integration", () => {
       retain_custom_instructions: "Write to db",
     });
     const bankConfigReset = await client.resetBankConfig?.("test-bank");
+    const documents = await client.listDocuments?.("test-bank", {
+      q: "session",
+      tags: ["source:pi"],
+      tagsMatch: "all",
+      limit: 5,
+      offset: 1,
+    });
+    const document = await client.getDocument?.("test-bank", "doc-1");
+    const updatedDocument = await client.updateDocument?.("test-bank", "doc-1", {
+      tags: ["updated"],
+    });
+    const entities = await client.listEntities?.("test-bank", { limit: 5, offset: 1 });
+    const entity = await client.getEntity?.("test-bank", "entity-1");
+    const regeneratedEntity = await client.regenerateEntity?.("test-bank", "entity-1");
+    const graph = await client.getGraph?.("test-bank", {
+      type: "world",
+      q: "alice",
+      limit: 7,
+      tags: ["source:pi"],
+      tagsMatch: "any",
+      documentId: "doc-1",
+      chunkId: "chunk-1",
+    });
+    const entityGraph = await client.getEntityGraph?.("test-bank", { limit: 4, minCount: 2 });
+    const tags = await client.listTags?.("test-bank", {
+      q: "source",
+      source: "memories",
+      limit: 5,
+      offset: 2,
+    });
+    const bankProfileUpdate = await client.updateBankProfile?.("test-bank", {
+      name: "Updated",
+      reflectMission: "Reflect precisely",
+    });
+    const dispositionUpdate = await client.updateBankDisposition?.("test-bank", {
+      skepticism: 1,
+      literalism: 2,
+      empathy: 3,
+    });
+    const backgroundUpdate = await client.addBankBackground?.("test-bank", {
+      content: "Background",
+      updateDisposition: true,
+    });
     const models = await client.listMentalModels?.("test-bank", {
       tags: ["source:pi"],
       tagsMatch: "all",
@@ -322,6 +433,20 @@ describe("Hindsight client adapter integration", () => {
     expect(bankConfig).toEqual({ config: { retain_custom_instructions: "Read from db" } });
     expect(bankConfigUpdate).toEqual({ updated: true });
     expect(bankConfigReset).toEqual({ reset: true });
+    expect(documents).toEqual({ items: [{ id: "doc-1", tags: ["source:pi"] }] });
+    expect(document).toEqual({ id: "doc-1", content: "doc" });
+    expect(updatedDocument).toEqual({ id: "doc-1", tags: ["updated"] });
+    expect(entities).toEqual({ items: [{ id: "entity-1", text: "Alice" }] });
+    expect(entity).toEqual({ id: "entity-1", text: "Alice" });
+    expect(regeneratedEntity).toEqual({ operation_id: "entity-op" });
+    expect(graph).toEqual({ nodes: [{ id: "entity-1" }], edges: [] });
+    expect(entityGraph).toEqual({ nodes: [{ id: "entity-1" }] });
+    expect(tags).toEqual({ items: [{ tag: "source:pi" }] });
+    expect(bankProfileUpdate).toEqual({ bank_id: "test-bank", name: "Updated" });
+    expect(dispositionUpdate).toEqual({
+      disposition: { skepticism: 1, literalism: 2, empathy: 3 },
+    });
+    expect(backgroundUpdate).toEqual({ updated: true });
     expect(models).toEqual({ items: [{ id: "model-1", name: "Model" }] });
     expect(model).toEqual({ id: "model-1", name: "Model", content: "full" });
     expect(createdModel).toEqual({ operation_id: "create-op", status: "queued" });
@@ -348,6 +473,18 @@ describe("Hindsight client adapter integration", () => {
       "GET /v1/default/banks/test-bank/config",
       "PATCH /v1/default/banks/test-bank/config",
       "DELETE /v1/default/banks/test-bank/config",
+      "GET /v1/default/banks/test-bank/documents?q=session&tags=source%3Api&tags_match=all&limit=5&offset=1",
+      "GET /v1/default/banks/test-bank/documents/doc-1",
+      "PATCH /v1/default/banks/test-bank/documents/doc-1",
+      "GET /v1/default/banks/test-bank/entities?limit=5&offset=1",
+      "GET /v1/default/banks/test-bank/entities/entity-1",
+      "POST /v1/default/banks/test-bank/entities/entity-1/regenerate",
+      "GET /v1/default/banks/test-bank/graph?type=world&q=alice&limit=7&tags=source%3Api&tags_match=any&document_id=doc-1&chunk_id=chunk-1",
+      "GET /v1/default/banks/test-bank/entities/graph?limit=4&min_count=2",
+      "GET /v1/default/banks/test-bank/tags?q=source&source=memories&limit=5&offset=2",
+      "PATCH /v1/default/banks/test-bank",
+      "PUT /v1/default/banks/test-bank/profile",
+      "POST /v1/default/banks/test-bank/background",
       "GET /v1/default/banks/test-bank/mental-models?tags=source%3Api&tags_match=all&detail=metadata&limit=10&offset=2",
       "GET /v1/default/banks/test-bank/mental-models/model-1?detail=full",
       "POST /v1/default/banks/test-bank/mental-models",
@@ -418,12 +555,21 @@ describe("Hindsight client adapter integration", () => {
     expect(requests[15]?.body).toEqual({
       updates: { retain_custom_instructions: "Write to db" },
     });
-    expect(requests[19]?.body).toEqual({
+    expect(requests[19]?.body).toEqual({ tags: ["updated"] });
+    expect(requests[26]?.body).toEqual({
+      name: "Updated",
+      reflect_mission: "Reflect precisely",
+    });
+    expect(requests[27]?.body).toEqual({
+      disposition: { skepticism: 1, literalism: 2, empathy: 3 },
+    });
+    expect(requests[28]?.body).toEqual({ content: "Background", update_disposition: true });
+    expect(requests[31]?.body).toEqual({
       name: "Model",
       source_query: "What should recur?",
       tags: ["source:pi"],
       max_tokens: 256,
     });
-    expect(requests[20]?.body).toEqual({ source_query: "Updated query", tags: null });
+    expect(requests[32]?.body).toEqual({ source_query: "Updated query", tags: null });
   });
 });

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assertHealthResponse,
   assertReflectResponse,
+  bankBackgroundPath,
   bankConfigPath,
+  bankProfilePath,
   bankTemplateExportPath,
   bankTemplateImportPath,
   bankTemplateSchemaPath,
@@ -10,9 +12,16 @@ import {
   createDirectiveRequestBody,
   createHindsightRestTransport,
   createMentalModelRequestBody,
+  documentItemPath,
+  documentsCollectionPath,
   directiveItemPath,
   directivesCollectionPath,
   encodeBankPath,
+  entitiesCollectionPath,
+  entityGraphPath,
+  entityItemPath,
+  entityRegeneratePath,
+  graphPath,
   mentalModelCollectionPath,
   mentalModelHistoryPath,
   mentalModelItemPath,
@@ -26,8 +35,11 @@ import {
   operationRetryPath,
   operationsCollectionPath,
   reflectRequestBody,
+  tagsCollectionPath,
   updateBankConfigRequestBody,
+  updateBankProfileRequestBody,
   updateDirectiveRequestBody,
+  updateDocumentRequestBody,
   updateMentalModelRequestBody,
 } from "../extensions/client-rest.js";
 
@@ -139,6 +151,60 @@ describe("Hindsight REST transport helpers", () => {
       "/v1/default/banks/bank%2Fid/memories/mem%2Fid/observations",
     );
     expect(chunkItemPath("chunk/id")).toBe("/v1/default/chunks/chunk%2Fid");
+  });
+
+  it("maps document/entity/graph/tag/bank profile REST helpers", () => {
+    expect(
+      documentsCollectionPath("bank/id", {
+        q: "needle",
+        tags: ["source:pi", "repo:x"],
+        tagsMatch: "all_strict",
+        limit: 10,
+        offset: 5,
+      }),
+    ).toBe(
+      "/v1/default/banks/bank%2Fid/documents?q=needle&tags=source%3Api&tags=repo%3Ax&tags_match=all_strict&limit=10&offset=5",
+    );
+    expect(documentItemPath("bank/id", "doc/id")).toBe(
+      "/v1/default/banks/bank%2Fid/documents/doc%2Fid",
+    );
+    expect(updateDocumentRequestBody({ tags: ["one"] })).toEqual({ tags: ["one"] });
+    expect(entitiesCollectionPath("bank/id", { limit: 3, offset: 2 })).toBe(
+      "/v1/default/banks/bank%2Fid/entities?limit=3&offset=2",
+    );
+    expect(entityItemPath("bank/id", "entity/id")).toBe(
+      "/v1/default/banks/bank%2Fid/entities/entity%2Fid",
+    );
+    expect(entityRegeneratePath("bank/id", "entity/id")).toBe(
+      "/v1/default/banks/bank%2Fid/entities/entity%2Fid/regenerate",
+    );
+    expect(
+      graphPath("bank/id", {
+        type: "person",
+        q: "alice",
+        limit: 7,
+        tags: ["source:pi"],
+        tagsMatch: "any_strict",
+        documentId: "doc/id",
+        chunkId: "chunk/id",
+      }),
+    ).toBe(
+      "/v1/default/banks/bank%2Fid/graph?type=person&q=alice&limit=7&tags=source%3Api&tags_match=any_strict&document_id=doc%2Fid&chunk_id=chunk%2Fid",
+    );
+    expect(entityGraphPath("bank/id", { limit: 9, minCount: 2 })).toBe(
+      "/v1/default/banks/bank%2Fid/entities/graph?limit=9&min_count=2",
+    );
+    expect(tagsCollectionPath("bank/id", { q: "source", source: "memories", limit: 4 })).toBe(
+      "/v1/default/banks/bank%2Fid/tags?q=source&source=memories&limit=4",
+    );
+    expect(bankProfilePath("bank/id")).toBe("/v1/default/banks/bank%2Fid/profile");
+    expect(bankBackgroundPath("bank/id")).toBe("/v1/default/banks/bank%2Fid/background");
+    expect(
+      updateBankProfileRequestBody({ reflectMission: "Reflect", retainMission: null }),
+    ).toEqual({
+      reflect_mission: "Reflect",
+      retain_mission: null,
+    });
   });
 
   it("maps mental model paths and query options to Hindsight REST shape", () => {

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -42,6 +42,19 @@ function client(): HindsightLikeClient {
     getChunk: async () => ({ id: "chunk" }),
     getMemoryHistory: async () => ({ items: [] }),
     deleteMemoryObservations: async () => ({ deleted: true }),
+    listDocuments: async () => ({ items: [] }),
+    getDocument: async () => ({ id: "document" }),
+    updateDocument: async () => ({ id: "document", tags: [] }),
+    listEntities: async () => ({ items: [] }),
+    getEntity: async () => ({ id: "entity" }),
+    regenerateEntity: async () => ({ id: "entity", status: "queued" }),
+    getGraph: async () => ({ nodes: [], edges: [] }),
+    getEntityGraph: async () => ({ nodes: [], edges: [] }),
+    listTags: async () => ({ items: [] }),
+    getBankProfile: async () => ({ id: "bank" }),
+    updateBankProfile: async () => ({ id: "bank" }),
+    updateBankDisposition: async () => ({ id: "bank", disposition: {} }),
+    addBankBackground: async () => ({ id: "bank", background: "added" }),
   };
 }
 
@@ -433,6 +446,58 @@ describe("operation catalog", () => {
           calls.push({ method: "deleteMemoryObservations", bank, memoryId });
           return { deleted: true };
         },
+        listDocuments: async (bank, options) => {
+          calls.push({ method: "listDocuments", bank, options });
+          return { items: [{ id: "doc-1", tags: ["source:pi"] }] };
+        },
+        getDocument: async (bank, documentId) => {
+          calls.push({ method: "getDocument", bank, documentId });
+          return { id: documentId };
+        },
+        updateDocument: async (bank, documentId, request) => {
+          calls.push({ method: "updateDocument", bank, documentId, request });
+          return { id: documentId, tags: request.tags };
+        },
+        listEntities: async (bank, options) => {
+          calls.push({ method: "listEntities", bank, options });
+          return { items: [{ id: "entity-1", text: "Alice" }] };
+        },
+        getEntity: async (bank, entityId) => {
+          calls.push({ method: "getEntity", bank, entityId });
+          return { id: entityId };
+        },
+        regenerateEntity: async (bank, entityId) => {
+          calls.push({ method: "regenerateEntity", bank, entityId });
+          return { id: entityId, status: "queued" };
+        },
+        getGraph: async (bank, options) => {
+          calls.push({ method: "getGraph", bank, options });
+          return { nodes: [], edges: [] };
+        },
+        getEntityGraph: async (bank, options) => {
+          calls.push({ method: "getEntityGraph", bank, options });
+          return { nodes: [], edges: [] };
+        },
+        listTags: async (bank, options) => {
+          calls.push({ method: "listTags", bank, options });
+          return { items: [{ tag: "source:pi", count: 1 }] };
+        },
+        getBankProfile: async (bank) => {
+          calls.push({ method: "getBankProfile", bank });
+          return { id: bank };
+        },
+        updateBankProfile: async (bank, request) => {
+          calls.push({ method: "updateBankProfile", bank, request });
+          return { id: bank, ...request };
+        },
+        updateBankDisposition: async (bank, disposition) => {
+          calls.push({ method: "updateBankDisposition", bank, disposition });
+          return { id: bank, disposition };
+        },
+        addBankBackground: async (bank, request) => {
+          calls.push({ method: "addBankBackground", bank, request });
+          return { id: bank, ...request };
+        },
       }),
       getConfig: () => DEFAULT_CONFIG,
       getProjectBankId: () => "project-bank",
@@ -495,6 +560,97 @@ describe("operation catalog", () => {
       () => undefined,
       ctx,
     );
+    await requireTool(catalog, "hindsight_list_documents").execute(
+      "call",
+      { tags: ["source:pi"], tagsMatch: "all_strict", limit: 2, offset: 1 },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_get_document").execute(
+      "call",
+      { documentId: "doc-1" },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_update_document_tags").execute(
+      "call",
+      { documentId: "doc-1", tags: ["source:pi", "repo:x"], confirm: true },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_list_entities").execute(
+      "call",
+      { limit: 3, offset: 0 },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_get_entity").execute(
+      "call",
+      { entityId: "entity-1" },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_regenerate_entity").execute(
+      "call",
+      { entityId: "entity-1", confirm: true },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_get_graph").execute(
+      "call",
+      { type: "world", q: "Alice", limit: 4, tags: ["source:pi"], tagsMatch: "any_strict" },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_get_entity_graph").execute(
+      "call",
+      { limit: 5, minCount: 2 },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_list_tags").execute(
+      "call",
+      { source: "memories", limit: 6 },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_get_bank_profile").execute(
+      "call",
+      {},
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_update_bank_profile").execute(
+      "call",
+      { reflectMission: "Use evidence", confirm: true },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_update_bank_disposition").execute(
+      "call",
+      { skepticism: 3, literalism: 4, empathy: 5, confirm: true },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
+    await requireTool(catalog, "hindsight_add_bank_background").execute(
+      "call",
+      { content: "Project background", updateDisposition: false, confirm: true },
+      new AbortController().signal,
+      () => undefined,
+      ctx,
+    );
 
     expect(calls).toEqual([
       {
@@ -513,6 +669,53 @@ describe("operation catalog", () => {
       { method: "getChunk", chunkId: "chunk-1" },
       { method: "getMemoryHistory", bank: "project-bank", memoryId: "mem-1" },
       { method: "deleteMemoryObservations", bank: "project-bank", memoryId: "mem-1" },
+      {
+        method: "listDocuments",
+        bank: "project-bank",
+        options: { tags: ["source:pi"], tagsMatch: "all_strict", limit: 2, offset: 1 },
+      },
+      { method: "getDocument", bank: "project-bank", documentId: "doc-1" },
+      {
+        method: "updateDocument",
+        bank: "project-bank",
+        documentId: "doc-1",
+        request: { tags: ["source:pi", "repo:x"] },
+      },
+      { method: "listEntities", bank: "project-bank", options: { limit: 3, offset: 0 } },
+      { method: "getEntity", bank: "project-bank", entityId: "entity-1" },
+      { method: "regenerateEntity", bank: "project-bank", entityId: "entity-1" },
+      {
+        method: "getGraph",
+        bank: "project-bank",
+        options: {
+          type: "world",
+          q: "Alice",
+          limit: 4,
+          tags: ["source:pi"],
+          tagsMatch: "any_strict",
+        },
+      },
+      { method: "getEntityGraph", bank: "project-bank", options: { limit: 5, minCount: 2 } },
+      { method: "listTags", bank: "project-bank", options: { source: "memories", limit: 6 } },
+      { method: "getBankProfile", bank: "project-bank" },
+      { method: "getBankProfile", bank: "project-bank" },
+      {
+        method: "updateBankProfile",
+        bank: "project-bank",
+        request: { reflectMission: "Use evidence" },
+      },
+      { method: "getBankProfile", bank: "project-bank" },
+      {
+        method: "updateBankDisposition",
+        bank: "project-bank",
+        disposition: { skepticism: 3, literalism: 4, empathy: 5 },
+      },
+      { method: "getBankProfile", bank: "project-bank" },
+      {
+        method: "addBankBackground",
+        bank: "project-bank",
+        request: { content: "Project background", updateDisposition: false },
+      },
     ]);
   });
 
@@ -553,6 +756,15 @@ describe("operation catalog", () => {
       "hindsight_retain_receipts",
       "hindsight_route_memory",
       "hindsight_delete_document",
+      "hindsight_list_documents",
+      "hindsight_get_document",
+      "hindsight_update_document_tags",
+      "hindsight_list_entities",
+      "hindsight_get_entity",
+      "hindsight_regenerate_entity",
+      "hindsight_get_graph",
+      "hindsight_get_entity_graph",
+      "hindsight_list_tags",
       "hindsight_list_operations",
       "hindsight_cancel_operation",
       "hindsight_retry_operation",
@@ -563,6 +775,10 @@ describe("operation catalog", () => {
       "hindsight_delete_memory_observations",
       "hindsight_configure",
       "hindsight_get_bank_config",
+      "hindsight_get_bank_profile",
+      "hindsight_update_bank_profile",
+      "hindsight_update_bank_disposition",
+      "hindsight_add_bank_background",
       "hindsight_reset_bank_config",
       "hindsight_list_directives",
       "hindsight_get_directive",

--- a/tests/tool-presenters.test.ts
+++ b/tests/tool-presenters.test.ts
@@ -3,11 +3,18 @@ import {
   createDirectiveToolResponse,
   deleteDirectiveToolResponse,
   exportBankTemplateToolResponse,
+  bankProfileToolResponse,
+  documentToolResponse,
+  entityToolResponse,
+  graphToolResponse,
   getBankTemplateSchemaToolResponse,
   getDirectiveToolResponse,
   listMemoriesToolResponse,
   listDirectivesToolResponse,
+  listDocumentsToolResponse,
+  listEntitiesToolResponse,
   listOperationsToolResponse,
+  listTagsToolResponse,
   operationToolResponse,
   updateDirectiveToolResponse,
 } from "../extensions/tool-presenters.js";
@@ -22,6 +29,7 @@ describe("tool presenters", () => {
         ],
       },
     });
+
     expect(list.content[0]?.text).toContain("Directives in bank: 1");
     expect(list.content[0]?.text).toContain("Rule (directive-1) · inactive · priority 3");
 
@@ -50,6 +58,66 @@ describe("tool presenters", () => {
         result: { deleted: true },
       }).content[0]?.text,
     ).toContain("Deleted directive directive-2 in bank.");
+  });
+
+  it("presents document/entity/graph/tag/profile inspection compactly", () => {
+    const documents = listDocumentsToolResponse({
+      bankId: "bank",
+      result: {
+        items: [
+          {
+            id: "doc-1",
+            tags: ["source:pi"],
+            document_metadata: { cwd: "/repo" },
+            memory_unit_count: 2,
+            created_at: "now",
+          },
+        ],
+      },
+    });
+    expect(documents.content[0]?.text).toContain("Documents in bank: 1");
+    expect(documents.content[0]?.text).toContain("doc-1 · tags=source:pi · metadata=cwd");
+    expect(documents.content[0]?.text).toContain("memories=2");
+
+    expect(
+      documentToolResponse("Document doc-1.", {
+        bankId: "bank",
+        documentId: "doc-1",
+        result: { id: "doc-1" },
+      }).content[0]?.text,
+    ).toContain("Document doc-1.");
+
+    expect(
+      listEntitiesToolResponse({
+        bankId: "bank",
+        result: {
+          items: [{ id: "entity-1", canonical_name: "Alice", type: "person", mention_count: 3 }],
+        },
+      }).content[0]?.text,
+    ).toContain("entity-1 · Alice · person · count=3");
+    expect(
+      entityToolResponse("Entity entity-1.", {
+        bankId: "bank",
+        entityId: "entity-1",
+        result: { id: "entity-1" },
+      }).content[0]?.text,
+    ).toContain("Entity entity-1.");
+    expect(
+      graphToolResponse("Graph.", {
+        bankId: "bank",
+        result: { nodes: [{ id: "n1" }], edges: [] },
+      }).content[0]?.text,
+    ).toContain("nodes=1; edges=0");
+    expect(
+      listTagsToolResponse({
+        bankId: "bank",
+        result: { items: [{ tag: "source:pi", count: 4 }] },
+      }).content[0]?.text,
+    ).toContain("source:pi · count=4");
+    expect(
+      bankProfileToolResponse("Profile.", { bankId: "bank", result: { id: "bank" } }).content[0]
+        ?.text,
+    ).toContain("Profile.");
   });
 
   it("presents operation and memory inspection summaries", () => {


### PR DESCRIPTION
## Summary

- Add Hindsight document inspection and tag-management tools.
- Add entity, graph, and tag exploration tools.
- Add bank profile, disposition, and background admin controls.
- Document safety boundaries and update generated surface references.

## Linked issue

- Closes #236
- Closes #242
- Closes #243

## Scope

- One maintainer-approved batch for related Hindsight admin/exploration tool parity.
- Keeps automatic recall and retain behavior unchanged.
- Adds no bank-wide destructive operation.
- Mutating or expensive tools require explicit `confirm`.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Local verification passed. PR CI fast check, coverage gate, TypeScript compiler fallback, CodeQL, dependency review passed. Configured live smoke failed once on delayed strict import recall visibility after other smoke phases passed; rerun requested after PR body fix.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds user-visible explicit Hindsight admin/exploration tools for documents, entities, graphs, tags, and bank profile/background controls.

## Risk and rollback

- Risk: new explicit admin tools call Hindsight REST endpoints and some mutate server state.
- Rollback/revert path: revert this PR to remove new tool registrations and REST helpers.

Mitigations: mutating/expensive operations require explicit `confirm`, no bank-wide destructive operation is added, request mapping follows current Hindsight OpenAPI/client types, and project reviewer found no request-shape blocker.

## Follow-ups

- None required for this slice. Optional future work: exact alias for `hindsight_regenerate_entity_observations`, `exclude_parents` graph filter, or tighter raw `details` truncation policy if users ask.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance-policy changes in this PR; AGENTS/CONTRIBUTING updates not needed.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Project reviewer ran before PR. Required new source files are tracked; local shepherd/reviewer logs are not tracked. Codex requested on current head.
