### PR TITLE
fix: support Request-incompatible fetch wrappers

### DIFF
--- a/extensions/client/client.ts
+++ b/extensions/client/client.ts
@@ -48,6 +48,7 @@ import {
   updateDocumentRequestBody,
   updateMentalModelRequestBody,
 } from "./client-rest.js";
+import { installFetchRequestCompat } from "./fetch-compat.js";
 import { withTimeout } from "./timeout.js";
 
 type ReflectOptions = Parameters<HindsightLikeClient["reflect"]>[2];
@@ -113,6 +114,8 @@ async function reflect(
 }
 
 export function createHindsightClient(config: ResolvedConfig): HindsightLikeClient {
+  installFetchRequestCompat();
+
   const raw = new HindsightClient({
     baseUrl: config.hindsight.baseUrl,
     ...(config.hindsight.apiKey ? { apiKey: config.hindsight.apiKey } : {}),

--- a/extensions/client/fetch-compat.ts
+++ b/extensions/client/fetch-compat.ts
@@ -1,0 +1,39 @@
+const PATCH_MARKER = Symbol.for("@luxusai/pi-hindsight.fetch-request-compat");
+
+type FetchWithMarker = typeof fetch & { [PATCH_MARKER]?: true };
+type RequestInitWithDuplex = RequestInit & { duplex?: "half" };
+
+function isRequest(value: unknown): value is Request {
+  return typeof Request !== "undefined" && value instanceof Request;
+}
+
+function requestToInit(request: Request): RequestInitWithDuplex {
+  return {
+    method: request.method,
+    headers: request.headers,
+    body: request.body,
+    signal: request.signal,
+    redirect: request.redirect,
+    credentials: request.credentials,
+    cache: request.cache,
+    mode: request.mode,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+    ...(request.body ? { duplex: "half" as const } : {}),
+  };
+}
+
+export function installFetchRequestCompat(): void {
+  const currentFetch = globalThis.fetch as FetchWithMarker | undefined;
+  if (!currentFetch || currentFetch[PATCH_MARKER]) return;
+
+  const originalFetch = currentFetch.bind(globalThis) as typeof fetch;
+  const patchedFetch: FetchWithMarker = ((input: RequestInfo | URL, init?: RequestInit) => {
+    if (!isRequest(input)) return originalFetch(input, init);
+    return originalFetch(input.url, { ...requestToInit(input), ...init });
+  }) as FetchWithMarker;
+  patchedFetch[PATCH_MARKER] = true;
+  globalThis.fetch = patchedFetch;
+}

--- a/extensions/client/fetch-compat.ts
+++ b/extensions/client/fetch-compat.ts
@@ -1,4 +1,4 @@
-const PATCH_MARKER = Symbol.for("@luxusai/pi-hindsight.fetch-request-compat");
+const PATCH_MARKER: unique symbol = Symbol("@luxusai/pi-hindsight.fetch-request-compat");
 
 type FetchWithMarker = typeof fetch & { [PATCH_MARKER]?: true };
 type RequestInitWithDuplex = RequestInit & { duplex?: "half" };

--- a/tests/client-integration.test.ts
+++ b/tests/client-integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { createHindsightClient } from "../extensions/client/client.js";
 import { ensureProjectBank } from "../extensions/banks/bank-operations.js";
@@ -261,6 +261,35 @@ describe("Hindsight client adapter integration", () => {
     await new Promise<void>((resolve, reject) =>
       server.close((error) => (error ? reject(error) : resolve())),
     );
+  });
+
+  it("supports Pi fetch wrappers that reject Request objects", async () => {
+    const originalFetch = globalThis.fetch;
+    const strictFetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      if (input instanceof Request)
+        throw new TypeError("Failed to parse URL from [object Request]");
+      return originalFetch(input, init);
+    });
+    globalThis.fetch = strictFetch as typeof fetch;
+
+    try {
+      const client = createHindsightClient({
+        ...DEFAULT_CONFIG,
+        hindsight: { ...DEFAULT_CONFIG.hindsight, baseUrl },
+      });
+
+      await ensureProjectBank(client, "test-bank");
+      await client.recall("test-bank", "query");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+      "GET /v1/default/banks/test-bank/profile",
+      "PUT /v1/default/banks/test-bank",
+      "POST /v1/default/banks/test-bank/memories/recall",
+    ]);
+    expect(strictFetch).toHaveBeenCalledWith(expect.any(String), expect.any(Object));
   });
 
   it("uses official client endpoints and Hindsight request fields", async () => {


### PR DESCRIPTION
## Summary

- Add a Hindsight Adapter fetch compatibility shim for Pi runtimes where `globalThis.fetch` rejects `Request` objects.
- Install the shim before constructing the official `@vectorize-io/hindsight-client` so bank ensure and Recall calls can reach Hindsight.
- Add integration coverage for a strict Pi-like fetch wrapper that throws `Failed to parse URL from [object Request]`.

## Linked issue

- Closes #399

## Scope

- Focused compatibility fix in the Hindsight Adapter seam only.
- No Hindsight request shapes, Retain Queue behavior, bank selection policy, or Recall Block formatting changed.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — not required for this focused adapter fix.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — not a release/package change.
- [ ] `npm run pack:verify` (release/package changes) — not a release/package change.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — attempted locally and timed out after 180s; lower-level integration coverage exercises bank ensure and Recall through a strict fetch wrapper.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Fixes startup/runtime failures where Pi reports Hindsight bank ensure failures with `Failed to parse URL from [object Request]` despite a healthy Hindsight container.

## Risk and rollback

- Risk: The shim wraps `globalThis.fetch` process-wide because the official Hindsight client does not expose a per-client fetch override. The wrapper is intentionally narrow: string/URL calls pass through unchanged, and `Request` calls are normalized to URL + init.
- Rollback/revert path: Revert this PR to remove the wrapper and restore the previous direct official-client construction path.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [ ] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. — Not applicable; no guidance changes.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation (upstream issue #399 was created before PR submission; the local fork has issues disabled).
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.