### PR TITLE
fix(security): redact setup error surfaces

### DIFF
--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -17,6 +17,7 @@ import type {
   UpdateDocumentRequest,
   UpdateMentalModelRequest,
 } from "./types.js";
+import { redactError } from "./sanitize.js";
 
 export interface HindsightRestTransport {
   request(path: string, init?: RequestInit): Promise<unknown>;
@@ -69,9 +70,8 @@ export function createHindsightRestTransport(config: ResolvedConfig): HindsightR
       const response = await fetch(`${baseUrl(config)}${path}`, { ...init, headers });
       const body = (await response.json().catch(() => undefined)) as unknown;
       if (!response.ok) {
-        const error = new Error(
-          `Hindsight request failed with status ${response.status}: ${JSON.stringify(body)}`,
-        ) as HindsightRestError;
+        const rawMessage = `Hindsight request failed with status ${response.status}: ${JSON.stringify(body)}`;
+        const error = new Error(redactError(rawMessage)) as HindsightRestError;
         error.status = response.status;
         error.body = body;
         throw error;

--- a/extensions/command-maintenance.ts
+++ b/extensions/command-maintenance.ts
@@ -9,6 +9,7 @@ import {
   sessionFile,
 } from "./command-utils.js";
 import { flushRetainQueueNotifyLevel, formatFlushRetainQueueResult } from "./flush-presenter.js";
+import { redactError } from "./sanitize.js";
 
 type Operations = ReturnType<typeof createMemoryOperations>;
 
@@ -56,7 +57,7 @@ export function maintenanceCommandOperations(operations: Operations): CommandOpe
             );
           } catch (error) {
             ctx.ui.notify(
-              `Hindsight last recall snapshot unreadable: ${(error as Error).message}`,
+              `Hindsight last recall snapshot unreadable: ${redactError(error)}`,
               "warning",
             );
           }

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { redactError } from "./sanitize.js";
 import {
   parseBankTemplateManifestJson,
   summarizeBankTemplateImportResult,
@@ -223,7 +224,7 @@ export async function editTemplateManifestForSetup(args: {
     try {
       manifest = updateBankTemplateField(manifest, field.id, value);
     } catch (error) {
-      args.ctx.ui.notify(error instanceof Error ? error.message : String(error), "warning");
+      args.ctx.ui.notify(redactError(error), "warning");
     }
   }
 }
@@ -428,7 +429,7 @@ async function maybeOfferMentalModelRefreshForSetup(args: {
       });
       refreshed.push(`${model.name}: ${operationSummary(result.result)}`);
     } catch (error) {
-      failed.push(`${model.name}: ${error instanceof Error ? error.message : String(error)}`);
+      failed.push(`${model.name}: ${redactError(error)}`);
     }
   }
   if (refreshed.length) {

--- a/extensions/memory-lifecycle-recall.ts
+++ b/extensions/memory-lifecycle-recall.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { recallForContext } from "./recall.js";
+import { redactError } from "./sanitize.js";
 import { writeLastRecallSnapshot } from "./recall-visibility.js";
 import { selectMemoryScopes } from "./memory-scope.js";
 import { getEffectiveSessionMemoryMode, readSessionMemoryMeta } from "./session-memory-meta.js";
@@ -111,7 +112,7 @@ export function createRecallTurnPolicy(deps: RecallTurnPolicyDeps): RecallTurnPo
           } catch (error) {
             deps.notify(
               runtime,
-              `Hindsight last recall snapshot write failed: ${(error as Error).message}`,
+              `Hindsight last recall snapshot write failed: ${redactError(error)}`,
               "warning",
             );
           }

--- a/extensions/setup-tui.ts
+++ b/extensions/setup-tui.ts
@@ -1,4 +1,5 @@
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import { redactError } from "./sanitize.js";
 import type { FieldId } from "./config-editing-model.js";
 import { createMemoryOperations, type MemoryOperationsDeps } from "./memory-operation-service.js";
 import { flushRetainQueueNotifyLevel, formatFlushRetainQueueResult } from "./flush-presenter.js";
@@ -89,7 +90,7 @@ export async function runHindsightSetupTui(
       } else
         await handleFieldEdit({ fieldId: action as FieldId, ctx, deps, config, projectBankId });
     } catch (error) {
-      ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+      ctx.ui.notify(redactError(error), "error");
     }
   }
 }

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -303,4 +303,25 @@ describe("Hindsight REST transport helpers", () => {
       message: 'Hindsight request failed with status 409: {"detail":"operation is not pending"}',
     });
   });
+
+  it("redacts secrets from REST error messages while preserving structured body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 401,
+        json: async () => ({ detail: "authorization: Bearer sk-testsecret1234567890" }),
+      })),
+    );
+    const transport = createHindsightRestTransport({
+      hindsight: { baseUrl: "http://hindsight.test/", apiKey: "secret", timeoutMs: 1000 },
+    } as never);
+
+    await expect(transport.request("/v1/default/banks/bank/profile")).rejects.toMatchObject({
+      status: 401,
+      body: { detail: "authorization: Bearer sk-testsecret1234567890" },
+      message:
+        'Hindsight request failed with status 401: {"detail":"authorization: [REDACTED] [REDACTED]"}',
+    });
+  });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { registerCommands } from "../extensions/commands.js";
+import { maintenanceCommandOperations } from "../extensions/command-maintenance.js";
 import { readSessionMemoryMeta, setSessionMemoryMode } from "../extensions/session-memory-meta.js";
 import type { HindsightLikeClient } from "../extensions/types.js";
 
@@ -155,6 +156,26 @@ describe("hindsight commands", () => {
       expect.stringContaining("Hindsight last recall snapshot unreadable"),
       "warning",
     );
+  });
+
+  it("redacts secrets from unreadable last recall snapshot errors", async () => {
+    const [operation] = maintenanceCommandOperations({
+      lastRecall: async () => {
+        throw new Error("failed to read api_key=supersecret123456");
+      },
+    } as never);
+    const ctx = {
+      cwd: mkdtempSync(join(tmpdir(), "pi-hindsight-commands-")),
+      ui: { notify: vi.fn(), setStatus: vi.fn() },
+      sessionManager: {},
+    };
+
+    await operation?.spec.handler("", ctx as never);
+
+    const message = ctx.ui.notify.mock.calls[0]?.[0] as string;
+    expect(message).toContain("Hindsight last recall snapshot unreadable");
+    expect(message).toContain("api_key=[REDACTED]");
+    expect(message).not.toContain("supersecret123456");
   });
 
   it("reports last recall snapshot summary", async () => {


### PR DESCRIPTION
## Summary

- Redact raw error displays with existing `redactError` in guided setup, setup TUI, last-recall snapshot read/write notifications, and REST fallback error messages.
- Preserve structured REST error bodies for programmatic handling while redacting only human-facing `Error.message` text.
- Add focused tests for REST error message redaction and last-recall command error redaction.

## Linked issue

- Closes #298

## Scope

- Error display/log redaction only for setup/guided setup/last recall/REST surfaces.
- No automatic retain/recall behavior changes.
- No release, namespace, or package changes.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped full matrix/package/pack/live smoke: this slice only redacts local error presentation and does not change release/package or memory-path behavior.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Users may see redacted secret-like substrings in setup, last-recall, and REST error messages instead of raw values.

## Risk and rollback

- Risk: Over-redaction may hide some diagnostic detail in human-facing error messages.
- Rollback/revert path: Revert this PR to restore prior raw error message display behavior.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance sync needed; this does not change contributor workflow or memory policy.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

No ADR conflicts. Pre-PR independent subagent review was not run because this child session has a higher-priority instruction not to launch subagents; local diff review and required checks passed.
