### PR TITLE
docs: restructure TUI-first documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,7 +43,7 @@ Explain changelog/release notes impact, or say none.
 
 - [ ] Retain still stores raw rich content, not summaries.
 - [ ] Recall Blocks remain ephemeral and are not retained back into Hindsight.
-- [ ] Project Bank and Global Bank isolation is preserved.
+- [ ] Project Bank and User Bank isolation is preserved.
 - [ ] Retain Queue behavior remains queue-first and retry-safe.
 - [ ] Debug output and sidecars remain opt-in and redacted.
 - [ ] Import behavior remains deterministic and idempotent when touched.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,7 @@ Every PR must complete the repository PR template. The PR body gate is intention
 ### Bank rules
 
 - Default to one project bank per repo.
-- Optional second global bank is allowed only through explicit config.
+- Optional second User Bank (legacy internal/config name: global bank) is allowed only through explicit config.
 - Do not default to one giant shared bank across unrelated repos.
 - If bank creation/configuration is needed, do it intentionally during initialization or setup, not accidentally on first write.
 
@@ -145,7 +145,7 @@ Use:
   - ensure bank settings if appropriate
   - update status
 - `context` delegates to `memory-lifecycle.recall`:
-  - select project/global memory scopes
+  - select project/user memory scopes
   - compose fresh recall query
   - fetch memory
   - inject ephemeral memory block
@@ -285,7 +285,7 @@ GitHub Actions has a `Hindsight Integration` workflow that runs for memory-path 
 - storing recalled context back into the transcript
 - using metadata instead of tags for scope
 - calling retain and then relying on that data in the same response path
-- mixing project and global memory without explicit labeling
+- mixing project and User Bank memory without explicit labeling
 - letting debug logs expose secrets
 - using provider-specific payload rewrites before the default `context` strategy is proven
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,19 +14,19 @@ The external memory service that stores banks, extracts observations, recalls re
 
 ### Memory Bank
 
-An isolated Hindsight namespace. Banks are the primary boundary between unrelated memory. `pi-hindsight` normally uses one Project Bank per repository and optionally one explicitly configured Global Bank.
+An isolated Hindsight namespace. Banks are the primary boundary between unrelated memory. `pi-hindsight` normally uses one Project Bank per repository and optionally one explicitly configured User Bank.
 
 ### Project Bank
 
 The bank selected for the current repository. It stores repo-specific architecture, decisions, bugs, tasks, import history, and operational context. Project recall is scoped with repository tags so memory from other repositories does not leak in.
 
-### Global Bank
+### User Bank
 
-An optional shared bank for durable user-level preferences, recurring workflows, and cross-project habits. It is disabled unless explicitly configured. Automatic global retain only happens in Router Mode; otherwise global writes are explicit.
+An optional shared bank for durable user-level preferences, recurring workflows, and cross-project habits. It is disabled unless explicitly configured. Automatic User Bank retain only happens when an explicit profile or Router Mode enables it; otherwise User Bank writes are explicit. Legacy config/tool aliases may still call this bank `global`.
 
 ### Bank Alias
 
-A stable user-facing name that resolves to a real bank ID. `project` means the selected Project Bank. `global` means the configured Global Bank. Prefer aliases in tools and docs when the exact bank ID is not important.
+A stable name that resolves to a real bank ID. `project` means the selected Project Bank. `global` is the legacy/internal alias for the configured User Bank. Prefer **User Bank** in user-facing docs when the exact bank ID is not important.
 
 ### Retain
 
@@ -38,7 +38,7 @@ The `agent_end` hook path that retains new transcript content after a turn. It i
 
 ### Explicit Retain
 
-A user-triggered retain operation through a tool or command. Explicit retains are queue-first like automatic retains, but they use user-provided content and context. Explicit retains can target the Project Bank or Global Bank by alias.
+A user-triggered retain operation through a tool or command. Explicit retains are queue-first like automatic retains, but they use user-provided content and context. Explicit retains can target the Project Bank or User Bank by alias.
 
 ### Retain Job
 
@@ -146,7 +146,7 @@ The single catalog that registers public tools and commands. It maps Pi-facing s
 
 ### Memory Router
 
-The opt-in policy that decides whether automatic retain should write to project, global, both, or skip. The default Global Retain mode is `explicit-only`; Router Mode must remain explicit because global-memory pollution is costly.
+The opt-in policy that decides whether automatic retain should write to project memory, user memory, both, or skip. The default User Bank retain mode is `explicit-only`; Router Mode must remain explicit because user-memory pollution is costly.
 
 ### Redaction
 
@@ -154,7 +154,7 @@ The safety layer that removes or masks secrets before retain, diagnostics, or de
 
 ## Naming rules
 
-- Use **Project Bank** and **Global Bank** when talking about bank policy.
+- Use **Project Bank** and **User Bank** when talking about bank policy. Use `global` only for exact legacy config/tool aliases.
 - Use **Retain**, **Recall**, and **Reflect** for the three Hindsight operations; do not collapse them into a generic “memory call.”
 - Use **Retain Queue**, **Retain Job**, **Queue Lock**, and **Dead Letter Queue** for durability behavior.
 - Use **Import Manifest** and **Import Checkpoint** for historical import state.
@@ -179,7 +179,7 @@ The safety layer that removes or masks secrets before retain, diagnostics, or de
 - Retain writes raw rich content, not summaries.
 - Live session retains use stable document IDs and `append` mode.
 - Historical imports use deterministic document IDs and `replace` mode where reimport idempotency requires it.
-- Project memory is the default; global memory requires explicit configuration and explicit writes unless Router Mode is enabled.
+- Project memory is the default; User Bank memory requires explicit configuration and explicit writes unless an explicit profile or Router Mode enables automatic User Bank retain.
 - Tags define scope and visibility; metadata records provenance and links back to source records.
 - Queue-first durability applies to automatic retain, explicit retain, and imports.
 - Debug visibility must be opt-in and must redact secrets before persistence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Before making a change, read:
 3. Any relevant ADR under `docs/adr/`.
 4. The official Hindsight and Pi documentation when changing API behavior, hook behavior, package shape, or extension lifecycle behavior.
 
-Use the terms from `CONTEXT.md` in issue titles, test names, PR descriptions, and docs. Prefer **Project Bank**, **Global Bank**, **Retain**, **Recall**, **Reflect**, **Retain Queue**, **Retain Job**, **Recall Block**, **Last-Recall Snapshot**, **Import Manifest**, **Import Checkpoint**, **Memory Operation Service**, and **Operation Catalog** over local synonyms.
+Use the terms from `CONTEXT.md` in issue titles, test names, PR descriptions, and docs. Prefer **Project Bank**, **User Bank** (legacy internal/config name: global bank), **Retain**, **Recall**, **Reflect**, **Retain Queue**, **Retain Job**, **Recall Block**, **Last-Recall Snapshot**, **Import Manifest**, **Import Checkpoint**, **Memory Operation Service**, and **Operation Catalog** over local synonyms.
 
 Human and agent guidance must stay aligned. If you change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition-of-done criteria, update both this file and `AGENTS.md` in the same PR.
 
@@ -100,7 +100,7 @@ Every code change must preserve these rules:
 - Historical imports use deterministic document IDs and preserve reimport idempotency.
 - **Recall** happens before answer generation and remains ephemeral.
 - **Recall Blocks** must not be persisted into transcript history or retained back into Hindsight.
-- **Global Bank** writes are explicit by default; automatic global retain requires explicit Router Mode.
+- **User Bank** writes are explicit by default; automatic User Bank retain requires an explicit profile or Router Mode.
 - Tags define scope and visibility; metadata records provenance.
 - Retain paths are queue-first.
 - Debug visibility is opt-in and must redact secrets before persistence.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ A useful report includes:
 Security-sensitive areas include:
 
 - secret redaction before Retain, diagnostics, logs, or Last-Recall Snapshot writes
-- Project Bank and Global Bank isolation
+- Project Bank and User Bank isolation
 - Retain Queue durability and malformed queue handling
 - exact document deletion behavior
 - import of historical Pi JSONL sessions

--- a/docs-site/src/content/docs/concepts/index.mdx
+++ b/docs-site/src/content/docs/concepts/index.mdx
@@ -5,7 +5,7 @@ description: Memory model, bank boundaries, Retain, Recall, Reflect, imports, qu
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Concept pages explain how Pi Hindsight uses Hindsight without repeating command or schema reference.
+Concept pages explain how Pi Hindsight uses Hindsight. They should describe stable mental models, not step-by-step procedures or generated schemas.
 
 <CardGrid>
   <Card title="Memory Banks" icon="laptop">
@@ -24,8 +24,8 @@ Concept pages explain how Pi Hindsight uses Hindsight without repeating command 
     Queue-first retain, retry, malformed-line quarantine, and dead-letter behavior.
     [Read](./queue-durability/)
   </Card>
-  <Card title="Session memory modes" icon="setting">
-    Risk boundaries for read-only, opt-out, and deferred memory controls.
+  <Card title="Session modes" icon="setting">
+    Normal, read-only, ignored, next-turn opt-out, and setup profiles.
     [Read](./session-memory-modes/)
   </Card>
   <Card title="Historical Import" icon="puzzle">
@@ -33,8 +33,8 @@ Concept pages explain how Pi Hindsight uses Hindsight without repeating command 
   </Card>
 </CardGrid>
 
-Additional background:
+## Supporting background
 
-- [Memory behavior](./memory-behavior/)
-- [Hindsight core functions](./hindsight-core-functions/)
-- [Starter mental model suggestions](./starter-mental-model-suggestions/)
+- [Memory behavior](./memory-behavior/) explains the automatic one-turn lifecycle.
+- [Hindsight core functions](./hindsight-core-functions/) links Pi behavior back to Hindsight primitives.
+- [Starter mental model suggestions](./starter-mental-model-suggestions/) explains seed material for bank templates and mental models.

--- a/docs-site/src/content/docs/development/docs-site-publishing.md
+++ b/docs-site/src/content/docs/development/docs-site-publishing.md
@@ -34,6 +34,35 @@ base: "/pi-hindsight",
 
 Keep `base` set to `/pi-hindsight` unless the repository moves to a root-domain Pages deployment. This makes absolute docs links and built assets work under GitHub Pages project hosting.
 
+## Mermaid rendering pipeline
+
+Pi Hindsight uses [`astro-mermaid`](https://github.com/joesaby/astro-mermaid) for Mermaid diagrams.
+
+The pipeline is hybrid:
+
+1. Markdown source keeps normal fenced blocks:
+
+   ````markdown
+   ```mermaid
+   flowchart LR
+     A --> B
+   ```
+   ````
+
+2. During `astro build`, `astro-mermaid` runs Remark/Rehype transforms before Starlight. Those transforms convert Mermaid fences into `<pre class="mermaid">` blocks.
+3. The built HTML still contains `<pre class="mermaid">`. This is expected. SVG is **not** generated at build time.
+4. In the browser, the client-side Mermaid runtime renders each `<pre class="mermaid">` into SVG.
+5. Theme changes and Astro view transitions re-render diagrams client-side.
+
+Implementation expectations:
+
+- Keep `mermaid()` before `starlight()` in `astro.config.mjs`.
+- Keep `mermaid` installed because the browser runtime imports it.
+- Keep `@mermaid-js/layout-elk` installed when diagrams use or may use ELK layout. The integration logs `Enabling ELK support` when the optional peer is present.
+- Do not add a second custom Mermaid renderer unless a concrete bug proves `astro-mermaid` cannot handle the needed case.
+
+Build logs such as `Remark transformed mermaid block` mean the fence was prepared for client-side rendering. They do not mean build-time SVG rendering happened.
+
 ## Deployment workflow
 
 `.github/workflows/docs-pages.yml` runs on pushes to `main` that touch docs-site inputs and on manual `workflow_dispatch`.
@@ -54,6 +83,8 @@ Pull requests do not publish. PR validation comes from the normal Check workflow
 ## Troubleshooting
 
 - If generated docs are stale, run `npm run surface-reference` or `npm run code-map`, then re-run `npm run docs:check`.
+- If Mermaid diagrams show as raw code in the browser, confirm `mermaid()` appears before `starlight()` in `astro.config.mjs`, then check the browser console for `[astro-mermaid]` errors.
+- If built HTML contains `<pre class="mermaid">`, that is normal. Verify browser rendering, not build-time SVG output.
 - If a docs link fails locally but works in the browser, prefer relative source links for same-section docs pages. Absolute deployed-site links must include the Pages base path.
 - If deployment fails before upload, inspect the build step first; Pages deployment only receives the already-built `docs-site/dist` artifact.
 - If the deployed site has broken assets, verify `site` and `base` in `astro.config.mjs` still match the GitHub Pages project URL.

--- a/docs-site/src/content/docs/development/documentation-architecture.md
+++ b/docs-site/src/content/docs/development/documentation-architecture.md
@@ -2,15 +2,15 @@
 title: "Documentation architecture"
 ---
 
-This note defines the target information architecture for Pi Hindsight documentation. It is the stable migration map for documentation-site work and for future documentation reviews.
+This note defines the target information architecture for Pi Hindsight documentation. It is the migration map for documentation-site work and future docs reviews.
 
 ## Goals
 
-The documentation should help readers answer six questions quickly:
+Docs should help readers answer six questions quickly:
 
 1. How do I install and configure Pi Hindsight?
 2. What memory concepts and safety rules do I need to understand?
-3. How do I use tools, commands, setup, imports, and diagnostics?
+3. How do I use the TUI, setup, imports, diagnostics, tools, and commands?
 4. How is the extension designed internally?
 5. How do I contribute, test, release, and review changes?
 6. Which material is generated, authoritative, or internal-only?
@@ -29,184 +29,110 @@ When these sources conflict, follow `AGENTS.md` and `CONTRIBUTING.md` source-of-
 
 ## Naming rules
 
-Use the project glossary in `CONTEXT.md`. In documentation navigation and page titles, prefer:
+Use the project glossary in `CONTEXT.md`. In user-facing docs and TUI copy, prefer:
 
 - **Memory Bank** for isolated Hindsight storage.
 - **Project Bank** for repository-scoped memory.
-- **Global Bank** for configured cross-project user memory, while UI copy may also say **User** where the product surface has migrated from older `global` wording.
+- **User Bank** for configured cross-project user memory.
 - **Retain**, **Recall**, and **Reflect** for Hindsight operations.
 - **Retain Queue**, **Retain Job**, **Document ID**, **Import Manifest**, and **Import Checkpoint** for durability and import behavior.
-- **Import** for historical session ingestion, not generic file upload.
+- **Pi session import** for repo/coding session history.
+- **Chat transcript import** for non-repo conversation history routed to User memory.
 
-Avoid introducing synonyms such as “memory bucket,” “cache,” “sync,” or “summarization import” unless the page explicitly explains why the term is not part of the product vocabulary.
+Keep legacy `global` and `gateway` names only where they are exact config aliases, historical document IDs, or internal compatibility details.
 
-## Target sections
+## Section roles
 
 ### Start
 
 Audience: first-time users.
 
-Purpose: get a working setup with minimal conceptual load.
-
-Pages:
-
-- Overview
-- Getting started
-- Installation and Hindsight server options
-- Guided setup
-- First checks and troubleshooting
+Purpose: shortest path to a working setup. Start pages can mention concepts, but should link out instead of fully explaining them.
 
 ### Concepts
 
-Audience: users who need the mental model before changing configuration.
+Audience: users who need the mental model before changing behavior.
 
-Purpose: explain memory behavior, bank boundaries, and safety invariants.
-
-Pages:
-
-- Memory model overview
-- Project Bank and Global/User Bank
-- Retain, Recall, and Reflect
-- Retain Queue and outage behavior
-- Session Memory Modes
-- Historical Import concepts
-- Bank templates, mental models, and directives
-- Safety and secret redaction
+Purpose: stable memory model, bank boundaries, Retain/Recall/Reflect, imports, queue durability, session modes, and safety invariants. Concepts should not duplicate command syntax or exact config schemas.
 
 ### Guides
 
 Audience: users performing tasks.
 
-Purpose: task-oriented instructions with examples.
-
-Pages:
-
-- Configure memory profiles
-- Use `/hindsight` setup and status
-- Import historical Pi sessions
-- Import chat transcripts
-- Export bank templates; guided setup bank-template import
-- Inspect recalls and retain receipts
-- Recover from outages or failed queue jobs
-- Run local smoke tests
+Purpose: task workflows. Guides should start from `/hindsight` and guided setup when those are the normal product paths. Command examples belong here only when they are the best way to repeat, script, or explicitly target a workflow.
 
 ### Reference
 
 Audience: users and maintainers checking exact names and schemas.
 
-Purpose: stable reference, with generated content clearly marked.
-
-Pages:
-
-- Tools and commands
-- Generated surface reference
-- Configuration reference
-- Bank template manifest reference
-- Memory modes reference
-- Hindsight API links
+Purpose: concise reference for tools, commands, config, hooks, import controls, and generated surface output. Reference pages should link to guides for procedures.
 
 ### Architecture
 
 Audience: contributors and maintainers.
 
-Purpose: explain design seams and invariants.
-
-Pages:
-
-- System architecture overview
-- Memory lifecycle hooks
-- Memory Operation Service and Operation Catalog
-- Hindsight Adapter and REST shim policy
-- Retain Queue durability
-- Import architecture
-- Setup TUI architecture
-- ADR index
+Purpose: design seams and invariants: lifecycle hooks, operation service, Hindsight adapter, queue durability, import architecture, setup TUI architecture, and ADRs.
 
 ### Development
 
 Audience: contributors and agents.
 
-Purpose: repository workflow, checks, releases, and issue discipline.
-
-Pages:
-
-- Development setup
-- Testing and verification
-- GitHub Issues workflow
-- Continuous issue iteration
-- Release process
-- Agent guidance
-- Documentation architecture
+Purpose: repository workflow, checks, releases, docs pipeline, issue discipline, and agent guidance.
 
 ### Internal and archive
 
 Audience: maintainers.
 
-Purpose: keep historical plans available without presenting them as current user docs.
+Purpose: keep historical plans available without presenting them as current user docs. Archive/delete scratch plans after actionable content moves into issues or stable docs.
 
-Pages should be hidden from primary navigation or clearly marked as internal when they are research notes, roadmaps, scratch plans, or superseded design material.
+## Duplication rules
 
-## Migration map
+- One page owns each explanation.
+- Other pages link to the owner and add only local context.
+- Start pages own happy-path onboarding.
+- Concepts own why/mental model.
+- Guides own procedures.
+- Reference owns exact names and schemas.
+- Generated pages own exhaustive generated listings.
 
-| Current file                                         | Target section                                                          | Action                                                                                                   |
-| ---------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `README.md`                                          | Start / Overview                                                        | Keep as repository landing page. Later mirror core overview into docs site.                              |
-| `docs/getting-started.md`                            | Start / Getting started                                                 | Keep. Refresh setup text when site navigation exists.                                                    |
-| `docs/configuration.md`                              | Reference / Configuration reference; Guides / Configure memory profiles | Split later: reference stays exact, guide becomes task-oriented.                                         |
-| `docs/memory-behavior.md`                            | Concepts / Memory model overview                                        | Keep and align with glossary.                                                                            |
-| `docs/hindsight-core-functions.md`                   | Concepts / Retain, Recall, Reflect                                      | Keep as concept page; link to official Hindsight docs for authoritative API behavior.                    |
-| `docs/risky-memory-modes.md`                         | Concepts / Session Memory Modes                                         | Keep; may merge with `docs/adr/003-tui-memory-mode-vocabulary.md` summary.                               |
-| `docs/importing-sessions.md`                         | Guides / Import historical sessions and chat transcripts                | Keep as task guide. Later split Pi sessions vs chat transcripts if it grows.                             |
-| `docs/tools-and-commands.md`                         | Reference / Tools and commands                                          | Keep hand-authored overview. Link to generated surface reference.                                        |
-| `docs-site/src/content/docs/development/code-map.md` | Development / Generated code map                                        | Generated site-only maintainer map. Keep generated by `scripts/generate-code-map.mjs`; do not hand-edit. |
-| `docs/surface-reference.md`                          | Reference / Generated surface reference                                 | Keep generated. Mark as generated and do not edit by hand.                                               |
-| `docs/core-vs-companion-adapters.md`                 | Architecture / System architecture overview                             | Keep. Link from architecture section.                                                                    |
-| `docs/adr/*.md`                                      | Architecture / ADR index                                                | Keep as authoritative decision records. Add index/navigation later.                                      |
-| `docs/development.md`                                | Development / Development setup and verification                        | Keep. Link this documentation architecture note.                                                         |
-| `docs/release.md`                                    | Development / Release process                                           | Keep.                                                                                                    |
-| `docs/starter-mental-model-suggestions.md`           | Concepts / Bank templates, mental models, directives                    | Keep as concept/reference seed material; clarify relationship to built-in templates if copied into site. |
-| `docs/next-opt-out-design.md`                        | Internal and archive                                                    | Keep internal unless next opt-out becomes user-facing guide.                                             |
-| `docs/architecture-todos.md`                         | Internal and archive                                                    | Convert actionable items to issues, then archive or remove.                                              |
-| `docs/agents/*.md`                                   | Development / Agent guidance                                            | Keep as contributor/agent support docs.                                                                  |
-| `CONTEXT.md`                                         | Development / Glossary and invariants                                   | Keep at repository root as shared vocabulary. Link from docs site.                                       |
-| `AGENTS.md`                                          | Development / Agent guidance                                            | Keep at repository root. Link from docs site but do not duplicate all rules.                             |
-| `CONTRIBUTING.md`                                    | Development / Contributing                                              | Keep at repository root. Link from docs site.                                                            |
-| `SECURITY.md`                                        | Start / Security and support; Development / Security policy             | Keep at repository root and link from docs site.                                                         |
-| `CHANGELOG.md`                                       | Reference / Changelog                                                   | Keep generated/release-owned. Do not hand-edit release entries.                                          |
+Examples:
+
+- Memory profile semantics live in [Memory profiles](/pi-hindsight/start/memory-profiles/). Guides may summarize the profile names but should link there for details.
+- Import concepts live in [Historical Import](/pi-hindsight/concepts/imports/). The [Importing sessions](/pi-hindsight/guides/importing-sessions/) guide owns task steps.
+- Exact import flags/tools live in [Import controls](/pi-hindsight/reference/import-controls/).
+
+## Mermaid rendering pipeline
+
+The docs site uses [`astro-mermaid`](https://github.com/joesaby/astro-mermaid). The pipeline is hybrid:
+
+1. Markdown keeps normal `mermaid` fenced code blocks.
+2. `astro-mermaid` must run before Starlight in `astro.config.mjs`.
+3. During `astro build`, Remark/Rehype transforms convert fences into `<pre class="mermaid">`.
+4. Built HTML still contains `<pre class="mermaid">`; that is expected.
+5. Browser-side Mermaid renders SVG client-side.
+
+Do not expect build-time SVG output. Build logs saying a Mermaid block was transformed mean the block was prepared for client-side rendering.
 
 ## Hand-authored versus generated
 
-Hand-authored documentation:
+Hand-authored docs explain intent, invariants, and workflows.
 
-- Overview, concepts, guides, architecture notes, ADRs, contributing guidance, and troubleshooting.
-- These pages explain intent, invariants, and user workflows.
-
-Generated documentation:
+Generated docs must stay reproducible from scripts:
 
 - `docs/surface-reference.md` and the docs-site surface reference from `scripts/generate-surface-reference.ts`.
 - `docs-site/src/content/docs/development/code-map.md` from `scripts/generate-code-map.mjs`.
 - `CHANGELOG.md` from release/changelog automation.
-- Future generated API tables should remain clearly labeled and reproducible from scripts.
 
-Do not manually patch generated content as the source of truth. Change the generator, source schema, or release metadata instead.
+Do not manually patch generated content as source of truth. Change the generator, source schema, or release metadata instead.
 
-## Migration order
-
-1. Define this information architecture and link it from development docs.
-2. Add documentation site scaffolding and navigation.
-3. Move getting-started and concept pages into the site structure.
-4. Move reference pages, including generated surface output.
-5. Move architecture and development pages.
-6. Add quality checks for links, generated docs freshness, and navigation coverage.
-7. Archive or delete superseded roadmap/scratch notes after their content is represented in issues or stable docs.
-
-## Review checklist for documentation changes
+## Review checklist
 
 Use this checklist when adding or moving docs:
 
 - Does the page belong to Start, Concepts, Guides, Reference, Architecture, Development, or Internal/Archive?
 - Does it use glossary terms from `CONTEXT.md`?
 - Does it distinguish Hindsight behavior from Pi Hindsight policy?
+- Does it link to the owning page instead of repeating long explanations?
 - Is generated content clearly marked as generated?
+- Are TUI/guided setup surfaces linked to the relevant docs page when users need context?
 - Are outdated roadmap or scratch notes converted to issues before removal?
-- Are links from contributor-facing docs updated if the documentation workflow changes?

--- a/docs-site/src/content/docs/guides/index.mdx
+++ b/docs-site/src/content/docs/guides/index.mdx
@@ -1,25 +1,26 @@
 ---
 title: Guides
-description: Task-focused workflows for setup, imports, diagnostics, recovery, and verification.
+description: Task-first workflows for setup, imports, diagnostics, recovery, and verification.
 ---
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Guides answer “how do I do this now?” Use Concepts for mental models and Reference for exact fields.
+Guides answer “what do I do now?” They avoid repeating the concept model and exact schema details. Use [Concepts](/pi-hindsight/concepts/) for mental models and [Reference](/pi-hindsight/reference/) for exact names.
 
 <CardGrid>
   <Card title="Configure memory profiles" icon="setting">
-    Choose Project + User, Project Only, User Only, or Recall Only behavior and map that choice to
-    config. [Configure profiles](./configure-memory-profiles/)
+    Choose Project + User, Project Only, User Only, or Recall Only through `/hindsight`. [Configure
+    profiles](./configure-memory-profiles/)
   </Card>
   <Card title="Use `/hindsight` status" icon="information">
     Inspect server reachability, active banks, retain queue state, imports, and receipts. [Check
     status](./use-hindsight-status/)
   </Card>
-  <Card title="Import sessions" icon="download">
-    Preview and import historical Pi session JSONL files. [Import sessions](./importing-sessions/)
+  <Card title="Import history" icon="download">
+    Preview and import historical Pi sessions or chat transcripts only when backfill is useful.
+    [Import guide](./importing-sessions/)
   </Card>
-  <Card title="Inspect recalls and receipts" icon="magnifier">
+  <Card title="Inspect memory" icon="magnifier">
     Debug what memory was recalled and what retain jobs were accepted. [Inspect
     memory](./inspect-recalls-and-receipts/)
   </Card>

--- a/docs-site/src/content/docs/index.mdx
+++ b/docs-site/src/content/docs/index.mdx
@@ -9,31 +9,37 @@ hero:
       link: /pi-hindsight/start/getting-started/
       icon: right-arrow
       variant: primary
-    - text: Configuration reference
-      link: /pi-hindsight/reference/configuration/
-      icon: document
+    - text: Open setup guide
+      link: /pi-hindsight/start/setup-tui/
+      icon: setting
 ---
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Pi Hindsight recalls relevant project memory before model calls, retains structured session deltas after agent runs, and exposes explicit memory tools when you want direct control.
+Pi Hindsight gives Pi long-term memory through Hindsight. The normal workflow is:
+
+1. install the package,
+2. run `/hindsight`,
+3. choose a memory profile,
+4. let automatic Recall/Retain handle future sessions,
+5. optionally import old sessions.
 
 <CardGrid>
-  <Card title="Start" icon="rocket">
-    Install the extension, connect Hindsight, choose a memory profile, and verify the first run.
-    [Begin setup →](/pi-hindsight/start/getting-started/)
+  <Card title="Start here" icon="rocket">
+    Install the extension, connect Hindsight, choose a profile, and verify status. [Begin setup
+    →](/pi-hindsight/start/getting-started/)
   </Card>
-  <Card title="Concepts" icon="open-book">
-    Understand Memory Banks, Retain, Recall, Reflect, queue durability, imports, and safety rules.
-    [Learn the model →](/pi-hindsight/concepts/)
+  <Card title="Use the TUI" icon="setting">
+    `/hindsight` is the main surface for setup, status, profile changes, queue flushes, imports, and
+    links back to these docs. [Open TUI guide →](/pi-hindsight/start/setup-tui/)
   </Card>
-  <Card title="Guides" icon="setting">
-    Follow task workflows for profiles, setup/status checks, imports, recall inspection, queue
-    recovery, and smoke tests. [Pick a workflow →](/pi-hindsight/guides/)
+  <Card title="Understand the model" icon="open-book">
+    Concepts explain bank boundaries, Retain, Recall, Reflect, imports, queue durability, and
+    safety. [Read concepts →](/pi-hindsight/concepts/)
   </Card>
-  <Card title="Reference" icon="document">
-    Look up exact config fields, tools, commands, hooks, import controls, and generated surface
-    details. [Open reference →](/pi-hindsight/reference/)
+  <Card title="Look up exact names" icon="document">
+    Reference pages list config fields, tools, commands, hooks, import controls, and generated
+    surface details. [Open reference →](/pi-hindsight/reference/)
   </Card>
 </CardGrid>
 
@@ -51,29 +57,29 @@ flowchart LR
 
 ## Safety defaults
 
-- Project memory stays in a project bank by default.
-- Global/user memory is opt-in and explicitly configured.
+- Project memory stays in a Project Bank by default.
+- User memory is opt-in and configured intentionally.
 - Recall injection is ephemeral; recalled memory is not written back into transcripts.
 - Retain uses stable document IDs and queue durability.
 - Automatic retain redacts common secrets before writing memory.
 
-## Where to go next
+## Task shortcuts
 
 <CardGrid>
-  <Card title="Five-minute setup" icon="right-arrow">
-    Use the shortest successful path from install to verified memory. [Getting
-    started](/pi-hindsight/start/getting-started/)
-  </Card>
   <Card title="Choose memory scope" icon="laptop">
     Compare Project + User, Project Only, User Only, and Recall Only profiles. [Memory
     profiles](/pi-hindsight/start/memory-profiles/)
   </Card>
   <Card title="Import old sessions" icon="download">
-    Preview and import Pi session JSONL history with deterministic document IDs. [Importing
-    sessions](/pi-hindsight/guides/importing-sessions/)
+    Preview first, then import Pi sessions or chat transcripts only when backfill is useful. [Import
+    guide](/pi-hindsight/guides/importing-sessions/)
   </Card>
-  <Card title="Troubleshoot memory" icon="information">
-    Inspect status, recalls, receipts, queue state, and smoke-test output. [Status and setup
-    guide](/pi-hindsight/guides/use-hindsight-status/)
+  <Card title="Inspect memory" icon="magnifier">
+    Check last recall, retain receipts, queue state, and status diagnostics. [Inspection
+    guide](/pi-hindsight/guides/inspect-recalls-and-receipts/)
+  </Card>
+  <Card title="Contribute" icon="puzzle">
+    Verify docs, understand generated references, and follow issue/PR workflow. [Development
+    docs](/pi-hindsight/development/)
   </Card>
 </CardGrid>

--- a/docs-site/src/content/docs/reference/index.mdx
+++ b/docs-site/src/content/docs/reference/index.mdx
@@ -5,16 +5,20 @@ description: Exact config fields, tools, commands, hooks, import controls, gener
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-Reference pages are for exact names and contracts. Use Guides when you want a workflow.
+Reference pages are for exact names and contracts. They should stay concise and link back to guides instead of re-explaining workflows.
 
 <CardGrid>
   <Card title="Configuration" icon="setting">
-    Config file locations, precedence, environment variables, and bank derivation fields.
+    Config locations, precedence, environment variables, profile fields, and bank derivation.
     [Open](./configuration/)
   </Card>
   <Card title="Tools and commands" icon="puzzle">
     Explicit memory tools, command shortcuts, and command intent groups.
     [Open](./tools-and-commands/)
+  </Card>
+  <Card title="Import controls" icon="download">
+    Exact command/tool controls for dry-runs, explicit files, and branch-leaf selection.
+    [Open](./import-controls/)
   </Card>
   <Card title="Hooks" icon="laptop">
     Pi extension hook mapping for session start, context, agent end, and shutdown. [Open](./hooks/)

--- a/docs-site/src/content/docs/start/setup-tui.md
+++ b/docs-site/src/content/docs/start/setup-tui.md
@@ -2,28 +2,32 @@
 title: "Setup TUI"
 ---
 
-`/hindsight` is the main control center. Use it before reaching for command shortcuts.
+`/hindsight` is the main control center. Use it before command shortcuts.
 
 ```text
 /hindsight
 ```
 
-The TUI shows:
+The TUI shows status first, then lets you edit settings, rerun guided setup, flush queued Retain Jobs, inspect imports, and open mental model details.
 
-- memory profile and enablement
-- selected Project Bank and optional User Bank
-- Hindsight server reachability
-- Retain Queue state and flush action
-- import manifest/checkpoint state
+## What to use it for
+
+- first setup and profile selection
+- server/base URL checks
+- Project Bank and User Bank confirmation
+- Retain Queue state and flushes
+- import manifest/checkpoint status
 - recent Retain receipts
-- editable local Pi configuration fields
+- local config overrides
 - read-only mental model inventory
+
+Each selected setting detail includes a section-level docs link. Use that link when a field needs more context than the TUI can show.
 
 ## Guided setup
 
 If no project config exists, `/hindsight` starts guided setup before the advanced TUI. You can rerun guided setup later with `g`.
 
-Guided setup asks for:
+Guided setup handles:
 
 1. Hindsight server URL
 2. memory profile
@@ -32,25 +36,29 @@ Guided setup asks for:
 5. optional dry-run-first historical import
 6. optional post-import mental model refresh
 
-Profiles decide which config scopes are written:
+Setup also prints docs links for the current area, such as [memory profiles](/pi-hindsight/start/memory-profiles/), [bank templates](/pi-hindsight/reference/bank-template-manifest/), and [imports](/pi-hindsight/guides/importing-sessions/).
 
-- **Project + User** writes repo project-memory settings plus reusable user-bank settings in global Pi config.
-- **Project Only** writes repo project-memory settings only.
-- **User Only** disables project memory and writes reusable user-bank settings in global Pi config.
-- **Recall Only** keeps automatic recall on and automatic retain off.
+## Profiles in one line
 
-Bank templates and mental models are Hindsight bank-owned settings. Pi Hindsight does not store mission text or directive definitions as normal Pi JSON source of truth.
+- **Project + User**: repo facts in Project memory; durable preferences in User memory.
+- **Project Only**: strict repo isolation.
+- **User Only**: cross-project/user memory without project memory.
+- **Recall Only**: recall on, automatic retain off.
+
+For details, see [Memory profiles](/pi-hindsight/start/memory-profiles/).
 
 ## Keyboard controls
 
 - `h`/`l` or `<`/`>`: switch tabs
 - `j`/`k`: move between settings
 - `Enter`: edit selected setting
-- `r`: remove the selected setting's active override
+- `r`: remove selected setting's active override
 - `f`: flush queued Retain Jobs
-- `m`: open the read-only mental model list/detail view
+- `m`: open read-only mental model list/detail view
+- `a`: toggle advanced fields
 - `d`: deployment setup
 - `g`: rerun guided setup
+- `q`: close
 
 ## First checks
 
@@ -63,8 +71,10 @@ After setup, confirm:
 - Retain Queue path is visible and writable
 - import state is empty, previewed, imported, queued, or failed as expected
 
+For status interpretation, see [Use `/hindsight` status](/pi-hindsight/guides/use-hindsight-status/).
+
 ## Import from the TUI first
 
-Guided setup can offer historical import after config/template setup. That path previews first, then asks before writing memory. Prefer it for first-time backfill.
+Guided setup can offer historical import after config/template setup. That path previews first, shows progress, then asks before writing memory. Prefer it for first-time backfill.
 
 Use command shortcuts later when you already know which session set you want to import. See [Importing sessions](/pi-hindsight/guides/importing-sessions/).

--- a/docs/documentation-architecture.md
+++ b/docs/documentation-architecture.md
@@ -1,14 +1,14 @@
 # Documentation architecture
 
-This note defines the target information architecture for Pi Hindsight documentation. It is the stable migration map for documentation-site work and for future documentation reviews.
+This note defines the target information architecture for Pi Hindsight documentation. It is the migration map for documentation-site work and future docs reviews.
 
 ## Goals
 
-The documentation should help readers answer six questions quickly:
+Docs should help readers answer six questions quickly:
 
 1. How do I install and configure Pi Hindsight?
 2. What memory concepts and safety rules do I need to understand?
-3. How do I use tools, commands, setup, imports, and diagnostics?
+3. How do I use the TUI, setup, imports, diagnostics, tools, and commands?
 4. How is the extension designed internally?
 5. How do I contribute, test, release, and review changes?
 6. Which material is generated, authoritative, or internal-only?
@@ -27,184 +27,110 @@ When these sources conflict, follow `AGENTS.md` and `CONTRIBUTING.md` source-of-
 
 ## Naming rules
 
-Use the project glossary in `CONTEXT.md`. In documentation navigation and page titles, prefer:
+Use the project glossary in `CONTEXT.md`. In user-facing docs and TUI copy, prefer:
 
 - **Memory Bank** for isolated Hindsight storage.
 - **Project Bank** for repository-scoped memory.
-- **Global Bank** for configured cross-project user memory, while UI copy may also say **User** where the product surface has migrated from older `global` wording.
+- **User Bank** for configured cross-project user memory.
 - **Retain**, **Recall**, and **Reflect** for Hindsight operations.
 - **Retain Queue**, **Retain Job**, **Document ID**, **Import Manifest**, and **Import Checkpoint** for durability and import behavior.
-- **Import** for historical session ingestion, not generic file upload.
+- **Pi session import** for repo/coding session history.
+- **Chat transcript import** for non-repo conversation history routed to User memory.
 
-Avoid introducing synonyms such as “memory bucket,” “cache,” “sync,” or “summarization import” unless the page explicitly explains why the term is not part of the product vocabulary.
+Keep legacy `global` and `gateway` names only where they are exact config aliases, historical document IDs, or internal compatibility details.
 
-## Target sections
+## Section roles
 
 ### Start
 
 Audience: first-time users.
 
-Purpose: get a working setup with minimal conceptual load.
-
-Pages:
-
-- Overview
-- Getting started
-- Installation and Hindsight server options
-- Guided setup
-- First checks and troubleshooting
+Purpose: shortest path to a working setup. Start pages can mention concepts, but should link out instead of fully explaining them.
 
 ### Concepts
 
-Audience: users who need the mental model before changing configuration.
+Audience: users who need the mental model before changing behavior.
 
-Purpose: explain memory behavior, bank boundaries, and safety invariants.
-
-Pages:
-
-- Memory model overview
-- Project Bank and Global/User Bank
-- Retain, Recall, and Reflect
-- Retain Queue and outage behavior
-- Session Memory Modes
-- Historical Import concepts
-- Bank templates, mental models, and directives
-- Safety and secret redaction
+Purpose: stable memory model, bank boundaries, Retain/Recall/Reflect, imports, queue durability, session modes, and safety invariants. Concepts should not duplicate command syntax or exact config schemas.
 
 ### Guides
 
 Audience: users performing tasks.
 
-Purpose: task-oriented instructions with examples.
-
-Pages:
-
-- Configure memory profiles
-- Use `/hindsight` setup and status
-- Import historical Pi sessions
-- Import chat transcripts
-- Export bank templates; guided setup bank-template import
-- Inspect recalls and retain receipts
-- Recover from outages or failed queue jobs
-- Run local smoke tests
+Purpose: task workflows. Guides should start from `/hindsight` and guided setup when those are the normal product paths. Command examples belong here only when they are the best way to repeat, script, or explicitly target a workflow.
 
 ### Reference
 
 Audience: users and maintainers checking exact names and schemas.
 
-Purpose: stable reference, with generated content clearly marked.
-
-Pages:
-
-- Tools and commands
-- Generated surface reference
-- Configuration reference
-- Bank template manifest reference
-- Memory modes reference
-- Hindsight API links
+Purpose: concise reference for tools, commands, config, hooks, import controls, and generated surface output. Reference pages should link to guides for procedures.
 
 ### Architecture
 
 Audience: contributors and maintainers.
 
-Purpose: explain design seams and invariants.
-
-Pages:
-
-- System architecture overview
-- Memory lifecycle hooks
-- Memory Operation Service and Operation Catalog
-- Hindsight Adapter and REST shim policy
-- Retain Queue durability
-- Import architecture
-- Setup TUI architecture
-- ADR index
+Purpose: design seams and invariants: lifecycle hooks, operation service, Hindsight adapter, queue durability, import architecture, setup TUI architecture, and ADRs.
 
 ### Development
 
 Audience: contributors and agents.
 
-Purpose: repository workflow, checks, releases, and issue discipline.
-
-Pages:
-
-- Development setup
-- Testing and verification
-- GitHub Issues workflow
-- Continuous issue iteration
-- Release process
-- Agent guidance
-- Documentation architecture
+Purpose: repository workflow, checks, releases, docs pipeline, issue discipline, and agent guidance.
 
 ### Internal and archive
 
 Audience: maintainers.
 
-Purpose: keep historical plans available without presenting them as current user docs.
+Purpose: keep historical plans available without presenting them as current user docs. Archive/delete scratch plans after actionable content moves into issues or stable docs.
 
-Pages should be hidden from primary navigation or clearly marked as internal when they are research notes, roadmaps, scratch plans, or superseded design material.
+## Duplication rules
 
-## Migration map
+- One page owns each explanation.
+- Other pages link to the owner and add only local context.
+- Start pages own happy-path onboarding.
+- Concepts own why/mental model.
+- Guides own procedures.
+- Reference owns exact names and schemas.
+- Generated pages own exhaustive generated listings.
 
-| Current file                                         | Target section                                                          | Action                                                                                                   |
-| ---------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `README.md`                                          | Start / Overview                                                        | Keep as repository landing page. Later mirror core overview into docs site.                              |
-| `docs/getting-started.md`                            | Start / Getting started                                                 | Keep. Refresh setup text when site navigation exists.                                                    |
-| `docs/configuration.md`                              | Reference / Configuration reference; Guides / Configure memory profiles | Split later: reference stays exact, guide becomes task-oriented.                                         |
-| `docs/memory-behavior.md`                            | Concepts / Memory model overview                                        | Keep and align with glossary.                                                                            |
-| `docs/hindsight-core-functions.md`                   | Concepts / Retain, Recall, Reflect                                      | Keep as concept page; link to official Hindsight docs for authoritative API behavior.                    |
-| `docs/risky-memory-modes.md`                         | Concepts / Session Memory Modes                                         | Keep; may merge with `docs/adr/003-tui-memory-mode-vocabulary.md` summary.                               |
-| `docs/importing-sessions.md`                         | Guides / Import historical sessions and chat transcripts                | Keep as task guide. Later split Pi sessions vs chat transcripts if it grows.                             |
-| `docs/tools-and-commands.md`                         | Reference / Tools and commands                                          | Keep hand-authored overview. Link to generated surface reference.                                        |
-| `docs-site/src/content/docs/development/code-map.md` | Development / Generated code map                                        | Generated site-only maintainer map. Keep generated by `scripts/generate-code-map.mjs`; do not hand-edit. |
-| `docs/surface-reference.md`                          | Reference / Generated surface reference                                 | Keep generated. Mark as generated and do not edit by hand.                                               |
-| `docs/core-vs-companion-adapters.md`                 | Architecture / System architecture overview                             | Keep. Link from architecture section.                                                                    |
-| `docs/adr/*.md`                                      | Architecture / ADR index                                                | Keep as authoritative decision records. Add index/navigation later.                                      |
-| `docs/development.md`                                | Development / Development setup and verification                        | Keep. Link this documentation architecture note.                                                         |
-| `docs/release.md`                                    | Development / Release process                                           | Keep.                                                                                                    |
-| `docs/starter-mental-model-suggestions.md`           | Concepts / Bank templates, mental models, directives                    | Keep as concept/reference seed material; clarify relationship to built-in templates if copied into site. |
-| `docs/next-opt-out-design.md`                        | Internal and archive                                                    | Keep internal unless next opt-out becomes user-facing guide.                                             |
-| `docs/architecture-todos.md`                         | Internal and archive                                                    | Convert actionable items to issues, then archive or remove.                                              |
-| `docs/agents/*.md`                                   | Development / Agent guidance                                            | Keep as contributor/agent support docs.                                                                  |
-| `CONTEXT.md`                                         | Development / Glossary and invariants                                   | Keep at repository root as shared vocabulary. Link from docs site.                                       |
-| `AGENTS.md`                                          | Development / Agent guidance                                            | Keep at repository root. Link from docs site but do not duplicate all rules.                             |
-| `CONTRIBUTING.md`                                    | Development / Contributing                                              | Keep at repository root. Link from docs site.                                                            |
-| `SECURITY.md`                                        | Start / Security and support; Development / Security policy             | Keep at repository root and link from docs site.                                                         |
-| `CHANGELOG.md`                                       | Reference / Changelog                                                   | Keep generated/release-owned. Do not hand-edit release entries.                                          |
+Examples:
+
+- Memory profile semantics live in the Memory profiles page. Guides may summarize the profile names but should link there for details.
+- Import concepts live in Historical Import. The Importing sessions guide owns task steps.
+- Exact import flags/tools live in Import controls.
+
+## Mermaid rendering pipeline
+
+The docs site uses [`astro-mermaid`](https://github.com/joesaby/astro-mermaid). The pipeline is hybrid:
+
+1. Markdown keeps normal `mermaid` fenced code blocks.
+2. `astro-mermaid` must run before Starlight in `astro.config.mjs`.
+3. During `astro build`, Remark/Rehype transforms convert fences into `<pre class="mermaid">`.
+4. Built HTML still contains `<pre class="mermaid">`; that is expected.
+5. Browser-side Mermaid renders SVG client-side.
+
+Do not expect build-time SVG output. Build logs saying a Mermaid block was transformed mean the block was prepared for client-side rendering.
 
 ## Hand-authored versus generated
 
-Hand-authored documentation:
+Hand-authored docs explain intent, invariants, and workflows.
 
-- Overview, concepts, guides, architecture notes, ADRs, contributing guidance, and troubleshooting.
-- These pages explain intent, invariants, and user workflows.
-
-Generated documentation:
+Generated docs must stay reproducible from scripts:
 
 - `docs/surface-reference.md` and the docs-site surface reference from `scripts/generate-surface-reference.ts`.
 - `docs-site/src/content/docs/development/code-map.md` from `scripts/generate-code-map.mjs`.
 - `CHANGELOG.md` from release/changelog automation.
-- Future generated API tables should remain clearly labeled and reproducible from scripts.
 
-Do not manually patch generated content as the source of truth. Change the generator, source schema, or release metadata instead.
+Do not manually patch generated content as source of truth. Change the generator, source schema, or release metadata instead.
 
-## Migration order
-
-1. Define this information architecture and link it from development docs.
-2. Add documentation site scaffolding and navigation.
-3. Move getting-started and concept pages into the site structure.
-4. Move reference pages, including generated surface output.
-5. Move architecture and development pages.
-6. Add quality checks for links, generated docs freshness, and navigation coverage.
-7. Archive or delete superseded roadmap/scratch notes after their content is represented in issues or stable docs.
-
-## Review checklist for documentation changes
+## Review checklist
 
 Use this checklist when adding or moving docs:
 
 - Does the page belong to Start, Concepts, Guides, Reference, Architecture, Development, or Internal/Archive?
 - Does it use glossary terms from `CONTEXT.md`?
 - Does it distinguish Hindsight behavior from Pi Hindsight policy?
+- Does it link to the owning page instead of repeating long explanations?
 - Is generated content clearly marked as generated?
+- Are TUI/guided setup surfaces linked to the relevant docs page when users need context?
 - Are outdated roadmap or scratch notes converted to issues before removal?
-- Are links from contributor-facing docs updated if the documentation workflow changes?

--- a/extensions/guided-setup.ts
+++ b/extensions/guided-setup.ts
@@ -295,6 +295,7 @@ async function maybeImportBankTemplate(args: {
     args.ctx.ui.notify("No enabled bank target for template import.", "warning");
     return [];
   }
+  args.ctx.ui.notify(setupDocsHint("Bank template", "/reference/bank-template-manifest/"), "info");
   const configure = await args.ctx.ui.confirm(
     "Configure Hindsight bank templates?",
     targets
@@ -414,6 +415,12 @@ function operationSummary(result: unknown): string {
   return [id?.trim(), status].filter(Boolean).join(" / ") || "operation accepted";
 }
 
+const DOCS_BASE_URL = "https://luxus.github.io/pi-hindsight";
+
+function setupDocsHint(topic: string, path: string): string {
+  return `${topic} docs: ${DOCS_BASE_URL}${path}`;
+}
+
 function setupImportProgressMessage(event: ImportProgressEvent): string {
   return `Hindsight import progress: ${event.message}`;
 }
@@ -488,6 +495,7 @@ export async function maybeOfferHistoricalImportForSetup(args: {
       .map((template) => template.profileId)
       .filter((profileId): profileId is BankTemplateProfileId => Boolean(profileId)),
   );
+  args.ctx.ui.notify(setupDocsHint("Import", "/guides/importing-sessions/"), "info");
   const choice = await args.ctx.ui.select(
     "Choose import source",
     importChoicesForSetup({
@@ -587,6 +595,8 @@ export async function runGuidedSetup(args: {
   deps: MemoryOperationsDeps;
   cwd: string;
 }): Promise<boolean> {
+  args.ctx.ui.notify(setupDocsHint("Guided setup", "/start/setup-tui/"), "info");
+  args.ctx.ui.notify(setupDocsHint("Memory profiles", "/start/memory-profiles/"), "info");
   const profile = await args.ctx.ui.select("Choose memory profile", [
     "Project + User",
     "Project Only",

--- a/extensions/setup-tui-render.ts
+++ b/extensions/setup-tui-render.ts
@@ -18,6 +18,17 @@ import {
 } from "./setup-tui-types.js";
 
 const MIN_BODY_LINES = 30;
+const DOCS_BASE_URL = "https://luxus.github.io/pi-hindsight";
+
+const TAB_DOCS: Record<string, string> = {
+  Status: `${DOCS_BASE_URL}/guides/use-hindsight-status/`,
+  Connection: `${DOCS_BASE_URL}/start/installation/`,
+  Banks: `${DOCS_BASE_URL}/concepts/memory-banks/`,
+  Recall: `${DOCS_BASE_URL}/concepts/retain-recall-reflect/`,
+  Retain: `${DOCS_BASE_URL}/concepts/queue-durability/`,
+  Import: `${DOCS_BASE_URL}/guides/importing-sessions/`,
+  UI: `${DOCS_BASE_URL}/start/setup-tui/`,
+};
 
 function fitColumns(left: string, right: string, width: number): string {
   if (width <= 0) return "";
@@ -175,6 +186,7 @@ export function createSetupComponent(
         lines.push(boxed("", width, theme));
         lines.push(boxed(theme.fg("accent", theme.bold("Details")), width, theme));
         const details = [
+          `Docs: ${TAB_DOCS[detailField.tab] ?? `${DOCS_BASE_URL}/reference/configuration/`}`,
           detailField.description,
           `Default: ${detailField.defaultValue}`,
           ...(detailField.projectValue ? [`Project: ${detailField.projectValue}`] : []),
@@ -185,6 +197,12 @@ export function createSetupComponent(
           for (const line of wrapWords(detail, innerWidth - 3)) {
             lines.push(boxed(`   ${theme.fg("dim", line)}`, width, theme));
           }
+        }
+      } else if (tab.id === "Status") {
+        lines.push(boxed("", width, theme));
+        lines.push(boxed(theme.fg("accent", theme.bold("Docs")), width, theme));
+        for (const line of wrapWords(`Status guide: ${TAB_DOCS.Status}`, innerWidth - 3)) {
+          lines.push(boxed(`   ${theme.fg("dim", line)}`, width, theme));
         }
       }
 

--- a/tests/setup-tui.test.ts
+++ b/tests/setup-tui.test.ts
@@ -47,6 +47,7 @@ describe("setup TUI receipt facts", () => {
     );
 
     const rendered = component.render(100).join("\n");
+    expect(rendered).toContain("Docs: https://luxus.github.io/pi-hindsight/concepts/memory-banks/");
     expect(rendered).toContain("Allows cross-project recall");
     expect(rendered).toContain("f flush");
     expect(rendered).toContain("m models read-only");


### PR DESCRIPTION
## Summary

- Restructure docs landing/index pages around task-first `/hindsight` TUI workflows.
- Add docs links from Setup TUI field details/status and guided setup notifications.
- Clarify Mermaid docs pipeline: build turns Mermaid fences into `<pre class="mermaid">`; browser JS renders SVG client-side.
- Sync user-facing bank vocabulary on **User Bank** while keeping legacy `global` alias compatibility notes.

## Linked issue

- Closes #265
- Closes #330

## Scope

- Docs navigation/content reshaping for start, concepts, guides, reference, setup TUI, and documentation architecture.
- Setup/guided setup UX docs hints only.
- Guidance wording sync for User Bank terminology.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — skipped; docs/UX hint change, no memory-path behavior change.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — skipped; `npm run check` includes `npm run typecheck`.
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not applicable.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — not applicable.
- [ ] `npm run pack:verify` (release/package changes) — not applicable.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — not applicable.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Docs and setup/guided setup now point users to task-first docs and clarify Mermaid rendering behavior.

## Risk and rollback

- Risk: Docs wording or URLs could drift from the docs-site route structure.
- Rollback/revert path: Revert this PR; no persisted memory data or package runtime behavior changes are involved.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- Reviewer pass found no blockers after bank vocabulary and bank-template docs-link fixes.
- Existing lint warning remains in `extensions/client-rest.ts:209`; unrelated to this PR.
