### PR TITLE
fix(release): harden audit surfaces

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,4 +65,12 @@ jobs:
 
       - name: Publish package to npm
         if: ${{ steps.release.outputs.release_created == 'true' }}
-        run: npm publish --provenance --access public
+        run: |
+          set -euo pipefail
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version already exists on npm; skipping publish."
+            exit 0
+          fi
+          npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,4 +74,12 @@ jobs:
         run: npm ci --engine-strict
 
       - name: Publish package
-        run: npm publish --provenance --access public
+        run: |
+          set -euo pipefail
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version already exists on npm; skipping publish."
+            exit 0
+          fi
+          npm publish --provenance --access public

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,7 +5,8 @@
       "release-type": "node",
       "package-name": "@luxusai/pi-hindsight",
       "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": ["extensions/version.ts"]
     }
   }
 }

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -1,14 +1,8 @@
 ---
-title: "Configuration reference"
+title: "Configuration"
 ---
 
 Pi Hindsight resolves configuration from defaults, global config, project config, and environment variables.
-
-For concepts behind Project Banks, User Banks, tags, metadata, Document IDs, and Update Modes, see:
-
-- [Memory Banks](/pi-hindsight/concepts/memory-banks/)
-- [Document IDs and update modes](/pi-hindsight/concepts/document-ids-update-modes/)
-- [Retain, Recall, and Reflect](/pi-hindsight/concepts/retain-recall-reflect/)
 
 ## Precedence
 
@@ -49,10 +43,10 @@ Project config SecretRef shape:
 
 ## Memory profiles
 
-- **Project + User**: Project Bank enabled; User Bank enabled; user bank settings are written once to global Pi config.
-- **Project Only**: Project Bank enabled; User Bank disabled; automatic Retain writes to the Project Bank.
-- **User Only**: Project Bank disabled; User Bank enabled from global Pi config.
-- **Recall Only**: automatic recall enabled; automatic Retain disabled; explicit tools and imports remain available.
+- **Project + User**: project bank enabled; user bank enabled; user bank settings are written once to global Pi config.
+- **Project Only**: project bank enabled; user bank disabled; automatic retain writes to the project bank.
+- **User Only**: project bank disabled; user bank enabled from global Pi config.
+- **Recall Only**: automatic recall enabled; automatic retain disabled; explicit tools and imports remain available.
 
 When a profile uses user memory, guided setup asks for a user bank ID and writes it to global Pi config. Override it later with `PI_HINDSIGHT_USER_BANK_ID`, `~/.pi/agent/hindsight.json` `banks.user.bankId`, or the setup TUI if you prefer a different shared bank. Legacy `PI_HINDSIGHT_GLOBAL_BANK_ID`, `banks.global`, and `global-only` config names are migrated/supported during transition.
 
@@ -63,34 +57,27 @@ Pi Hindsight distinguishes local Pi behavior from bank-owned Hindsight settings.
 - `Location: Project` or `Location: User` describes the Pi memory route.
 - `Bank: <bank-id>` names the concrete Hindsight bank that owns missions, config overrides, mental models, and directives.
 
-Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config.
+Mission text and mental models remain Hindsight bank settings, not normal Pi JSON config. Use `hindsight_get_bank_config` to inspect resolved bank config and override counts. Use `hindsight_update_bank_config` with `confirm: true` for raw Hindsight per-bank config override fields. Use `hindsight_reset_bank_config` only when you intentionally want to clear bank config overrides and fall back to Hindsight defaults/template state. Use `hindsight_get_bank_template_schema` to fetch the server JSON Schema for portable bank template manifests. Use `hindsight_export_bank_template` with `outputFile` to save a portable manifest JSON file. Use `hindsight_import_bank_template` to dry-run or apply a local/inline manifest; applying requires `dryRun: false` and `confirmApply: true`. Use `hindsight_list_directives`, `hindsight_get_directive`, `hindsight_create_directive`, `hindsight_update_directive`, and `hindsight_delete_directive` to manage bank-owned hard rules.
 
-Use these public tools for bank-owned settings:
+### Bank config surface audit
 
-- `hindsight_get_bank_config`
-- `hindsight_update_bank_config`
-- `hindsight_reset_bank_config`
-- `hindsight_get_bank_template_schema`
-- `hindsight_export_bank_template`
-- `hindsight_import_bank_template`
-- `hindsight_list_directives`
-- `hindsight_get_directive`
-- `hindsight_create_directive`
-- `hindsight_update_directive`
-- `hindsight_delete_directive`
+Current Hindsight OpenAPI exposes generic per-bank config updates through `BankConfigUpdate.updates`, so Pi exposes raw field updates via `hindsight_update_bank_config` instead of adding local Pi config keys for every server field. High-value per-bank fields supported through raw updates or bank-template manifests include retain extraction/chunking, observation/consolidation limits, reflect source-fact budgets, MCP tool allowlists, retain strategies, and recall budget mapping fields. Keep server-admin or credential-like fields out of Pi local config unless Hindsight documents them as safe per-bank overrides.
 
-## Bank config surface audit
+## Compatibility and runtime identity
 
-Current Hindsight OpenAPI exposes generic per-bank config updates through `BankConfigUpdate.updates`, so Pi exposes raw field updates via `hindsight_update_bank_config` instead of adding local Pi config keys for every server field. This keeps Hindsight's config resolver as the source of truth.
+Pi Hindsight targets the official `@vectorize-io/hindsight-client` package and the current documented Hindsight REST/OpenAPI behavior. The runtime client sends a `pi-hindsight/<package-version>` user-agent on both official-client and REST fallback paths. `/hindsight` and debug/status diagnostics surface local package identity, configured server URL, append-mode support, bank reachability, queue state, and failed-consolidation hints where the server exposes them.
 
-High-value per-bank fields supported through raw updates or bank-template manifests include:
+## Setup TUI
 
-- retain extraction and chunking: `retain_extraction_mode`, `retain_custom_instructions`, `retain_chunk_size`, `retain_chunk_batch_size`, `retain_default_strategy`, `retain_strategies`
-- observation/consolidation controls: `enable_observations`, `observations_mission`, `consolidation_llm_batch_size`, `consolidation_source_facts_max_tokens`, `consolidation_source_facts_max_tokens_per_observation`, `max_observations_per_scope`
-- reflect and recall budgets: `reflect_source_facts_max_tokens`, `recall_budget_function`, `recall_budget_fixed_low`, `recall_budget_fixed_mid`, `recall_budget_fixed_high`, `recall_budget_adaptive_low`, `recall_budget_adaptive_mid`, `recall_budget_adaptive_high`, `recall_budget_min`, `recall_budget_max`
-- bank behavior and tool policy: `entity_labels`, `entities_allow_free_form`, `mcp_enabled_tools`, disposition fields, directives, and mental models
+Run:
 
-Keep server-admin or credential-like fields, such as LLM provider credentials and Gemini safety settings, out of Pi local config unless Hindsight documents them as safe per-bank overrides. Use `hindsight_get_bank_config` to inspect resolved config and bank-specific overrides before and after updates.
+```text
+/hindsight
+```
+
+The setup TUI opens with status facts, then offers focused edit tabs for connection, banks, recall, retain, import, and UI settings. Setting rows show the effective value plus its source (`project`, `global`, `env`, or `default`). Setting descriptions, default values, and all layers are shown inside edit prompts.
+
+Deployment choices cover Hindsight Cloud, an existing local/external API, and local `hindsight-embed` guidance. The local `hindsight-embed` option gives commands to run yourself and can set the base URL to `http://localhost:8888`; it does not manage daemons.
 
 ## Advanced project config example
 
@@ -140,10 +127,17 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
     "manifestPath": ".pi/hindsight/import-manifest.json",
     "checkpointPath": ".pi/hindsight/import-checkpoint.json",
     "resume": true
+  },
+  "status": {
+    "style": "text",
+    "detail": "activity",
+    "maxLength": 24,
+    "showActivity": true
+  },
+  "notifications": {
+    "startup": true,
+    "recall": false,
+    "retain": false
   }
 }
 ```
-
-## Generated editable-field reference
-
-The exact generated tool and editable config field surface lives in [Generated surface reference](/pi-hindsight/reference/surface-reference/). Do not edit that generated page by hand; update the operation catalog, config editing registry, or generator.

--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -320,6 +320,14 @@ Clear all observations for one bank. Destructive; requires confirm=true.
 | `bank`    | string | no       | Optional bank id. Defaults to project bank. |
 | `confirm` | true   | yes      | Required destructive-action confirmation.   |
 
+### `hindsight_inspect_retain_queue`
+
+Inspect local retain queue and dead-letter metadata without returning retained payloads.
+
+| Parameter     | Type    | Required | Description                                       |
+| ------------- | ------- | -------- | ------------------------------------------------- |
+| `includeJobs` | boolean | no       | Include redacted job metadata. Defaults to false. |
+
 ### `hindsight_list_operations`
 
 List Hindsight async operations for a bank with supported server filters.
@@ -639,6 +647,7 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 | `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                   |
 | `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                   |
 | `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript. |
+| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                    |
 | `/hindsight:flush`                   | Flush queued retain jobs.                                                                         |
 
 ## Config fields

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -39,6 +39,8 @@ Use dry-run before non-dry-run imports. See [Import controls](/pi-hindsight/refe
 ## Queue and snapshots
 
 ```text
+/hindsight:queue
+/hindsight:queue --jobs --json
 /hindsight:flush
 /hindsight:last-recall
 /hindsight:last-recall --json
@@ -46,7 +48,7 @@ Use dry-run before non-dry-run imports. See [Import controls](/pi-hindsight/refe
 /hindsight:recall-cleanup <session.jsonl> --prune
 ```
 
-`/hindsight:flush` flushes queued retain jobs. `/hindsight:last-recall` reads the opt-in local recall snapshot. Recall cleanup reports or prunes accidentally persisted `<hindsight-memory>` transcript lines.
+`/hindsight:queue` summarizes active and dead-letter retain queues without printing retained payloads. Add `--jobs --json` for redacted job metadata such as job id, bank id, document id, tags, byte counts, retry count, and last error. `/hindsight:flush` flushes queued retain jobs. `/hindsight:last-recall` reads the opt-in local recall snapshot. Recall cleanup reports or prunes accidentally persisted `<hindsight-memory>` transcript lines.
 
 ## Session controls
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,6 +61,10 @@ Mission text and mental models remain Hindsight bank settings, not normal Pi JSO
 
 Current Hindsight OpenAPI exposes generic per-bank config updates through `BankConfigUpdate.updates`, so Pi exposes raw field updates via `hindsight_update_bank_config` instead of adding local Pi config keys for every server field. High-value per-bank fields supported through raw updates or bank-template manifests include retain extraction/chunking, observation/consolidation limits, reflect source-fact budgets, MCP tool allowlists, retain strategies, and recall budget mapping fields. Keep server-admin or credential-like fields out of Pi local config unless Hindsight documents them as safe per-bank overrides.
 
+## Compatibility and runtime identity
+
+Pi Hindsight targets the official `@vectorize-io/hindsight-client` package and the current documented Hindsight REST/OpenAPI behavior. The runtime client sends a `pi-hindsight/<package-version>` user-agent on both official-client and REST fallback paths. `/hindsight` and debug/status diagnostics surface local package identity, configured server URL, append-mode support, bank reachability, queue state, and failed-consolidation hints where the server exposes them.
+
 ## Setup TUI
 
 Run:

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -316,6 +316,14 @@ Clear all observations for one bank. Destructive; requires confirm=true.
 | `bank`    | string | no       | Optional bank id. Defaults to project bank. |
 | `confirm` | true   | yes      | Required destructive-action confirmation.   |
 
+### `hindsight_inspect_retain_queue`
+
+Inspect local retain queue and dead-letter metadata without returning retained payloads.
+
+| Parameter     | Type    | Required | Description                                       |
+| ------------- | ------- | -------- | ------------------------------------------------- |
+| `includeJobs` | boolean | no       | Include redacted job metadata. Defaults to false. |
+
 ### `hindsight_list_operations`
 
 List Hindsight async operations for a bank with supported server filters.
@@ -635,6 +643,7 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 | `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                   |
 | `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                   |
 | `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript. |
+| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                    |
 | `/hindsight:flush`                   | Flush queued retain jobs.                                                                         |
 
 ## Config fields

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -37,6 +37,8 @@ Use dry-run before non-dry-run imports. See [`import-controls.md`](import-contro
 ## Queue and snapshots
 
 ```text
+/hindsight:queue
+/hindsight:queue --jobs --json
 /hindsight:flush
 /hindsight:last-recall
 /hindsight:last-recall --json
@@ -44,7 +46,7 @@ Use dry-run before non-dry-run imports. See [`import-controls.md`](import-contro
 /hindsight:recall-cleanup <session.jsonl> --prune
 ```
 
-`/hindsight:flush` flushes queued retain jobs. `/hindsight:last-recall` reads the opt-in local recall snapshot. Recall cleanup reports or prunes accidentally persisted `<hindsight-memory>` transcript lines.
+`/hindsight:queue` summarizes active and dead-letter retain queues without printing retained payloads. Add `--jobs --json` for redacted job metadata such as job id, bank id, document id, tags, byte counts, retry count, and last error. `/hindsight:flush` flushes queued retain jobs. `/hindsight:last-recall` reads the opt-in local recall snapshot. Recall cleanup reports or prunes accidentally persisted `<hindsight-memory>` transcript lines.
 
 ## Session controls
 

--- a/extensions/client-rest.ts
+++ b/extensions/client-rest.ts
@@ -1,3 +1,4 @@
+import { PI_HINDSIGHT_USER_AGENT } from "./version.js";
 import type {
   CreateDirectiveRequest,
   CreateMentalModelRequest,
@@ -62,7 +63,7 @@ export function createHindsightRestTransport(config: ResolvedConfig): HindsightR
   return {
     async request(path, init = {}) {
       const headers = new Headers(init.headers);
-      headers.set("User-Agent", "pi-hindsight/0.1.0");
+      headers.set("User-Agent", PI_HINDSIGHT_USER_AGENT);
       if (!headers.has("Content-Type") && init.body && !(init.body instanceof FormData))
         headers.set("Content-Type", "application/json");
       if (config.hindsight.apiKey)

--- a/extensions/client.ts
+++ b/extensions/client.ts
@@ -1,6 +1,7 @@
 import { HindsightClient } from "@vectorize-io/hindsight-client";
 import { redactError } from "./sanitize.js";
 import type { HindsightLikeClient, ResolvedConfig } from "./types.js";
+import { PI_HINDSIGHT_USER_AGENT } from "./version.js";
 import {
   assertHealthResponse,
   assertReflectResponse,
@@ -114,7 +115,7 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
   const raw = new HindsightClient({
     baseUrl: config.hindsight.baseUrl,
     ...(config.hindsight.apiKey ? { apiKey: config.hindsight.apiKey } : {}),
-    userAgent: "pi-hindsight/0.1.0",
+    userAgent: PI_HINDSIGHT_USER_AGENT,
   });
   const rest = createHindsightRestTransport(config);
   const timeoutMs = config.hindsight.timeoutMs;

--- a/extensions/command-maintenance.ts
+++ b/extensions/command-maintenance.ts
@@ -103,6 +103,32 @@ export function maintenanceCommandOperations(operations: Operations): CommandOpe
       },
     },
     {
+      name: "hindsight:queue",
+      spec: {
+        description:
+          "Inspect local retain queue and dead-letter metadata without printing payloads.",
+        getArgumentCompletions: (prefix) => completeFlags(prefix, ["--jobs", "--json"]),
+        handler: async (args, ctx) => {
+          const argsList = argList(args);
+          const result = await operations.inspectRetainQueue({
+            cwd: ctx.cwd,
+            includeJobs: argsList.includes("--jobs"),
+          });
+          if (argsList.includes("--json")) {
+            ctx.ui.notify(JSON.stringify(result, null, 2), "info");
+            return;
+          }
+          const active = result.active.valid;
+          const dead = result.deadLetter.valid;
+          const malformed = result.active.malformed + result.deadLetter.malformed;
+          ctx.ui.notify(
+            `Hindsight retain queue active=${active}; dead-letter=${dead}; malformed=${malformed}; path=${result.queuePath}`,
+            dead || malformed ? "warning" : "info",
+          );
+        },
+      },
+    },
+    {
       name: "hindsight:flush",
       spec: {
         description: "Flush queued retain jobs.",

--- a/extensions/diagnostics.ts
+++ b/extensions/diagnostics.ts
@@ -1,4 +1,5 @@
 import type { HindsightCapabilities, ResolvedConfig } from "./types.js";
+import { PI_HINDSIGHT_USER_AGENT, PI_HINDSIGHT_VERSION } from "./version.js";
 import { baseTags, findRepoRoot } from "./banking.js";
 import { stableSessionId } from "./session.js";
 import { createMemoryIdentity } from "./memory-identity.js";
@@ -108,6 +109,12 @@ export function formatDebugReport(args: DebugReportArgs): string {
   return JSON.stringify(
     {
       enabled: args.config.enabled,
+      integration: {
+        packageVersion: PI_HINDSIGHT_VERSION,
+        userAgent: PI_HINDSIGHT_USER_AGENT,
+        hindsightBaseUrl: args.config.hindsight.baseUrl,
+        clientPackage: "@vectorize-io/hindsight-client",
+      },
       health,
       cwd: args.cwd,
       repoRoot: findRepoRoot(args.cwd),

--- a/extensions/memory-operation-service.ts
+++ b/extensions/memory-operation-service.ts
@@ -14,6 +14,7 @@ import { createDocumentOperations } from "./memory-document-operations.js";
 import { createExplorationOperations } from "./memory-exploration-operations.js";
 import { createFileRetainOperations } from "./file-retain-operations.js";
 import { createMentalModelOperations } from "./memory-mental-model-operations.js";
+import { createQueueOperations } from "./queue-operations.js";
 import { createRecallOperations } from "./memory-recall-operations.js";
 import { createRetainOperations } from "./memory-retain-operations.js";
 import { createRoutingOperations } from "./memory-routing-operations.js";
@@ -78,6 +79,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createAdminOperations(deps),
     ...createImportOperations(deps),
     ...createSeedImportOperations(deps),
+    ...createQueueOperations(deps),
     ...createSessionOperations(),
   };
 }

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -968,6 +968,28 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       },
     }),
     defineCatalogTool({
+      name: "hindsight_inspect_retain_queue",
+      label: "Hindsight Inspect Retain Queue",
+      description:
+        "Inspect local retain queue and dead-letter metadata without returning retained payloads.",
+      parameters: Type.Object({
+        includeJobs: Type.Optional(
+          Type.Boolean({ description: "Include redacted job metadata. Defaults to false." }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.inspectRetainQueue({
+          cwd: ctx.cwd,
+          includeJobs: params.includeJobs ?? false,
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+    }),
+    defineCatalogTool({
       name: "hindsight_list_operations",
       label: "Hindsight List Operations",
       description: "List Hindsight async operations for a bank with supported server filters.",

--- a/extensions/queue-operations.ts
+++ b/extensions/queue-operations.ts
@@ -1,0 +1,57 @@
+import {
+  resolveQueuePath,
+  summarizeRetainQueue,
+  readRetainQueueTolerant,
+  readDeadLetterQueueTolerant,
+} from "./queue.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+import { redactError } from "./sanitize.js";
+import type { RetainJob } from "./types.js";
+
+function redactJob(job: RetainJob) {
+  return {
+    id: job.id,
+    bankId: job.bankId,
+    documentId: job.documentId,
+    updateMode: job.updateMode,
+    retries: job.retries,
+    lastError: job.lastError ? redactError(job.lastError) : undefined,
+    deadLetteredAt: job.deadLetteredAt,
+    tags: job.item.tags,
+    metadataKeys: job.item.metadata ? Object.keys(job.item.metadata).sort() : undefined,
+    contentBytes: Buffer.byteLength(job.item.content, "utf8"),
+    contextBytes: Buffer.byteLength(job.item.context, "utf8"),
+  };
+}
+
+export function createQueueOperations(deps: MemoryOperationsDeps) {
+  return {
+    async inspectRetainQueue(args: { cwd: string; includeJobs?: boolean }) {
+      const config = deps.getConfig();
+      const queuePath = resolveQueuePath(args.cwd, config.retain.queuePath);
+      const summary = await summarizeRetainQueue(queuePath);
+      const activeJobs = args.includeJobs
+        ? await readRetainQueueTolerant(queuePath)
+            .then((parsed) => parsed.jobs)
+            .catch(() => [])
+        : [];
+      const deadLetterJobs = args.includeJobs
+        ? await readDeadLetterQueueTolerant(queuePath)
+            .then((parsed) => parsed.jobs)
+            .catch(() => [])
+        : [];
+      return {
+        queuePath,
+        deadLetterPath: `${queuePath}.dead.jsonl`,
+        active: summary.active,
+        deadLetter: summary.deadLetter,
+        jobs: args.includeJobs
+          ? {
+              active: activeJobs.map(redactJob),
+              deadLetter: deadLetterJobs.map(redactJob),
+            }
+          : undefined,
+      };
+    },
+  };
+}

--- a/extensions/queue.ts
+++ b/extensions/queue.ts
@@ -53,6 +53,14 @@ export async function readDeadLetterQueue(path: string): Promise<RetainJob[]> {
   return readRetainQueue(resolveDeadLetterQueuePath(path));
 }
 
+export async function readRetainQueueTolerant(path: string) {
+  return retainQueueStore(path).readTolerant();
+}
+
+export async function readDeadLetterQueueTolerant(path: string) {
+  return readRetainQueueTolerant(resolveDeadLetterQueuePath(path));
+}
+
 export type RetainQueueFileSummary = JsonlQueueFileSummary;
 
 export interface RetainQueueSummary {
@@ -138,10 +146,6 @@ function isRetainJob(value: unknown): value is RetainJob {
 
 function retainQueueStore(path: string): JsonlQueueStore<RetainJob> {
   return new JsonlQueueStore(path, isRetainJob);
-}
-
-async function readRetainQueueTolerant(path: string) {
-  return retainQueueStore(path).readTolerant();
 }
 
 async function appendMalformedQueueLines(path: string, lines: string[]): Promise<void> {

--- a/extensions/version.ts
+++ b/extensions/version.ts
@@ -1,0 +1,2 @@
+export const PI_HINDSIGHT_VERSION = "0.4.0"; // x-release-please-version
+export const PI_HINDSIGHT_USER_AGENT = `pi-hindsight/${PI_HINDSIGHT_VERSION}`;

--- a/tests/client-adapter.test.ts
+++ b/tests/client-adapter.test.ts
@@ -1,20 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { PI_HINDSIGHT_USER_AGENT } from "../extensions/version.js";
 
 const mocks = vi.hoisted(() => ({
+  constructor: vi.fn(),
   retain: vi.fn(async () => ({ accepted: true })),
   retainBatch: vi.fn(async () => ({ accepted: true })),
 }));
 
 vi.mock("@vectorize-io/hindsight-client", () => ({
-  HindsightClient: vi.fn(() => ({
-    retain: mocks.retain,
-    retainBatch: mocks.retainBatch,
-  })),
+  HindsightClient: vi.fn((options) => {
+    mocks.constructor(options);
+    return {
+      retain: mocks.retain,
+      retainBatch: mocks.retainBatch,
+    };
+  }),
 }));
 
 describe("Hindsight client adapter", () => {
   beforeEach(() => {
+    mocks.constructor.mockClear();
     mocks.retain.mockClear();
     mocks.retainBatch.mockClear();
   });
@@ -22,6 +28,10 @@ describe("Hindsight client adapter", () => {
   it("uses official retain for single memories when document tags are absent", async () => {
     const { createHindsightClient } = await import("../extensions/client.js");
     const client = createHindsightClient(DEFAULT_CONFIG);
+
+    expect(mocks.constructor).toHaveBeenCalledWith(
+      expect.objectContaining({ userAgent: PI_HINDSIGHT_USER_AGENT }),
+    );
 
     await client.retain("bank", "content", {
       context: "ctx",

--- a/tests/client-rest.test.ts
+++ b/tests/client-rest.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { PI_HINDSIGHT_USER_AGENT } from "../extensions/version.js";
 import {
   assertHealthResponse,
   assertReflectResponse,
@@ -73,6 +75,17 @@ describe("Hindsight REST transport helpers", () => {
       tags: ["source:pi"],
       tags_match: "any_strict",
     });
+  });
+
+  it("sets the package-aligned user-agent on REST requests", async () => {
+    const fetch = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+
+    await createHindsightRestTransport(DEFAULT_CONFIG).request("/v1/health");
+
+    const headers = (fetch as unknown as { mock: { calls: Array<[string, RequestInit]> } }).mock
+      .calls[0]?.[1].headers as Headers;
+    expect(headers.get("User-Agent")).toBe(PI_HINDSIGHT_USER_AGENT);
   });
 
   it("encodes bank ids in REST paths", () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -7,6 +7,7 @@ import {
   safeConfig,
 } from "../extensions/diagnostics.js";
 import type { ImportManifestEntry } from "../extensions/import-manifest.js";
+import { PI_HINDSIGHT_USER_AGENT, PI_HINDSIGHT_VERSION } from "../extensions/version.js";
 
 function latestImport(overrides: Partial<ImportManifestEntry> = {}): ImportManifestEntry {
   return {
@@ -67,6 +68,11 @@ describe("diagnostics", () => {
 
     expect(report.projectBankId).toBe("bank");
     expect(report.health).toBe("reachable");
+    expect(report.integration).toMatchObject({
+      packageVersion: PI_HINDSIGHT_VERSION,
+      userAgent: PI_HINDSIGHT_USER_AGENT,
+      clientPackage: "@vectorize-io/hindsight-client",
+    });
     expect(report.queueLength).toBe(2);
     expect(report.queue).toEqual({
       path: DEFAULT_CONFIG.retain.queuePath,

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -789,6 +789,7 @@ describe("operation catalog", () => {
       "hindsight_trigger_consolidation",
       "hindsight_recover_consolidation",
       "hindsight_clear_observations",
+      "hindsight_inspect_retain_queue",
       "hindsight_list_operations",
       "hindsight_cancel_operation",
       "hindsight_retry_operation",
@@ -833,6 +834,7 @@ describe("operation catalog", () => {
       "hindsight:tag",
       "hindsight:last-recall",
       "hindsight:recall-cleanup",
+      "hindsight:queue",
       "hindsight:flush",
     ]);
   });

--- a/tests/queue-operations.test.ts
+++ b/tests/queue-operations.test.ts
@@ -1,0 +1,67 @@
+import { appendFile, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config.js";
+import { createQueueOperations } from "../extensions/queue-operations.js";
+import { enqueueRetainJob, resolveQueuePath } from "../extensions/queue.js";
+import type { RetainJob } from "../extensions/types.js";
+
+function job(cwd: string): RetainJob {
+  return {
+    id: "job-1",
+    bankId: "bank",
+    createdAt: "2026-05-09T00:00:00.000Z",
+    documentId: "doc-1",
+    updateMode: "append",
+    retries: 1,
+    lastError: "failed with api_key=secret1234567890",
+    item: {
+      content: "secret payload content",
+      context: "secret context",
+      tags: ["source:pi"],
+      metadata: { cwd, pi_session_file: join(cwd, "session.jsonl"), safe: "value" },
+    },
+  };
+}
+
+describe("queue operations", () => {
+  it("returns queue summaries and redacted job metadata without payloads or metadata values", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "pi-hindsight-queue-ops-"));
+    const queuePath = resolveQueuePath(cwd, DEFAULT_CONFIG.retain.queuePath);
+    await enqueueRetainJob(queuePath, job(cwd));
+    await appendFile(queuePath, "{malformed json\n", "utf8");
+    await writeFile(
+      `${queuePath}.dead.jsonl`,
+      `${JSON.stringify(job(cwd)).replace("job-1", "dead-1")}\n{malformed dead json\n`,
+    );
+    const ops = createQueueOperations({
+      getClient: () => ({
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+      }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "bank",
+    });
+
+    const result = await ops.inspectRetainQueue({ cwd, includeJobs: true });
+
+    expect(result.active.valid).toBe(1);
+    expect(result.active.malformed).toBe(1);
+    expect(result.deadLetter.valid).toBe(1);
+    expect(result.deadLetter.malformed).toBe(1);
+    expect(result.jobs?.active[0]).toMatchObject({
+      id: "job-1",
+      metadataKeys: ["cwd", "pi_session_file", "safe"],
+      contentBytes: Buffer.byteLength("secret payload content", "utf8"),
+      contextBytes: Buffer.byteLength("secret context", "utf8"),
+      lastError: "failed with api_key=[REDACTED]",
+    });
+    const jobsJson = JSON.stringify(result.jobs);
+    expect(jobsJson).not.toContain("secret payload content");
+    expect(jobsJson).not.toContain("secret context");
+    expect(jobsJson).not.toContain("session.jsonl");
+    expect(jobsJson).not.toContain(cwd);
+  });
+});

--- a/tests/release-please-config.test.mjs
+++ b/tests/release-please-config.test.mjs
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const config = JSON.parse(readFileSync(".release-please-config.json", "utf8"));
+
+describe("release-please config", () => {
+  it("keeps runtime version metadata release-managed", () => {
+    expect(config.packages["."]["extra-files"]).toContain("extensions/version.ts");
+  });
+});

--- a/tests/release-workflows.test.mjs
+++ b/tests/release-workflows.test.mjs
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+for (const workflow of [".github/workflows/release.yml", ".github/workflows/release-please.yml"]) {
+  describe(workflow, () => {
+    it("skips npm publish when the package version already exists", () => {
+      const content = readFileSync(workflow, "utf8");
+      expect(content).toContain('npm view "$name@$version" version');
+      expect(content).toContain("already exists on npm; skipping publish");
+      expect(content).toContain("npm publish --provenance --access public");
+    });
+  });
+}

--- a/tests/version.test.ts
+++ b/tests/version.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import packageJson from "../package.json" with { type: "json" };
+import { PI_HINDSIGHT_USER_AGENT, PI_HINDSIGHT_VERSION } from "../extensions/version.js";
+
+describe("runtime version metadata", () => {
+  it("keeps user-agent version aligned with package.json", () => {
+    expect(PI_HINDSIGHT_VERSION).toBe(packageJson.version);
+    expect(PI_HINDSIGHT_USER_AGENT).toBe(`pi-hindsight/${packageJson.version}`);
+  });
+});


### PR DESCRIPTION
## Summary

- Align runtime User-Agent with the package version for both official Hindsight client and REST fallback paths.
- Make Release and Release Please publish steps idempotent when the target npm version already exists.
- Add local retain queue inspection tool/command with redacted job metadata.
- Surface package/runtime compatibility identity in diagnostics and docs.
- Add tests for version alignment, release workflow publish skip, queue surface registration, diagnostics, and REST/client user-agent behavior.

## Linked issue

- Closes #342
- Closes #343
- Closes #344
- Closes #345
- Closes #346

## Scope

One maintainer-requested audit-hardening batch covering release safety, runtime identity, queue inspection, and compatibility/surface-drift docs. No memory model or retain/recall behavior changes.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not applicable.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — not run locally; workflow idempotency is covered by tests and CI will run package-relevant checks when labeled.
- [ ] `npm run pack:verify` (release/package changes) — not run locally; no package payload/source behavior change.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — not applicable; no memory-path behavior change.

## Release impact

Check exactly one:

- [ ] No release impact
- [ ] User-visible change
- [x] Package/release path change

## Risk and rollback

- Risk: Low/medium; release workflow publish behavior changes from fail-on-existing to explicit skip-after-verification, and a new queue inspection surface exposes redacted metadata.
- Rollback/revert path: Revert this PR to restore previous publish behavior and remove the queue inspection surface.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. — not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- Project reviewer found no blockers.
- Existing unrelated oxlint warning remains in `extensions/client-rest.ts` for a no-useless-spread warning.
