### PR TITLE
chore: migrate Pi package namespace

### DIFF
--- a/coding-plan.md
+++ b/coding-plan.md
@@ -565,7 +565,7 @@ Exit criteria:
 ### Extension skeleton
 
 ```ts
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import { registerCommands } from "./commands.js";
 import { registerTools } from "./tools.js";

--- a/docs-site/src/content/docs/development/package-verification.md
+++ b/docs-site/src/content/docs/development/package-verification.md
@@ -10,8 +10,10 @@ Supported runtime and package ranges are declared in `package.json` and enforced
 
 - Node.js: `>=24 <25`
 - npm: `>=11 <12`
-- Pi peer package: `@mariozechner/pi-coding-agent >=0.72.1 <0.73.0`
+- Pi peer packages: `@earendil-works/pi-coding-agent`, `@earendil-works/pi-agent-core`, and `@earendil-works/pi-tui` `>=0.74.0 <0.75.0`
 - TypeBox peer package: `typebox >=1.1.24 <2`
+
+Pi Hindsight versions with these peers require Pi packages from the `@earendil-works` scope. Older Pi installs that only provide the retired `@mariozechner` scope are no longer supported by this compatibility line.
 
 Keep this compatibility detail in maintainer docs instead of the README unless the install story changes.
 

--- a/docs-site/src/content/docs/development/package-verification.md
+++ b/docs-site/src/content/docs/development/package-verification.md
@@ -10,10 +10,10 @@ Supported runtime and package ranges are declared in `package.json` and enforced
 
 - Node.js: `>=24 <25`
 - npm: `>=11 <12`
-- Pi peer packages: `@earendil-works/pi-coding-agent`, `@earendil-works/pi-agent-core`, and `@earendil-works/pi-tui` `>=0.74.0 <0.75.0`
+- Pi peer packages: `@earendil-works/pi-coding-agent`, `@earendil-works/pi-agent-core`, and `@earendil-works/pi-tui` use `*` because Pi supplies runtime packages.
 - TypeBox peer package: `typebox >=1.1.24 <2`
 
-Pi Hindsight versions with these peers require Pi packages from the `@earendil-works` scope. Older Pi installs that only provide the retired `@mariozechner` scope are no longer supported by this compatibility line.
+Pi Hindsight versions with these peers require Pi packages from the `@earendil-works` scope and are tested locally against Pi `0.74.0` dev dependencies. Older Pi installs that only provide the retired `@mariozechner` scope are no longer supported by this compatibility line.
 
 Keep this compatibility detail in maintainer docs instead of the README unless the install story changes.
 

--- a/docs-site/src/content/docs/internal/coding-plan.md
+++ b/docs-site/src/content/docs/internal/coding-plan.md
@@ -567,7 +567,7 @@ Exit criteria:
 ### Extension skeleton
 
 ```ts
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 import { registerCommands } from "./commands.js";
 import { registerTools } from "./tools.js";

--- a/extensions/commands.ts
+++ b/extensions/commands.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { MemoryOperationsDeps } from "./memory-operation-service.js";
 import { createOperationCatalog } from "./operation-catalog.js";
 

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { redactError } from "./sanitize.js";
 import {
   parseBankTemplateManifestJson,

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerTools } from "./tools.js";
 import { registerCommands } from "./commands.js";
 import { createMemoryLifecycle } from "./memory-lifecycle.js";

--- a/extensions/memory-lifecycle-recall.ts
+++ b/extensions/memory-lifecycle-recall.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { recallForContext } from "./recall.js";
 import { redactError } from "./sanitize.js";
 import { writeLastRecallSnapshot } from "./recall-visibility.js";

--- a/extensions/memory-lifecycle-retain.ts
+++ b/extensions/memory-lifecycle-retain.ts
@@ -1,5 +1,5 @@
-import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { projectMessages } from "./messages.js";
 import { routeMemoryCandidate, type MemoryRouteDecision } from "./memory-router.js";
 import { enqueueRetainFromAgentEnd } from "./retain.js";

--- a/extensions/memory-lifecycle-runtime.ts
+++ b/extensions/memory-lifecycle-runtime.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { getSessionFile } from "./session.js";
 import { formatHindsightStatus, type HindsightActivity } from "./status.js";
 import type { ResolvedConfig } from "./types.js";

--- a/extensions/memory-lifecycle.ts
+++ b/extensions/memory-lifecycle.ts
@@ -1,4 +1,4 @@
-import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
 import { resolveConfig } from "./config.js";
 import { consumeLastConfigMigrationResults } from "./config-migration.js";
 import { deriveProjectBankId } from "./banking.js";

--- a/extensions/messages.ts
+++ b/extensions/messages.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ResolvedConfig } from "./types.js";
 
 function stringValue(value: unknown, fallback = ""): string {

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -1,5 +1,9 @@
 import { Type } from "typebox";
-import { defineTool, type ExtensionAPI, type ToolDefinition } from "@mariozechner/pi-coding-agent";
+import {
+  defineTool,
+  type ExtensionAPI,
+  type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
 import { importCommandOperations } from "./command-imports.js";
 import { maintenanceCommandOperations } from "./command-maintenance.js";
 import { sessionCommandOperations } from "./command-session.js";

--- a/extensions/recall.ts
+++ b/extensions/recall.ts
@@ -1,5 +1,5 @@
 import { basename } from "node:path";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type {
   HindsightLikeClient,
   RecallBlock,

--- a/extensions/retain-cursor.ts
+++ b/extensions/retain-cursor.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 
 export interface RetainCursorStore {
   sessions: Record<string, string[]>;

--- a/extensions/retain.ts
+++ b/extensions/retain.ts
@@ -1,4 +1,4 @@
-import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
 import type {
   HindsightCapabilities,
   HindsightLikeClient,

--- a/extensions/setup-flow.ts
+++ b/extensions/setup-flow.ts
@@ -1,4 +1,4 @@
-import { Key, matchesKey } from "@mariozechner/pi-tui";
+import { Key, matchesKey } from "@earendil-works/pi-tui";
 import type { ConfigEditingField, ConfigEditingTab } from "./config-editing-model.js";
 import type {
   SetupActionId,

--- a/extensions/setup-tui-actions.ts
+++ b/extensions/setup-tui-actions.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { ResolvedConfig } from "./types.js";
 import {
   buildConfigEditingFields,

--- a/extensions/setup-tui-facts.ts
+++ b/extensions/setup-tui-facts.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { ResolvedConfig } from "./types.js";
 import {
   buildConfigEditingTabs,

--- a/extensions/setup-tui-mental-models.ts
+++ b/extensions/setup-tui-mental-models.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { createMemoryOperations, type MemoryOperationsDeps } from "./memory-operation-service.js";
 import {
   mentalModelFromUnknown,

--- a/extensions/setup-tui-render.ts
+++ b/extensions/setup-tui-render.ts
@@ -1,5 +1,5 @@
-import { DynamicBorder } from "@mariozechner/pi-coding-agent";
-import { truncateToWidth, visibleWidth, type Component } from "@mariozechner/pi-tui";
+import { DynamicBorder } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth, type Component } from "@earendil-works/pi-tui";
 import type { ConfigEditingTab } from "./config-editing-model.js";
 import type { RetainReceipt } from "./retain-receipts.js";
 import {

--- a/extensions/setup-tui.ts
+++ b/extensions/setup-tui.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { redactError } from "./sanitize.js";
 import type { FieldId } from "./config-editing-model.js";
 import { createMemoryOperations, type MemoryOperationsDeps } from "./memory-operation-service.js";

--- a/extensions/tools.ts
+++ b/extensions/tools.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { MemoryOperationsDeps } from "./memory-operation-service.js";
 import { createOperationCatalog } from "./operation-catalog.js";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "@astrojs/starlight": "^0.38.5",
         "@commitlint/cli": "^20.5.2",
         "@commitlint/config-conventional": "^20.5.3",
-        "@mariozechner/pi-coding-agent": "0.72.1",
+        "@earendil-works/pi-agent-core": "0.74.0",
+        "@earendil-works/pi-coding-agent": "0.74.0",
+        "@earendil-works/pi-tui": "0.74.0",
         "@mermaid-js/layout-elk": "^0.2.1",
         "@types/node": "^24.12.2",
         "@typescript/native-preview": "7.0.0-dev.20260426.1",
@@ -38,7 +40,9 @@
         "npm": ">=11 <12"
       },
       "peerDependencies": {
-        "@mariozechner/pi-coding-agent": ">=0.72.1 <0.73.0",
+        "@earendil-works/pi-agent-core": ">=0.74.0 <0.75.0",
+        "@earendil-works/pi-coding-agent": ">=0.74.0 <0.75.0",
+        "@earendil-works/pi-tui": ">=0.74.0 <0.75.0",
         "typebox": ">=1.1.24 <2"
       }
     },
@@ -427,9 +431,9 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1041.0.tgz",
-      "integrity": "sha512-1QehYO3jhdvNQ5mOKtwIiNV04y4aywaNZw9HzCp7SSYCX4yy+AGXc2hhYjCiMDUvQPIELuvbR8MXw81NGAj8ZQ==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1045.0.tgz",
+      "integrity": "sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -445,7 +449,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.38",
         "@aws-sdk/middleware-websocket": "^3.972.16",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/token-providers": "3.1045.0",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
@@ -648,6 +652,25 @@
         "@aws-sdk/core": "^3.974.8",
         "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -914,9 +937,9 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
-      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1045.0.tgz",
+      "integrity": "sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1645,6 +1668,115 @@
         "node": ">=14"
       }
     },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+      "integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.74.0",
+        "typebox": "^1.1.24"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+      "integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "^2.2.0",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.74.0.tgz",
+      "integrity": "sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.74.0",
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-tui": "^0.74.0",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "chalk": "^5.5.0",
+        "cli-highlight": "^2.1.11",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
+        "marked": "^15.0.12",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "strip-ansi": "^7.1.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.5"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
+      "integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime-types": "^2.1.4",
+        "chalk": "^5.5.0",
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
@@ -2148,9 +2280,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.51.0.tgz",
-      "integrity": "sha512-vTZZF3CSimN7cn2zsLpW2p5WF0eZa5Gz69ITMPCNHpPrDlAstOfGifSfi0p/s9Z9400f7xJRkgvkQNrcM7pJ6w==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3041,119 +3173,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.72.1.tgz",
-      "integrity": "sha512-Z5XH9mUDsBymh7Prtk5Eun4Cs+s9C3uzynug+oWAjzQESjjnCuy7KU6Ek8E9Eg+b9yroCwVw2ItLDxp2E3vYjA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/pi-ai": "^0.72.1",
-        "typebox": "^1.1.24"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.72.1.tgz",
-      "integrity": "sha512-mOq71Pjnu72xxzwrh52VIiNwt+/a+Wpa11k5segi01/zTZJt8eMDc5Q2z6GhczYMr5+6EpZ8T+BaeHqq0jk5ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "^2.2.0",
-        "chalk": "^5.6.2",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "proxy-agent": "^6.5.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.72.1.tgz",
-      "integrity": "sha512-gKApiLfAYpvPnWThvwXrLjZIhsziSSUKBph7DHCy/1IomuIGN1MTxS/9ZtcuFqPy3/+VfEUOKegGlY6m+CRNlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.72.1",
-        "@mariozechner/pi-ai": "^0.72.1",
-        "@mariozechner/pi-tui": "^0.72.1",
-        "@silvia-odwyer/photon-node": "^0.3.4",
-        "chalk": "^5.5.0",
-        "cli-highlight": "^2.1.11",
-        "diff": "^8.0.2",
-        "extract-zip": "^2.0.1",
-        "file-type": "^21.1.1",
-        "glob": "^13.0.1",
-        "hosted-git-info": "^9.0.2",
-        "ignore": "^7.0.5",
-        "marked": "^15.0.12",
-        "minimatch": "^10.2.3",
-        "proper-lockfile": "^4.1.2",
-        "strip-ansi": "^7.1.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "uuid": "^14.0.0",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.5"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui": {
-      "version": "0.72.1",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.72.1.tgz",
-      "integrity": "sha512-KjeqzMQp4vafomfkvI8HKv5/52PqRP5BmlowGC8WKyOaB+u0UkkTdfM5U1Ui3ty2gA7FOfglVRiyvcitiWwvMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime-types": "^2.1.4",
-        "chalk": "^5.5.0",
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12",
-        "mime-types": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -8575,9 +8594,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
       "dev": true,
       "funding": [
         {
@@ -10059,9 +10078,9 @@
       }
     },
     "node_modules/koffi": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
-      "integrity": "sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
+      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -13422,9 +13441,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "dev": true,
       "funding": [
         {
@@ -14713,19 +14732,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
         "npm": ">=11 <12"
       },
       "peerDependencies": {
-        "@earendil-works/pi-agent-core": ">=0.74.0 <0.75.0",
-        "@earendil-works/pi-coding-agent": ">=0.74.0 <0.75.0",
-        "@earendil-works/pi-tui": ">=0.74.0 <0.75.0",
+        "@earendil-works/pi-agent-core": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
         "typebox": ">=1.1.24 <2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -94,9 +94,9 @@
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
-    "@earendil-works/pi-agent-core": ">=0.74.0 <0.75.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0 <0.75.0",
-    "@earendil-works/pi-tui": ">=0.74.0 <0.75.0",
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
     "typebox": ">=1.1.24 <2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,9 @@
     "@astrojs/starlight": "^0.38.5",
     "@commitlint/cli": "^20.5.2",
     "@commitlint/config-conventional": "^20.5.3",
-    "@mariozechner/pi-coding-agent": "0.72.1",
+    "@earendil-works/pi-agent-core": "0.74.0",
+    "@earendil-works/pi-coding-agent": "0.74.0",
+    "@earendil-works/pi-tui": "0.74.0",
     "@mermaid-js/layout-elk": "^0.2.1",
     "@types/node": "^24.12.2",
     "@typescript/native-preview": "7.0.0-dev.20260426.1",
@@ -92,7 +94,9 @@
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": ">=0.72.1 <0.73.0",
+    "@earendil-works/pi-agent-core": ">=0.74.0 <0.75.0",
+    "@earendil-works/pi-coding-agent": ">=0.74.0 <0.75.0",
+    "@earendil-works/pi-tui": ">=0.74.0 <0.75.0",
     "typebox": ">=1.1.24 <2"
   },
   "engines": {

--- a/tests/best-practices.test.ts
+++ b/tests/best-practices.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { buildRetainJob } from "../extensions/retain.js";
 import { selectMemoryScopes } from "../extensions/memory-scope.js";

--- a/tests/golden-memory-stability.test.ts
+++ b/tests/golden-memory-stability.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { createMemoryOperations } from "../extensions/memory-operation-service.js";
 import { createRetainTurnPolicy } from "../extensions/memory-lifecycle-retain.js";

--- a/tests/import-recall-roundtrip.test.ts
+++ b/tests/import-recall-roundtrip.test.ts
@@ -2,7 +2,7 @@ import { mkdirSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { createMemoryOperations } from "../extensions/memory-operation-service.js";
 import { createRetainTurnPolicy } from "../extensions/memory-lifecycle-retain.js";

--- a/tests/recall-format.test.ts
+++ b/tests/recall-format.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { composeRecallQuery, recallForContext, renderRecallBlocks } from "../extensions/recall.js";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 
 describe("recall formatting", () => {
   it("builds query from recent user messages", () => {

--- a/tests/recall-quality-fixtures.test.ts
+++ b/tests/recall-quality-fixtures.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { filterRecallQuality } from "../extensions/recall-quality-policy.js";
 import { recallForContext, renderRecallBlocks } from "../extensions/recall.js";

--- a/tests/recall-query-quality.test.ts
+++ b/tests/recall-query-quality.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { composeRecallQuery } from "../extensions/recall.js";
 
 describe("recall query quality", () => {

--- a/tests/retain.test.ts
+++ b/tests/retain.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { buildRetainJob } from "../extensions/retain.js";
-import type { AgentEndEvent } from "@mariozechner/pi-coding-agent";
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
 
 describe("buildRetainJob", () => {
   it("stores structured JSON with append mode and context", () => {


### PR DESCRIPTION
## Summary

- Migrated Pi imports from `@mariozechner` to `@earendil-works` for coding-agent, agent-core, and TUI APIs used by this package.
- Updated `package.json` peers/dev dependencies and `package-lock.json` to Pi `0.74.0` under the new scope.
- Documented the compatibility cut line: this Pi Hindsight version requires `@earendil-works` Pi packages `>=0.74.0 <0.75.0`; older Pi installs that only provide `@mariozechner` are no longer supported.

## Linked issue

- Closes #310

## Scope

- Package dependency and lockfile migration for the Pi packages directly imported by this repo.
- Source, test, and docs import/reference migration from `@mariozechner/pi-*` to `@earendil-works/pi-*`.
- Package verification docs update for the new compatibility line.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [x] package verification requested/passed (release/package changes or `ci:package`)
- [x] `npm run pack:verify` (release/package changes)
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Additional verification:

- `npm run audit:signatures`
- `npm info @earendil-works/pi-ai version` -> `0.74.0`
- `npm info @earendil-works/pi-agent-core version` -> `0.74.0`
- `npm info @earendil-works/pi-coding-agent version` -> `0.74.0`
- `npm info @earendil-works/pi-tui version` -> `0.74.0`
- `npm info @earendil-works/pi-web-ui version` -> `0.74.0`
- `npm ls @earendil-works/pi-coding-agent @earendil-works/pi-agent-core @earendil-works/pi-tui @earendil-works/pi-ai @earendil-works/pi-web-ui --depth=0`
- `grep -R "@mariozechner/pi-" -n --exclude-dir=node_modules .` found no remaining old Pi package imports.

## Release impact

Check exactly one:

- [ ] No release impact
- [ ] User-visible change
- [x] Package/release path change

This is a breaking compatibility cut for Pi runtime packages: new pi-hindsight releases from this line require Pi packages in the `@earendil-works` scope at `>=0.74.0 <0.75.0`. Older Pi installs that only provide `@mariozechner` are no longer supported by this version. Release PR #302 will pick up this impact after merge.

## Risk and rollback

- Risk: Users on older Pi packages will not satisfy the new peer dependency range and imports will not resolve under the retired scope.
- Rollback/revert path: Revert this PR to restore the previous `@mariozechner` peer/import surface and lockfile state.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No source-of-truth order, contributor workflow, verification expectation, memory policy, or definition-of-done change is included; only package compatibility docs changed.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Full matrix was not requested because this is not a release PR, manual full-CI dispatch, or platform-sensitive change. Nested reviewer subagent was not launched because this session is already a child subagent and is instructed not to run subagents; I performed an evidence-backed self-review using diff inspection, old-scope grep, npm package availability checks, dependency tree checks, and the verification commands listed above.
