### PR TITLE
feat: adopt retainStructuredChunkSize bank config from Hindsight 0.8.x

### DIFF
--- a/extensions/banks/bank-operations.ts
+++ b/extensions/banks/bank-operations.ts
@@ -92,6 +92,9 @@ export async function ensureProjectBank(
     ...missions,
     retainExtractionMode: "concise",
     enableObservations: config.enableObservations ?? true,
+    ...(config.retainStructuredChunkSize !== undefined
+      ? { retainStructuredChunkSize: config.retainStructuredChunkSize }
+      : {}),
   });
 }
 
@@ -107,5 +110,8 @@ export async function ensureGlobalBank(
     ...missions,
     retainExtractionMode: "concise",
     enableObservations: config.enableObservations ?? true,
+    ...(config.retainStructuredChunkSize !== undefined
+      ? { retainStructuredChunkSize: config.retainStructuredChunkSize }
+      : {}),
   });
 }

--- a/extensions/config/config-normalize.ts
+++ b/extensions/config/config-normalize.ts
@@ -148,6 +148,10 @@ function missionFields(bankConfig: unknown) {
     ...(typeof bankConfig.observationsMission === "string"
       ? { observationsMission: bankConfig.observationsMission }
       : {}),
+    ...(typeof bankConfig.retainStructuredChunkSize === "number" &&
+    Number.isFinite(bankConfig.retainStructuredChunkSize)
+      ? { retainStructuredChunkSize: bankConfig.retainStructuredChunkSize }
+      : {}),
   };
 }
 

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -36,6 +36,7 @@ export interface BankMissionSettings {
   retainMission?: string;
   reflectMission?: string;
   observationsMission?: string;
+  retainStructuredChunkSize?: number;
 }
 
 export interface HindsightEntityInput {
@@ -295,6 +296,7 @@ export interface HindsightLikeClient {
       reflectMission?: string;
       retainMission?: string;
       retainExtractionMode?: string;
+      retainStructuredChunkSize?: number;
       enableObservations?: boolean;
       observationsMission?: string;
     },

--- a/tests/bank-operations.test.ts
+++ b/tests/bank-operations.test.ts
@@ -74,6 +74,28 @@ describe("bank operations", () => {
     );
   });
 
+  it("passes retainStructuredChunkSize to createBank when configured", async () => {
+    const createBank = vi.fn(async () => undefined);
+    await ensureProjectBank(client({ createBank }), "project-bank", {
+      retainStructuredChunkSize: 4000,
+    });
+
+    expect(createBank).toHaveBeenCalledWith(
+      "project-bank",
+      expect.objectContaining({ retainStructuredChunkSize: 4000 }),
+    );
+  });
+
+  it("omits retainStructuredChunkSize from createBank when not configured", async () => {
+    const createBank = vi.fn(async () => undefined);
+    await ensureProjectBank(client({ createBank }), "project-bank");
+
+    const options = (createBank.mock.calls as unknown[][])[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(options).not.toHaveProperty("retainStructuredChunkSize");
+  });
+
   it("uses only explicit global mission fields when global bank is created", async () => {
     const createBank = vi.fn(async () => undefined);
     await ensureGlobalBank(client({ createBank }), "global-bank", {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -81,6 +81,20 @@ describe("resolveConfig", () => {
     expect(config.banks.global.retainMission).toBe("Global retain");
   });
 
+  it("normalizes retainStructuredChunkSize in bank mission config", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({
+        banks: { project: { retainStructuredChunkSize: 4000 } },
+      }),
+    );
+
+    const config = resolveConfig(cwd);
+    expect(config.banks.project.retainStructuredChunkSize).toBe(4000);
+  });
+
   it("resolves env SecretRef API keys and lets direct env override win", () => {
     const cwd = tmp();
     mkdirSync(join(cwd, ".pi"));


### PR DESCRIPTION
## Summary

- Exposes `retainStructuredChunkSize` as a per-bank mission setting that flows from config (`banks.project.retainStructuredChunkSize` / `banks.user.retainStructuredChunkSize`) through bank creation to the Hindsight server.
- The setting controls how structured JSONL conversation turns are chunked during retain on the server. Defaults to undefined (conservative — server default applies) and only takes effect when a bank is first created; existing banks keep their server-side config.

## Linked issue

- Refs #439

## Scope

- `extensions/types.ts`: add `retainStructuredChunkSize` to `BankMissionSettings` and to `createBank` options on `HindsightLikeClient`.
- `extensions/config/config-normalize.ts`: normalize `retainStructuredChunkSize` in `missionFields`.
- `extensions/banks/bank-operations.ts`: pass `retainStructuredChunkSize` to `createBank` in `ensureProjectBank`/`ensureGlobalBank` when configured; omit when not configured.
- Tests: bank-operations pass-through and omission; config normalization.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — skipped; config/bank-creation slice, not coverage-threshold-sensitive.
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — skipped; `npm run typecheck` (tsgo) is part of `npm run check` and passes.
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — skipped because this is not release or platform-sensitive work.
- [ ] package verification requested/passed (release/package changes or `ci:package`) — skipped because package/release artifacts were not changed.
- [ ] `npm run pack:verify` (release/package changes) — skipped because package/release artifacts were not changed.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — skipped because no live Hindsight server is available; bank-creation pass-through is covered by unit tests.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds a new optional config field (`banks.*.retainStructuredChunkSize`) that users can set to tune structured-content chunking during retain. Changelog/release notes should mention the new bank config option.

## Risk and rollback

- Risk: Low. The setting defaults to undefined and is omitted from `createBank` when not configured, preserving current behavior. It only applies on first bank creation; existing banks are unaffected. Tool schemas, retain payloads, recall, reflect, queue, and import behavior are unchanged.
- Rollback/revert path: Revert this PR to remove the `retainStructuredChunkSize` field from config and bank creation.

## Follow-ups

- None. Remaining 0.8.x surface adoption tracked in #439.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] This does not change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, so `AGENTS.md` and `CONTRIBUTING.md` did not need updates.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

`retainStructuredChunkSize` is a bank-level config (set at bank creation via `createBank`/`updateBank`), not a per-retain-call parameter. This slice wires it into bank creation only; updating existing banks' chunk size would require an `updateBank` path, which is out of scope for this slice.