### PR TITLE
docs: refresh ADR relevance

### DIFF
--- a/docs-site/src/content/docs/architecture/adr/001-memory-lifecycle-and-scope.md
+++ b/docs-site/src/content/docs/architecture/adr/001-memory-lifecycle-and-scope.md
@@ -4,17 +4,17 @@ title: "ADR-001: Memory lifecycle and scope policy"
 
 ## Status
 
-Accepted
+Accepted. Reviewed 2026-05-09; still relevant.
 
 ## Context
 
 Pi Hindsight needs one coherent lifecycle for recall, retain, queueing, import, and diagnostics.
 
-The MVP currently has the right hook placement and Hindsight defaults, but turn-level policy is distributed across the Pi hook adapter and several helper modules. That makes the core invariant harder to test: recall must happen before provider context, recalled memory must never be retained, retain must store safe session content, writes must be queued before network flush, bank and tag scope must be correct, status must reflect actual outcomes, and failures must degrade predictably.
+The MVP had the right hook placement and Hindsight defaults, but turn-level policy was distributed across the Pi hook adapter and several helper modules. That made the core invariant harder to test: recall must happen before provider context, recalled memory must never be retained, retain must store safe session content, writes must be queued before network flush, bank and tag scope must be correct, status must reflect actual outcomes, and failures must degrade predictably.
 
 ## Decision
 
-The Pi hook adapter delegates to a MemoryLifecycle module.
+The Pi hook adapter delegates to MemoryLifecycle modules.
 
 MemoryLifecycle owns turn-level policy:
 
@@ -26,11 +26,11 @@ MemoryLifecycle owns turn-level policy:
 - queue orchestration
 - status transitions
 
-Memory identity is centralized in MemoryIdentity:
+Memory identity stays centralized in focused identity and banking helpers:
 
 - repo key
 - project bank ID
-- global bank scope
+- User Bank scope, using `global` only as a legacy config/tool alias
 - session ID
 - live document ID
 - import document ID
@@ -43,16 +43,16 @@ Tools and commands call shared intent operations where the same user intent is e
 
 - Recalled memory is never retained.
 - Project recall is repo-scoped.
-- Global recall has explicit non-repo scope.
+- User Bank recall has explicit non-repo scope.
 - Explicit retain always includes base scope tags.
 - Retain jobs are durably queued before network flush.
 - Disabled memory does not emit active retain or recall status.
 - Import document IDs are deterministic.
-- Historical import defaults to replace mode.
+- Historical Pi session import defaults to replace mode.
 
 ## Consequences
 
-- `extensions/index.ts` becomes a thin Pi adapter.
-- Some current helpers move under lifecycle and identity modules.
+- `extensions/index.ts` remains a thin Pi adapter.
+- Turn policy remains testable outside Pi hook plumbing.
 - Tests target lifecycle outcomes, not hook implementation details.
 - Hindsight HTTP request shapes, Pi JSONL parsing, secret regex internals, and UI rendering strings remain outside MemoryLifecycle.

--- a/docs-site/src/content/docs/architecture/adr/002-explicit-routing-strategy-seam.md
+++ b/docs-site/src/content/docs/architecture/adr/002-explicit-routing-strategy-seam.md
@@ -4,117 +4,113 @@ title: "ADR 002: Explicit routing strategy seam"
 
 ## Status
 
-Proposed.
+Accepted and partially implemented. Reviewed 2026-05-09; still relevant.
+
+The typed strategy seam, richer dry-run presenter output, and expanded eval fixtures have shipped. The broader guidance remains active for future routing work, especially named-bank or identity-aware routing.
 
 ## Context
 
-Pi Hindsight currently defaults to safe project-local automatic retain. Global automatic retain is disabled unless `globalRetain.mode = "router"` is explicitly enabled.
+Pi Hindsight defaults to safe project-local automatic retain. User Bank automatic retain is disabled unless the user selects a profile or config mode that explicitly enables it. Legacy config/tool aliases still use `global` for this User Bank route.
 
-The current router is intentionally conservative and heuristic. It classifies candidate memory as `project`, `global`, `both`, or `skip`, and `hindsight_route_memory` exposes the decision as a dry run in explicit-only mode. This is useful, but the seam needs a clearer product contract before adding richer bank topologies such as per-user, per-agent, shared-knowledge, or explicit named banks.
+The current router is intentionally conservative and heuristic. It classifies candidate memory as `project`, `global`, `both`, or `skip`, where `global` is the legacy route name for the configured User Bank. `hindsight_route_memory` exposes the decision as a dry run in explicit-only mode. This is useful, but the seam needs a clear product contract before adding richer bank topologies such as per-user, per-agent, shared-knowledge, or explicit named banks.
 
-The main safety risk is silent global memory pollution. Better routing must not make global writes the default.
+The main safety risk is silent User Bank pollution. Better routing must not make User Bank writes the default.
 
 ## Decision
 
-Routing remains opt-in for automatic writes. `globalRetain.mode = "explicit-only"` stays the default.
+Routing remains opt-in for automatic writes. `userRetain.mode = "explicit-only"` stays the default. `globalRetain.mode` remains a legacy compatibility alias, not the preferred user-facing term.
 
-Pi Hindsight will treat routing as an explicit strategy seam with stable input and output shapes. The default strategy keeps today's project/global behavior. Future strategies may route to additional bank topologies only behind explicit configuration and dry-run inspection.
+Pi Hindsight treats routing as an explicit strategy seam with stable input and output shapes. The default strategy keeps today's project/User Bank behavior while preserving legacy route values (`project`, `global`, `both`, `skip`) for compatibility. Future strategies may route to additional bank topologies only behind explicit configuration and dry-run inspection.
 
 ## Routing input shape
 
-A routing strategy receives a normalized candidate:
+Current implementation uses a compact typed seam:
 
 ```ts
 interface RoutingCandidate {
   content: string;
   context?: string;
-  repo?: {
-    cwd: string;
-    name?: string;
-    branch?: string;
-    remoteUrl?: string;
-  };
-  session?: {
-    id?: string;
-    title?: string;
-    cwd?: string;
-  };
-  message?: {
-    role?: "user" | "assistant" | "system" | "tool";
-    kind?: "conversation" | "explicit-retain" | "import" | "tool-result";
-    timestamp?: string;
-  };
-  explicitTarget?: "project" | "global" | "both" | "skip" | string;
-  identity?: {
-    userId?: string;
-    agentId?: string;
-    channelId?: string;
-  };
-  config: {
-    globalRetainMode: "explicit-only" | "router";
-    projectBankId?: string;
-    globalBankId?: string;
-    globalBankEnabled?: boolean;
-  };
+  config: ResolvedConfig;
+  cwd?: string;
+  projectBankId?: string;
+  sessionFile?: string;
+}
+
+interface RoutingStrategyInput {
+  content: string;
+  context?: string;
+  config: ResolvedConfig;
   missions: {
-    project?: string;
-    global?: string;
+    project: string;
+    global: string; // legacy route name for User Bank mission
   };
+  cwd?: string;
+  projectBankId?: string;
+  sessionFile?: string;
 }
 ```
 
-Only `content`, `config`, and missions are required for today's implementation. Other fields are forward-compatible context for future strategies.
+Future strategies may add normalized identity or channel context only after the source of that identity is documented.
 
 ## Routing output shape
 
-A routing strategy returns an explainable decision:
+The dry-run operation returns an explainable decision:
 
 ```ts
-interface RoutingDecision {
-  route: "project" | "global" | "both" | "skip" | string;
-  targets: Array<{
-    bankId: string;
-    bankRole: "project" | "global" | "user" | "agent" | "shared" | "named";
-    tags: string[];
-    updateMode?: "append" | "replace";
-  }>;
+type MemoryRoute = "project" | "global" | "both" | "skip";
+type RoutingBankRole = "project" | "global";
+
+interface MemoryRouteDecision {
+  route: MemoryRoute;
   confidence: number;
-  reason: string;
+  signals: Array<"project" | "global" | "skip">;
   matchedSignals: string[];
-  safetyNotes: string[];
+  reason: string;
   mode: "explicit-only" | "router";
-  writes: string[];
+  writes: RoutingBankRole[];
+  targets: Array<{
+    bankRole: RoutingBankRole;
+    bankId: string;
+    tags: string[];
+    willWrite: boolean;
+  }>;
+  safetyNotes: string[];
+  projectMission: string;
+  globalMission: string; // legacy route name for User Bank mission
 }
 ```
 
-`hindsight_route_memory` should evolve toward this shape while preserving current fields until a compatibility break is intentional.
+The legacy `global` route name should be preserved until a compatibility break is intentional. User-facing copy should describe that target as User Bank memory.
 
 ## Safety policy
 
-- `explicit-only` means dry-run only. No automatic global writes.
+- `explicit-only` means dry-run only. No automatic User Bank writes.
 - Router mode must be opt-in and visible in `/hindsight` status/config.
-- Global writes require high confidence or explicit user action.
-- Ambiguous project+global content should prefer `both` with conservative tags, or ask/dry-run rather than silently picking global.
+- User Bank writes require high confidence or explicit user action.
+- Ambiguous project/User Bank content should prefer `both` with conservative tags, or ask/dry-run rather than silently picking User Bank.
 - Secrets, private URLs, bearer tokens, cookies, and transient artifact paths should route to `skip` or require redaction before retain.
 - Metadata records provenance; tags control scope and visibility.
 - Recalled memory must not be routed back into retain.
 
 ## Strategy seam
 
-Initial strategies:
+Implemented strategy:
 
-1. `project-global-default`: current project/global/both/skip classifier using missions and heuristics.
-2. `dry-run-only`: always produces an explainable decision but writes nothing.
-3. Future `named-bank`: resolves explicit named bank targets once config supports them.
-4. Future `identity-aware`: includes per-user/per-agent context only after identity source is documented.
+1. `project-global-default`: current project/User Bank/both/skip classifier using missions and heuristics. The implementation keeps `global` in type names as a legacy route value.
+
+Future strategies:
+
+1. `dry-run-only`: always produces an explainable decision but writes nothing.
+2. `named-bank`: resolves explicit named bank targets once config supports them.
+3. `identity-aware`: includes per-user/per-agent context only after identity source is documented.
 
 The seam should not know Pi provider internals. It should receive normalized routing input from lifecycle/tool code.
 
 ## Eval fixture taxonomy
 
-Routing evals should cover at least:
+Routing evals should continue to cover at least:
 
-- durable global preference
+- durable User Bank preference
 - stable identity preference
 - cross-project workflow habit
 - project architecture fact
@@ -122,7 +118,7 @@ Routing evals should cover at least:
 - project delivery state
 - project-scoped user preference
 - identity-like fact embedded in project work
-- ambiguous project/global content
+- ambiguous project/User Bank content
 - secret or credential-like content
 - transient screenshot/artifact
 - temporary command/test output
@@ -138,7 +134,7 @@ Fixtures should assert:
 
 ## Tool and TUI implications
 
-`hindsight_route_memory` should become the primary dry-run surface for routing decisions. It should show:
+`hindsight_route_memory` remains the primary dry-run surface for routing decisions. It should show:
 
 - suggested route
 - confidence
@@ -157,10 +153,15 @@ A future `/hindsight` TUI route preview can call the same operation and should a
 - Richer bank topologies remain possible without coupling core to a specific platform identity model.
 - More tests are required before enabling any new automatic route.
 
-## Follow-up implementation issues
+## Follow-up implementation status
+
+Completed:
 
 - #154: Update `hindsight_route_memory` presenter to include target bank roles, tags, safety notes, and explicit write/no-write status.
 - #155: Expand router eval fixtures with secret/noise/ambiguous confidence cases and safety-note assertions.
 - #156: Add a `RoutingStrategy` type and adapter boundary separate from current heuristic implementation.
-- Add a future TUI route-preview action that calls the shared routing operation.
+
+Still future:
+
+- Add a TUI route-preview action that calls the shared routing operation.
 - Design named-bank resolver config before supporting per-user/per-agent/shared-bank targets.

--- a/docs-site/src/content/docs/architecture/adr/003-tui-memory-mode-vocabulary.md
+++ b/docs-site/src/content/docs/architecture/adr/003-tui-memory-mode-vocabulary.md
@@ -29,12 +29,12 @@ These names are TUI vocabulary, not a replacement for the lower-level config mod
 
 ## Mode matrix
 
-| Mode                | Automatic recall | Automatic retain | Explicit tools and commands                                           | Import  | Flush queued jobs | Intended use                                             |
-| ------------------- | ---------------- | ---------------- | --------------------------------------------------------------------- | ------- | ----------------- | -------------------------------------------------------- |
-| `normal`            | on if configured | on if configured | allowed                                                               | allowed | allowed           | Default coding with project memory continuity.           |
-| `read-only`         | on if configured | off              | read tools allowed; explicit writes require confirmation/command path | allowed | allowed           | Use existing memory without adding new transcript facts. |
-| `ignored`           | off              | off              | explicit operations remain available from commands/tools              | allowed | allowed           | Work without automatic memory participation.             |
-| future `tools-only` | off              | off              | allowed                                                               | allowed | allowed           | No automatic memory; user manually calls tools.          |
+| Mode                | Automatic recall | Automatic retain | Explicit tools and commands                                       | Import  | Flush queued jobs | Intended use                                             |
+| ------------------- | ---------------- | ---------------- | ----------------------------------------------------------------- | ------- | ----------------- | -------------------------------------------------------- |
+| `normal`            | on if configured | on if configured | allowed                                                           | allowed | allowed           | Default coding with project memory continuity.           |
+| `read-only`         | on if configured | off              | read tools allowed; explicit retain is blocked until mode changes | allowed | allowed           | Use existing memory without adding new transcript facts. |
+| `ignored`           | off              | off              | explicit operations remain available from commands/tools          | allowed | allowed           | Work without automatic memory participation.             |
+| future `tools-only` | off              | off              | allowed                                                           | allowed | allowed           | No automatic memory; user manually calls tools.          |
 
 ## Semantics
 
@@ -54,7 +54,7 @@ These names are TUI vocabulary, not a replacement for the lower-level config mod
 
 - automatic recall can still run
 - automatic retain does not enqueue new transcript deltas
-- explicit write operations should stay visible but must remain deliberate actions
+- explicit retain is blocked until the session returns to `normal`; other deliberate write operations such as imports keep their own confirmations
 - imports remain deliberate operations, not automatic session retention
 - queue flush remains allowed because it drains already accepted jobs
 

--- a/docs-site/src/content/docs/architecture/adr/003-tui-memory-mode-vocabulary.md
+++ b/docs-site/src/content/docs/architecture/adr/003-tui-memory-mode-vocabulary.md
@@ -4,17 +4,19 @@ title: "ADR 003: TUI memory mode vocabulary"
 
 ## Status
 
-Proposed.
+Accepted and implemented for `normal`, `read-only`, and `ignored`. Reviewed 2026-05-09; still relevant.
+
+`tools-only` remains reserved vocabulary and must not appear as an enabled mode until behavior is implemented.
 
 ## Context
 
-Pi Hindsight already has separate controls for recall, automatic retain, explicit tools, imports, flush, and one-turn opt-out. Those controls are correct but too implementation-shaped for the `/hindsight` TUI. Users need a small vocabulary that explains what memory will do without changing the underlying safe defaults.
+Pi Hindsight has separate controls for recall, automatic retain, explicit tools, imports, flush, and one-turn opt-out. Those controls are correct but too implementation-shaped for the `/hindsight` TUI. Users need a small vocabulary that explains what memory will do without changing the underlying safe defaults.
 
 The design should not add provider recall caching, prompt hashtag controls, automatic reflect prefetch, or new routing behavior.
 
 ## Decision
 
-The TUI will describe memory behavior with four user-facing modes:
+The TUI and `/hindsight:mode` command describe session memory behavior with three implemented user-facing modes and one reserved future mode:
 
 1. `normal`
 2. `read-only`
@@ -42,7 +44,7 @@ These names are TUI vocabulary, not a replacement for the lower-level config mod
 
 - recall injects ephemeral memory before answer generation when enabled
 - retain queues sanitized transcript deltas at agent end when enabled
-- global automatic retain stays governed by `globalRetain.mode`
+- User Bank automatic retain stays governed by `userRetain.mode` and profile choices; `globalRetain.mode` remains only a legacy alias
 - explicit tools and TUI actions are available
 - imports and queue flushes are available
 
@@ -79,7 +81,7 @@ The `/hindsight` TUI should prefer these labels when explaining session memory s
 - `ignored`: "Automatic recall and retain are off."
 - future `tools-only`: "Automatic memory is off; explicit tools stay available."
 
-The TUI should still expose underlying facts where useful, such as recall enabled/disabled, retain enabled/disabled, global retain mode, queue state, and bank status.
+The TUI should still expose underlying facts where useful, such as recall enabled/disabled, retain enabled/disabled, User Bank retain mode, queue state, and bank status.
 
 ## Non-goals
 
@@ -88,14 +90,19 @@ The TUI should still expose underlying facts where useful, such as recall enable
 - Do not add provider recall caching.
 - Do not prefetch reflect results automatically.
 - Do not collapse import or explicit retain semantics into automatic retain.
-- Do not make global automatic retain default.
+- Do not make User Bank automatic retain default.
 
-## Follow-up implementation slices
+## Follow-up implementation status
+
+Completed:
 
 1. Add a presenter that derives the TUI mode label from resolved config plus session metadata.
 2. Add status facts for the mode matrix row currently in effect.
 3. Add TUI copy for `normal`, `read-only`, and `ignored`.
-4. Keep `tools-only` documented as reserved until behavior is implemented.
+
+Still future:
+
+1. Keep `tools-only` documented as reserved until behavior is implemented.
 
 ## Consequences
 

--- a/docs/adr/001-memory-lifecycle-and-scope.md
+++ b/docs/adr/001-memory-lifecycle-and-scope.md
@@ -2,17 +2,17 @@
 
 ## Status
 
-Accepted
+Accepted. Reviewed 2026-05-09; still relevant.
 
 ## Context
 
 Pi Hindsight needs one coherent lifecycle for recall, retain, queueing, import, and diagnostics.
 
-The MVP currently has the right hook placement and Hindsight defaults, but turn-level policy is distributed across the Pi hook adapter and several helper modules. That makes the core invariant harder to test: recall must happen before provider context, recalled memory must never be retained, retain must store safe session content, writes must be queued before network flush, bank and tag scope must be correct, status must reflect actual outcomes, and failures must degrade predictably.
+The MVP had the right hook placement and Hindsight defaults, but turn-level policy was distributed across the Pi hook adapter and several helper modules. That made the core invariant harder to test: recall must happen before provider context, recalled memory must never be retained, retain must store safe session content, writes must be queued before network flush, bank and tag scope must be correct, status must reflect actual outcomes, and failures must degrade predictably.
 
 ## Decision
 
-The Pi hook adapter delegates to a MemoryLifecycle module.
+The Pi hook adapter delegates to MemoryLifecycle modules.
 
 MemoryLifecycle owns turn-level policy:
 
@@ -24,11 +24,11 @@ MemoryLifecycle owns turn-level policy:
 - queue orchestration
 - status transitions
 
-Memory identity is centralized in MemoryIdentity:
+Memory identity stays centralized in focused identity and banking helpers:
 
 - repo key
 - project bank ID
-- global bank scope
+- User Bank scope, using `global` only as a legacy config/tool alias
 - session ID
 - live document ID
 - import document ID
@@ -41,16 +41,16 @@ Tools and commands call shared intent operations where the same user intent is e
 
 - Recalled memory is never retained.
 - Project recall is repo-scoped.
-- Global recall has explicit non-repo scope.
+- User Bank recall has explicit non-repo scope.
 - Explicit retain always includes base scope tags.
 - Retain jobs are durably queued before network flush.
 - Disabled memory does not emit active retain or recall status.
 - Import document IDs are deterministic.
-- Historical import defaults to replace mode.
+- Historical Pi session import defaults to replace mode.
 
 ## Consequences
 
-- `extensions/index.ts` becomes a thin Pi adapter.
-- Some current helpers move under lifecycle and identity modules.
+- `extensions/index.ts` remains a thin Pi adapter.
+- Turn policy remains testable outside Pi hook plumbing.
 - Tests target lifecycle outcomes, not hook implementation details.
 - Hindsight HTTP request shapes, Pi JSONL parsing, secret regex internals, and UI rendering strings remain outside MemoryLifecycle.

--- a/docs/adr/002-explicit-routing-strategy-seam.md
+++ b/docs/adr/002-explicit-routing-strategy-seam.md
@@ -2,117 +2,113 @@
 
 ## Status
 
-Proposed.
+Accepted and partially implemented. Reviewed 2026-05-09; still relevant.
+
+The typed strategy seam, richer dry-run presenter output, and expanded eval fixtures have shipped. The broader guidance remains active for future routing work, especially named-bank or identity-aware routing.
 
 ## Context
 
-Pi Hindsight currently defaults to safe project-local automatic retain. Global automatic retain is disabled unless `globalRetain.mode = "router"` is explicitly enabled.
+Pi Hindsight defaults to safe project-local automatic retain. User Bank automatic retain is disabled unless the user selects a profile or config mode that explicitly enables it. Legacy config/tool aliases still use `global` for this User Bank route.
 
-The current router is intentionally conservative and heuristic. It classifies candidate memory as `project`, `global`, `both`, or `skip`, and `hindsight_route_memory` exposes the decision as a dry run in explicit-only mode. This is useful, but the seam needs a clearer product contract before adding richer bank topologies such as per-user, per-agent, shared-knowledge, or explicit named banks.
+The current router is intentionally conservative and heuristic. It classifies candidate memory as `project`, `global`, `both`, or `skip`, where `global` is the legacy route name for the configured User Bank. `hindsight_route_memory` exposes the decision as a dry run in explicit-only mode. This is useful, but the seam needs a clear product contract before adding richer bank topologies such as per-user, per-agent, shared-knowledge, or explicit named banks.
 
-The main safety risk is silent global memory pollution. Better routing must not make global writes the default.
+The main safety risk is silent User Bank pollution. Better routing must not make User Bank writes the default.
 
 ## Decision
 
-Routing remains opt-in for automatic writes. `globalRetain.mode = "explicit-only"` stays the default.
+Routing remains opt-in for automatic writes. `userRetain.mode = "explicit-only"` stays the default. `globalRetain.mode` remains a legacy compatibility alias, not the preferred user-facing term.
 
-Pi Hindsight will treat routing as an explicit strategy seam with stable input and output shapes. The default strategy keeps today's project/global behavior. Future strategies may route to additional bank topologies only behind explicit configuration and dry-run inspection.
+Pi Hindsight treats routing as an explicit strategy seam with stable input and output shapes. The default strategy keeps today's project/User Bank behavior while preserving legacy route values (`project`, `global`, `both`, `skip`) for compatibility. Future strategies may route to additional bank topologies only behind explicit configuration and dry-run inspection.
 
 ## Routing input shape
 
-A routing strategy receives a normalized candidate:
+Current implementation uses a compact typed seam:
 
 ```ts
 interface RoutingCandidate {
   content: string;
   context?: string;
-  repo?: {
-    cwd: string;
-    name?: string;
-    branch?: string;
-    remoteUrl?: string;
-  };
-  session?: {
-    id?: string;
-    title?: string;
-    cwd?: string;
-  };
-  message?: {
-    role?: "user" | "assistant" | "system" | "tool";
-    kind?: "conversation" | "explicit-retain" | "import" | "tool-result";
-    timestamp?: string;
-  };
-  explicitTarget?: "project" | "global" | "both" | "skip" | string;
-  identity?: {
-    userId?: string;
-    agentId?: string;
-    channelId?: string;
-  };
-  config: {
-    globalRetainMode: "explicit-only" | "router";
-    projectBankId?: string;
-    globalBankId?: string;
-    globalBankEnabled?: boolean;
-  };
+  config: ResolvedConfig;
+  cwd?: string;
+  projectBankId?: string;
+  sessionFile?: string;
+}
+
+interface RoutingStrategyInput {
+  content: string;
+  context?: string;
+  config: ResolvedConfig;
   missions: {
-    project?: string;
-    global?: string;
+    project: string;
+    global: string; // legacy route name for User Bank mission
   };
+  cwd?: string;
+  projectBankId?: string;
+  sessionFile?: string;
 }
 ```
 
-Only `content`, `config`, and missions are required for today's implementation. Other fields are forward-compatible context for future strategies.
+Future strategies may add normalized identity or channel context only after the source of that identity is documented.
 
 ## Routing output shape
 
-A routing strategy returns an explainable decision:
+The dry-run operation returns an explainable decision:
 
 ```ts
-interface RoutingDecision {
-  route: "project" | "global" | "both" | "skip" | string;
-  targets: Array<{
-    bankId: string;
-    bankRole: "project" | "global" | "user" | "agent" | "shared" | "named";
-    tags: string[];
-    updateMode?: "append" | "replace";
-  }>;
+type MemoryRoute = "project" | "global" | "both" | "skip";
+type RoutingBankRole = "project" | "global";
+
+interface MemoryRouteDecision {
+  route: MemoryRoute;
   confidence: number;
-  reason: string;
+  signals: Array<"project" | "global" | "skip">;
   matchedSignals: string[];
-  safetyNotes: string[];
+  reason: string;
   mode: "explicit-only" | "router";
-  writes: string[];
+  writes: RoutingBankRole[];
+  targets: Array<{
+    bankRole: RoutingBankRole;
+    bankId: string;
+    tags: string[];
+    willWrite: boolean;
+  }>;
+  safetyNotes: string[];
+  projectMission: string;
+  globalMission: string; // legacy route name for User Bank mission
 }
 ```
 
-`hindsight_route_memory` should evolve toward this shape while preserving current fields until a compatibility break is intentional.
+The legacy `global` route name should be preserved until a compatibility break is intentional. User-facing copy should describe that target as User Bank memory.
 
 ## Safety policy
 
-- `explicit-only` means dry-run only. No automatic global writes.
+- `explicit-only` means dry-run only. No automatic User Bank writes.
 - Router mode must be opt-in and visible in `/hindsight` status/config.
-- Global writes require high confidence or explicit user action.
-- Ambiguous project+global content should prefer `both` with conservative tags, or ask/dry-run rather than silently picking global.
+- User Bank writes require high confidence or explicit user action.
+- Ambiguous project/User Bank content should prefer `both` with conservative tags, or ask/dry-run rather than silently picking User Bank.
 - Secrets, private URLs, bearer tokens, cookies, and transient artifact paths should route to `skip` or require redaction before retain.
 - Metadata records provenance; tags control scope and visibility.
 - Recalled memory must not be routed back into retain.
 
 ## Strategy seam
 
-Initial strategies:
+Implemented strategy:
 
-1. `project-global-default`: current project/global/both/skip classifier using missions and heuristics.
-2. `dry-run-only`: always produces an explainable decision but writes nothing.
-3. Future `named-bank`: resolves explicit named bank targets once config supports them.
-4. Future `identity-aware`: includes per-user/per-agent context only after identity source is documented.
+1. `project-global-default`: current project/User Bank/both/skip classifier using missions and heuristics. The implementation keeps `global` in type names as a legacy route value.
+
+Future strategies:
+
+1. `dry-run-only`: always produces an explainable decision but writes nothing.
+2. `named-bank`: resolves explicit named bank targets once config supports them.
+3. `identity-aware`: includes per-user/per-agent context only after identity source is documented.
 
 The seam should not know Pi provider internals. It should receive normalized routing input from lifecycle/tool code.
 
 ## Eval fixture taxonomy
 
-Routing evals should cover at least:
+Routing evals should continue to cover at least:
 
-- durable global preference
+- durable User Bank preference
 - stable identity preference
 - cross-project workflow habit
 - project architecture fact
@@ -120,7 +116,7 @@ Routing evals should cover at least:
 - project delivery state
 - project-scoped user preference
 - identity-like fact embedded in project work
-- ambiguous project/global content
+- ambiguous project/User Bank content
 - secret or credential-like content
 - transient screenshot/artifact
 - temporary command/test output
@@ -136,7 +132,7 @@ Fixtures should assert:
 
 ## Tool and TUI implications
 
-`hindsight_route_memory` should become the primary dry-run surface for routing decisions. It should show:
+`hindsight_route_memory` remains the primary dry-run surface for routing decisions. It should show:
 
 - suggested route
 - confidence
@@ -155,10 +151,15 @@ A future `/hindsight` TUI route preview can call the same operation and should a
 - Richer bank topologies remain possible without coupling core to a specific platform identity model.
 - More tests are required before enabling any new automatic route.
 
-## Follow-up implementation issues
+## Follow-up implementation status
+
+Completed:
 
 - #154: Update `hindsight_route_memory` presenter to include target bank roles, tags, safety notes, and explicit write/no-write status.
 - #155: Expand router eval fixtures with secret/noise/ambiguous confidence cases and safety-note assertions.
 - #156: Add a `RoutingStrategy` type and adapter boundary separate from current heuristic implementation.
-- Add a future TUI route-preview action that calls the shared routing operation.
+
+Still future:
+
+- Add a TUI route-preview action that calls the shared routing operation.
 - Design named-bank resolver config before supporting per-user/per-agent/shared-bank targets.

--- a/docs/adr/003-tui-memory-mode-vocabulary.md
+++ b/docs/adr/003-tui-memory-mode-vocabulary.md
@@ -27,12 +27,12 @@ These names are TUI vocabulary, not a replacement for the lower-level config mod
 
 ## Mode matrix
 
-| Mode                | Automatic recall | Automatic retain | Explicit tools and commands                                           | Import  | Flush queued jobs | Intended use                                             |
-| ------------------- | ---------------- | ---------------- | --------------------------------------------------------------------- | ------- | ----------------- | -------------------------------------------------------- |
-| `normal`            | on if configured | on if configured | allowed                                                               | allowed | allowed           | Default coding with project memory continuity.           |
-| `read-only`         | on if configured | off              | read tools allowed; explicit writes require confirmation/command path | allowed | allowed           | Use existing memory without adding new transcript facts. |
-| `ignored`           | off              | off              | explicit operations remain available from commands/tools              | allowed | allowed           | Work without automatic memory participation.             |
-| future `tools-only` | off              | off              | allowed                                                               | allowed | allowed           | No automatic memory; user manually calls tools.          |
+| Mode                | Automatic recall | Automatic retain | Explicit tools and commands                                       | Import  | Flush queued jobs | Intended use                                             |
+| ------------------- | ---------------- | ---------------- | ----------------------------------------------------------------- | ------- | ----------------- | -------------------------------------------------------- |
+| `normal`            | on if configured | on if configured | allowed                                                           | allowed | allowed           | Default coding with project memory continuity.           |
+| `read-only`         | on if configured | off              | read tools allowed; explicit retain is blocked until mode changes | allowed | allowed           | Use existing memory without adding new transcript facts. |
+| `ignored`           | off              | off              | explicit operations remain available from commands/tools          | allowed | allowed           | Work without automatic memory participation.             |
+| future `tools-only` | off              | off              | allowed                                                           | allowed | allowed           | No automatic memory; user manually calls tools.          |
 
 ## Semantics
 
@@ -52,7 +52,7 @@ These names are TUI vocabulary, not a replacement for the lower-level config mod
 
 - automatic recall can still run
 - automatic retain does not enqueue new transcript deltas
-- explicit write operations should stay visible but must remain deliberate actions
+- explicit retain is blocked until the session returns to `normal`; other deliberate write operations such as imports keep their own confirmations
 - imports remain deliberate operations, not automatic session retention
 - queue flush remains allowed because it drains already accepted jobs
 

--- a/docs/adr/003-tui-memory-mode-vocabulary.md
+++ b/docs/adr/003-tui-memory-mode-vocabulary.md
@@ -2,17 +2,19 @@
 
 ## Status
 
-Proposed.
+Accepted and implemented for `normal`, `read-only`, and `ignored`. Reviewed 2026-05-09; still relevant.
+
+`tools-only` remains reserved vocabulary and must not appear as an enabled mode until behavior is implemented.
 
 ## Context
 
-Pi Hindsight already has separate controls for recall, automatic retain, explicit tools, imports, flush, and one-turn opt-out. Those controls are correct but too implementation-shaped for the `/hindsight` TUI. Users need a small vocabulary that explains what memory will do without changing the underlying safe defaults.
+Pi Hindsight has separate controls for recall, automatic retain, explicit tools, imports, flush, and one-turn opt-out. Those controls are correct but too implementation-shaped for the `/hindsight` TUI. Users need a small vocabulary that explains what memory will do without changing the underlying safe defaults.
 
 The design should not add provider recall caching, prompt hashtag controls, automatic reflect prefetch, or new routing behavior.
 
 ## Decision
 
-The TUI will describe memory behavior with four user-facing modes:
+The TUI and `/hindsight:mode` command describe session memory behavior with three implemented user-facing modes and one reserved future mode:
 
 1. `normal`
 2. `read-only`
@@ -40,7 +42,7 @@ These names are TUI vocabulary, not a replacement for the lower-level config mod
 
 - recall injects ephemeral memory before answer generation when enabled
 - retain queues sanitized transcript deltas at agent end when enabled
-- global automatic retain stays governed by `globalRetain.mode`
+- User Bank automatic retain stays governed by `userRetain.mode` and profile choices; `globalRetain.mode` remains only a legacy alias
 - explicit tools and TUI actions are available
 - imports and queue flushes are available
 
@@ -77,7 +79,7 @@ The `/hindsight` TUI should prefer these labels when explaining session memory s
 - `ignored`: "Automatic recall and retain are off."
 - future `tools-only`: "Automatic memory is off; explicit tools stay available."
 
-The TUI should still expose underlying facts where useful, such as recall enabled/disabled, retain enabled/disabled, global retain mode, queue state, and bank status.
+The TUI should still expose underlying facts where useful, such as recall enabled/disabled, retain enabled/disabled, User Bank retain mode, queue state, and bank status.
 
 ## Non-goals
 
@@ -86,14 +88,19 @@ The TUI should still expose underlying facts where useful, such as recall enable
 - Do not add provider recall caching.
 - Do not prefetch reflect results automatically.
 - Do not collapse import or explicit retain semantics into automatic retain.
-- Do not make global automatic retain default.
+- Do not make User Bank automatic retain default.
 
-## Follow-up implementation slices
+## Follow-up implementation status
+
+Completed:
 
 1. Add a presenter that derives the TUI mode label from resolved config plus session metadata.
 2. Add status facts for the mode matrix row currently in effect.
 3. Add TUI copy for `normal`, `read-only`, and `ignored`.
-4. Keep `tools-only` documented as reserved until behavior is implemented.
+
+Still future:
+
+1. Keep `tools-only` documented as reserved until behavior is implemented.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

- Mark ADR 001-003 as reviewed and still relevant.
- Update stale Global Bank/globalRetain wording to User Bank terminology while preserving legacy `global` aliases where code still uses them.
- Refresh ADR 002 routing shapes/status against the current typed strategy seam and closed follow-up issues.
- Mirror root ADR updates into docs-site ADR pages.

## Linked issue

- Closes #334

## Scope

- Documentation-only ADR relevance refresh.
- No runtime behavior changes.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — skipped; documentation-only change.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — skipped; `npm run check` includes `npm run typecheck`.
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not applicable.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — not applicable.
- [ ] `npm run pack:verify` (release/package changes) — not applicable.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — not applicable.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

ADR docs now reflect current User Bank terminology and implemented routing/TUI mode status.

## Risk and rollback

- Risk: ADR wording could overstate implementation status.
- Rollback/revert path: Revert this PR; no runtime or persisted memory behavior changes.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- Project reviewer found no blockers.
- First precommit `npm run check` attempt hit the known transient queue stress timeout; immediate reruns passed.
- Existing lint warning remains in `extensions/client-rest.ts:209`; unrelated to this PR.
