### PR TITLE
ci: publish releases from Release Please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -20,7 +21,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@v4
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Check out release commit
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js for trusted publishing
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        run: npm ci --engine-strict
+
+      - name: Publish package to npm
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        run: npm publish --provenance --access public

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,6 +43,26 @@ jobs:
         if: ${{ steps.release.outputs.release_created == 'true' }}
         run: npm ci --engine-strict
 
+      - name: Run checks
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        run: npm run check
+
+      - name: Run coverage gate
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        run: npm run check:coverage
+
+      - name: Run TypeScript compiler fallback
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        run: npm run typecheck:tsc
+
+      - name: Verify registry signatures
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        run: npm run audit:signatures
+
+      - name: Verify release metadata and package install
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        run: npm run pack:verify
+
       - name: Publish package to npm
         if: ${{ steps.release.outputs.release_created == 'true' }}
         run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,9 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
   schedule:
     - cron: "23 4 * * *"
   workflow_dispatch:
-    inputs:
-      publish:
-        description: Publish to npm after verification
-        required: false
-        default: "false"
-        type: choice
-        options:
-          - "false"
-          - "true"
 
 permissions:
   contents: read
@@ -58,25 +46,3 @@ jobs:
       - name: Verify release metadata and package install
         if: matrix.os == 'ubuntu-latest'
         run: npm run pack:verify
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: verify
-    if: >-
-      startsWith(github.ref, 'refs/tags/v') ||
-      (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: npm
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: npm ci --engine-strict
-
-      - name: Publish package
-        run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: "23 4 * * *"
   workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish to npm after verification
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 permissions:
   contents: read
@@ -46,3 +55,23 @@ jobs:
       - name: Verify release metadata and package install
         if: matrix.os == 'ubuntu-latest'
         run: npm run pack:verify
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: verify
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == 'true' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci --engine-strict
+
+      - name: Publish package
+        run: npm publish --provenance --access public

--- a/tests/verify-release.test.mjs
+++ b/tests/verify-release.test.mjs
@@ -9,6 +9,7 @@ const execFileAsync = promisify(execFile);
 const script = resolve("scripts/verify-release.mjs");
 const releasePleaseConfig = resolve(".release-please-config.json");
 const releaseWorkflow = resolve(".github/workflows/release.yml");
+const releasePleaseWorkflow = resolve(".github/workflows/release-please.yml");
 const testEnv = { ...process.env, GITHUB_REF_NAME: "", GITHUB_REF_TYPE: "" };
 
 async function repo(version, changelog) {
@@ -78,13 +79,17 @@ describe("verify-release", () => {
     });
   });
 
-  it("keeps release-please tag namespace aligned with release workflow", async () => {
+  it("keeps release-please publishing aligned with npm trusted publishing", async () => {
     const config = JSON.parse(await readFile(releasePleaseConfig, "utf8"));
-    const workflow = await readFile(releaseWorkflow, "utf8");
+    const release = await readFile(releaseWorkflow, "utf8");
+    const releasePlease = await readFile(releasePleaseWorkflow, "utf8");
 
     expect(config.packages["."]["package-name"]).toBe("@luxusai/pi-hindsight");
     expect(config.packages["."]["include-component-in-tag"]).toBe(false);
-    expect(workflow).toContain('- "v*.*.*"');
-    expect(workflow).not.toContain("pi-hindsight-v");
+    expect(releasePlease).toContain("id-token: write");
+    expect(releasePlease).toContain("steps.release.outputs.release_created == 'true'");
+    expect(releasePlease).toContain("npm publish --provenance --access public");
+    expect(release).not.toContain("npm publish");
+    expect(releasePlease).not.toContain("pi-hindsight-v");
   });
 });

--- a/tests/verify-release.test.mjs
+++ b/tests/verify-release.test.mjs
@@ -88,8 +88,16 @@ describe("verify-release", () => {
     expect(config.packages["."]["include-component-in-tag"]).toBe(false);
     expect(releasePlease).toContain("id-token: write");
     expect(releasePlease).toContain("steps.release.outputs.release_created == 'true'");
+    expect(releasePlease).toContain("npm run check");
+    expect(releasePlease).toContain("npm run check:coverage");
+    expect(releasePlease).toContain("npm run typecheck:tsc");
+    expect(releasePlease).toContain("npm run audit:signatures");
+    expect(releasePlease).toContain("npm run pack:verify");
     expect(releasePlease).toContain("npm publish --provenance --access public");
-    expect(release).not.toContain("npm publish");
+    expect(release).toContain(
+      "github.event_name == 'workflow_dispatch' && inputs.publish == 'true'",
+    );
+    expect(release).not.toContain("refs/tags/v");
     expect(releasePlease).not.toContain("pi-hindsight-v");
   });
 });


### PR DESCRIPTION
## Summary

- Publish npm from Release Please when a release is created, using npm Trusted Publishing/OIDC.
- Remove the unreliable tag-triggered publish path from the separate Release workflow.
- Update release verification coverage for the new workflow contract.

## Linked issue

- Closes #322

## Scope

- Focused CI/release workflow change only.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [x] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

## Release impact

Check exactly one:

- [ ] No release impact
- [ ] User-visible change
- [x] Package/release path change

Release notes impact: release automation changes only; no runtime package behavior change.

## Risk and rollback

- Risk: npm publish could fail if the npm trusted publisher workflow name is misconfigured.
- Rollback/revert path: revert this PR and manually publish or restore the old manual workflow path.

## Follow-ups

- None.

## Memory invariants

- [ ] Retain still stores raw rich content, not summaries.
- [ ] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [ ] Project Bank and Global Bank isolation is preserved.
- [ ] Retain Queue behavior remains queue-first and retry-safe.
- [ ] Debug output and sidecars remain opt-in and redacted.
- [ ] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [ ] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Skipped checks:

- `npm run check:coverage`: not run locally; PR CI coverage gate passed.
- `npm run typecheck:tsc`: not run locally; PR CI TypeScript compiler fallback passed.
- `npm run pack:verify`: not run locally; PR CI package verification passed.
- `npm run smoke:hindsight`: not run locally; Hindsight Integration passed and change does not touch memory runtime behavior.

Memory invariant checkboxes are intentionally not checked because this PR only changes release workflows and a release verification test.
