### PR TITLE
feat(diagnostics): surface connected server version and feature flags

### DIFF
--- a/extensions/client/client.ts
+++ b/extensions/client/client.ts
@@ -220,6 +220,10 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
           return unwrapSdkResponse(response, "health");
         }),
       ),
+    getVersion: () =>
+      withTimeout("hindsight getVersion", timeoutMs, (signal) =>
+        withRetry("getVersion", () => raw.getVersion({ signal })),
+      ),
   };
 }
 

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -299,4 +299,5 @@ export interface HindsightLikeClient {
   getBankStats?(bankId: string): Promise<unknown>;
   getBankConfig?(bankId: string): Promise<unknown>;
   health?(): Promise<unknown>;
+  getVersion?(): Promise<unknown>;
 }

--- a/extensions/utils/status-health.ts
+++ b/extensions/utils/status-health.ts
@@ -161,6 +161,30 @@ async function bankFact(client: HindsightLikeClient, route: BankRoute): Promise<
   }
 }
 
+async function serverVersionFact(
+  client: HindsightLikeClient,
+): Promise<[string, string] | undefined> {
+  if (!client.getVersion) return undefined;
+  try {
+    const version = await withStatusTimeout(client.getVersion(), "Hindsight version");
+    const apiVersion = textField(version, "api_version");
+    if (!apiVersion) return undefined;
+    const features = nestedRecord(version, "features");
+    const enabled = features
+      ? Object.keys(features)
+          .filter((key) => features[key] === true)
+          .sort()
+      : [];
+    return [
+      "Server version",
+      enabled.length ? `${apiVersion} · features: ${enabled.join(", ")}` : apiVersion,
+    ];
+  } catch {
+    // Version endpoint is optional enrichment; older servers lack /version.
+    return undefined;
+  }
+}
+
 export async function collectStatusHealthFacts(args: {
   client: HindsightLikeClient;
   config: ResolvedConfig;
@@ -170,6 +194,8 @@ export async function collectStatusHealthFacts(args: {
   try {
     if (args.client.health) await withStatusTimeout(args.client.health(), "Hindsight health");
     facts.push(["Server", "reachable"]);
+    const versionFact = await serverVersionFact(args.client);
+    if (versionFact) facts.push(versionFact);
   } catch (error) {
     facts.push(["Server", `unreachable · ${redactError(error)}`]);
   }

--- a/tests/status-health.test.ts
+++ b/tests/status-health.test.ts
@@ -11,6 +11,10 @@ describe("status health", () => {
       recall: vi.fn(),
       reflect: vi.fn(),
       health: vi.fn(async () => ({ ok: true })),
+      getVersion: vi.fn(async () => ({
+        api_version: "0.8.3",
+        features: { observations: true, mcp: false, worker: true, bank_config_api: false },
+      })),
       getBankProfile: vi.fn(async (bankId: string) => ({
         bank_id: bankId,
         name: `${bankId} name`,
@@ -48,6 +52,7 @@ describe("status health", () => {
     expect(facts).toEqual(
       expect.arrayContaining([
         ["Server", "reachable"],
+        ["Server version", "0.8.3 · features: observations, worker"],
         ["Project bank", "reachable · project-bank name · Project → Bank: project-bank"],
         ["User bank", "reachable · global-bank name · User → Bank: global-bank"],
         ["Project bank config", "Bank overrides: 1 · Resolved config fields: 2"],
@@ -83,5 +88,48 @@ describe("status health", () => {
 
     expect(facts.find(([key]) => key === "Server")?.[1]).toContain("unreachable");
     expect(facts.find(([key]) => key === "Project bank")?.[1]).toContain("unreachable");
+  });
+
+  it("omits server version when getVersion is unavailable", async () => {
+    const client: HindsightLikeClient = {
+      retain: vi.fn(),
+      retainBatch: vi.fn(),
+      recall: vi.fn(),
+      reflect: vi.fn(),
+      health: vi.fn(async () => ({ ok: true })),
+      getBankProfile: vi.fn(async (bankId: string) => ({ bank_id: bankId, name: bankId })),
+    };
+
+    const facts = await collectStatusHealthFacts({
+      client,
+      config: DEFAULT_CONFIG,
+      projectBankId: "bank",
+    });
+
+    expect(facts.find(([key]) => key === "Server")?.[1]).toBe("reachable");
+    expect(facts.some(([key]) => key === "Server version")).toBe(false);
+  });
+
+  it("degrades silently when getVersion throws or returns no api_version", async () => {
+    const client: HindsightLikeClient = {
+      retain: vi.fn(),
+      retainBatch: vi.fn(),
+      recall: vi.fn(),
+      reflect: vi.fn(),
+      health: vi.fn(async () => ({ ok: true })),
+      getVersion: vi.fn(async () => {
+        throw new Error("no /version endpoint");
+      }),
+      getBankProfile: vi.fn(async (bankId: string) => ({ bank_id: bankId, name: bankId })),
+    };
+
+    const facts = await collectStatusHealthFacts({
+      client,
+      config: DEFAULT_CONFIG,
+      projectBankId: "bank",
+    });
+
+    expect(facts.find(([key]) => key === "Server")?.[1]).toBe("reachable");
+    expect(facts.some(([key]) => key === "Server version")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adopts the 0.8.x client `getVersion()` capability so the live status surface reports the **connected** Hindsight deployment's `api_version` and enabled feature flags, instead of only `Server: reachable`.

- Adds optional `getVersion?()` to the `HindsightLikeClient` interface.
- Implements it in the client adapter via the native high-level SDK, with the same timeout + idempotent retry treatment as other read calls.
- In `collectStatusHealthFacts` (rendered by the `/hindsight` setup TUI), after the reachability check, best-effort adds a `Server version` fact: `<api_version> · features: <enabled flags>`. Older servers without a `/version` endpoint degrade silently and the existing `Server: reachable` fact is unchanged.

## Linked issue

- Closes #437

## Scope

One focused slice: `getVersion` on the client interface + adapter, one helper in `status-health.ts`, and tests. No tool/command surface change. The orphaned `formatDebugReport` (separate finding) is intentionally left alone and tracked in #438.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — skipped because a live Hindsight instance is **unavailable** here; behavior is covered by unit tests (present/absent/error cases in `status-health.test.ts`) and the adapter wiring is type-checked against the 0.8.3 SDK. The `ci:live-smoke` lane runs and skips gracefully without secrets.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Explain changelog/release notes impact, or say none: User-visible — the `/hindsight` status view gains a `Server version` line showing the connected deployment's version and enabled features. Lands as a `feat(diagnostics)` changelog entry.

## Risk and rollback

- Risk: Low. Purely additive, best-effort, and gated on an optional client method; failures/older servers degrade silently without affecting reachability reporting or any memory path.
- Rollback/revert path: `git revert <sha>`; the change is isolated to one interface field, one adapter method, and one status helper.

## Follow-ups

- #438 (orphaned `formatDebugReport` cleanup-vs-revive decision), #439 (remaining 0.8.x surfaces), #440 (stale coverage `include` globs). None block this change.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. (No governance change.)

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

`getVersion` returns `{ api_version, features }` (FeaturesInfo boolean flags); the status fact lists the enabled feature names. Live-smoke limitation documented above; follow-ups tracked in #438/#439/#440.
