### PR TITLE
chore(deps): upgrade hindsight-client to 0.8.3

### DIFF
--- a/docs-site/src/content/docs/reference/compatibility.md
+++ b/docs-site/src/content/docs/reference/compatibility.md
@@ -12,8 +12,8 @@ Pi Hindsight 1.0 is a Pi-first Hindsight integration. This page is the support c
 | npm                         | `>=10`                                                                                                                                                                               | `package.json#engines.npm`                                           |
 | Pi runtime packages         | Tested with the `@earendil-works/pi-*` versions pinned in `devDependencies`; peer dependencies accept Pi runtime packages supplied by the host Pi installation.                      | `package.json#devDependencies` and `package.json#peerDependencies`   |
 | TypeBox                     | `>=1.1.24 <2`                                                                                                                                                                        | `package.json#peerDependencies.typebox`                              |
-| Hindsight TypeScript client | `@vectorize-io/hindsight-client ^0.8.1`                                                                                                                                              | `package.json#dependencies`                                          |
-| Hindsight server            | **Hindsight 0.8+** with append `update_mode` support, compatible with `@vectorize-io/hindsight-client ^0.8.1`. Advanced surfaces are capability-gated where upstream support varies. | `/hindsight:doctor`, live smoke, and official Hindsight API behavior |
+| Hindsight TypeScript client | `@vectorize-io/hindsight-client ^0.8.3`                                                                                                                                              | `package.json#dependencies`                                          |
+| Hindsight server            | **Hindsight 0.8+** with append `update_mode` support, compatible with `@vectorize-io/hindsight-client ^0.8.3`. Advanced surfaces are capability-gated where upstream support varies. | `/hindsight:doctor`, live smoke, and official Hindsight API behavior |
 
 ## Required Hindsight capabilities
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,8 +10,8 @@ Pi Hindsight 1.0 is a Pi-first Hindsight integration. This page is the support c
 | npm                         | `>=10`                                                                                                                                                                               | `package.json#engines.npm`                                           |
 | Pi runtime packages         | Tested with the `@earendil-works/pi-*` versions pinned in `devDependencies`; peer dependencies accept Pi runtime packages supplied by the host Pi installation.                      | `package.json#devDependencies` and `package.json#peerDependencies`   |
 | TypeBox                     | `>=1.1.24 <2`                                                                                                                                                                        | `package.json#peerDependencies.typebox`                              |
-| Hindsight TypeScript client | `@vectorize-io/hindsight-client ^0.8.1`                                                                                                                                              | `package.json#dependencies`                                          |
-| Hindsight server            | **Hindsight 0.8+** with append `update_mode` support, compatible with `@vectorize-io/hindsight-client ^0.8.1`. Advanced surfaces are capability-gated where upstream support varies. | `/hindsight:doctor`, live smoke, and official Hindsight API behavior |
+| Hindsight TypeScript client | `@vectorize-io/hindsight-client ^0.8.3`                                                                                                                                              | `package.json#dependencies`                                          |
+| Hindsight server            | **Hindsight 0.8+** with append `update_mode` support, compatible with `@vectorize-io/hindsight-client ^0.8.3`. Advanced surfaces are capability-gated where upstream support varies. | `/hindsight:doctor`, live smoke, and official Hindsight API behavior |
 
 ## Required Hindsight capabilities
 

--- a/extensions/version.ts
+++ b/extensions/version.ts
@@ -4,5 +4,5 @@ export const PI_HINDSIGHT_USER_AGENT = `pi-hindsight/${PI_HINDSIGHT_VERSION}`;
 export const PI_HINDSIGHT_SUPPORTED_NODE = ">=20";
 export const PI_HINDSIGHT_SUPPORTED_NPM = ">=10";
 export const PI_HINDSIGHT_CLIENT_PACKAGE = "@vectorize-io/hindsight-client";
-export const PI_HINDSIGHT_CLIENT_RANGE = "^0.6.1";
+export const PI_HINDSIGHT_CLIENT_RANGE = "^0.8.3";
 export const PI_HINDSIGHT_SUPPORTED_TYPEBOX = ">=1.1.24 <2";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@vectorize-io/hindsight-client": "^0.8.1",
+        "@vectorize-io/hindsight-client": "^0.8.3",
         "jsonc-parser": "^3.3.1"
       },
       "devDependencies": {
@@ -5837,9 +5837,9 @@
       }
     },
     "node_modules/@vectorize-io/hindsight-client": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.8.1.tgz",
-      "integrity": "sha512-F0mMep0DuF2bTagoFsooDWUk28DLjdTqb8oKtrTVcipe/eytsNuPuqdfXrqkwWGvRthrcwokuugBLzQXpMyHtA==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@vectorize-io/hindsight-client/-/hindsight-client-0.8.3.tgz",
+      "integrity": "sha512-I2pBWOzvj8SB3rBoQIzk2pFQ3C6e9veoNr54dvXuCT1HWkCIPFDoLcmmpAlWbcXxukKUnMI/f6/ib4M21D36JA==",
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "code-map:check": "node scripts/generate-code-map.mjs --check"
   },
   "dependencies": {
-    "@vectorize-io/hindsight-client": "^0.8.1",
+    "@vectorize-io/hindsight-client": "^0.8.3",
     "jsonc-parser": "^3.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Upgrades the runtime Hindsight client and fixes a stale diagnostic constant.

- Bumps `@vectorize-io/hindsight-client` `0.8.1 -> 0.8.3` (latest). The diff is additive/backward-compatible — new `getVersion()` (server version + feature flags), `"shared"` observation scope, `"exact"` `tagsMatch`, recall `state`/`documentId` filters, and `retainStructuredChunkSize`. No required code changes; the new surfaces are opt-in.
- Corrects `PI_HINDSIGHT_CLIENT_RANGE`, which was left at `^0.6.1` during the 0.6→0.8 bump. The `/hindsight:doctor` and status diagnostics report this as the supported client range, so it was misreporting. Updated it and both `compatibility.md` docs to `^0.8.3`.

## Linked issue

- Closes #432

## Scope

One focused slice: dependency range bump + lockfile + the diagnostic range constant + compatibility docs. No logic changes; new SDK features intentionally left for separate issues.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — skipped because a live Hindsight instance is **unavailable** here; the bump is type-compatible (0.8.x line, additive diff) and covered by the client adapter/integration unit tests. The `ci:live-smoke` lane runs on this PR and skips gracefully without configured secrets.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Explain changelog/release notes impact, or say none: User-visible — the shipped runtime client moves to 0.8.3 (new capabilities available) and diagnostics now report the correct supported client range. Lands as a `chore(deps)` changelog entry.

## Risk and rollback

- Risk: Low. Patch/minor bump within the 0.8 line with a verified additive type surface; full `npm run check` + coverage + `tsc` fallback green. No runtime code paths changed.
- Rollback/revert path: revert this commit to restore `^0.8.1` and the prior constant; `git revert <sha>` is clean since the change is isolated to package metadata, one constant, and docs.

## Follow-ups

- None required. Optional: separate issues to adopt the new 0.8.x surfaces (`getVersion` in doctor, `shared`/`exact` tag modes, `retainStructuredChunkSize`).

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. (No governance change.)

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Supersedes the stale dependabot PR #409 (bumped only to 0.7.1); #409 will be closed. Live-smoke limitation documented above.
