### PR TITLE
test(flush-presenter): add edge case tests for empty and malformed-only results

### DIFF
--- a/tests/flush-presenter.test.ts
+++ b/tests/flush-presenter.test.ts
@@ -21,4 +21,19 @@ describe("flush presenter", () => {
     expect(flushRetainQueueNotifyLevel(result({ remaining: 1 }))).toBe("warning");
     expect(flushRetainQueueNotifyLevel(result({ deadLettered: 1 }))).toBe("warning");
   });
+
+  it("info level for empty or malformed-only results", () => {
+    expect(flushRetainQueueNotifyLevel(result({ sent: 0 }))).toBe("info");
+    expect(flushRetainQueueNotifyLevel(result({ sent: 0, malformed: 5 }))).toBe("info");
+    expect(flushRetainQueueNotifyLevel(result({ sent: 1, malformed: 3 }))).toBe("info");
+  });
+
+  it("formats edge case results correctly", () => {
+    expect(formatFlushRetainQueueResult(result({ sent: 0, remaining: 0, deadLettered: 0 }))).toBe(
+      "Hindsight flushed 0; dead-lettered 0; remaining 0",
+    );
+    expect(
+      formatFlushRetainQueueResult(result({ sent: 100, remaining: 50, deadLettered: 25 })),
+    ).toBe("Hindsight flushed 100; dead-lettered 25; remaining 50");
+  });
 });


### PR DESCRIPTION
## Summary

Add edge case tests for `flushRetainQueueNotifyLevel` and `formatFlushRetainQueueResult` to cover empty results, malformed-only results, and large number formatting.

## Linked issue

Part of Todo #4: Add integration tests for failure scenarios.

## Scope

- Add test for info level with empty results (all zeros)
- Add test for info level with malformed-only results
- Add test for correct formatting of zero and large-number edge cases

## Verification

- [x] `npm run check` (65 test files, 508 tests, 0 errors)
- [ ] `npm run check:coverage`
- [ ] `npm run typecheck:tsc`
- [ ] full matrix requested/passed
- [ ] package verification requested/passed
- [ ] `npm run pack:verify`
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

Test-only change. No user-visible behavior changed.

## Risk and rollback

- Risk: None. Test-only change.
- Rollback/revert path: Revert this single commit.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [ ] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [ ] I documented skipped checks with reasons.

## Notes

- No smoke test or coverage run needed for this test-only change.
