### PR TITLE
fix(release): publish through trusted workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write
+  actions: write
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -27,50 +27,12 @@ jobs:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Check out release commit
+      - name: Dispatch trusted release workflow
         if: ${{ steps.release.outputs.release_created == 'true' }}
-        uses: actions/checkout@v6
-
-      - name: Set up Node.js for trusted publishing
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: npm
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        run: npm ci --engine-strict
-
-      - name: Run checks
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        run: npm run check
-
-      - name: Run coverage gate
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        run: npm run check:coverage
-
-      - name: Run TypeScript compiler fallback
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        run: npm run typecheck:tsc
-
-      - name: Verify registry signatures
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        run: npm run audit:signatures
-
-      - name: Verify release metadata and package install
-        if: ${{ steps.release.outputs.release_created == 'true' }}
-        run: npm run pack:verify
-
-      - name: Publish package to npm
-        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
         run: |
           set -euo pipefail
-          name=$(node -p "require('./package.json').name")
-          version=$(node -p "require('./package.json').version")
-          if npm view "$name@$version" version >/dev/null 2>&1; then
-            echo "$name@$version already exists on npm; skipping publish."
-            exit 0
-          fi
-          npm publish --provenance --access public
+          test -n "${RELEASE_TAG}"
+          gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=true

--- a/docs-site/src/content/docs/development/release.md
+++ b/docs-site/src/content/docs/development/release.md
@@ -4,7 +4,7 @@ title: "Release"
 
 Release automation uses [`release-please`](https://github.com/googleapis/release-please) to turn Conventional Commits on `main` into a release PR. The release PR updates `package.json`, `package-lock.json`, `.release-please-manifest.json`, and `CHANGELOG.md`.
 
-After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. The existing `Release` workflow then verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
+After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. Release Please then dispatches the trusted `Release` workflow at the immutable release tag with `publish=true`; that workflow verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
 
 ## Release checks
 
@@ -40,7 +40,8 @@ npm run check:release
 4. Confirm release/package verification passes. Use the `ci:package` or `ci:full` labels if additional gates are needed.
 5. Merge the release PR.
 6. Release-please creates the `v*.*.*` tag and GitHub release.
-7. The `Release` workflow verifies the tag and publishes to npm through trusted publishing.
+7. Release Please dispatches the trusted `Release` workflow at the release tag with `publish=true`.
+8. The `Release` workflow verifies the tagged release commit and publishes to npm through trusted publishing.
 
 Manual `Release Please` workflow dispatch can refresh the release PR if needed.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,7 +2,7 @@
 
 Release automation uses [`release-please`](https://github.com/googleapis/release-please) to turn Conventional Commits on `main` into a release PR. The release PR updates `package.json`, `package-lock.json`, `.release-please-manifest.json`, and `CHANGELOG.md`.
 
-After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. The existing `Release` workflow then verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
+After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. Release Please then dispatches the trusted `Release` workflow at the immutable release tag with `publish=true`; that workflow verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
 
 ## Release checks
 
@@ -38,7 +38,8 @@ npm run check:release
 4. Confirm release/package verification passes. Use the `ci:package` or `ci:full` labels if additional gates are needed.
 5. Merge the release PR.
 6. Release-please creates the `v*.*.*` tag and GitHub release.
-7. The `Release` workflow verifies the tag and publishes to npm through trusted publishing.
+7. Release Please dispatches the trusted `Release` workflow at the release tag with `publish=true`.
+8. The `Release` workflow verifies the tagged release commit and publishes to npm through trusted publishing.
 
 Manual `Release Please` workflow dispatch can refresh the release PR if needed.
 

--- a/tests/release-workflows.test.mjs
+++ b/tests/release-workflows.test.mjs
@@ -1,13 +1,26 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-for (const workflow of [".github/workflows/release.yml", ".github/workflows/release-please.yml"]) {
-  describe(workflow, () => {
-    it("skips npm publish when the package version already exists", () => {
-      const content = readFileSync(workflow, "utf8");
-      expect(content).toContain('npm view "$name@$version" version');
-      expect(content).toContain("already exists on npm; skipping publish");
-      expect(content).toContain("npm publish --provenance --access public");
-    });
+describe(".github/workflows/release-please.yml", () => {
+  it("delegates npm publishing to the trusted Release workflow", () => {
+    const content = readFileSync(".github/workflows/release-please.yml", "utf8");
+    expect(content).toContain("actions: write");
+    expect(content).toContain("Dispatch trusted release workflow");
+    expect(content).toContain("RELEASE_TAG: ${{ steps.release.outputs.tag_name }}");
+    expect(content).toContain('test -n "${RELEASE_TAG}"');
+    expect(content).toContain('gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=true');
+    expect(content).not.toContain("npm publish --provenance --access public");
   });
-}
+});
+
+describe(".github/workflows/release.yml", () => {
+  it("skips npm publish when the package version already exists", () => {
+    const content = readFileSync(".github/workflows/release.yml", "utf8");
+    expect(content).toContain(
+      "github.event_name == 'workflow_dispatch' && inputs.publish == 'true'",
+    );
+    expect(content).toContain('npm view "$name@$version" version');
+    expect(content).toContain("already exists on npm; skipping publish");
+    expect(content).toContain("npm publish --provenance --access public");
+  });
+});

--- a/tests/verify-release.test.mjs
+++ b/tests/verify-release.test.mjs
@@ -86,14 +86,20 @@ describe("verify-release", () => {
 
     expect(config.packages["."]["package-name"]).toBe("@luxusai/pi-hindsight");
     expect(config.packages["."]["include-component-in-tag"]).toBe(false);
-    expect(releasePlease).toContain("id-token: write");
+    expect(releasePlease).toContain("actions: write");
     expect(releasePlease).toContain("steps.release.outputs.release_created == 'true'");
-    expect(releasePlease).toContain("npm run check");
-    expect(releasePlease).toContain("npm run check:coverage");
-    expect(releasePlease).toContain("npm run typecheck:tsc");
-    expect(releasePlease).toContain("npm run audit:signatures");
-    expect(releasePlease).toContain("npm run pack:verify");
-    expect(releasePlease).toContain("npm publish --provenance --access public");
+    expect(releasePlease).toContain("RELEASE_TAG: ${{ steps.release.outputs.tag_name }}");
+    expect(releasePlease).toContain(
+      'gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=true',
+    );
+    expect(releasePlease).not.toContain("npm publish --provenance --access public");
+    expect(release).toContain("id-token: write");
+    expect(release).toContain("npm run check");
+    expect(release).toContain("npm run check:coverage");
+    expect(release).toContain("npm run typecheck:tsc");
+    expect(release).toContain("npm run audit:signatures");
+    expect(release).toContain("npm run pack:verify");
+    expect(release).toContain("npm publish --provenance --access public");
     expect(release).toContain(
       "github.event_name == 'workflow_dispatch' && inputs.publish == 'true'",
     );


### PR DESCRIPTION
## Summary

- Stop publishing to npm directly from `Release Please` because npm Trusted Publishing is configured for the `Release` workflow.
- After Release Please creates a GitHub release, dispatch `.github/workflows/release.yml` with `publish=true` at the immutable release tag.
- Keep npm publish idempotency and verification in the trusted `Release` workflow.
- Update release docs and workflow tests to lock in the two-workflow handoff.

## Linked issue

- Closes #349

## Scope

Release workflow plumbing only. No runtime, package contents, or memory-path behavior changes.

## Verification

- [x] `npm test -- tests/release-workflows.test.mjs tests/verify-release.test.mjs`
- [x] `npm run docs:check`
- [x] `npm run check`
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [x] `npm run audit:signatures`
- [x] `npm run pack:verify`
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — CI will cover PR gates; local workflow-only change has no platform runtime.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — not applicable; no memory-path behavior change.

## Release impact

Check exactly one:

- [ ] No release impact
- [ ] User-visible change
- [x] Package/release path change

## Risk and rollback

- Risk: medium; changes first-pass publish orchestration. It removes direct Release Please npm publish and relies on automatic dispatch to the already trusted `Release` workflow.
- Rollback/revert path: revert this PR to restore direct Release Please publish plus manual fallback behavior.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. — not applicable.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- Root cause: npm Trusted Publishing accepted the `Release` workflow but rejected direct publish from `Release Please`; the same package/version published successfully when manual `Release` workflow ran.
- Reviewer found one blocker about branch ref dispatch; fixed by dispatching `release.yml` at `steps.release.outputs.tag_name`.
