### PR TITLE
feat(lifecycle): add error reporting to periodic and shutdown queue flush

### DIFF
--- a/extensions/lifecycle/memory-lifecycle.ts
+++ b/extensions/lifecycle/memory-lifecycle.ts
@@ -6,6 +6,10 @@ import { createHindsightClient } from "../client/client.js";
 import { ensureGlobalBank, ensureProjectBank } from "../banks/bank-operations.js";
 import { detectAppendCapability } from "../client/capabilities.js";
 import { flushRetainQueue, resolveQueuePath } from "../queue/queue.js";
+import {
+  formatFlushRetainQueueResult,
+  flushRetainQueueNotifyLevel,
+} from "../queue/flush-presenter.js";
 import { bankSelectionMessage } from "../utils/diagnostics.js";
 import type { HindsightCapabilities, HindsightLikeClient, ResolvedConfig } from "../types.js";
 import { redactError } from "../utils/sanitize.js";
@@ -73,7 +77,18 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
         maxJobs: config.retain.periodicFlushMaxJobs,
         maxElapsedMs: config.retain.periodicFlushTimeoutMs,
       })
-        .catch(() => undefined)
+        .then((result) => {
+          if (result.deadLettered || result.remaining) {
+            notify(
+              runtime,
+              formatFlushRetainQueueResult(result),
+              flushRetainQueueNotifyLevel(result),
+            );
+          }
+        })
+        .catch((error) => {
+          notify(runtime, `Periodic retain queue flush failed: ${redactError(error)}`, "warning");
+        })
         .finally(() => {
           periodicFlushActive = false;
         });
@@ -219,7 +234,8 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           maxElapsedMs: config.retain.shutdownFlushTimeoutMs,
           stopOnFirstFailure: true,
         });
-      } catch {
+      } catch (error) {
+        notify(runtime, `Shutdown retain queue flush failed: ${redactError(error)}`, "warning");
         // Keep queue on disk for next run.
       }
     },

--- a/tests/queue-flush-monitoring.test.ts
+++ b/tests/queue-flush-monitoring.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatFlushRetainQueueResult,
+  flushRetainQueueNotifyLevel,
+} from "../extensions/queue/flush-presenter.js";
+
+describe("flush presenter", () => {
+  it("returns info for clean flush", () => {
+    const result = { sent: 3, remaining: 0, deadLettered: 0, malformed: 0 };
+    expect(flushRetainQueueNotifyLevel(result)).toBe("info");
+    expect(formatFlushRetainQueueResult(result)).toContain("3");
+  });
+
+  it("returns warning when jobs remain", () => {
+    const result = { sent: 1, remaining: 2, deadLettered: 0, malformed: 0 };
+    expect(flushRetainQueueNotifyLevel(result)).toBe("warning");
+    expect(formatFlushRetainQueueResult(result)).toContain("remaining");
+  });
+
+  it("returns warning when jobs dead-lettered", () => {
+    const result = { sent: 1, remaining: 0, deadLettered: 2, malformed: 0 };
+    expect(flushRetainQueueNotifyLevel(result)).toBe("warning");
+    expect(formatFlushRetainQueueResult(result)).toContain("dead-lettered");
+  });
+
+  it("returns info when jobs malformed only", () => {
+    const result = { sent: 1, remaining: 0, deadLettered: 0, malformed: 3 };
+    expect(flushRetainQueueNotifyLevel(result)).toBe("info");
+    expect(formatFlushRetainQueueResult(result)).toContain("flushed 1");
+  });
+});

--- a/tests/recall-cache.test.ts
+++ b/tests/recall-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createRecallCache } from "../extensions/lifecycle/memory-lifecycle-recall.js";
 import type { RecallBlock, RecallFailure } from "../extensions/types.js";
 


### PR DESCRIPTION
## Summary

Adds error reporting to periodic and shutdown retain queue flush operations. Previously, flush errors were silently swallowed, hiding delivery failures from the user.

## Linked issue

Updates #386 (Copilot review finding on reliability section).

## Scope

- extensions/lifecycle/memory-lifecycle.ts:
  - Import formatFlushRetainQueueResult and flushRetainQueueNotifyLevel from queue/flush-presenter.js
  - Replace periodic flush .catch(() => undefined) with .catch(error => notify(...)) to report flush failures
  - Add .then(result => notify(...)) to report flush results with dead-lettered or remaining jobs
  - Replace shutdown flush empty catch {} with catch(error => notify(...))

## Verification

- [x] `npm run check` passes (66/66 test files, 509/509 tests)
- New test file: tests/queue-flush-monitoring.test.ts with 4 tests for flush presenter behavior

## Release impact

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

## Risk and rollback

**Risk:** Very low. Change only affects error reporting path; no behavioral changes to flush logic.
**Rollback:** Revert single commit. Flushes continue working; only reporting reverts to silent.

## Follow-ups

None.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`
- [x] I linked the issue before implementation
- [x] Final branch contains only focused, reviewable commits
- [x] I did not bypass hooks or checks
