### PR TITLE
docs: format 0.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## [0.4.0](https://github.com/luxus/pi-hindsight/compare/v0.3.0...v0.4.0) (2026-05-09)
 
-
 ### Features
 
-* **client:** adopt Hindsight client 0.6.1 ([caa4a48](https://github.com/luxus/pi-hindsight/commit/caa4a48b92129c394eb72fa8c0044d851464407e))
-* **import:** show progress for transcript imports ([098c469](https://github.com/luxus/pi-hindsight/commit/098c469cc2113e553f070d584d14d02e2a18fa78))
-* **tools:** add bank template import surface ([f30ca02](https://github.com/luxus/pi-hindsight/commit/f30ca0224ea080d4c294f65d8a0883332d0a0adf))
-* **tools:** expose remaining memory surfaces ([3c071ac](https://github.com/luxus/pi-hindsight/commit/3c071ac9ce8c93c21e358f72690a3cc4ba51e006))
+- **client:** adopt Hindsight client 0.6.1 ([caa4a48](https://github.com/luxus/pi-hindsight/commit/caa4a48b92129c394eb72fa8c0044d851464407e))
+- **import:** show progress for transcript imports ([098c469](https://github.com/luxus/pi-hindsight/commit/098c469cc2113e553f070d584d14d02e2a18fa78))
+- **tools:** add bank template import surface ([f30ca02](https://github.com/luxus/pi-hindsight/commit/f30ca0224ea080d4c294f65d8a0883332d0a0adf))
+- **tools:** expose remaining memory surfaces ([3c071ac](https://github.com/luxus/pi-hindsight/commit/3c071ac9ce8c93c21e358f72690a3cc4ba51e006))
 
 ## [0.3.0](https://github.com/luxus/pi-hindsight/compare/v0.2.0...v0.3.0) (2026-05-07)
 


### PR DESCRIPTION
## Summary

- Format the generated 0.4.0 changelog so release verification can pass.

## Linked issue

- Closes #340

## Scope

Post-release formatting fix for `CHANGELOG.md` only. No source/package behavior changes.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — not run because docs-only formatting fix.
- [ ] `npm run typecheck:tsc` — covered by `npm run check`; no source changes.
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not applicable to docs-only formatting fix.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — follow-up manual release workflow will verify package before publish.
- [ ] `npm run pack:verify` (release/package changes) — follow-up manual release workflow will run this before publish.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — not applicable; no memory-path changes.

## Release impact

Check exactly one:

- [ ] No release impact
- [ ] User-visible change
- [x] Package/release path change

## Risk and rollback

- Risk: Low; Markdown formatting only.
- Rollback/revert path: Revert this PR if formatting causes unexpected docs issues.

## Follow-ups

- #340 tracks manual Release workflow with `publish=true` after merge to publish npm 0.4.0.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. — not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.
