### PR TITLE
fix(ci): repoint stale coverage include/thresholds after slim-core reorg

### DIFF
--- a/tests/coverage-config.test.ts
+++ b/tests/coverage-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readdirSync } from "node:fs";
+import { basename, dirname } from "node:path";
+import vitestConfig from "../vitest.config.js";
+
+type CoverageConfig = {
+  include?: string[];
+  thresholds?: Record<string, unknown>;
+};
+
+const coverage = (vitestConfig as { test?: { coverage?: CoverageConfig } }).test?.coverage ?? {};
+
+// Single-level glob/exact-path matcher (portable across the supported Node range,
+// unlike fs.globSync which is Node 22+). All coverage patterns are single-level.
+function matchesExistingFile(pattern: string): boolean {
+  const base = basename(pattern);
+  if (!base.includes("*")) return existsSync(pattern);
+  const dir = dirname(pattern);
+  if (!existsSync(dir)) return false;
+  const regex = new RegExp(`^${base.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")}$`);
+  return readdirSync(dir).some((entry) => regex.test(entry));
+}
+
+describe("coverage config paths", () => {
+  const includePaths = coverage.include ?? [];
+  const thresholdPaths = Object.keys(coverage.thresholds ?? {}).filter((key) => key.includes("/"));
+
+  it("includes coverage targets", () => {
+    expect(includePaths.length).toBeGreaterThan(0);
+  });
+
+  it.each([...includePaths, ...thresholdPaths])(
+    "coverage path %s resolves to an existing file",
+    (pattern) => {
+      expect(matchesExistingFile(pattern)).toBe(true);
+    },
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,98 +6,83 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov"],
       include: [
-        "extensions/queue.ts",
-        "extensions/queue-lock.ts",
-        "extensions/jsonl-queue-store.ts",
-        "extensions/import-*.ts",
-        "extensions/config*.ts",
-        "extensions/memory-lifecycle*.ts",
-        "extensions/client.ts",
+        "extensions/queue/queue.ts",
+        "extensions/queue/queue-lock.ts",
+        "extensions/queue/jsonl-queue-store.ts",
+        "extensions/imports/import-*.ts",
+        "extensions/config/config*.ts",
+        "extensions/lifecycle/memory-lifecycle*.ts",
+        "extensions/client/client.ts",
         "extensions/client/client-retry.ts",
-        "extensions/timeout.ts",
+        "extensions/client/timeout.ts",
       ],
       thresholds: {
         statements: 75,
         branches: 75,
         functions: 75,
         lines: 75,
-        "extensions/queue.ts": {
+        // Per-file floors are set below current measured coverage so they guard
+        // against regression without flaking. Keep them mapped to real paths;
+        // tests/coverage-config.test.ts guards against path rot.
+        "extensions/queue/queue.ts": {
           statements: 100,
           branches: 100,
           functions: 100,
           lines: 100,
         },
-        "extensions/queue-lock.ts": {
+        "extensions/queue/queue-lock.ts": {
           statements: 75,
           branches: 60,
           functions: 80,
-          lines: 80,
+          lines: 78,
         },
-        "extensions/jsonl-queue-store.ts": {
+        "extensions/queue/jsonl-queue-store.ts": {
           statements: 90,
           branches: 70,
           functions: 100,
           lines: 90,
         },
-        "extensions/import-checkpoint.ts": {
-          statements: 95,
-          branches: 80,
-          functions: 100,
-          lines: 95,
-        },
-        "extensions/import-delivery.ts": {
-          statements: 95,
-          branches: 85,
-          functions: 100,
-          lines: 95,
-        },
-        "extensions/import-execution.ts": {
-          statements: 95,
-          branches: 80,
-          functions: 85,
-          lines: 95,
-        },
-        "extensions/import-chat-transcript.ts": {
-          statements: 90,
-          branches: 70,
-          functions: 100,
-          lines: 90,
-        },
-        "extensions/import-manifest.ts": {
+        "extensions/imports/import-execute.ts": {
           statements: 85,
-          branches: 75,
-          functions: 75,
-          lines: 85,
-        },
-        "extensions/import-parser.ts": {
-          statements: 70,
-          branches: 70,
-          functions: 80,
-          lines: 70,
-        },
-        "extensions/import-retain.ts": {
-          statements: 95,
-          branches: 85,
-          functions: 95,
-          lines: 95,
-        },
-        "extensions/import-sessions.ts": {
-          statements: 90,
-          branches: 70,
-          functions: 100,
+          branches: 74,
+          functions: 92,
           lines: 90,
         },
-        "extensions/config.ts": {
+        "extensions/imports/import-parse.ts": {
+          statements: 78,
+          branches: 70,
+          functions: 90,
+          lines: 82,
+        },
+        "extensions/imports/import-plan.ts": {
+          statements: 88,
+          branches: 80,
+          functions: 88,
+          lines: 92,
+        },
+        "extensions/imports/import-presentation.ts": {
+          statements: 95,
+          branches: 78,
+          functions: 100,
+          lines: 95,
+        },
+        "extensions/imports/import-sessions.ts": {
+          statements: 90,
+          branches: 74,
+          functions: 95,
+          lines: 92,
+        },
+        "extensions/config/config.ts": {
           statements: 80,
           branches: 75,
           functions: 80,
           lines: 80,
         },
-        "extensions/client.ts": {
-          statements: 65,
-          branches: 30,
-          functions: 55,
-          lines: 65,
+        "extensions/client/client.ts": {
+          statements: 60,
+          branches: 40,
+          functions: 60,
+          lines: 62,
         },
         "extensions/client/client-retry.ts": {
           statements: 70,
@@ -105,9 +90,9 @@ export default defineConfig({
           functions: 70,
           lines: 70,
         },
-        "extensions/timeout.ts": {
+        "extensions/client/timeout.ts": {
           statements: 80,
-          branches: 75,
+          branches: 72,
           functions: 80,
           lines: 80,
         },


### PR DESCRIPTION
## Summary

Restores the coverage gate that the slim-core rewrite silently disabled.

- The rewrite moved queue/client/imports/config/lifecycle modules into subdirectories (`extensions/queue/…`, `extensions/client/…`, `extensions/imports/…`, `extensions/config/…`, `extensions/lifecycle/…`) but left `vitest.config.ts` `coverage.include` pointing at the old root paths (`extensions/queue.ts`, `extensions/client.ts`, `extensions/import-*.ts`, …). Only `extensions/client/client-retry.ts` still matched, so `check:coverage` was effectively measuring a single file and the per-file `thresholds` keys silently matched nothing.
- Re-points `include` and `thresholds` to current paths; drops keys for modules the rewrite deleted (e.g. `import-delivery`, `import-execution`, `import-manifest`, `import-retain`, `import-checkpoint`). Per-file floors are set just below current measured coverage so they guard against regression without flaking. `queue.ts` stays pinned at 100%.
- Adds `tests/coverage-config.test.ts`, which fails if any `include`/`threshold` path stops resolving to a real file, so this can't silently rot again.

With the fix the gate honestly measures the critical modules: aggregate **86.9% stmts / 77.2% branch / 93.9% funcs / 89.8% lines**.

## Linked issue

- Closes #440

## Scope

One focused slice: `vitest.config.ts` coverage `include`/`thresholds` + a guard test. No source/behavior changes.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — not applicable: test-config-only change, no memory-path code touched.

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

Explain changelog/release notes impact, or say none: None — internal CI/test configuration only; nothing shipped changes. Lands as a `fix(ci)` maintenance entry.

## Risk and rollback

- Risk: Low, but it re-enables real coverage enforcement on modules that were previously unmeasured, so future PRs that drop coverage on these paths will now (correctly) fail. Floors were chosen below current measured values to avoid immediate flakiness.
- Rollback/revert path: `git revert <sha>` restores the prior config; isolated to `vitest.config.ts` + one test file.

## Follow-ups

- None required. Optional: raise per-file floors over time as coverage improves on `client.ts` / `config-editing-registry.ts`.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. (No governance change; this restores an existing verification expectation rather than altering policy.)

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Discovered while adding test coverage for #437. The pre-fix gate had been measuring only `client-retry.ts` since the rewrite landed.
