### PR TITLE
feat(lifecycle): add 60s TTL recall cache per session

### DIFF
--- a/extensions/lifecycle/memory-lifecycle-recall.ts
+++ b/extensions/lifecycle/memory-lifecycle-recall.ts
@@ -8,7 +8,7 @@ import {
   readSessionMemoryMeta,
 } from "../utils/session-memory-meta.js";
 import type { HindsightActivity } from "../utils/status.js";
-import type { HindsightLikeClient, ResolvedConfig } from "../types.js";
+import type { HindsightLikeClient, RecallBlock, RecallFailure, ResolvedConfig } from "../types.js";
 import type { ContextEvent, ContextPatch, RuntimeSnapshot } from "./memory-lifecycle-runtime.js";
 
 export type RecallStatusActivity = Extract<
@@ -29,6 +29,31 @@ export interface RecallTurnPolicyDeps {
     memoryCount?: number,
   ): void;
   notify(runtime: RuntimeSnapshot, message: string, level: "info" | "warning"): void;
+}
+
+interface RecallCacheEntry {
+  rendered: string;
+  blocks: RecallBlock[];
+  failed: number;
+  failures: RecallFailure[];
+}
+
+export function createRecallCache(ttlMs: number = 60000) {
+  const cache = new Map<string, { entry: RecallCacheEntry; timestamp: number }>();
+  return {
+    get(key: string): RecallCacheEntry | undefined {
+      const cached = cache.get(key);
+      if (!cached) return undefined;
+      if (Date.now() - cached.timestamp > ttlMs) {
+        cache.delete(key);
+        return undefined;
+      }
+      return cached.entry;
+    },
+    set(key: string, entry: RecallCacheEntry) {
+      cache.set(key, { entry, timestamp: Date.now() });
+    },
+  };
 }
 
 function canAppendRecallMessage(event: ContextEvent): boolean {
@@ -58,6 +83,7 @@ function patchWithRecallMessage(
 }
 
 export function createRecallTurnPolicy(deps: RecallTurnPolicyDeps): RecallTurnPolicy {
+  const cache = createRecallCache(60000);
   return {
     async recall(event: ContextEvent, runtime: RuntimeSnapshot): Promise<ContextPatch | undefined> {
       const config = deps.getConfig();
@@ -74,15 +100,22 @@ export function createRecallTurnPolicy(deps: RecallTurnPolicyDeps): RecallTurnPo
         return undefined;
       }
 
+      const cacheKey = scopes.map((s) => s.bankId).join(",") + "|" + event.messages.length;
+      let recallResult = cache.get(cacheKey);
+
       try {
-        deps.setMemoryStatus(runtime, "recalling");
-        const { rendered, blocks, failed, failures } = await recallForContext({
-          client: deps.getClient(),
-          config,
-          scopes,
-          messages: event.messages,
-          cwd: runtime.cwd,
-        });
+        if (!recallResult) {
+          deps.setMemoryStatus(runtime, "recalling");
+          recallResult = await recallForContext({
+            client: deps.getClient(),
+            config,
+            scopes,
+            messages: event.messages,
+            cwd: runtime.cwd,
+          });
+          cache.set(cacheKey, recallResult);
+        }
+        const { rendered, blocks, failed, failures } = recallResult;
         const memoryCount = blocks.reduce((count, block) => count + block.memoryCount, 0);
         deps.setMemoryStatus(
           runtime,

--- a/tests/recall-cache.test.ts
+++ b/tests/recall-cache.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRecallCache } from "../extensions/lifecycle/memory-lifecycle-recall.js";
+import type { RecallBlock, RecallFailure } from "../extensions/types.js";
+
+function makeEntry(rendered: string): {
+  rendered: string;
+  blocks: RecallBlock[];
+  failed: number;
+  failures: RecallFailure[];
+} {
+  return {
+    rendered,
+    blocks: [
+      {
+        bankId: "test-bank",
+        query: "test",
+        results: [],
+        memoryCount: 1,
+        rendered,
+      } as RecallBlock,
+    ],
+    failed: 0,
+    failures: [],
+  };
+}
+
+describe("createRecallCache", () => {
+  it("returns undefined for missing keys", () => {
+    const cache = createRecallCache(60000);
+    expect(cache.get("missing")).toBeUndefined();
+  });
+
+  it("returns cached entry within TTL", () => {
+    const cache = createRecallCache(60000);
+    const entry = makeEntry("cached");
+    cache.set("key", entry);
+    expect(cache.get("key")).toEqual(entry);
+  });
+
+  it("stores different entries for different keys", () => {
+    const cache = createRecallCache(60000);
+    const entryA = makeEntry("a");
+    const entryB = makeEntry("b");
+    cache.set("key-a", entryA);
+    cache.set("key-b", entryB);
+    expect(cache.get("key-a")).toEqual(entryA);
+    expect(cache.get("key-b")).toEqual(entryB);
+  });
+
+  it("expires entries after TTL", async () => {
+    const cache = createRecallCache(1);
+    const entry = makeEntry("expired");
+    cache.set("key", entry);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(cache.get("key")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an in-memory recall cache inside createRecallTurnPolicy with 60s TTL. Reduces latency on large banks by avoiding redundant Hindsight API calls when the same banks are queried within a session window.

## Linked issue

Updates #386 (Copilot review finding, performance section).

## Scope

- Add createRecallCache() with TTL expiration in memory-lifecycle-recall.ts
- Wire cache into createRecallTurnPolicy
- Cache key: bankIds joined with message count
- Only cache recallForContext result; post-processing runs every time
- Add tests/recall-cache.test.ts

## Verification

- [x] `npm run check` passes (65/65 test files, 505/505 tests)
- New test file with 4 tests: miss, hit, multi-key, TTL expiration

## Release impact

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

## Risk and rollback

**Risk:** Very low. Cache is transparent — misses fall through to existing behavior. TTL ensures freshness.
**Rollback:** Revert single commit. No state persisted outside the session.

## Follow-ups

- #388 (make TTL configurable via memory profile)

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`
- [x] I linked the issue before implementation
- [x] Final branch contains only focused, reviewable commits
- [x] I did not bypass hooks or checks
