### PR TITLE
fix(smoke): always clean up temporary smoke-test banks, add opt-out env var

### DIFF
--- a/scripts/smoke-helpers.ts
+++ b/scripts/smoke-helpers.ts
@@ -5,6 +5,7 @@ export interface SmokeConfig {
   bankIsTemporary: boolean;
   attempts: number;
   cleanupTimeoutMs: number;
+  cleanupOnFailure: boolean;
 }
 
 export interface SmokeEntry {
@@ -36,6 +37,7 @@ export function smokeConfig(
     bankIsTemporary: !configuredBankId,
     attempts: Number(env.HINDSIGHT_SMOKE_ATTEMPTS ?? 20),
     cleanupTimeoutMs: Number(env.HINDSIGHT_SMOKE_CLEANUP_TIMEOUT_MS ?? 5000),
+    cleanupOnFailure: env.PI_HINDSIGHT_SMOKE_CLEANUP_ON_FAILURE !== "false",
   };
 }
 
@@ -113,10 +115,10 @@ function cleanupTimeoutSignal(timeoutMs: number) {
   return controller.signal;
 }
 
-type CleanupSmokeConfig = Pick<SmokeConfig, "bankIsTemporary"> &
+type CleanupSmokeConfig = Pick<SmokeConfig, "bankIsTemporary" | "cleanupOnFailure"> &
   Partial<Pick<SmokeConfig, "baseUrl" | "apiKey" | "cleanupTimeoutMs">>;
 
-export async function cleanupSmokeBankOnSuccess({
+export async function cleanupSmokeBank({
   config,
   bankId,
   succeeded,
@@ -137,13 +139,13 @@ export async function cleanupSmokeBankOnSuccess({
     signal: AbortSignal,
   ) => Promise<{ status: number }>;
 }) {
-  if (!succeeded) {
-    recorder.step("cleanup_skipped", { reason: "smoke_failed", bankId });
-    return { cleaned: false, reason: "smoke_failed" };
-  }
   if (!config.bankIsTemporary) {
     recorder.step("cleanup_skipped", { reason: "configured_bank", bankId });
     return { cleaned: false, reason: "configured_bank" };
+  }
+  if (!succeeded && config.cleanupOnFailure === false) {
+    recorder.step("cleanup_skipped", { reason: "smoke_failed_debug", bankId });
+    return { cleaned: false, reason: "smoke_failed_debug" };
   }
   try {
     const result = await deleteBank(

--- a/scripts/smoke-hindsight.ts
+++ b/scripts/smoke-hindsight.ts
@@ -9,7 +9,7 @@ import { DEFAULT_CONFIG } from "../extensions/config.js";
 import { createMemoryOperations } from "../extensions/memory-operation-service.js";
 import { operationIdsFromResponse } from "../extensions/queue-delivery.js";
 import {
-  cleanupSmokeBankOnSuccess,
+  cleanupSmokeBank,
   createSmokeRecorder,
   renderSmokeSummary,
   retry,
@@ -741,7 +741,7 @@ try {
   );
   process.exitCode = 1;
 } finally {
-  await cleanupSmokeBankOnSuccess({ config, bankId: config.bankId, succeeded, recorder });
+  await cleanupSmokeBank({ config, bankId: config.bankId, succeeded, recorder });
   const summary = await writeGitHubSummary(renderSmokeSummary(recorder.entries()));
   if (summary.error) recorder.step("summary_failed", { error: summary.error });
 }

--- a/tests/smoke-helpers.test.ts
+++ b/tests/smoke-helpers.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
-  cleanupSmokeBankOnSuccess,
+  cleanupSmokeBank,
   createSmokeRecorder,
   envValue,
   logStep,
@@ -46,6 +46,7 @@ describe("smoke helpers", () => {
       bankIsTemporary: false,
       attempts: 3,
       cleanupTimeoutMs: 5000,
+      cleanupOnFailure: true,
     });
   });
 
@@ -125,40 +126,38 @@ describe("smoke helpers", () => {
     ).resolves.toMatchObject({ written: false, error: expect.any(String) });
   });
 
-  it("cleans up temporary smoke bank only after success", async () => {
+  it("cleans up temporary smoke bank after success or failure by default", async () => {
     const recorder = createSmokeRecorder({ now: () => 0, output: () => undefined });
     const deleteBank = vi.fn(async () => ({ status: 204 }));
     await expect(
-      cleanupSmokeBankOnSuccess({
-        config: { bankIsTemporary: true },
-        bankId: "bank",
+      cleanupSmokeBank({
+        config: { bankIsTemporary: true, cleanupOnFailure: true },
+        bankId: "bank-success",
         succeeded: true,
         recorder,
         deleteBank,
       }),
     ).resolves.toEqual({ cleaned: true, status: 204 });
-    expect(deleteBank).toHaveBeenCalledWith(
-      { bankIsTemporary: true },
-      "bank",
-      expect.any(AbortSignal),
-    );
-    expect(recorder.entries().at(-1)).toMatchObject({ step: "cleanup_ok", bankId: "bank" });
+    await expect(
+      cleanupSmokeBank({
+        config: { bankIsTemporary: true, cleanupOnFailure: true },
+        bankId: "bank-failure",
+        succeeded: false,
+        recorder,
+        deleteBank,
+      }),
+    ).resolves.toEqual({ cleaned: true, status: 204 });
+    expect(deleteBank).toHaveBeenCalledTimes(2);
+    expect(recorder.entries().at(-1)).toMatchObject({ step: "cleanup_ok", bankId: "bank-failure" });
   });
 
-  it("keeps smoke artifacts on failure or configured bank", async () => {
+  it("skips cleanup for configured bank regardless of success", async () => {
     const output = vi.fn();
     const recorder = createSmokeRecorder({ now: () => 0, output });
     const deleteBank = vi.fn(async () => ({ status: 204 }));
 
-    await cleanupSmokeBankOnSuccess({
-      config: { bankIsTemporary: true },
-      bankId: "bank",
-      succeeded: false,
-      recorder,
-      deleteBank,
-    });
-    await cleanupSmokeBankOnSuccess({
-      config: { bankIsTemporary: false },
+    await cleanupSmokeBank({
+      config: { bankIsTemporary: false, cleanupOnFailure: true },
       bankId: "bank",
       succeeded: true,
       recorder,
@@ -167,18 +166,34 @@ describe("smoke helpers", () => {
 
     expect(deleteBank).not.toHaveBeenCalled();
     expect(output).toHaveBeenCalledWith(
-      '{"step":"cleanup_skipped","durationMs":0,"reason":"smoke_failed","bankId":"bank"}',
-    );
-    expect(output).toHaveBeenCalledWith(
       '{"step":"cleanup_skipped","durationMs":0,"reason":"configured_bank","bankId":"bank"}',
+    );
+  });
+
+  it("skips cleanup on failure when cleanupOnFailure is false", async () => {
+    const output = vi.fn();
+    const recorder = createSmokeRecorder({ now: () => 0, output });
+    const deleteBank = vi.fn(async () => ({ status: 204 }));
+
+    await cleanupSmokeBank({
+      config: { bankIsTemporary: true, cleanupOnFailure: false },
+      bankId: "bank",
+      succeeded: false,
+      recorder,
+      deleteBank,
+    });
+
+    expect(deleteBank).not.toHaveBeenCalled();
+    expect(output).toHaveBeenCalledWith(
+      '{"step":"cleanup_skipped","durationMs":0,"reason":"smoke_failed_debug","bankId":"bank"}',
     );
   });
 
   it("logs cleanup failures without throwing", async () => {
     const recorder = createSmokeRecorder({ now: () => 0, output: () => undefined });
     await expect(
-      cleanupSmokeBankOnSuccess({
-        config: { bankIsTemporary: true },
+      cleanupSmokeBank({
+        config: { bankIsTemporary: true, cleanupOnFailure: true },
         bankId: "bank",
         succeeded: true,
         recorder,
@@ -196,8 +211,8 @@ describe("smoke helpers", () => {
       expect(signal).toBeInstanceOf(AbortSignal);
       return { status: 204 };
     });
-    await cleanupSmokeBankOnSuccess({
-      config: { bankIsTemporary: true, cleanupTimeoutMs: 1 },
+    await cleanupSmokeBank({
+      config: { bankIsTemporary: true, cleanupOnFailure: true, cleanupTimeoutMs: 1 },
       bankId: "bank",
       succeeded: true,
       recorder,


### PR DESCRIPTION
## Summary

Smoke test temporary banks are currently left behind when the test fails. This change always cleans up temporary banks, with an opt-out env var for debugging.

## Linked issue

- Closes #382

## Scope

- Rename `cleanupSmokeBankOnSuccess` → `cleanupSmokeBank`.
- Remove the `!succeeded` early return that skipped cleanup on failure.
- Add `PI_HINDSIGHT_SMOKE_CLEANUP_ON_FAILURE` env var to `smokeConfig` (default `true`).
- When `cleanupOnFailure === false`, skip cleanup on failure for debug purposes.
- Update `CleanupSmokeConfig` type to include `cleanupOnFailure`.
- Update all tests: verify cleanup on both success and failure by default, verify skip when `cleanupOnFailure=false`, verify skip for configured banks.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (not required — no source logic changed)
- [ ] `npm run typecheck:tsc` (not required — tsgo passes)
- [ ] full matrix requested/passed (not required — smoke helper change only)
- [ ] package verification requested/passed (not required — no package changes)
- [ ] `npm run pack:verify` (not required)
- [ ] `npm run smoke:hindsight` (not required — no memory-path behavior changes)

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

This is a smoke-test helper change with no user-visible or runtime behavior change.

## Risk and rollback

- Risk: low — only smoke-test helper and tests changed.
- Rollback/revert path: revert this commit.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, AGENTS.md and CONTRIBUTING.md were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`
- [x] I linked the issue before implementation.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

No ADR conflicts. Skipped coverage, tsc fallback, full matrix, package verify, and live-smoke because this is a pure smoke-test helper change with zero source or runtime behavior change.
