### PR TITLE
fix(operation-catalog): flatten recursive HindsightTagGroup tool schema

### DIFF
--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -84,23 +84,23 @@ Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi w
 
 Recall raw memories from Hindsight for this project.
 
-| Parameter               | Type                                        | Required | Description                                                                                                                         |
-| ----------------------- | ------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `query`                 | string                                      | yes      | Natural language memory query                                                                                                       |
-| `bank`                  | string                                      | no       | Optional bank id. Defaults to project bank.                                                                                         |
-| `types`                 | array<world \| experience \| observation>   | no       | Optional Hindsight fact types to retrieve.                                                                                          |
-| `budget`                | low \| mid \| high                          | no       | Optional Hindsight recall budget override for this tool call.                                                                       |
-| `maxTokens`             | integer                                     | no       | Optional Hindsight recall token cap override for this tool call. Use 0 for metadata/source-only recall when supported by Hindsight. |
-| `queryTimestamp`        | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                                                      |
-| `includeChunks`         | boolean                                     | no       | Ask Hindsight to include source chunks when supported.                                                                              |
-| `recallChunksMaxTokens` | integer                                     | no       | Optional token cap for included recall chunks.                                                                                      |
-| `includeSourceFacts`    | boolean                                     | no       | Ask Hindsight to include source facts when supported.                                                                               |
-| `maxSourceFactsTokens`  | integer                                     | no       | Optional token cap for included source facts.                                                                                       |
-| `includeEntities`       | boolean                                     | no       | Ask Hindsight to include entities when supported.                                                                                   |
-| `trace`                 | boolean                                     | no       | Ask Hindsight to include recall trace/debug data.                                                                                   |
-| `tags`                  | array<string>                               | no       | Additional tag filter.                                                                                                              |
-| `tagsMatch`             | any \| all \| any_strict \| all_strict      | no       |                                                                                                                                     |
-| `tagGroups`             | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                       |
+| Parameter               | Type                                      | Required | Description                                                                                                                         |
+| ----------------------- | ----------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `query`                 | string                                    | yes      | Natural language memory query                                                                                                       |
+| `bank`                  | string                                    | no       | Optional bank id. Defaults to project bank.                                                                                         |
+| `types`                 | array<world \| experience \| observation> | no       | Optional Hindsight fact types to retrieve.                                                                                          |
+| `budget`                | low \| mid \| high                        | no       | Optional Hindsight recall budget override for this tool call.                                                                       |
+| `maxTokens`             | integer                                   | no       | Optional Hindsight recall token cap override for this tool call. Use 0 for metadata/source-only recall when supported by Hindsight. |
+| `queryTimestamp`        | string                                    | no       | Optional ISO timestamp for time-scoped recall.                                                                                      |
+| `includeChunks`         | boolean                                   | no       | Ask Hindsight to include source chunks when supported.                                                                              |
+| `recallChunksMaxTokens` | integer                                   | no       | Optional token cap for included recall chunks.                                                                                      |
+| `includeSourceFacts`    | boolean                                   | no       | Ask Hindsight to include source facts when supported.                                                                               |
+| `maxSourceFactsTokens`  | integer                                   | no       | Optional token cap for included source facts.                                                                                       |
+| `includeEntities`       | boolean                                   | no       | Ask Hindsight to include entities when supported.                                                                                   |
+| `trace`                 | boolean                                   | no       | Ask Hindsight to include recall trace/debug data.                                                                                   |
+| `tags`                  | array<string>                             | no       | Additional tag filter.                                                                                                              |
+| `tagsMatch`             | any \| all \| any_strict \| all_strict    | no       |                                                                                                                                     |
+| `tagGroups`             | array<object>                             | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                       |
 
 ### `hindsight_retain`
 
@@ -688,19 +688,19 @@ Import a chat transcript JSONL file into the configured user memory bank. Explic
 
 Ask Hindsight to synthesize an answer from memory. Use explicitly, not for default recall.
 
-| Parameter          | Type                                        | Required | Description                                                                                   |
-| ------------------ | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `query`            | string                                      | yes      |                                                                                               |
-| `context`          | string                                      | no       |                                                                                               |
-| `bank`             | string                                      | no       |                                                                                               |
-| `budget`           | low \| mid \| high                          | no       | Optional Hindsight reflect budget override for this tool call.                                |
-| `maxTokens`        | integer                                     | no       | Optional Hindsight reflect token cap override for this tool call.                             |
-| `responseSchema`   | object/map                                  | no       |                                                                                               |
-| `includeFacts`     | boolean                                     | no       | Ask Hindsight reflect to include facts when supported.                                        |
-| `includeToolCalls` | boolean                                     | no       | Ask Hindsight reflect to include tool-call trace data when supported.                         |
-| `tags`             | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`        | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
-| `tagGroups`        | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
+| Parameter          | Type                                   | Required | Description                                                                                   |
+| ------------------ | -------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `query`            | string                                 | yes      |                                                                                               |
+| `context`          | string                                 | no       |                                                                                               |
+| `bank`             | string                                 | no       |                                                                                               |
+| `budget`           | low \| mid \| high                     | no       | Optional Hindsight reflect budget override for this tool call.                                |
+| `maxTokens`        | integer                                | no       | Optional Hindsight reflect token cap override for this tool call.                             |
+| `responseSchema`   | object/map                             | no       |                                                                                               |
+| `includeFacts`     | boolean                                | no       | Ask Hindsight reflect to include facts when supported.                                        |
+| `includeToolCalls` | boolean                                | no       | Ask Hindsight reflect to include tool-call trace data when supported.                         |
+| `tags`             | array<string>                          | no       | Additional tag filter.                                                                        |
+| `tagsMatch`        | any \| all \| any_strict \| all_strict | no       |                                                                                               |
+| `tagGroups`        | array<object>                          | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ## Commands
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -80,23 +80,23 @@ Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi w
 
 Recall raw memories from Hindsight for this project.
 
-| Parameter               | Type                                        | Required | Description                                                                                                                         |
-| ----------------------- | ------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `query`                 | string                                      | yes      | Natural language memory query                                                                                                       |
-| `bank`                  | string                                      | no       | Optional bank id. Defaults to project bank.                                                                                         |
-| `types`                 | array<world \| experience \| observation>   | no       | Optional Hindsight fact types to retrieve.                                                                                          |
-| `budget`                | low \| mid \| high                          | no       | Optional Hindsight recall budget override for this tool call.                                                                       |
-| `maxTokens`             | integer                                     | no       | Optional Hindsight recall token cap override for this tool call. Use 0 for metadata/source-only recall when supported by Hindsight. |
-| `queryTimestamp`        | string                                      | no       | Optional ISO timestamp for time-scoped recall.                                                                                      |
-| `includeChunks`         | boolean                                     | no       | Ask Hindsight to include source chunks when supported.                                                                              |
-| `recallChunksMaxTokens` | integer                                     | no       | Optional token cap for included recall chunks.                                                                                      |
-| `includeSourceFacts`    | boolean                                     | no       | Ask Hindsight to include source facts when supported.                                                                               |
-| `maxSourceFactsTokens`  | integer                                     | no       | Optional token cap for included source facts.                                                                                       |
-| `includeEntities`       | boolean                                     | no       | Ask Hindsight to include entities when supported.                                                                                   |
-| `trace`                 | boolean                                     | no       | Ask Hindsight to include recall trace/debug data.                                                                                   |
-| `tags`                  | array<string>                               | no       | Additional tag filter.                                                                                                              |
-| `tagsMatch`             | any \| all \| any_strict \| all_strict      | no       |                                                                                                                                     |
-| `tagGroups`             | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                       |
+| Parameter               | Type                                      | Required | Description                                                                                                                         |
+| ----------------------- | ----------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `query`                 | string                                    | yes      | Natural language memory query                                                                                                       |
+| `bank`                  | string                                    | no       | Optional bank id. Defaults to project bank.                                                                                         |
+| `types`                 | array<world \| experience \| observation> | no       | Optional Hindsight fact types to retrieve.                                                                                          |
+| `budget`                | low \| mid \| high                        | no       | Optional Hindsight recall budget override for this tool call.                                                                       |
+| `maxTokens`             | integer                                   | no       | Optional Hindsight recall token cap override for this tool call. Use 0 for metadata/source-only recall when supported by Hindsight. |
+| `queryTimestamp`        | string                                    | no       | Optional ISO timestamp for time-scoped recall.                                                                                      |
+| `includeChunks`         | boolean                                   | no       | Ask Hindsight to include source chunks when supported.                                                                              |
+| `recallChunksMaxTokens` | integer                                   | no       | Optional token cap for included recall chunks.                                                                                      |
+| `includeSourceFacts`    | boolean                                   | no       | Ask Hindsight to include source facts when supported.                                                                               |
+| `maxSourceFactsTokens`  | integer                                   | no       | Optional token cap for included source facts.                                                                                       |
+| `includeEntities`       | boolean                                   | no       | Ask Hindsight to include entities when supported.                                                                                   |
+| `trace`                 | boolean                                   | no       | Ask Hindsight to include recall trace/debug data.                                                                                   |
+| `tags`                  | array<string>                             | no       | Additional tag filter.                                                                                                              |
+| `tagsMatch`             | any \| all \| any_strict \| all_strict    | no       |                                                                                                                                     |
+| `tagGroups`             | array<object>                             | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                       |
 
 ### `hindsight_retain`
 
@@ -684,19 +684,19 @@ Import a chat transcript JSONL file into the configured user memory bank. Explic
 
 Ask Hindsight to synthesize an answer from memory. Use explicitly, not for default recall.
 
-| Parameter          | Type                                        | Required | Description                                                                                   |
-| ------------------ | ------------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
-| `query`            | string                                      | yes      |                                                                                               |
-| `context`          | string                                      | no       |                                                                                               |
-| `bank`             | string                                      | no       |                                                                                               |
-| `budget`           | low \| mid \| high                          | no       | Optional Hindsight reflect budget override for this tool call.                                |
-| `maxTokens`        | integer                                     | no       | Optional Hindsight reflect token cap override for this tool call.                             |
-| `responseSchema`   | object/map                                  | no       |                                                                                               |
-| `includeFacts`     | boolean                                     | no       | Ask Hindsight reflect to include facts when supported.                                        |
-| `includeToolCalls` | boolean                                     | no       | Ask Hindsight reflect to include tool-call trace data when supported.                         |
-| `tags`             | array<string>                               | no       | Additional tag filter.                                                                        |
-| `tagsMatch`        | any \| all \| any_strict \| all_strict      | no       |                                                                                               |
-| `tagGroups`        | array<object \| object \| object \| object> | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
+| Parameter          | Type                                   | Required | Description                                                                                   |
+| ------------------ | -------------------------------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `query`            | string                                 | yes      |                                                                                               |
+| `context`          | string                                 | no       |                                                                                               |
+| `bank`             | string                                 | no       |                                                                                               |
+| `budget`           | low \| mid \| high                     | no       | Optional Hindsight reflect budget override for this tool call.                                |
+| `maxTokens`        | integer                                | no       | Optional Hindsight reflect token cap override for this tool call.                             |
+| `responseSchema`   | object/map                             | no       |                                                                                               |
+| `includeFacts`     | boolean                                | no       | Ask Hindsight reflect to include facts when supported.                                        |
+| `includeToolCalls` | boolean                                | no       | Ask Hindsight reflect to include tool-call trace data when supported.                         |
+| `tags`             | array<string>                          | no       | Additional tag filter.                                                                        |
+| `tagsMatch`        | any \| all \| any_strict \| all_strict | no       |                                                                                               |
+| `tagGroups`        | array<object>                          | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter. |
 
 ## Commands
 

--- a/extensions/operation-catalog.ts
+++ b/extensions/operation-catalog.ts
@@ -79,36 +79,13 @@ const mentalModelTagsMatchSchema = Type.Union([
 ]);
 
 const tagGroupJsonSchema = {
-  $id: "HindsightTagGroup",
-  anyOf: [
-    {
-      type: "object",
-      required: ["tags"],
-      properties: {
-        tags: { type: "array", items: { type: "string" } },
-        match: { enum: ["any", "all", "any_strict", "all_strict"] },
-      },
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      required: ["and"],
-      properties: { and: { type: "array", items: { $ref: "HindsightTagGroup" } } },
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      required: ["or"],
-      properties: { or: { type: "array", items: { $ref: "HindsightTagGroup" } } },
-      additionalProperties: false,
-    },
-    {
-      type: "object",
-      required: ["not"],
-      properties: { not: { $ref: "HindsightTagGroup" } },
-      additionalProperties: false,
-    },
-  ],
+  type: "object",
+  required: ["tags"],
+  properties: {
+    tags: { type: "array", items: { type: "string" } },
+    match: { enum: ["any", "all", "any_strict", "all_strict"] },
+  },
+  additionalProperties: false,
 };
 
 const tagGroupSchema = Type.Unsafe<import("./types.js").HindsightTagGroup>(tagGroupJsonSchema);


### PR DESCRIPTION
## Summary

Flatten the `HindsightTagGroup` tool schema to remove recursive `$ref` self-references that crash LLM provider schema resolvers.

## Linked issue

- Closes #365

## Scope

- `extensions/operation-catalog.ts`: replace recursive `tagGroupJsonSchema` with leaf-only schema
- Regenerate surface reference docs

## Verification

- [x] `npm run check` — 491/491 tests pass, docs:check clean
- [ ] `npm run check:coverage` — not needed, schema-only change
- [ ] `npm run typecheck:tsc` — not needed, covered by `npm run check`
- [ ] full matrix requested/passed — not needed, single-file schema change
- [ ] package verification requested/passed — not needed
- [ ] `npm run pack:verify` — not needed
- [ ] `npm run smoke:hindsight` — not needed, no memory-path behavior change

## Release impact

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Fixes a bug where tool registration failed with 400 errors from OpenAI due to recursive schema. Users can now use `hindsight_recall` and `hindsight_retain` tools reliably.

## Risk and rollback

- **Risk:** Very low. Removes unsupported recursive schema variants from tool interface only. Internal HindsightTagGroup type and client API remain unchanged.
- **Rollback/revert path:** Revert commit and restore old recursive schema.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] Not applicable — no source-of-truth, workflow, or policy changes.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Schema-only change. No ADR conflicts. No live-smoke needed because this is a tool schema fix, not a memory-path behavior change.