### PR TITLE
feat(retain): add optional post-retain reflect

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,7 +119,8 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
     "periodicFlushTimeoutMs": 2000,
     "updateMode": "append",
     "shutdownFlushMaxJobs": 10,
-    "shutdownFlushTimeoutMs": 2000
+    "shutdownFlushTimeoutMs": 2000,
+    "postRetainReflect": false
   },
   "import": {
     "manifestPath": ".pi/hindsight/import-manifest.json",

--- a/extensions/config/config-defaults.ts
+++ b/extensions/config/config-defaults.ts
@@ -91,6 +91,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
     periodicFlushTimeoutMs: 2_000,
     shutdownFlushMaxJobs: 10,
     shutdownFlushTimeoutMs: 2_000,
+    postRetainReflect: false,
   },
   import: {
     mode: "curated",

--- a/extensions/config/config-normalize.ts
+++ b/extensions/config/config-normalize.ts
@@ -296,6 +296,10 @@ export function normalizeConfig(
         config.retain?.shutdownFlushTimeoutMs,
         DEFAULT_CONFIG.retain.shutdownFlushTimeoutMs,
       ),
+      postRetainReflect: bool(
+        config.retain?.postRetainReflect,
+        DEFAULT_CONFIG.retain.postRetainReflect,
+      ),
     },
     import: {
       mode: enumValue(

--- a/extensions/lifecycle/retain.ts
+++ b/extensions/lifecycle/retain.ts
@@ -75,5 +75,16 @@ export async function enqueueRetainFromAgentEnd(args: {
   if (!job) return { queued: false, sent: 0, remaining: 0 };
   await enqueueRetain(args.cwd, args.config, job);
   const result = await flushRetain(args.cwd, args.config, args.client);
+  if (args.config.retain.postRetainReflect) {
+    try {
+      await args.client.reflect(
+        args.bankId,
+        "Reflect on the recently retained session to extract insights",
+        { context: "Post-retain reflection" },
+      );
+    } catch {
+      /* best-effort reflect after retain */
+    }
+  }
   return { queued: true, sent: result.sent, remaining: result.remaining };
 }

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -114,6 +114,7 @@ export interface ResolvedConfig {
     periodicFlushTimeoutMs: number;
     shutdownFlushMaxJobs: number;
     shutdownFlushTimeoutMs: number;
+    postRetainReflect: boolean;
   };
   import: {
     mode: ImportMode;

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -1718,4 +1718,41 @@ describe("extension hooks", () => {
       "info",
     );
   });
+
+  it("calls client.reflect after retain when postRetainReflect is enabled", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({ retain: { postRetainReflect: true } }),
+    );
+    const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
+    const pi = {
+      on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
+        handlers[name] = [...(handlers[name] ?? []), handler];
+      }),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+    };
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => join(cwd, "session.jsonl") },
+    };
+
+    const { default: hindsightExtension } = await import("../extensions/index.js");
+    hindsightExtension(pi as any);
+    await handlers.session_start?.[0]?.({}, ctx);
+    await handlers.agent_end?.[0]?.(
+      { messages: [{ role: "assistant", content: "new decision", timestamp: 2 }] },
+      ctx,
+    );
+
+    expect(mocked.client.reflect).toHaveBeenCalledWith(
+      expect.stringMatching(/^pi-project-/),
+      "Reflect on the recently retained session to extract insights",
+      { context: "Post-retain reflection" },
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Add an opt-in `postRetainReflect` configuration option that triggers a Hindsight `reflect` call after successful retain, enabling automatic insight extraction from retained session content.

## Linked issue

Closes #391

## Scope

- Add `postRetainReflect: boolean` to `ResolvedConfig.retain`
- Add default `postRetainReflect: false` in `DEFAULT_CONFIG`
- Add normalization for `postRetainReflect` in config pipeline
- After `flushRetain` in `enqueueRetainFromAgentEnd`, call `client.reflect` when `postRetainReflect` is enabled (best-effort, errors caught)
- Add integration test in `extension-hooks.test.ts`
- Add `postRetainReflect` to docs configuration reference

## Verification

- [x] `npm run check` (65 test files, 506 tests, 0 errors)
- [ ] `npm run check:coverage`
- [ ] `npm run typecheck:tsc`
- [ ] full matrix requested/passed
- [ ] package verification requested/passed
- [ ] `npm run pack:verify`
- [x] `npm run smoke:hindsight` or configured `Hindsight Integration` pass

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

New `retain.postRetainReflect` config option (default: `false`). When enabled, triggers an automatic `hindsight_reflect` after successful retain. No breaking changes.

## Risk and rollback

- Risk: Low. Feature is opt-in (default: `false`). Reflect call is best-effort (errors caught, does not affect retain success). No API or config breaking changes.
- Rollback/revert path: Revert this single commit.

## Follow-ups

- None, or link issue(s): #391

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [ ] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [ ] I documented skipped checks with reasons.

## Notes

- Hindsight Integration workflow passed on re-run (initial run had a flaky recall indexing delay, unrelated to this PR).
- `postRetainReflect` added to docs configuration reference (`docs/configuration.md`).
