### PR TITLE
feat(client): adopt Hindsight client 0.6.1

### DIFF
--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -46,8 +46,9 @@ import {
 import { withTimeout } from "./timeout.js";
 
 type ReflectOptions = Parameters<HindsightLikeClient["reflect"]>[2];
+type RetainOptions = Parameters<HindsightLikeClient["retain"]>[2];
 
-function retainBatchItem(content: string, options: Parameters<HindsightLikeClient["retain"]>[2]) {
+function retainBatchItem(content: string, options: RetainOptions) {
   return {
     content,
     ...(options?.timestamp ? { timestamp: options.timestamp } : {}),
@@ -61,6 +62,25 @@ function retainBatchItem(content: string, options: Parameters<HindsightLikeClien
       : {}),
     ...(options?.updateMode ? { update_mode: options.updateMode } : {}),
   };
+}
+
+function retainSingle(
+  raw: HindsightClient,
+  bankId: string,
+  content: string,
+  options: RetainOptions,
+  signal: AbortSignal,
+) {
+  if (options?.documentTags?.length) {
+    return raw.retainBatch(bankId, [retainBatchItem(content, options)], {
+      ...(options.async !== undefined ? { async: options.async } : {}),
+      documentTags: options.documentTags,
+      signal,
+    });
+  }
+
+  const { documentTags: _documentTags, signal: _signal, ...retainOptions } = options ?? {};
+  return raw.retain(bankId, content, { ...retainOptions, signal });
 }
 
 async function reflect(
@@ -100,12 +120,7 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
       withTimeout(
         "hindsight retain",
         timeoutMs,
-        (signal) =>
-          raw.retainBatch(bankId, [retainBatchItem(content, options)], {
-            ...(options?.async !== undefined ? { async: options.async } : {}),
-            ...(options?.documentTags ? { documentTags: options.documentTags } : {}),
-            signal,
-          }),
+        (signal) => retainSingle(raw, bankId, content, options, signal),
         options?.signal,
       ),
     retainBatch: (...args) =>

--- a/extensions/status-health.ts
+++ b/extensions/status-health.ts
@@ -96,16 +96,20 @@ function formatStats(stats: unknown): string | undefined {
   const memories = numberField(stats, "total_nodes");
   const documents = numberField(stats, "total_documents");
   const observations = numberField(stats, "total_observations");
+  const facts = numberField(stats, "fact_count");
   const pending = numberField(stats, "pending_consolidation");
   const failed = numberField(stats, "failed_consolidation");
   const last = dateField(stats, "last_consolidated_at");
+  const lastDocument = dateField(stats, "last_document_at");
   const parts = [
     memories !== undefined ? `memories ${memories}` : undefined,
     documents !== undefined ? `docs ${documents}` : undefined,
     observations !== undefined ? `observations ${observations}` : undefined,
+    facts !== undefined ? `facts ${facts}` : undefined,
     pending !== undefined ? `pending ${pending}` : undefined,
     failed !== undefined ? `failed ${failed}` : undefined,
     last ? `last consolidated ${last}` : undefined,
+    lastDocument ? `last document ${lastDocument}` : undefined,
   ].filter(Boolean);
   return parts.length ? parts.join(" · ") : undefined;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@vectorize-io/hindsight-client": "^0.6.0",
+        "@vectorize-io/hindsight-client": "^0.6.1",
         "jsonc-parser": "^3.3.1"
       },
       "devDependencies": {
@@ -6044,9 +6044,9 @@
       }
     },
     "node_modules/@vectorize-io/hindsight-client": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.6.0.tgz",
-      "integrity": "sha512-Vp308C8XOE1Pd/bDiRW0wxVceJtB2y26GxrhLflv6jmQ0zq7EcRag3Oe2fXaf3YS+aOb2xpvIwZYGSEvov/d5Q==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.6.1.tgz",
+      "integrity": "sha512-MFe7jCoypRg2kXu1Yxmq/OWsX3hwXYjy+CM3bgXZYntVu9TVxSUNxhNdz3Do/bhZpI2wqh/XDcygAP8DzIMSIA==",
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "code-map:check": "node scripts/generate-code-map.mjs --check"
   },
   "dependencies": {
-    "@vectorize-io/hindsight-client": "^0.6.0",
+    "@vectorize-io/hindsight-client": "^0.6.1",
     "jsonc-parser": "^3.3.1"
   },
   "devDependencies": {

--- a/tests/client-adapter.test.ts
+++ b/tests/client-adapter.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+
+const mocks = vi.hoisted(() => ({
+  retain: vi.fn(async () => ({ accepted: true })),
+  retainBatch: vi.fn(async () => ({ accepted: true })),
+}));
+
+vi.mock("@vectorize-io/hindsight-client", () => ({
+  HindsightClient: vi.fn(() => ({
+    retain: mocks.retain,
+    retainBatch: mocks.retainBatch,
+  })),
+}));
+
+describe("Hindsight client adapter", () => {
+  beforeEach(() => {
+    mocks.retain.mockClear();
+    mocks.retainBatch.mockClear();
+  });
+
+  it("uses official retain for single memories when document tags are absent", async () => {
+    const { createHindsightClient } = await import("../extensions/client.js");
+    const client = createHindsightClient(DEFAULT_CONFIG);
+
+    await client.retain("bank", "content", {
+      context: "ctx",
+      documentId: "doc",
+      updateMode: "append",
+      observationScopes: [["repo:abc"]],
+      async: true,
+    });
+
+    expect(mocks.retain).toHaveBeenCalledWith(
+      "bank",
+      "content",
+      expect.objectContaining({
+        context: "ctx",
+        documentId: "doc",
+        updateMode: "append",
+        observationScopes: [["repo:abc"]],
+        async: true,
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(mocks.retainBatch).not.toHaveBeenCalled();
+  });
+
+  it("keeps retainBatch fallback when document tags are present", async () => {
+    const { createHindsightClient } = await import("../extensions/client.js");
+    const client = createHindsightClient(DEFAULT_CONFIG);
+
+    await client.retain("bank", "content", {
+      context: "ctx",
+      documentId: "doc",
+      documentTags: ["doc:tag"],
+      updateMode: "append",
+      observationScopes: [["repo:abc"]],
+      async: false,
+    });
+
+    expect(mocks.retain).not.toHaveBeenCalled();
+    expect(mocks.retainBatch).toHaveBeenCalledWith(
+      "bank",
+      [
+        expect.objectContaining({
+          content: "content",
+          context: "ctx",
+          document_id: "doc",
+          update_mode: "append",
+          observation_scopes: [["repo:abc"]],
+        }),
+      ],
+      expect.objectContaining({
+        async: false,
+        documentTags: ["doc:tag"],
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+});

--- a/tests/status-health.test.ts
+++ b/tests/status-health.test.ts
@@ -26,8 +26,10 @@ describe("status health", () => {
         total_nodes: 3,
         total_documents: 2,
         total_observations: 1,
+        fact_count: 5,
         pending_consolidation: 4,
         failed_consolidation: 0,
+        last_document_at: "2026-05-08T00:00:00Z",
       })),
     };
 
@@ -51,7 +53,10 @@ describe("status health", () => {
         ["Project bank config", "Bank overrides: 1 · Resolved config fields: 2"],
         ["User bank config", "Bank overrides: 1 · Resolved config fields: 2"],
         ["Project bank missions", "db · retain Override retain from db · reflect Reflect from db"],
-        ["Project bank stats", "memories 3 · docs 2 · observations 1 · pending 4 · failed 0"],
+        [
+          "Project bank stats",
+          "memories 3 · docs 2 · observations 1 · facts 5 · pending 4 · failed 0 · last document 2026-05-08T00:00:00Z",
+        ],
       ]),
     );
   });


### PR DESCRIPTION
## Summary

- Bump `@vectorize-io/hindsight-client` to `^0.6.1`.
- Use the official single-memory `retain()` path when document tags are absent, while keeping the `retainBatch()` fallback for `documentTags`.
- Surface `fact_count` and `last_document_at` when bank stats include the new Hindsight fields.

## Linked issue

- Closes #324

## Scope

- Focused client dependency and adapter cleanup.
- Adds focused adapter branch tests plus status-health coverage for new stats fields.
- Does not add a bank-list API surface because pi-hindsight has no bank-list presenter path today; it presents the new fields when the existing stats/status path receives them.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped: full matrix, package verification, and `npm run pack:verify` because this is not a release/package-path PR.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes: Hindsight client dependency updated to 0.6.1; status can display Hindsight fact count and last-document timestamps when returned by the server.

## Risk and rollback

- Risk: retain transport branch could differ for `documentTags` or scoped observations.
- Rollback/revert path: revert this PR to restore client 0.6.0 and the previous retainBatch-only single retain adapter.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance sync needed; source-of-truth order, workflows, memory policy, and definition of done are unchanged.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- Reviewer pass found no blockers. Non-blocking branch-test suggestion was addressed in `tests/client-adapter.test.ts`.
