### PR TITLE
docs: streamline install and import guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # Pi Hindsight Extension
 
-Persistent memory for [Pi](https://github.com/mariozechner/pi) backed by [Hindsight](https://hindsight.vectorize.io/).
+Persistent memory for [Pi](https://github.com/earendil-works/pi-coding-agent) backed by [Hindsight](https://hindsight.vectorize.io/).
 
 **Documentation:** <https://luxus.github.io/pi-hindsight/>
 
 Pi Hindsight recalls relevant project memory before model calls, retains structured session deltas after completed agent runs, and exposes explicit memory tools for direct retain/recall/reflect operations.
 
-The extension is inspired by [`noctuid/pi-hindsight`](https://github.com/noctuid/pi-hindsight). This version keeps the same useful idea, then tightens project isolation, queue durability, diagnostics, and release hardening.
-
 ## Install
 
-Install from GitHub:
+Install the published npm package:
+
+```bash
+pi install npm:@luxusai/pi-hindsight
+```
+
+You can still install from GitHub when you want the current repository source instead of the latest npm release:
 
 ```bash
 pi install https://github.com/luxus/pi-hindsight
 ```
 
-For local development, install a checkout path instead:
-
-```bash
-pi install /path/to/pi-hindsight
-```
-
 Package name: `@luxusai/pi-hindsight`.
+
+For local checkout installs, see [Development](#development).
 
 ## Quick start
 
@@ -39,7 +39,7 @@ See the [getting started guide](https://luxus.github.io/pi-hindsight/start/getti
 ## Safety defaults
 
 - Project memory stays in a project bank by default.
-- Global/user memory is opt-in and explicitly configured.
+- User memory is opt-in and explicitly configured.
 - Recall injection is ephemeral; recalled memory is not written back into transcripts.
 - Automatic retain redacts common secrets before writing memory.
 - Exact document deletion requires exact bank ID, exact document ID, and `confirm: true`.
@@ -69,4 +69,14 @@ Run Pi with the local extension:
 pi -e ./extensions/index.ts
 ```
 
+Install a local checkout into Pi when you need to test package loading from your working tree:
+
+```bash
+pi install /path/to/pi-hindsight
+```
+
 For maintainer details, see [Development setup](https://luxus.github.io/pi-hindsight/development/development/) and [Release process](https://luxus.github.io/pi-hindsight/development/release/).
+
+## Prior art
+
+Pi Hindsight is inspired by [`noctuid/pi-hindsight`](https://github.com/noctuid/pi-hindsight). This package keeps the same useful idea, then tightens project isolation, queue durability, diagnostics, and release hardening.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pi Hindsight Extension
 
-Persistent memory for [Pi](https://github.com/earendil-works/pi-coding-agent) backed by [Hindsight](https://hindsight.vectorize.io/).
+Persistent memory for [Pi](https://github.com/earendil-works/pi) backed by [Hindsight](https://hindsight.vectorize.io/).
 
 **Documentation:** <https://luxus.github.io/pi-hindsight/>
 

--- a/docs-site/src/content/docs/architecture/lifecycle-and-scope.md
+++ b/docs-site/src/content/docs/architecture/lifecycle-and-scope.md
@@ -14,7 +14,7 @@ Pi Hindsight maps documented Pi extension hooks to Hindsight memory operations.
 ## Scope boundaries
 
 - Project memory uses the selected Project Bank.
-- Optional user/global memory uses the configured Global/User Bank.
+- Optional user memory uses the configured User Bank.
 - Tags isolate recall and retain behavior.
 - Metadata records provenance but is not the filtering boundary.
 

--- a/docs-site/src/content/docs/concepts/imports.md
+++ b/docs-site/src/content/docs/concepts/imports.md
@@ -2,35 +2,41 @@
 title: "Historical Import"
 ---
 
-**Import** is the historical session ingestion path. It parses Pi JSONL sessions or gateway transcripts, builds deterministic source documents, queues Retain Jobs, and records manifests/checkpoints.
+Import is optional historical backfill. It is not required for live memory after setup.
 
-Import is not generic summarization. Curated import keeps filtered structured source material so Hindsight still receives evidence with provenance.
+Pi Hindsight has two import families:
+
+- **Pi session import** for project/coding sessions stored as Pi JSONL.
+- **Gateway transcript import** for user conversation history stored as gateway/chat transcript JSONL.
+
+The `/hindsight` guided setup flow can offer import after bank/template setup and previews before writing memory. Use the command and tool surfaces when you need repeatable or explicit-file imports.
+
+## What import writes
+
+Import builds deterministic source documents, sends them through Retain, and records local checkpoint/manifest state. The retained content is filtered structured source evidence, not a summary.
+
+Default files:
+
+```text
+.pi/hindsight/import-manifest.json
+.pi/hindsight/import-checkpoint.json
+```
 
 ## Quality vocabulary
 
 - **Durable signal**: raw source evidence worth keeping because it records facts, decisions, tasks, bugs, errors, verification, issues, PRs, commits, blockers, follow-ups, or workflow outcomes.
 - **Import noise**: transcript material that should not become source truth by default, such as streaming UI records, process/status chatter, repeated successful output, large file reads, and replay artifacts.
-- **Tool evidence**: tool output with memory value. Failed tool results are usually useful evidence when kept concise; large successful tool output is usually noise. Curated import defaults to `toolResults: "errors-only"`; use `summary` or `content` only for deliberate low-noise imports.
+- **Tool evidence**: tool output with memory value. Failed tool results are usually useful evidence when concise; large successful output is usually noise.
 - **Workflow signal**: project execution evidence such as issue selection, branch/PR/commit references, review decisions, CI/smoke checks, release gates, blockers, and follow-ups.
-- **Recall contamination**: retaining or importing prior Recall Blocks or Last-Recall artifacts as if they were new source evidence. Curated import and live retain must avoid it.
+- **Recall contamination**: retaining prior Recall Blocks or Last-Recall artifacts as if they were new source evidence.
 
 ## Modes
 
 - `curated`: default high-signal projection for normal historical imports.
-- `raw`: explicit raw branch import for compatibility/debugging.
-- `forensic`: raw-style import that preserves recalled memory blocks and other artifacts for audit use.
+- `raw`: compatibility/debug escape hatch.
+- `forensic`: audit/recovery mode that can preserve normally filtered artifacts.
 
-Raw and forensic modes preserve legacy document IDs and payload shape.
-
-## Profiles
-
-Setup-selected bank templates can inform import defaults:
-
-- coding/project template → repo-scoped Pi agent sessions
-- assistant/personal template → gateway/chat transcripts
-- general/user template → conversation/open-thread import
-
-Source types are explicit. Pi Hindsight does not silently mix repo sessions and gateway transcripts.
+Curated import defaults to failed-tool evidence only for tool output. Use successful-tool summaries/content only for deliberate low-noise imports.
 
 ## Dry-run first
 
@@ -39,3 +45,7 @@ Historical import should be previewed before writing. Dry-run reports include co
 ## Provenance
 
 Import records provenance in tags and metadata. Use tags for filtering and metadata for traceability back to source sessions, branches, conversations, and chunks.
+
+## More detail
+
+For task steps and command/tool examples, see [Importing sessions](/pi-hindsight/guides/importing-sessions/) and [Import controls reference](/pi-hindsight/reference/import-controls/).

--- a/docs-site/src/content/docs/concepts/index.mdx
+++ b/docs-site/src/content/docs/concepts/index.mdx
@@ -9,7 +9,7 @@ Concept pages explain how Pi Hindsight uses Hindsight without repeating command 
 
 <CardGrid>
   <Card title="Memory Banks" icon="laptop">
-    Project and Global/User Bank boundaries, scope isolation, and default bank policy.
+    Project Bank and User Bank boundaries, scope isolation, and default bank policy.
     [Read](./memory-banks/)
   </Card>
   <Card title="Retain, Recall, Reflect" icon="open-book">

--- a/docs-site/src/content/docs/guides/importing-sessions.md
+++ b/docs-site/src/content/docs/guides/importing-sessions.md
@@ -2,7 +2,7 @@
 title: "Importing Pi sessions"
 ---
 
-Historical import is optional backfill. It reads old Pi session JSONL files or gateway transcripts, writes deterministic Hindsight documents, and records checkpoint/manifest state so imports can resume safely.
+Historical import is optional backfill. It reads old Pi session JSONL files or gateway transcripts and writes deterministic Hindsight documents. Pi session imports also record checkpoint/manifest state so they can resume safely.
 
 Live memory does not need import. After setup, normal retain starts from new completed agent turns.
 

--- a/docs-site/src/content/docs/guides/importing-sessions.md
+++ b/docs-site/src/content/docs/guides/importing-sessions.md
@@ -2,28 +2,50 @@
 title: "Importing Pi sessions"
 ---
 
-Historical import is for seeding or rebuilding Hindsight memory from Pi session JSONL files.
+Historical import is optional backfill. It reads old Pi session JSONL files or gateway transcripts, writes deterministic Hindsight documents, and records checkpoint/manifest state so imports can resume safely.
+
+Live memory does not need import. After setup, normal retain starts from new completed agent turns.
+
+## Start with guided setup
+
+For first-time setup, prefer the `/hindsight` guided import prompt. It appears after config/template setup when import makes sense.
+
+Guided import:
+
+1. chooses the source type from the selected profile/template
+2. previews first
+3. shows counts and target bank
+4. asks before writing memory
+5. can refresh mental models after successful import
+
+Project/coding setup offers repo-scoped Pi session import. User/assistant setup offers gateway transcript import into User memory.
 
 ## What can be imported
 
-The extension supports:
+Pi Hindsight supports:
 
 - current Pi session
-- explicit JSONL session file
-- all repo-scoped JSONL sessions in the current session directory
-- explicit gateway/chat transcript JSONL files for user memory
+- explicit Pi session JSONL file
+- repo-scoped Pi sessions from the current session directory
+- explicit gateway/chat transcript JSONL files for User memory
 
-Pi session imports write deterministic document IDs and update an import manifest summarized in `/hindsight`. Gateway transcript imports use a separate explicit tool path and do not share the repo-session import flow.
+Pi session imports and gateway transcript imports are separate paths. They do not silently mix repo history with user conversation history.
 
-## Preview first
+## Use commands when you need control
 
-Preview imports before writing memory:
+Command shortcuts are useful after setup, for repeat imports, or for explicit files:
 
 ```text
 /hindsight:import-current --dry-run
 /hindsight:import-file /path/to/session.jsonl --dry-run
 /hindsight:import-project-sessions --dry-run
 ```
+
+If the preview looks right, rerun without `--dry-run`. Non-dry-run imports announce the start and require confirmation because they write memory plus local checkpoint/manifest files.
+
+Use `--all-leaves` only when you intentionally want every fork leaf from a session file. Default import follows the current branch.
+
+## Use tools for agent/script workflows
 
 Tool equivalents:
 
@@ -32,111 +54,48 @@ hindsight_import({ dryRun: true })
 hindsight_import_gateway({ sourceFile: "/path/to/gateway.jsonl", dryRun: true })
 ```
 
-Pi session preview output includes document count, import mode, raw message count, curated projection count, dropped non-error tool-result count, kept tool-error count, estimated chunk count, byte counts, update mode, target bank, checkpoint path, and manifest path. Curated projection metrics show likely import noise before writing the filtered structured source payload.
+`hindsight_import` targets Pi session JSONL. `hindsight_import_gateway` targets gateway/chat transcript JSONL and defaults to the configured User Bank.
 
-Gateway preview output includes kept event count, retained user-turn count, dropped event count/type totals, malformed-line count, target user bank, content hash, and byte count.
+## Preview output
 
-## Guided setup import prompt
+Pi session dry-run shows document count, import mode/profile, raw and projected message counts, dropped successful tool output, kept tool errors, estimated chunks, byte counts, target bank, checkpoint path, and manifest path.
 
-Guided setup offers historical import after config/template setup. It always previews first. Project/coding setup offers repo-scoped Pi session import; user/assistant setup offers gateway transcript import. After a successful setup import, Pi can explicitly refresh the target mental models from the selected bank template and shows returned operation IDs/status. You can skip import or refresh and run the tools later.
+Gateway dry-run shows kept event count, retained user-turn count, dropped event totals, malformed lines, target User Bank, content hash, and byte count.
 
-## Import commands
-
-```text
-# Import current session, current branch only.
-/hindsight:import-current
-
-# Import every fork leaf in an explicit session file.
-/hindsight:import-file /path/to/session.jsonl --all-leaves
-
-# Import sessions in the active session directory whose parsed cwd belongs to this repo.
-/hindsight:import-project-sessions
-```
-
-Use `--all-leaves` only when you explicitly want every fork leaf. The default imports only the current branch.
-
-Non-dry-run import commands announce the start and require confirmation because they write memory and update local checkpoint/manifest files.
-
-## Gateway transcript import
-
-Gateway import is explicit and separate from Pi session import:
-
-```text
-hindsight_import_gateway({ sourceFile: "/path/to/gateway.jsonl", dryRun: true })
-```
-
-By default it targets the configured user bank. Pass `bank` only when intentionally importing into a different bank.
-
-Accepted event type keys are `type`, `event`, `event_type`, and `kind`. High-signal events retained as source material are:
-
-- `user_message`
-- `assistant_reply`
-- `process_end`
-
-Streaming/UI/process noise such as `message_update` and `extension_ui_request` is dropped by default and counted in dry-run metrics. Gateway provenance is preserved with tags/metadata when present: `channel`, `channel_id`, `session_id`, `sessionId`, `conversation_id`, `conversationId`, and `thread_id`. Raw provenance values stay in metadata; tag values are normalized.
-
-If no high-signal events are found, gateway import skips writing instead of creating an empty memory document.
+Use these numbers to catch noisy imports before writing memory.
 
 ## Project session discovery
 
-Project session discovery intentionally avoids broad history imports. It scans only the current session file's directory and keeps only `.jsonl` files whose parsed `cwd` normalizes to the current repo/cwd.
+Project session discovery avoids broad history imports. It scans only the current session file's directory and keeps `.jsonl` files whose parsed `cwd` resolves to the current repo/cwd.
 
-Equivalent path forms are treated as the same project:
+Equivalent path forms are treated as the same project, including trailing separators, `.` segments, `..` traversal that resolves back to the repo, and resolved absolute paths.
 
-- same absolute path
-- trailing separators
-- `.` segments
-- `..` traversal that resolves back to the repo
-- resolved absolute paths
+## Document IDs and rebuilds
 
-## Document IDs and update modes
+Imports use deterministic document IDs based on session, branch leaf, chunk profile, and projection namespace. Reimporting the same document updates the same Hindsight document instead of appending duplicates.
 
-Imports use deterministic document IDs based on session and branch leaf identity.
+Changing chunking or another document-ID namespace input creates a new deterministic set. Treat that as a rebuild:
 
-Curated import document IDs also include the derived chunking profile (`turnsPerDocument` and `maxDocumentBytes`), projection namespace, and chunk range. Changing those chunk settings, or changing another input that participates in the document-ID namespace, creates a distinct deterministic set of imported documents. `import.qualityProfile` and successful-tool-result settings change retained content or metadata, but they do not create a separate document-ID namespace.
+1. dry-run first
+2. decide whether old and new imported docs should coexist
+3. clear or move checkpoint/manifest only when you want a fresh import namespace
+4. flush or clear stale queued retain jobs before reimporting if old IDs should not deliver later
 
-Historical imports default to deterministic replace semantics so reimporting the same document updates the same Hindsight document instead of appending duplicates.
-
-Live sessions still use stable live-session document IDs with `updateMode: "append"`.
-
-## Manifest and checkpoint files
-
-Default paths:
+Default files:
 
 ```text
 .pi/hindsight/import-manifest.json
 .pi/hindsight/import-checkpoint.json
 ```
-
-The checkpoint records document delivery state so interrupted imports can resume. When `import.resume` is enabled, completed documents are skipped instead of retained again.
-
-If an import is queued but not delivered because Hindsight is unavailable, the checkpoint records the document as `queued` and the retain queue keeps the job for later flushing. Checkpoint run and document entries also record import quality context such as `toolResults` and strict curated `importQualityProfile` when available, so recovery can show which projection policy produced pending, completed, queued, or failed documents.
-
-## Rebuilds and namespace changes
-
-To rebuild from historical sessions after clearing a Hindsight bank, remove or move:
-
-```text
-.pi/hindsight/import-checkpoint.json
-.pi/hindsight/import-manifest.json
-```
-
-Then rerun the import. Use `--dry-run` first.
-
-When you intentionally change chunking or another document-ID namespace input, plan the change as a rebuild. Preview first, then decide whether to keep both namespaces or clean up old imported documents in Hindsight. If old retain jobs are still queued, clear or flush the retain queue before reimporting so stale document IDs are not delivered later. Remove or move the import checkpoint and manifest when you want the new namespace to be imported from scratch instead of resumed from prior state.
 
 ## Import modes
 
-The default import mode is `curated`. It writes deterministic filtered historical documents as retained source evidence and computes projection metrics using the live retain filter so previews show how much successful tool-output noise is likely irrelevant.
+- `curated` is the default. It keeps filtered structured source evidence and drops obvious transcript noise.
+- `raw` is a compatibility/debug escape hatch.
+- `forensic` is for audit/recovery and can preserve normally filtered artifacts such as recalled memory blocks.
 
-Curated import defaults to `import.qualityProfile: "compatible"` and `import.toolResults: "errors-only"`. Compatible preserves the current curated behavior. Successful tool results are dropped unless you deliberately configure `summary` or `content`; even then, existing tool filters still exclude noisy tools such as `read`, `grep`, `find`, and `ls`. `import.toolResultSummaryMaxChars` bounds successful-tool summaries.
-
-Set `import.qualityProfile: "strict"` only when you want stronger curated noise handling. Strict mode still keeps failed tool results as evidence and may keep useful tiny successful summaries/content, but it drops successful tool results that are process/UI/status-like, larger than 2 KiB before summarization, or duplicate/repeated within the curated chunk. Strict only affects `curated`; `raw` and `forensic` remain escape hatches.
-
-Use `raw` when you want the previous branch-document behavior without curated drop metrics. Raw mode still filters Hindsight recall blocks to avoid re-retaining injected memory.
-
-Use `forensic` only for audit/recovery. It preserves recall blocks and other normally filtered records, so preview output includes an explicit warning.
+Curated import defaults to `import.qualityProfile: "compatible"` and `import.toolResults: "errors-only"`. Use `strict` only when you want stronger noise filtering. Use successful tool-result `summary` or `content` only for deliberate low-noise imports.
 
 ## Safety
 
-Imports retain structured raw conversation content, not summaries. Secret redaction still applies. Recalled memory blocks injected by this extension are filtered in `curated` and `raw` modes so they are not retained back into Hindsight. Import previews compute curated projection metrics using the live retain filter.
+Imports retain structured raw conversation content, not summaries. Secret redaction still applies. Curated and raw imports filter Pi Hindsight recall blocks so recalled memory is not retained back into Hindsight as new source truth.

--- a/docs-site/src/content/docs/guides/use-hindsight-status.md
+++ b/docs-site/src/content/docs/guides/use-hindsight-status.md
@@ -17,7 +17,7 @@ The setup TUI shows:
 
 - Hindsight server URL and reachability
 - active memory profile
-- Project Bank and Global/User Bank IDs
+- Project Bank and User Bank IDs
 - automatic recall/retain mode
 - Retain Queue path and pending jobs
 - recent retain receipts
@@ -30,7 +30,7 @@ After setup, confirm:
 1. the expected server URL is active
 2. the expected memory profile is active
 3. the Project Bank is selected for project memory
-4. Global/User Bank appears only when configured intentionally
+4. User Bank appears only when configured intentionally
 5. Retain Queue path exists and is writable
 6. recent retain receipts appear after completed agent runs
 
@@ -49,8 +49,6 @@ Use command shortcuts when you do not need the full TUI:
 ```text
 /hindsight:flush
 /hindsight:last-recall
-/hindsight:import-current --dry-run
-/hindsight:import-project-sessions --dry-run
 ```
 
-See [Tools and commands](../reference/tools-and-commands/) for the full command surface.
+For first-time imports, prefer guided setup's dry-run-first import prompt. For later explicit imports, see [Importing sessions](./importing-sessions/). See [Tools and commands](../reference/tools-and-commands/) for the full command surface.

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -4,7 +4,7 @@ title: "Configuration reference"
 
 Pi Hindsight resolves configuration from defaults, global config, project config, and environment variables.
 
-For concepts behind Project Banks, Global/User Banks, tags, metadata, Document IDs, and Update Modes, see:
+For concepts behind Project Banks, User Banks, tags, metadata, Document IDs, and Update Modes, see:
 
 - [Memory Banks](/pi-hindsight/concepts/memory-banks/)
 - [Document IDs and update modes](/pi-hindsight/concepts/document-ids-update-modes/)

--- a/docs-site/src/content/docs/reference/hindsight-api-links.md
+++ b/docs-site/src/content/docs/reference/hindsight-api-links.md
@@ -16,7 +16,7 @@ Official Hindsight documentation and API behavior are the source of truth for Hi
 Pi Hindsight defines repository-specific policy around Hindsight:
 
 - default Project Bank derivation
-- optional Global/User Bank config
+- optional User Bank config
 - automatic Recall injection through Pi context hooks
 - queue-first automatic Retain
 - deterministic import document IDs

--- a/docs-site/src/content/docs/reference/import-controls.md
+++ b/docs-site/src/content/docs/reference/import-controls.md
@@ -2,7 +2,9 @@
 title: "Import controls reference"
 ---
 
-Import controls preview and ingest historical Pi sessions or gateway transcripts. For the concept model, see [Historical Import](/pi-hindsight/concepts/imports/).
+Import controls are the advanced surface for previewing and ingesting historical Pi sessions or gateway transcripts. For first-time setup, prefer `/hindsight` guided setup; it can offer a dry-run-first import flow.
+
+For the concept model, see [Historical Import](/pi-hindsight/concepts/imports/). For task guidance, see [Importing sessions](/pi-hindsight/guides/importing-sessions/).
 
 ## Commands
 
@@ -14,7 +16,7 @@ Import controls preview and ingest historical Pi sessions or gateway transcripts
 /hindsight:import-project-sessions
 ```
 
-Use `--dry-run` before writing memory.
+Use `--dry-run` before writing memory. Use `--all-leaves` only when you want every fork leaf in an explicit session file.
 
 ## Tools
 
@@ -23,7 +25,7 @@ hindsight_import({ dryRun: true })
 hindsight_import_gateway({ sourceFile: "/path/to/gateway.jsonl", dryRun: true })
 ```
 
-`hindsight_import` imports Pi session JSONL. `hindsight_import_gateway` imports gateway/chat transcript JSONL into the configured user memory bank by default.
+`hindsight_import` imports Pi session JSONL. `hindsight_import_gateway` imports gateway/chat transcript JSONL into the configured User Bank by default.
 
 ## Modes
 
@@ -35,43 +37,24 @@ Raw and forensic modes preserve legacy document IDs and payload shape.
 
 ## Curated quality profiles
 
-- `compatible` (default): preserves current curated import behavior.
-- `strict`: explicit opt-in profile for stronger curated noise handling.
+- `compatible` (default): preserves the default curated import behavior.
+- `strict`: opt-in stronger noise handling.
 
-Strict applies only to `curated`. It keeps failed tool results as evidence and may keep useful tiny successful summaries/content, but drops successful tool results that are process/UI/status-like, larger than 2 KiB before summarization, or duplicate/repeated within the curated chunk. Raw and forensic ignore `import.qualityProfile`.
+Strict applies only to `curated`. It keeps failed tool results as evidence and may keep useful tiny successful summaries/content, but drops successful tool results that are process/UI/status-like, larger than 2 KiB before summarization, or duplicate/repeated within the curated chunk.
 
 ## Dry-run metrics
 
-Pi session dry-runs report items such as:
+Pi session dry-runs report document count, import mode/profile, raw/projected message counts, tool-output counts, signal/noise categories when available, estimated chunks, byte counts, target bank, and checkpoint/manifest paths.
 
-- document count
-- import mode/profile
-- raw message count
-- curated projection count
-- dropped non-error tool-result count
-- kept tool-error count
-- kept signal categories (`keptSignals=`), when curated reason counts exist
-- dropped noise categories (`droppedNoise=`), when curated reason counts exist
-- estimated chunk count
-- byte counts
-- target bank
-- checkpoint/manifest paths
-
-Gateway dry-runs report items such as:
-
-- kept event count
-- retained user-turn count
-- dropped event count/type totals
-- malformed-line count
-- target user bank
-- content hash
-- byte count
+Gateway dry-runs report kept event count, retained user-turn count, dropped event totals, malformed-line count, target User Bank, content hash, and byte count.
 
 ## Checkpoints and manifests
 
 Historical import writes an Import Manifest and Import Checkpoint so work is inspectable, resumable, and idempotent. Curated document IDs include profile/projection/chunk information. Raw and forensic modes preserve legacy IDs.
 
-Changing the derived chunking profile (`turnsPerDocument` and `maxDocumentBytes`) or another document-ID namespace input creates a different deterministic ID set. Reimporting after such a change writes new imported documents rather than replacing the previous namespace. `import.qualityProfile` and successful-tool-result settings change retained content or metadata, but they do not create a separate document-ID namespace. Treat namespace changes as rebuilds: dry-run first, clean up old imported documents if you do not want both namespaces, and reset relevant checkpoint/manifest or queued retain jobs when stale IDs should not resume.
+Changing the derived chunking profile (`turnsPerDocument` and `maxDocumentBytes`) or another document-ID namespace input creates a different deterministic ID set. Treat namespace changes as rebuilds: dry-run first, decide whether old and new imported documents should coexist, then reset relevant checkpoint/manifest or queued retain jobs only when stale IDs should not resume.
+
+## Tool-output policy
 
 Curated import has a successful-tool-result policy:
 

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -4,7 +4,7 @@ title: "Tools and commands"
 
 For generated details of registered tools and editable config fields, see [Generated surface reference](/pi-hindsight/reference/surface-reference/).
 
-`/hindsight` is the main control center. Commands are convenience shortcuts and escape hatches for advanced workflows.
+`/hindsight` is the main control center. Commands are convenience shortcuts for advanced, repeat, or scripted workflows.
 
 ## Main command
 
@@ -34,7 +34,7 @@ The `hindsight_configure` tool can write config from agents. Prefer `/hindsight`
 /hindsight:import-project-sessions
 ```
 
-Use dry-run before non-dry-run imports. See [Import controls reference](/pi-hindsight/reference/import-controls/) and [Importing sessions](/pi-hindsight/guides/importing-sessions/).
+For first-time backfill, prefer the guided import prompt in `/hindsight`. Use these commands when you need repeat imports or explicit files. Always dry-run before non-dry-run imports. See [Import controls reference](/pi-hindsight/reference/import-controls/) and [Importing sessions](/pi-hindsight/guides/importing-sessions/).
 
 ## Queue and snapshots
 

--- a/docs-site/src/content/docs/start/getting-started.md
+++ b/docs-site/src/content/docs/start/getting-started.md
@@ -2,98 +2,78 @@
 title: "Getting started"
 ---
 
-Pi Hindsight gives Pi durable memory through Hindsight. Start with a setup profile, then inspect the generated config before you rely on it.
+Pi Hindsight gives Pi durable memory through Hindsight. For normal use, install the published package, run `/hindsight`, choose a memory profile, and let the TUI guide setup.
 
 ## 1. Install
+
+Install the npm package:
+
+```bash
+pi install npm:@luxusai/pi-hindsight
+```
+
+If you need unreleased source from GitHub:
 
 ```bash
 pi install https://github.com/luxus/pi-hindsight
 ```
 
-For a local checkout:
-
-```bash
-pi install /path/to/pi-hindsight
-```
+Local checkout installs are for contributors; see [Development](/pi-hindsight/development/development/).
 
 ## 2. Choose a Hindsight server
 
-Use one of these paths:
+Use either:
 
 - [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
 - [Self-hosted Hindsight installation](https://hindsight.vectorize.io/developer/installation)
 
-For self-hosted setup, prefer Hindsight's built-in llama.cpp/local-LLM option when you want a private setup without an external LLM API key. The expected self-hosted default URL is:
+The default self-hosted URL is:
 
 ```text
 http://localhost:8888
 ```
 
-## 3. Run guided setup
+For private local setup, use Hindsight's built-in llama.cpp/local-LLM path.
 
-In Pi, run:
+## 3. Run `/hindsight`
+
+Open Pi in your repository and run:
 
 ```text
 /hindsight
 ```
 
-If the repository has no project config yet, `/hindsight` starts guided setup. You can rerun guided setup later from the setup TUI with `g`.
+If no project config exists, guided setup starts automatically. You can rerun it later from the TUI with `g`.
 
-Guided setup asks for a memory profile, bank IDs, optional bank templates, and optional dry-run-first historical import. It writes explicit config so you can inspect what changed.
+Guided setup handles:
 
-## 4. Pick a memory profile
+1. Hindsight server URL
+2. memory profile
+3. project and/or user bank
+4. optional bank template
+5. optional dry-run-first historical import
+6. optional mental model refresh
 
-Choose the narrowest profile that fits the work.
+## 4. Pick the narrowest profile
 
-### Project + User
+- **Project + User**: best personal-coding default. Project facts stay repo-scoped; user memory carries durable preferences across repos.
+- **Project Only**: best for strict isolation, client work, sensitive repos, and team projects.
+- **User Only**: best for non-repo assistance where project memory would be noise.
+- **Recall Only**: best cautious start. Recall works; automatic retain is off.
 
-Best default for personal coding. Project memory stays scoped to this repository. User memory is configured once in global Pi config and can carry stable preferences, coding style, and cross-repo workflows.
+## 5. Check status
 
-Use this when you want Pi to remember both repo facts and durable user habits.
+After setup, `/hindsight` should show:
 
-### Project Only
+- reachable Hindsight server
+- expected memory profile
+- expected Project Bank and/or User Bank
+- automatic recall/retain state
+- retain queue path
+- import checkpoint/manifest state when imports have run
 
-Best for strict isolation. Project recall and automatic retain use the selected project bank. User memory is not enabled for the repository.
+## 6. Import old sessions only when useful
 
-Use this for client code, sensitive repos, work projects, or anything that should not share memory across repositories.
+Live retain starts after setup. Historical import is optional backfill. Use guided setup's import prompt first when it appears; it previews before writing memory.
 
-### User Only
-
-Best for non-repo assistance. Project memory is disabled. User memory is configured in global Pi config and can be reused across repositories.
-
-Use this when repo-specific memory would be noise but user preferences still matter.
-
-### Recall Only
-
-Best for cautious adoption. Automatic recall stays enabled, automatic retain is disabled, and explicit tools/import remain available.
-
-Use this when you want memory context but do not want the current session written automatically.
-
-## 5. Mental model
-
-Pi Hindsight is the Pi integration. Hindsight is the external memory service.
-
-- **Recall** runs before model requests and injects ephemeral context. Recalled memory is not written back to the transcript by default.
-- **Retain** runs after completed agent turns and writes sanitized session deltas through the durable retain queue.
-- **Project banks** hold repository-specific memory and are selected per repo.
-- **User banks** hold durable cross-repo memory and are configured once in global Pi config when you choose a user-memory profile.
-- **Explicit tools** let you inspect, retain, recall, reflect, import, and administer memory intentionally.
-- **Import** is deterministic backfill from historical sessions. It is not the same path as live retain.
-
-## 6. First checks
-
-After setup, use `/hindsight` to confirm:
-
-- memory is enabled
-- expected profile is active
-- expected project bank is selected when project memory is enabled
-- expected user bank is selected only when user memory is intended
-- Hindsight server is reachable
-- retain queue path is visible
-
-Preview imports before writing memory:
-
-```text
-/hindsight:import-current --dry-run
-/hindsight:import-project-sessions --dry-run
-```
+For later imports, use the [Importing sessions guide](/pi-hindsight/guides/importing-sessions/). Commands and tools remain available for advanced or scripted imports.

--- a/docs-site/src/content/docs/start/index.mdx
+++ b/docs-site/src/content/docs/start/index.mdx
@@ -5,19 +5,19 @@ description: Install Pi Hindsight, connect a Hindsight server, choose a memory p
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Start pages get you from no memory to a verified Pi Hindsight setup with minimal conceptual load.
+Start here when you want Pi memory running quickly. The normal path is npm install, `/hindsight`, guided setup, then optional import.
 
 <CardGrid>
   <Card title="Getting started" icon="rocket">
     The shortest path from install to verified project memory. [Start here](./getting-started/)
   </Card>
   <Card title="Installation" icon="download">
-    Install from GitHub or a local checkout and confirm runtime compatibility.
+    Install the npm package, use GitHub source when needed, and choose a Hindsight server.
     [Install](./installation/)
   </Card>
   <Card title="Guided setup" icon="setting">
-    Use `/hindsight` to configure the server, banks, profile, and queue state. [Open setup
-    guide](./setup-tui/)
+    Use `/hindsight` to configure the server, banks, profile, queue state, and optional import.
+    [Open setup guide](./setup-tui/)
   </Card>
   <Card title="Memory profiles" icon="laptop">
     Pick Project + User, Project Only, User Only, or Recall Only memory scope. [Compare

--- a/docs-site/src/content/docs/start/installation.md
+++ b/docs-site/src/content/docs/start/installation.md
@@ -2,20 +2,29 @@
 title: "Installation"
 ---
 
-Pi Hindsight is a Pi package. Install it into Pi, then point it at a Hindsight server.
+Pi Hindsight is published as an npm Pi package.
 
-## Install from GitHub
+## Install from npm
+
+```bash
+pi install npm:@luxusai/pi-hindsight
+```
+
+Use a version when you want a pinned install:
+
+```bash
+pi install npm:@luxusai/pi-hindsight@0.3.0
+```
+
+## Install from GitHub source
+
+Use GitHub source only when you intentionally want the repository state instead of the latest npm release:
 
 ```bash
 pi install https://github.com/luxus/pi-hindsight
 ```
 
-## Install from a local checkout
-
-```bash
-git clone https://github.com/luxus/pi-hindsight
-pi install /path/to/pi-hindsight
-```
+Local checkout installs are for contributors and test builds. See [Development](/pi-hindsight/development/development/).
 
 ## Choose a Hindsight server
 
@@ -23,8 +32,6 @@ Use Hindsight Cloud or a self-hosted Hindsight API server:
 
 - [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
 - [Self-hosted Hindsight installation](https://hindsight.vectorize.io/developer/installation)
-
-For self-hosted setup, prefer Hindsight's built-in llama.cpp/local-LLM option when you want a private setup without an external LLM API key. That path requires Hindsight's `local-llm` extra; otherwise configure a normal LLM provider and API key as described in the Hindsight installation and model docs.
 
 The conventional self-hosted URL is:
 

--- a/docs-site/src/content/docs/start/setup-tui.md
+++ b/docs-site/src/content/docs/start/setup-tui.md
@@ -2,7 +2,7 @@
 title: "Setup TUI"
 ---
 
-Run the setup TUI from Pi:
+`/hindsight` is the main control center. Use it before reaching for command shortcuts.
 
 ```text
 /hindsight
@@ -10,33 +10,34 @@ Run the setup TUI from Pi:
 
 The TUI shows:
 
-- memory status
+- memory profile and enablement
 - selected Project Bank and optional User Bank
 - Hindsight server reachability
-- Retain Queue state
-- import state
+- Retain Queue state and flush action
+- import manifest/checkpoint state
 - recent Retain receipts
 - editable local Pi configuration fields
 - read-only mental model inventory
 
 ## Guided setup
 
-If no project config exists, `/hindsight` starts guided setup before the advanced TUI.
+If no project config exists, `/hindsight` starts guided setup before the advanced TUI. You can rerun guided setup later with `g`.
 
-Guided setup helps you choose:
+Guided setup asks for:
 
-1. memory profile
-2. project and/or user bank target
-3. built-in or custom bank template
-4. optional dry-run-first historical import
-5. optional post-import mental model refresh
+1. Hindsight server URL
+2. memory profile
+3. project and/or user bank target
+4. built-in or custom bank template
+5. optional dry-run-first historical import
+6. optional post-import mental model refresh
 
-The profile controls which config scopes are written:
+Profiles decide which config scopes are written:
 
-- **Project + User** writes repository project-memory settings and writes reusable user-bank settings to global Pi config.
-- **Project Only** writes repository project-memory settings only.
-- **User Only** disables project memory and writes reusable user-bank settings to global Pi config.
-- **Recall Only** keeps automatic recall enabled and disables automatic retain.
+- **Project + User** writes repo project-memory settings plus reusable user-bank settings in global Pi config.
+- **Project Only** writes repo project-memory settings only.
+- **User Only** disables project memory and writes reusable user-bank settings in global Pi config.
+- **Recall Only** keeps automatic recall on and automatic retain off.
 
 Bank templates and mental models are Hindsight bank-owned settings. Pi Hindsight does not store mission text or directive definitions as normal Pi JSON source of truth.
 
@@ -55,16 +56,15 @@ Bank templates and mental models are Hindsight bank-owned settings. Pi Hindsight
 
 After setup, confirm:
 
-- memory is enabled
+- server is reachable
 - expected profile is active
-- expected Project Bank is selected only when project memory is intended
-- expected User Bank is selected only when user memory is intended
-- Hindsight server is reachable
-- Retain Queue path is visible
+- Project Bank appears only when project memory is intended
+- User Bank appears only when user memory is intended
+- Retain Queue path is visible and writable
+- import state is empty, previewed, imported, queued, or failed as expected
 
-Preview imports before writing memory:
+## Import from the TUI first
 
-```text
-/hindsight:import-current --dry-run
-/hindsight:import-project-sessions --dry-run
-```
+Guided setup can offer historical import after config/template setup. That path previews first, then asks before writing memory. Prefer it for first-time backfill.
+
+Use command shortcuts later when you already know which session set you want to import. See [Importing sessions](/pi-hindsight/guides/importing-sessions/).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,89 +1,77 @@
 # Getting started
 
-Pi Hindsight gives Pi durable memory through Hindsight. Start with a setup profile, then inspect the generated config before you rely on it.
+Pi Hindsight gives Pi durable memory through Hindsight. For normal use, install the published package, run `/hindsight`, choose a memory profile, and let the TUI guide setup.
 
 ## 1. Install
+
+Install the npm package:
+
+```bash
+pi install npm:@luxusai/pi-hindsight
+```
+
+If you need unreleased source from GitHub:
 
 ```bash
 pi install https://github.com/luxus/pi-hindsight
 ```
 
-For a local checkout:
-
-```bash
-pi install /path/to/pi-hindsight
-```
+Local checkout installs are for contributors; see the development docs.
 
 ## 2. Choose a Hindsight server
 
-Use one of these paths:
+Use either:
 
 - [Hindsight Cloud signup](https://ui.hindsight.vectorize.io/signup)
 - [Self-hosted Hindsight installation](https://hindsight.vectorize.io/developer/installation)
 
-For self-hosted setup, prefer Hindsight's built-in llama.cpp/local-LLM option when you want a private setup without an external LLM API key. The expected self-hosted default URL is:
+The default self-hosted URL is:
 
 ```text
 http://localhost:8888
 ```
 
-## 3. Run guided setup
+For private local setup, use Hindsight's built-in llama.cpp/local-LLM path.
 
-In Pi, run:
+## 3. Run `/hindsight`
+
+Open Pi in your repository and run:
 
 ```text
 /hindsight
 ```
 
-If the repository has no project config yet, `/hindsight` starts guided setup. You can rerun guided setup later from the setup TUI with `g`.
+If no project config exists, guided setup starts automatically. You can rerun it later from the TUI with `g`.
 
-Guided setup asks for a memory profile, bank IDs, optional bank templates, and optional dry-run-first historical import. It writes explicit config so you can inspect what changed.
+Guided setup handles:
 
-## 4. Pick a memory profile
+1. Hindsight server URL
+2. memory profile
+3. project and/or user bank
+4. optional bank template
+5. optional dry-run-first historical import
+6. optional mental model refresh
 
-Choose the narrowest profile that fits the work.
+## 4. Pick the narrowest profile
 
-### Project + User
+- **Project + User**: best personal-coding default. Project facts stay repo-scoped; user memory carries durable preferences across repos.
+- **Project Only**: best for strict isolation, client work, sensitive repos, and team projects.
+- **User Only**: best for non-repo assistance where project memory would be noise.
+- **Recall Only**: best cautious start. Recall works; automatic retain is off.
 
-Best default for personal coding. Project memory stays scoped to this repository. User memory is configured once in global Pi config and can carry stable preferences, coding style, and cross-repo workflows.
+## 5. Check status
 
-### Project Only
+After setup, `/hindsight` should show:
 
-Best for strict isolation. Project recall and automatic retain use the selected project bank. User memory is not enabled for the repository.
+- reachable Hindsight server
+- expected memory profile
+- expected Project Bank and/or User Bank
+- automatic recall/retain state
+- retain queue path
+- import checkpoint/manifest state when imports have run
 
-### User Only
+## 6. Import old sessions only when useful
 
-Best for non-repo assistance. Project memory is disabled. User memory is configured in global Pi config and can be reused across repositories.
+Live retain starts after setup. Historical import is optional backfill. Use guided setup's import prompt first when it appears; it previews before writing memory.
 
-### Recall Only
-
-Best for cautious adoption. Automatic recall stays enabled, automatic retain is disabled, and explicit tools/import remain available.
-
-## 5. Mental model
-
-Pi Hindsight is the Pi integration. Hindsight is the external memory service.
-
-- **Recall** runs before model requests and injects ephemeral context. Recalled memory is not written back to the transcript by default.
-- **Retain** runs after completed agent turns and writes sanitized session deltas through the durable retain queue.
-- **Project banks** hold repository-specific memory and are selected per repo.
-- **User banks** hold durable cross-repo memory and are configured once in global Pi config when you choose a user-memory profile.
-- **Explicit tools** let you inspect, retain, recall, reflect, import, and administer memory intentionally.
-- **Import** is deterministic backfill from historical sessions. It is not the same path as live retain.
-
-## 6. First checks
-
-After setup, use `/hindsight` to confirm:
-
-- memory is enabled
-- expected profile is active
-- expected project bank is selected when project memory is enabled
-- expected user bank is selected only when user memory is intended
-- Hindsight server is reachable
-- retain queue path is visible
-
-Preview imports before writing memory:
-
-```text
-/hindsight:import-current --dry-run
-/hindsight:import-project-sessions --dry-run
-```
+For later imports, use the importing sessions guide. Commands and tools remain available for advanced or scripted imports.

--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -1,6 +1,6 @@
 # Importing Pi sessions
 
-Historical import is optional backfill. It reads old Pi session JSONL files or gateway transcripts, writes deterministic Hindsight documents, and records checkpoint/manifest state so imports can resume safely.
+Historical import is optional backfill. It reads old Pi session JSONL files or gateway transcripts and writes deterministic Hindsight documents. Pi session imports also record checkpoint/manifest state so they can resume safely.
 
 Live memory does not need import. After setup, normal retain starts from new completed agent turns.
 

--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -1,27 +1,49 @@
 # Importing Pi sessions
 
-Historical import is for seeding or rebuilding Hindsight memory from Pi session JSONL files.
+Historical import is optional backfill. It reads old Pi session JSONL files or gateway transcripts, writes deterministic Hindsight documents, and records checkpoint/manifest state so imports can resume safely.
+
+Live memory does not need import. After setup, normal retain starts from new completed agent turns.
+
+## Start with guided setup
+
+For first-time setup, prefer the `/hindsight` guided import prompt. It appears after config/template setup when import makes sense.
+
+Guided import:
+
+1. chooses the source type from the selected profile/template
+2. previews first
+3. shows counts and target bank
+4. asks before writing memory
+5. can refresh mental models after successful import
+
+Project/coding setup offers repo-scoped Pi session import. User/assistant setup offers gateway transcript import into User memory.
 
 ## What can be imported
 
-The extension supports:
+Pi Hindsight supports:
 
 - current Pi session
-- explicit JSONL session file
-- all repo-scoped JSONL sessions in the current session directory
-- explicit gateway/chat transcript JSONL files for user memory
+- explicit Pi session JSONL file
+- repo-scoped Pi sessions from the current session directory
+- explicit gateway/chat transcript JSONL files for User memory
 
-Pi session imports write deterministic document IDs and update an import manifest summarized in `/hindsight`. Gateway transcript imports use a separate explicit tool path and do not share the repo-session import flow.
+Pi session imports and gateway transcript imports are separate paths. They do not silently mix repo history with user conversation history.
 
-## Preview first
+## Use commands when you need control
 
-Preview imports before writing memory:
+Command shortcuts are useful after setup, for repeat imports, or for explicit files:
 
 ```text
 /hindsight:import-current --dry-run
 /hindsight:import-file /path/to/session.jsonl --dry-run
 /hindsight:import-project-sessions --dry-run
 ```
+
+If the preview looks right, rerun without `--dry-run`. Non-dry-run imports announce the start and require confirmation because they write memory plus local checkpoint/manifest files.
+
+Use `--all-leaves` only when you intentionally want every fork leaf from a session file. Default import follows the current branch.
+
+## Use tools for agent/script workflows
 
 Tool equivalents:
 
@@ -30,111 +52,48 @@ hindsight_import({ dryRun: true })
 hindsight_import_gateway({ sourceFile: "/path/to/gateway.jsonl", dryRun: true })
 ```
 
-Pi session preview output includes document count, import mode, raw message count, curated projection count, dropped non-error tool-result count, kept tool-error count, estimated chunk count, byte counts, update mode, target bank, checkpoint path, and manifest path. Curated projection metrics show likely import noise without replacing the raw structured source payload.
+`hindsight_import` targets Pi session JSONL. `hindsight_import_gateway` targets gateway/chat transcript JSONL and defaults to the configured User Bank.
 
-Gateway preview output includes kept event count, retained user-turn count, dropped event count/type totals, malformed-line count, target user bank, content hash, and byte count.
+## Preview output
 
-## Guided setup import prompt
+Pi session dry-run shows document count, import mode/profile, raw and projected message counts, dropped successful tool output, kept tool errors, estimated chunks, byte counts, target bank, checkpoint path, and manifest path.
 
-Guided setup offers historical import after config/template setup. It always previews first. Project/coding setup offers repo-scoped Pi session import; user/assistant setup offers gateway transcript import. After a successful setup import, Pi can explicitly refresh the target mental models from the selected bank template and shows returned operation IDs/status. You can skip import or refresh and run the tools later.
+Gateway dry-run shows kept event count, retained user-turn count, dropped event totals, malformed lines, target User Bank, content hash, and byte count.
 
-## Import commands
-
-```text
-# Import current session, current branch only.
-/hindsight:import-current
-
-# Import every fork leaf in an explicit session file.
-/hindsight:import-file /path/to/session.jsonl --all-leaves
-
-# Import sessions in the active session directory whose parsed cwd belongs to this repo.
-/hindsight:import-project-sessions
-```
-
-Use `--all-leaves` only when you explicitly want every fork leaf. The default imports only the current branch.
-
-Non-dry-run import commands announce the start and require confirmation because they write memory and update local checkpoint/manifest files.
-
-## Gateway transcript import
-
-Gateway import is explicit and separate from Pi session import:
-
-```text
-hindsight_import_gateway({ sourceFile: "/path/to/gateway.jsonl", dryRun: true })
-```
-
-By default it targets the configured user bank. Pass `bank` only when intentionally importing into a different bank.
-
-Accepted event type keys are `type`, `event`, `event_type`, and `kind`. High-signal events retained as source material are:
-
-- `user_message`
-- `assistant_reply`
-- `process_end`
-
-Streaming/UI/process noise such as `message_update` and `extension_ui_request` is dropped by default and counted in dry-run metrics. Gateway provenance is preserved with tags/metadata when present: `channel`, `channel_id`, `session_id`, `sessionId`, `conversation_id`, `conversationId`, and `thread_id`. Raw provenance values stay in metadata; tag values are normalized.
-
-If no high-signal events are found, gateway import skips writing instead of creating an empty memory document.
+Use these numbers to catch noisy imports before writing memory.
 
 ## Project session discovery
 
-Project session discovery intentionally avoids broad history imports. It scans only the current session file's directory and keeps only `.jsonl` files whose parsed `cwd` normalizes to the current repo/cwd.
+Project session discovery avoids broad history imports. It scans only the current session file's directory and keeps `.jsonl` files whose parsed `cwd` resolves to the current repo/cwd.
 
-Equivalent path forms are treated as the same project:
+Equivalent path forms are treated as the same project, including trailing separators, `.` segments, `..` traversal that resolves back to the repo, and resolved absolute paths.
 
-- same absolute path
-- trailing separators
-- `.` segments
-- `..` traversal that resolves back to the repo
-- resolved absolute paths
+## Document IDs and rebuilds
 
-## Document IDs and update modes
+Imports use deterministic document IDs based on session, branch leaf, chunk profile, and projection namespace. Reimporting the same document updates the same Hindsight document instead of appending duplicates.
 
-Imports use deterministic document IDs based on session and branch leaf identity.
+Changing chunking or another document-ID namespace input creates a new deterministic set. Treat that as a rebuild:
 
-Curated import document IDs also include the derived chunking profile (`turnsPerDocument` and `maxDocumentBytes`), projection namespace, and chunk range. Changing those chunk settings, or changing another input that participates in the document-ID namespace, creates a distinct deterministic set of imported documents. `import.qualityProfile` and successful-tool-result settings change retained content or metadata, but they do not create a separate document-ID namespace.
+1. dry-run first
+2. decide whether old and new imported docs should coexist
+3. clear or move checkpoint/manifest only when you want a fresh import namespace
+4. flush or clear stale queued retain jobs before reimporting if old IDs should not deliver later
 
-Historical imports default to deterministic replace semantics so reimporting the same document updates the same Hindsight document instead of appending duplicates.
-
-Live sessions still use stable live-session document IDs with `updateMode: "append"`.
-
-## Manifest and checkpoint files
-
-Default paths:
+Default files:
 
 ```text
 .pi/hindsight/import-manifest.json
 .pi/hindsight/import-checkpoint.json
 ```
-
-The checkpoint records document delivery state so interrupted imports can resume. When `import.resume` is enabled, completed documents are skipped instead of retained again.
-
-If an import is queued but not delivered because Hindsight is unavailable, the checkpoint records the document as `queued` and the retain queue keeps the job for later flushing. Checkpoint run and document entries also record import quality context such as `toolResults` and strict curated `importQualityProfile` when available, so recovery can show which projection policy produced pending, completed, queued, or failed documents.
-
-## Rebuilds and namespace changes
-
-To rebuild from historical sessions after clearing a Hindsight bank, remove or move:
-
-```text
-.pi/hindsight/import-checkpoint.json
-.pi/hindsight/import-manifest.json
-```
-
-Then rerun the import. Use `--dry-run` first.
-
-When you intentionally change chunking or another document-ID namespace input, plan the change as a rebuild. Preview first, then decide whether to keep both namespaces or clean up old imported documents in Hindsight. If old retain jobs are still queued, clear or flush the retain queue before reimporting so stale document IDs are not delivered later. Remove or move the import checkpoint and manifest when you want the new namespace to be imported from scratch instead of resumed from prior state.
 
 ## Import modes
 
-The default import mode is `curated`. It writes deterministic filtered historical documents as retained source evidence and computes projection metrics using the live retain filter so previews show how much successful tool-output noise is likely irrelevant.
+- `curated` is the default. It keeps filtered structured source evidence and drops obvious transcript noise.
+- `raw` is a compatibility/debug escape hatch.
+- `forensic` is for audit/recovery and can preserve normally filtered artifacts such as recalled memory blocks.
 
-Curated import defaults to `import.qualityProfile: "compatible"` and `import.toolResults: "errors-only"`. Compatible preserves the current curated behavior. Successful tool results are dropped unless you deliberately configure `summary` or `content`; even then, existing tool filters still exclude noisy tools such as `read`, `grep`, `find`, and `ls`. `import.toolResultSummaryMaxChars` bounds successful-tool summaries.
-
-Set `import.qualityProfile: "strict"` only when you want stronger curated noise handling. Strict mode still keeps failed tool results as evidence and may keep useful tiny successful summaries/content, but it drops successful tool results that are process/UI/status-like, larger than 2 KiB before summarization, or duplicate/repeated within the curated chunk. Strict only affects `curated`; `raw` and `forensic` remain escape hatches.
-
-Use `raw` when you want the previous branch-document behavior without curated drop metrics. Raw mode still filters Hindsight recall blocks to avoid re-retaining injected memory.
-
-Use `forensic` only for audit/recovery. It preserves recall blocks and other normally filtered records, so preview output includes an explicit warning.
+Curated import defaults to `import.qualityProfile: "compatible"` and `import.toolResults: "errors-only"`. Use `strict` only when you want stronger noise filtering. Use successful tool-result `summary` or `content` only for deliberate low-noise imports.
 
 ## Safety
 
-Imports retain structured raw conversation content, not summaries. Secret redaction still applies. Recalled memory blocks injected by this extension are filtered in `curated` and `raw` modes so they are not retained back into Hindsight. Import previews compute curated projection metrics using the live retain filter.
+Imports retain structured raw conversation content, not summaries. Secret redaction still applies. Curated and raw imports filter Pi Hindsight recall blocks so recalled memory is not retained back into Hindsight as new source truth.


### PR DESCRIPTION
## Summary

- Make npm install the primary README and start-docs path.
- Move local checkout install guidance into development-oriented wording.
- Streamline getting-started, setup, import concept/guide/reference pages around `/hindsight` and the guided TUI flow.
- Reduce repeated import prose and reserve command/tool examples for advanced or repeat workflows.
- Move prior-art mention to the bottom of the README.

## Linked issue

- Closes #326

## Scope

- Docs-only cleanup across README, packaged Markdown, and docs-site pages.
- Updates user-facing wording toward User Bank/User memory where touched.
- Does not change runtime behavior, command behavior, or generated reference schemas.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped: coverage, standalone `typecheck:tsc`, package verification, full matrix, and live smoke because this is docs-only. `npm run check` includes docs checks, format, lint, typecheck, and tests.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Release notes: documentation now presents npm install and guided TUI/import flows as the default path.

## Risk and rollback

- Risk: docs wording may omit advanced import detail from first-read pages.
- Rollback/revert path: revert this PR to restore previous docs wording.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and Global Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance sync needed; this changes docs wording only.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

No ADR conflicts. Existing lint warning in `extensions/client-rest.ts` remains unrelated.
