### PR TITLE
DRAFT: hindsight_list_memories tool (discussion, see #452)

### DIFF
--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -10,12 +10,13 @@ This reference is generated from the operation catalog and config editing regist
 
 Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi workflow tools are part of the stable 1.0 contract. Capability-gated tools are supported when the connected Hindsight server exposes the required upstream endpoint or field; unsupported servers should return a clear capability error.
 
-| Tool                      | Scope    |
-| ------------------------- | -------- |
-| `hindsight_recall`        | core 1.0 |
-| `hindsight_retain`        | core 1.0 |
-| `hindsight_retain_global` | core 1.0 |
-| `hindsight_reflect`       | core 1.0 |
+| Tool                      | Scope                |
+| ------------------------- | -------------------- |
+| `hindsight_recall`        | core 1.0             |
+| `hindsight_list_memories` | capability-gated 1.0 |
+| `hindsight_retain`        | core 1.0             |
+| `hindsight_retain_global` | core 1.0             |
+| `hindsight_reflect`       | core 1.0             |
 
 ## Deferred or non-goal upstream surfaces
 
@@ -51,6 +52,21 @@ Recall raw memories from Hindsight for this project.
 | `tags`                  | array<string>                                   | no       | Additional tag filter.                                                                                                                                                                  |
 | `tagsMatch`             | any \| all \| any_strict \| all_strict \| exact | no       |                                                                                                                                                                                         |
 | `tagGroups`             | array<object>                                   | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                                                                           |
+
+### `hindsight_list_memories`
+
+DRAFT/DISCUSSION ONLY (see #452): List raw memory units in a bank with pagination, unlike hindsight_recall which does semantic search. Use for inspecting retain results or auditing bank state.
+
+| Parameter            | Type                      | Required | Description                                             |
+| -------------------- | ------------------------- | -------- | ------------------------------------------------------- |
+| `bank`               | string                    | no       | Optional bank id. Defaults to project bank.             |
+| `limit`              | integer                   | no       | Page size.                                              |
+| `offset`             | integer                   | no       | Page offset.                                            |
+| `type`               | string                    | no       | Optional Hindsight fact type filter (e.g. observation). |
+| `q`                  | string                    | no       | Optional text search within memory content.             |
+| `consolidationState` | failed \| pending \| done | no       | Filter by observation consolidation state.              |
+| `state`              | valid \| invalidated      | no       | Filter by memory validity state.                        |
+| `documentId`         | string                    | no       | Optional Hindsight document id filter.                  |
 
 ### `hindsight_retain`
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -6,12 +6,13 @@ This reference is generated from the operation catalog and config editing regist
 
 Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi workflow tools are part of the stable 1.0 contract. Capability-gated tools are supported when the connected Hindsight server exposes the required upstream endpoint or field; unsupported servers should return a clear capability error.
 
-| Tool                      | Scope    |
-| ------------------------- | -------- |
-| `hindsight_recall`        | core 1.0 |
-| `hindsight_retain`        | core 1.0 |
-| `hindsight_retain_global` | core 1.0 |
-| `hindsight_reflect`       | core 1.0 |
+| Tool                      | Scope                |
+| ------------------------- | -------------------- |
+| `hindsight_recall`        | core 1.0             |
+| `hindsight_list_memories` | capability-gated 1.0 |
+| `hindsight_retain`        | core 1.0             |
+| `hindsight_retain_global` | core 1.0             |
+| `hindsight_reflect`       | core 1.0             |
 
 ## Deferred or non-goal upstream surfaces
 
@@ -47,6 +48,21 @@ Recall raw memories from Hindsight for this project.
 | `tags`                  | array<string>                                   | no       | Additional tag filter.                                                                                                                                                                  |
 | `tagsMatch`             | any \| all \| any_strict \| all_strict \| exact | no       |                                                                                                                                                                                         |
 | `tagGroups`             | array<object>                                   | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                                                                           |
+
+### `hindsight_list_memories`
+
+DRAFT/DISCUSSION ONLY (see #452): List raw memory units in a bank with pagination, unlike hindsight_recall which does semantic search. Use for inspecting retain results or auditing bank state.
+
+| Parameter            | Type                      | Required | Description                                             |
+| -------------------- | ------------------------- | -------- | ------------------------------------------------------- |
+| `bank`               | string                    | no       | Optional bank id. Defaults to project bank.             |
+| `limit`              | integer                   | no       | Page size.                                              |
+| `offset`             | integer                   | no       | Page offset.                                            |
+| `type`               | string                    | no       | Optional Hindsight fact type filter (e.g. observation). |
+| `q`                  | string                    | no       | Optional text search within memory content.             |
+| `consolidationState` | failed \| pending \| done | no       | Filter by observation consolidation state.              |
+| `state`              | valid \| invalidated      | no       | Filter by memory validity state.                        |
+| `documentId`         | string                    | no       | Optional Hindsight document id filter.                  |
 
 ### `hindsight_retain`
 

--- a/extensions/client/client.ts
+++ b/extensions/client/client.ts
@@ -224,6 +224,16 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
       withTimeout("hindsight getVersion", timeoutMs, (signal) =>
         withRetry("getVersion", () => raw.getVersion({ signal })),
       ),
+    listMemories: (...args) =>
+      withTimeout(
+        "hindsight listMemories",
+        timeoutMs,
+        (signal) => {
+          const [bankId, options] = args;
+          return raw.listMemories(bankId, { ...options, signal });
+        },
+        args[1]?.signal,
+      ),
   };
 }
 

--- a/extensions/operations/memory-recall-operations.ts
+++ b/extensions/operations/memory-recall-operations.ts
@@ -134,6 +134,33 @@ export function createRecallOperations(deps: MemoryOperationsDeps) {
       return { bankId, result };
     },
 
+    async listMemories(
+      bank: string | undefined,
+      filters: {
+        limit?: number;
+        offset?: number;
+        type?: string;
+        q?: string;
+        consolidationState?: "failed" | "pending" | "done";
+        state?: "valid" | "invalidated";
+        documentId?: string;
+        signal?: AbortSignal;
+      } = {},
+    ) {
+      const config = deps.getConfig();
+      const bankId = resolveOperationBank({
+        requestedBank: bank,
+        config,
+        projectBankId: deps.getProjectBankId(),
+      });
+      const client = deps.getClient();
+      if (!client.listMemories) {
+        throw new Error("Connected Hindsight server does not support listing memories.");
+      }
+      const result = await client.listMemories(bankId, filters);
+      return { bankId, result };
+    },
+
     async lastRecall(cwd: string) {
       const config = deps.getConfig();
       const path = resolveLastRecallPath(cwd, config.recall.lastRecallPath);

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -277,6 +277,56 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       renderResult: renderMemoryToolTextResult,
     }),
     defineCatalogTool({
+      name: "hindsight_list_memories",
+      label: "Hindsight List Memories",
+      description:
+        "DRAFT/DISCUSSION ONLY (see #452): List raw memory units in a bank with pagination, unlike hindsight_recall which does semantic search. Use for inspecting retain results or auditing bank state.",
+      parameters: Type.Object({
+        bank: Type.Optional(
+          Type.String({ description: "Optional bank id. Defaults to project bank." }),
+        ),
+        limit: Type.Optional(Type.Integer({ minimum: 1, description: "Page size." })),
+        offset: Type.Optional(Type.Integer({ minimum: 0, description: "Page offset." })),
+        type: Type.Optional(
+          Type.String({ description: "Optional Hindsight fact type filter (e.g. observation)." }),
+        ),
+        q: Type.Optional(
+          Type.String({ description: "Optional text search within memory content." }),
+        ),
+        consolidationState: Type.Optional(
+          Type.Union([Type.Literal("failed"), Type.Literal("pending"), Type.Literal("done")], {
+            description: "Filter by observation consolidation state.",
+          }),
+        ),
+        state: Type.Optional(
+          Type.Union([Type.Literal("valid"), Type.Literal("invalidated")], {
+            description: "Filter by memory validity state.",
+          }),
+        ),
+        documentId: Type.Optional(
+          Type.String({ description: "Optional Hindsight document id filter." }),
+        ),
+      }),
+      async execute(_id, params, signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const { bankId, result } = await operations.listMemories(params.bank, {
+          ...(params.limit !== undefined ? { limit: params.limit } : {}),
+          ...(params.offset !== undefined ? { offset: params.offset } : {}),
+          ...(params.type ? { type: params.type } : {}),
+          ...(params.q ? { q: params.q } : {}),
+          ...(params.consolidationState ? { consolidationState: params.consolidationState } : {}),
+          ...(params.state ? { state: params.state } : {}),
+          ...(params.documentId ? { documentId: params.documentId } : {}),
+          ...(signal ? { signal } : {}),
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: { bankId },
+        };
+      },
+      renderResult: renderMemoryToolTextResult,
+    }),
+    defineCatalogTool({
       name: "hindsight_retain",
       label: "Hindsight Retain",
       description: "Retain explicit raw content in Hindsight. Use for durable facts or decisions.",

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -311,4 +311,17 @@ export interface HindsightLikeClient {
   getBankConfig?(bankId: string): Promise<unknown>;
   health?(): Promise<unknown>;
   getVersion?(): Promise<unknown>;
+  listMemories?(
+    bankId: string,
+    options?: {
+      limit?: number;
+      offset?: number;
+      type?: string;
+      q?: string;
+      consolidationState?: "failed" | "pending" | "done";
+      state?: "valid" | "invalidated";
+      documentId?: string;
+      signal?: AbortSignal;
+    },
+  ): Promise<unknown>;
 }

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -476,7 +476,11 @@ describe("extension hooks", () => {
     const { default: hindsightExtension } = await import("../extensions/index.js");
     hindsightExtension(pi as any);
 
+    // DRAFT/DISCUSSION (see #452): this assertion encodes the "exactly four tools" policy from
+    // #417. Adding hindsight_list_memories here is the change under discussion, not a decided
+    // outcome -- revert this test alongside the rest of this branch if the policy holds.
     expect(Object.keys(tools).sort()).toEqual([
+      "hindsight_list_memories",
       "hindsight_recall",
       "hindsight_reflect",
       "hindsight_retain",

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -289,6 +289,30 @@ describe("operation catalog", () => {
     );
   });
 
+  it("DRAFT #452: hindsight_list_memories lists raw memory units with pagination filters", async () => {
+    const listMemories = vi.fn(async () => ({ items: [], total: 0, limit: 20, offset: 0 }));
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-catalog-"));
+    const catalog = createOperationCatalog({
+      getClient: () => ({ ...client(), listMemories }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+    const tool = requireTool(catalog, "hindsight_list_memories");
+
+    await tool.execute(
+      "call",
+      { limit: 20, state: "invalidated", documentId: "doc-1" },
+      new AbortController().signal,
+      () => undefined,
+      { cwd, sessionManager: {} } as never,
+    );
+
+    expect(listMemories).toHaveBeenCalledWith(
+      "project-bank",
+      expect.objectContaining({ limit: 20, state: "invalidated", documentId: "doc-1" }),
+    );
+  });
+
   it("exposes and maps low-risk explicit reflect controls", async () => {
     const reflect = vi.fn(async (_bankId: string, _query: string, _options?: ReflectOptions) => ({
       ok: true,
@@ -400,8 +424,11 @@ describe("operation catalog", () => {
       getProjectBankId: () => "bank",
     });
 
+    // DRAFT/DISCUSSION (see #452): hindsight_list_memories addition is the change under
+    // discussion, not a decided outcome.
     expect(catalog.tools.map((tool) => tool.name)).toEqual([
       "hindsight_recall",
+      "hindsight_list_memories",
       "hindsight_retain",
       "hindsight_retain_global",
       "hindsight_reflect",


### PR DESCRIPTION
## Summary

**DRAFT — not intended for merge as-is.** This PR exists to make the #452 policy discussion concrete, not to ship a decided feature.

- Implements a `hindsight_list_memories` tool wired end-to-end (client → operation → tool schema) using Hindsight's `listMemories()` endpoint: paginated, non-semantic listing of raw memory units with `limit`/`offset`/`type`/`q`/`consolidationState`/`state`/`documentId` filters.
- Originates from #439 slice 4, which asked for `state`/`documentId` recall filters. Investigation showed these live on `listMemories()`, not `recall()` — so satisfying the ask means a new tool, which conflicts with the documented "exactly four tools" policy from the slim-core rewrite (#417).
- Two exhaustive tool-list tests were updated to include the 5th tool; these updates **are the crux of the policy question**, not incidental fixes — see the `DRAFT/DISCUSSION` comments left in `tests/extension-hooks.test.ts` and `tests/operation-catalog.test.ts`.

## Linked issue

- Refs #452 (discussion issue with the full tradeoff writeup)

## Scope

- `extensions/types.ts`: add `listMemories` to `HindsightLikeClient`.
- `extensions/client/client.ts`: implement `listMemories` via the raw Hindsight client.
- `extensions/operations/memory-recall-operations.ts`: add a `listMemories` operation (bank resolution + capability check).
- `extensions/operations/operation-catalog.ts`: register `hindsight_list_memories` tool with schema + execute.
- Tests updated/added for the new tool and the (now 5-tool) exhaustive catalog assertions.
- Generated `docs/surface-reference.md` regenerated.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — skipped because this is a draft for discussion, not a change intended to ship as-is.
- [ ] `npm run typecheck:tsc` — skipped because `npm run typecheck` (tsgo) is part of `npm run check` and passes.
- [ ] full matrix — skipped because this is a draft, not release or platform-sensitive work.
- [ ] package verification — skipped because package/release artifacts were not changed.
- [ ] `npm run pack:verify` — skipped because package/release artifacts were not changed.
- [ ] `npm run smoke:hindsight` — skipped because no live Hindsight server is unavailable in this environment; the new tool is covered by a unit test against the typed client surface.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

If accepted as-is, this would add a 5th agent-invoked tool and formally amend the four-tool policy in `docs/tools-and-commands.md` (not yet updated in this draft, pending the #452 decision).

## Risk and rollback

- Risk: Medium if merged as-is — not because the code is risky (it's a read-only, capability-gated addition), but because it reverses a deliberate architecture decision (#417) without the doc/policy updates that decision would require, and adds permanent per-session token cost for every Pi user regardless of whether they use it.
- Rollback/revert path: Close this PR without merging; #452 tracks the decision. If a command-based approach is chosen instead, this branch can be repurposed or discarded.

## Follow-ups

- #452 tracks the decision this PR exists to inform.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [ ] Not applicable yet — if accepted, `docs/tools-and-commands.md`'s four-tool policy statement and `AGENTS.md`/`CONTRIBUTING.md` (if they reference tool count) would need updating as part of finishing this PR, not as a separate follow-up.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice (the tool itself; no unrelated changes).
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Do not merge without an explicit decision on #452. This PR is intentionally left as a concrete artifact for that discussion.