### PR TITLE
feat: support expandable memory tool output

### DIFF
--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -81,7 +81,7 @@ Everything else — bank config/profile administration, document/entity/graph/ta
 
 Tool notes:
 
-- In Pi's interactive TUI, memory tool outputs support the normal tool-output expansion toggle (`Ctrl+O` by default). Long recall and reflect outputs render as compact previews until expanded.
+- In Pi's interactive TUI, memory tool outputs share one normalized text renderer and support the normal tool-output expansion toggle (`Ctrl+O` by default). Short outputs render in the same model without needing to fold; long outputs render as compact previews until expanded.
 - `hindsight_recall` accepts `queryTimestamp` plus advanced one-off controls: `types`, `budget`, `maxTokens` (including `0`), `includeChunks`, `recallChunksMaxTokens`, `includeSourceFacts`, `maxSourceFactsTokens`, `includeEntities`, and `trace`.
 - `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp` (including literal `unset`), `metadata`, `updateMode`, `observationScopes`, `documentTags`, and `async`. `observationScopes` accepts `per_tag`, `combined`, `all_combinations`, or explicit string groups. Hindsight supports `documentTags` for compatibility, but upstream marks it deprecated; prefer normal `tags` unless document-level interop requires it.
 - For `updateMode: "append"`, use a stable `documentId` when continuing a known document. If omitted, pi-hindsight still uses its deterministic explicit-retain document ID; repeated calls only append together when content/context/session produce the same ID.

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -81,6 +81,7 @@ Everything else — bank config/profile administration, document/entity/graph/ta
 
 Tool notes:
 
+- In Pi's interactive TUI, memory tool outputs support the normal tool-output expansion toggle (`Ctrl+O` by default). Long recall and reflect outputs render as compact previews until expanded.
 - `hindsight_recall` accepts `queryTimestamp` plus advanced one-off controls: `types`, `budget`, `maxTokens` (including `0`), `includeChunks`, `recallChunksMaxTokens`, `includeSourceFacts`, `maxSourceFactsTokens`, `includeEntities`, and `trace`.
 - `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp` (including literal `unset`), `metadata`, `updateMode`, `observationScopes`, `documentTags`, and `async`. `observationScopes` accepts `per_tag`, `combined`, `all_combinations`, or explicit string groups. Hindsight supports `documentTags` for compatibility, but upstream marks it deprecated; prefer normal `tags` unless document-level interop requires it.
 - For `updateMode: "append"`, use a stable `documentId` when continuing a known document. If omitted, pi-hindsight still uses its deterministic explicit-retain document ID; repeated calls only append together when content/context/session produce the same ID.

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -79,7 +79,7 @@ Everything else — bank config/profile administration, document/entity/graph/ta
 
 Tool notes:
 
-- In Pi's interactive TUI, memory tool outputs support the normal tool-output expansion toggle (`Ctrl+O` by default). Long recall and reflect outputs render as compact previews until expanded.
+- In Pi's interactive TUI, memory tool outputs share one normalized text renderer and support the normal tool-output expansion toggle (`Ctrl+O` by default). Short outputs render in the same model without needing to fold; long outputs render as compact previews until expanded.
 - `hindsight_recall` accepts `queryTimestamp` plus advanced one-off controls: `types`, `budget`, `maxTokens` (including `0`), `includeChunks`, `recallChunksMaxTokens`, `includeSourceFacts`, `maxSourceFactsTokens`, `includeEntities`, and `trace`.
 - `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp` (including literal `unset`), `metadata`, `updateMode`, `observationScopes`, `documentTags`, and `async`. `observationScopes` accepts `per_tag`, `combined`, `all_combinations`, or explicit string groups. Hindsight supports `documentTags` for compatibility, but upstream marks it deprecated; prefer normal `tags` unless document-level interop requires it.
 - For `updateMode: "append"`, use a stable `documentId` when continuing a known document. If omitted, pi-hindsight still uses its deterministic explicit-retain document ID; repeated calls only append together when content/context/session produce the same ID.

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -79,6 +79,7 @@ Everything else — bank config/profile administration, document/entity/graph/ta
 
 Tool notes:
 
+- In Pi's interactive TUI, memory tool outputs support the normal tool-output expansion toggle (`Ctrl+O` by default). Long recall and reflect outputs render as compact previews until expanded.
 - `hindsight_recall` accepts `queryTimestamp` plus advanced one-off controls: `types`, `budget`, `maxTokens` (including `0`), `includeChunks`, `recallChunksMaxTokens`, `includeSourceFacts`, `maxSourceFactsTokens`, `includeEntities`, and `trace`.
 - `hindsight_retain` and `hindsight_retain_global` accept explicit Hindsight retain options: `entities`, `documentId`, `timestamp` (including literal `unset`), `metadata`, `updateMode`, `observationScopes`, `documentTags`, and `async`. `observationScopes` accepts `per_tag`, `combined`, `all_combinations`, or explicit string groups. Hindsight supports `documentTags` for compatibility, but upstream marks it deprecated; prefer normal `tags` unless document-level interop requires it.
 - For `updateMode: "append"`, use a stable `documentId` when continuing a known document. If omitted, pi-hindsight still uses its deterministic explicit-retain document ID; repeated calls only append together when content/context/session produce the same ID.

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -11,7 +11,7 @@ import type { MemoryOperationsDeps } from "./memory-operation-service.js";
 import { createMemoryOperations } from "./memory-operation-service.js";
 import { formatReflectResult } from "./reflect-presenter.js";
 import { runHindsightSetupTui } from "../tui/setup-tui.js";
-import { retainToolResponse } from "../tui/tool-presenters.js";
+import { renderMemoryToolTextResult, retainToolResponse } from "../tui/tool-presenters.js";
 
 export type ToolOperation = Parameters<ExtensionAPI["registerTool"]>[0];
 
@@ -246,6 +246,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           details: { bankId },
         };
       },
+      renderResult: renderMemoryToolTextResult,
     }),
     defineCatalogTool({
       name: "hindsight_retain",
@@ -282,6 +283,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         });
         return retainToolResponse(result);
       },
+      renderResult: renderMemoryToolTextResult,
     }),
     defineCatalogTool({
       name: "hindsight_retain_global",
@@ -314,6 +316,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         });
         return retainToolResponse(result);
       },
+      renderResult: renderMemoryToolTextResult,
     }),
     defineCatalogTool({
       name: "hindsight_reflect",
@@ -408,6 +411,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           details: { bankId },
         };
       },
+      renderResult: renderMemoryToolTextResult,
     }),
   ];
 

--- a/extensions/tui/tool-presenters.ts
+++ b/extensions/tui/tool-presenters.ts
@@ -11,24 +11,44 @@ type ToolTextContent = { type: string; text?: string };
 
 export const DEFAULT_COLLAPSED_TOOL_RESULT_LINES = 12;
 
-export type CollapsedToolText = {
+export type NormalizedToolText = {
   text: string;
   hiddenLineCount: number;
+  totalLineCount: number;
+  canFold: boolean;
 };
 
 export type RetainToolResult = Awaited<ReturnType<MemoryOperations["retainExplicit"]>>;
 
-export function collapseToolResultText(
+export function normalizeToolResultText(
   text: string,
   expanded: boolean,
   maxLines = DEFAULT_COLLAPSED_TOOL_RESULT_LINES,
-): CollapsedToolText {
+): NormalizedToolText {
   const lines = text.split("\n");
-  if (expanded || lines.length <= maxLines) return { text, hiddenLineCount: 0 };
+  const canFold = lines.length > maxLines;
+  const hiddenLineCount = canFold && !expanded ? lines.length - maxLines : 0;
   return {
-    text: lines.slice(0, maxLines).join("\n"),
-    hiddenLineCount: lines.length - maxLines,
+    text: hiddenLineCount > 0 ? lines.slice(0, maxLines).join("\n") : text,
+    hiddenLineCount,
+    totalLineCount: lines.length,
+    canFold,
   };
+}
+
+function renderFoldHint(normalized: NormalizedToolText, theme: Theme) {
+  if (!normalized.canFold) return "";
+  if (normalized.hiddenLineCount > 0) {
+    const plural = normalized.hiddenLineCount === 1 ? "" : "s";
+    return `\n${theme.fg("muted", `... ${normalized.hiddenLineCount} more line${plural} (`)}${theme.fg(
+      "dim",
+      keyText("app.tools.expand"),
+    )}${theme.fg("muted", " to expand)")}`;
+  }
+  return `\n${theme.fg("muted", "(")}${theme.fg("dim", keyText("app.tools.expand"))}${theme.fg(
+    "muted",
+    " to collapse)",
+  )}`;
 }
 
 export function renderMemoryToolTextResult(
@@ -37,32 +57,9 @@ export function renderMemoryToolTextResult(
   theme: Theme,
 ) {
   const rawText = result.content.find((part) => part.type === "text")?.text ?? "";
-  const collapsed = collapseToolResultText(rawText, options.expanded);
-  const text = collapsed.text || theme.fg("dim", "(no text output)");
-
-  if (collapsed.hiddenLineCount > 0) {
-    return new Text(
-      `${text}\n${theme.fg(
-        "muted",
-        `... ${collapsed.hiddenLineCount} more line${collapsed.hiddenLineCount === 1 ? "" : "s"} (`,
-      )}${theme.fg("dim", keyText("app.tools.expand"))}${theme.fg("muted", " to expand)")}`,
-      0,
-      0,
-    );
-  }
-
-  if (options.expanded && rawText.split("\n").length > DEFAULT_COLLAPSED_TOOL_RESULT_LINES) {
-    return new Text(
-      `${text}\n${theme.fg("muted", "(")}${theme.fg("dim", keyText("app.tools.expand"))}${theme.fg(
-        "muted",
-        " to collapse)",
-      )}`,
-      0,
-      0,
-    );
-  }
-
-  return new Text(text, 0, 0);
+  const normalized = normalizeToolResultText(rawText, options.expanded);
+  const text = normalized.text || theme.fg("dim", "(no text output)");
+  return new Text(`${text}${renderFoldHint(normalized, theme)}`, 0, 0);
 }
 
 export function retainToolResponse(result: RetainToolResult): ToolTextResponse<RetainToolResult> {

--- a/extensions/tui/tool-presenters.ts
+++ b/extensions/tui/tool-presenters.ts
@@ -1,3 +1,5 @@
+import { keyText, type Theme, type ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import type { MemoryOperations } from "../operations/memory-operation-service.js";
 
 type ToolTextResponse<Details> = {
@@ -5,7 +7,63 @@ type ToolTextResponse<Details> = {
   details: Details;
 };
 
+type ToolTextContent = { type: string; text?: string };
+
+export const DEFAULT_COLLAPSED_TOOL_RESULT_LINES = 12;
+
+export type CollapsedToolText = {
+  text: string;
+  hiddenLineCount: number;
+};
+
 export type RetainToolResult = Awaited<ReturnType<MemoryOperations["retainExplicit"]>>;
+
+export function collapseToolResultText(
+  text: string,
+  expanded: boolean,
+  maxLines = DEFAULT_COLLAPSED_TOOL_RESULT_LINES,
+): CollapsedToolText {
+  const lines = text.split("\n");
+  if (expanded || lines.length <= maxLines) return { text, hiddenLineCount: 0 };
+  return {
+    text: lines.slice(0, maxLines).join("\n"),
+    hiddenLineCount: lines.length - maxLines,
+  };
+}
+
+export function renderMemoryToolTextResult(
+  result: { content: ToolTextContent[] },
+  options: Pick<ToolRenderResultOptions, "expanded">,
+  theme: Theme,
+) {
+  const rawText = result.content.find((part) => part.type === "text")?.text ?? "";
+  const collapsed = collapseToolResultText(rawText, options.expanded);
+  const text = collapsed.text || theme.fg("dim", "(no text output)");
+
+  if (collapsed.hiddenLineCount > 0) {
+    return new Text(
+      `${text}\n${theme.fg(
+        "muted",
+        `... ${collapsed.hiddenLineCount} more line${collapsed.hiddenLineCount === 1 ? "" : "s"} (`,
+      )}${theme.fg("dim", keyText("app.tools.expand"))}${theme.fg("muted", " to expand)")}`,
+      0,
+      0,
+    );
+  }
+
+  if (options.expanded && rawText.split("\n").length > DEFAULT_COLLAPSED_TOOL_RESULT_LINES) {
+    return new Text(
+      `${text}\n${theme.fg("muted", "(")}${theme.fg("dim", keyText("app.tools.expand"))}${theme.fg(
+        "muted",
+        " to collapse)",
+      )}`,
+      0,
+      0,
+    );
+  }
+
+  return new Text(text, 0, 0);
+}
 
 export function retainToolResponse(result: RetainToolResult): ToolTextResponse<RetainToolResult> {
   const deadLetterStatus = result.deadLettered

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -41,6 +41,23 @@ function requireTool(catalog: ReturnType<typeof createOperationCatalog>, name: s
 }
 
 describe("operation catalog", () => {
+  it("registers expandable renderers for explicit memory tool results", () => {
+    const catalog = createOperationCatalog({
+      getClient: () => client(),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    for (const name of [
+      "hindsight_recall",
+      "hindsight_retain",
+      "hindsight_retain_global",
+      "hindsight_reflect",
+    ]) {
+      expect(requireTool(catalog, name).renderResult).toBeTypeOf("function");
+    }
+  });
+
   it("exposes and maps advanced explicit retain options on the project retain tool", async () => {
     const retain = retainMock();
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-catalog-"));

--- a/tests/tool-presenters.test.ts
+++ b/tests/tool-presenters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  collapseToolResultText,
+  normalizeToolResultText,
   renderMemoryToolTextResult,
   retainToolResponse,
 } from "../extensions/tui/tool-presenters.js";
@@ -10,14 +10,44 @@ const fakeTheme = {
 } as never;
 
 describe("tool presenters", () => {
-  it("collapses long tool result text to a preview", () => {
+  it("normalizes short tool result text through the shared fold model", () => {
+    expect(normalizeToolResultText("short output", false)).toEqual({
+      text: "short output",
+      hiddenLineCount: 0,
+      totalLineCount: 1,
+      canFold: false,
+    });
+  });
+
+  it("normalizes long tool result text to a foldable preview", () => {
     const text = Array.from({ length: 15 }, (_, index) => `line ${index + 1}`).join("\n");
 
-    expect(collapseToolResultText(text, false)).toEqual({
+    expect(normalizeToolResultText(text, false)).toEqual({
       text: Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n"),
       hiddenLineCount: 3,
+      totalLineCount: 15,
+      canFold: true,
     });
-    expect(collapseToolResultText(text, true)).toEqual({ text, hiddenLineCount: 0 });
+    expect(normalizeToolResultText(text, true)).toEqual({
+      text,
+      hiddenLineCount: 0,
+      totalLineCount: 15,
+      canFold: true,
+    });
+  });
+
+  it("renders short tool results through the normalized text renderer", () => {
+    const component = renderMemoryToolTextResult(
+      { content: [{ type: "text", text: "short output" }] },
+      { expanded: false },
+      fakeTheme,
+    );
+
+    const rendered = component.render(120).join("\n");
+
+    expect(rendered.trimEnd()).toBe("short output");
+    expect(rendered).not.toContain("to expand");
+    expect(rendered).not.toContain("to collapse");
   });
 
   it("renders collapsed tool results with an expansion hint", () => {

--- a/tests/tool-presenters.test.ts
+++ b/tests/tool-presenters.test.ts
@@ -1,7 +1,55 @@
 import { describe, expect, it } from "vitest";
-import { retainToolResponse } from "../extensions/tui/tool-presenters.js";
+import {
+  collapseToolResultText,
+  renderMemoryToolTextResult,
+  retainToolResponse,
+} from "../extensions/tui/tool-presenters.js";
+
+const fakeTheme = {
+  fg: (_color: string, text: string) => text,
+} as never;
 
 describe("tool presenters", () => {
+  it("collapses long tool result text to a preview", () => {
+    const text = Array.from({ length: 15 }, (_, index) => `line ${index + 1}`).join("\n");
+
+    expect(collapseToolResultText(text, false)).toEqual({
+      text: Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n"),
+      hiddenLineCount: 3,
+    });
+    expect(collapseToolResultText(text, true)).toEqual({ text, hiddenLineCount: 0 });
+  });
+
+  it("renders collapsed tool results with an expansion hint", () => {
+    const text = Array.from({ length: 13 }, (_, index) => `line ${index + 1}`).join("\n");
+    const component = renderMemoryToolTextResult(
+      { content: [{ type: "text", text }] },
+      { expanded: false },
+      fakeTheme,
+    );
+
+    const rendered = component.render(120).join("\n");
+
+    expect(rendered).toContain("line 12");
+    expect(rendered).not.toContain("line 13");
+    expect(rendered).toContain("... 1 more line (");
+    expect(rendered).toContain("to expand");
+  });
+
+  it("renders expanded tool results with a collapse hint", () => {
+    const text = Array.from({ length: 13 }, (_, index) => `line ${index + 1}`).join("\n");
+    const component = renderMemoryToolTextResult(
+      { content: [{ type: "text", text }] },
+      { expanded: true },
+      fakeTheme,
+    );
+
+    const rendered = component.render(120).join("\n");
+
+    expect(rendered).toContain("line 13");
+    expect(rendered).toContain("to collapse");
+  });
+
   it("summarizes immediate retain results", () => {
     const response = retainToolResponse({
       bankId: "bank",


### PR DESCRIPTION
## Summary

- Adds Pi interactive TUI normalized text rendering for explicit Hindsight memory tool outputs through the tool `renderResult` API.
- All explicit memory tool outputs now share one fold model: short outputs render through the same normalized renderer without fold hints, while long outputs render as compact previews by default and expand with Pi's normal tool-output toggle (`Ctrl+O` by default).
- Keeps tool schemas, execution behavior, Hindsight requests, and returned model-visible content unchanged.

## Linked issue

- Closes #443

## Scope

- Adds a shared normalized text-result renderer in `extensions/tui/tool-presenters.ts` with collapsed and expanded states.
- Registers that renderer on `hindsight_recall`, `hindsight_retain`, `hindsight_retain_global`, and `hindsight_reflect` in the Operation Catalog.
- Adds focused tests for short-output normalization, long-output preview/expansion behavior, presenter rendering, and catalog renderer wiring.
- Documents the unified renderer and TUI expansion behavior in packaged and docs-site tool references.

## Verification

- [x] `npm test -- tests/tool-presenters.test.ts tests/operation-catalog.test.ts`
- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — skipped because this is a Pi TUI/source-docs slice, not release or platform-sensitive work.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — skipped because package/release artifacts were not changed.
- [ ] `npm run pack:verify` (release/package changes) — skipped because package/release artifacts were not changed.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — skipped because this is a UI-only renderer change that does not alter retain payloads, recall queries/formatting returned to the model, reflect calls, bank selection, queue delivery, import delivery, adapter transport, or packaging.
- [x] Reviewer subagent pass found no blockers after the normalized-renderer follow-up.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds user-visible Pi TUI rendering behavior for explicit memory tool outputs. Changelog/release notes should mention normalized memory tool output rendering, compact previews, and `Ctrl+O` expansion support for Hindsight tool results.

## Risk and rollback

- Risk: Low. The change is limited to custom rendering for existing text tool results; schemas, execute paths, Hindsight calls, queue behavior, and model-visible tool content remain unchanged.
- Rollback/revert path: Revert this PR to remove the `renderResult` registrations and shared renderer, restoring Pi's previous default tool output rendering.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] This does not change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, so `AGENTS.md` and `CONTRIBUTING.md` did not need updates.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- GitNexus gates for the follow-up normalization slice ran after indexing this branch: impact on `normalizeToolResultText` and `renderMemoryToolTextResult` was LOW with no affected processes; `detect-changes --scope all` reported 4 files / 7 symbols, 0 affected processes, low risk.
- No live interactive Ctrl+O TUI smoke was run; verification relies on Pi renderer API inspection, focused presenter/catalog tests, repository checks, and reviewer pass.
