### PR TITLE
fix(observability): surface best-effort failures in post-retain reflect and lifecycle recall

### DIFF
--- a/extensions/lifecycle/memory-lifecycle-recall.ts
+++ b/extensions/lifecycle/memory-lifecycle-recall.ts
@@ -164,8 +164,31 @@ export function createRecallTurnPolicy(deps: RecallTurnPolicyDeps): RecallTurnPo
           return patchWithRecallMessage(event, recallMessage);
         }
         return { messages: [recallMessage, ...event.messages] };
-      } catch {
+      } catch (error) {
         deps.setMemoryStatus(runtime, "recall-failed");
+        // Recall runs every turn, so this stays debug-gated behind the same opt-in flags that
+        // already gate the last-recall sidecar, instead of notifying (which would spam normal
+        // usage). Users who enabled storeLastRecall + storeLastRecallFailures can inspect the
+        // redacted cause via /hindsight:last-recall.
+        if (config.recall.storeLastRecall && config.recall.storeLastRecallFailures) {
+          try {
+            await writeLastRecallSnapshot(runtime.cwd, config.recall.lastRecallPath, {
+              query: "",
+              rendered: "",
+              blocks: [],
+              failed: 1,
+              failures: [
+                {
+                  bankId: "pre-scope-failure",
+                  query: "",
+                  error: `Unexpected recall failure: ${redactError(error)}`,
+                },
+              ],
+            });
+          } catch {
+            // Best-effort debug snapshot; do not let a write failure mask the original recall failure.
+          }
+        }
         return undefined;
       }
     },

--- a/extensions/lifecycle/memory-lifecycle-retain.ts
+++ b/extensions/lifecycle/memory-lifecycle-retain.ts
@@ -166,6 +166,7 @@ export function createRetainTurnPolicy(deps: RetainTurnPolicyDeps): RetainTurnPo
         let sent = 0;
         let remaining = 0;
         let queued = false;
+        let reflectError: string | undefined;
         for (const bankId of targets) {
           const result = await enqueueRetainFromAgentEnd({
             event: { ...event, messages },
@@ -179,6 +180,7 @@ export function createRetainTurnPolicy(deps: RetainTurnPolicyDeps): RetainTurnPo
           queued ||= result.queued;
           sent += result.sent;
           remaining = result.remaining;
+          reflectError ??= result.reflectError;
         }
         if (queued) await markRetainedMessages(runtime, event.messages, messages);
         deps.setMemoryStatus(runtime, remaining > 0 ? "retain-queued" : "retained", remaining);
@@ -188,6 +190,12 @@ export function createRetainTurnPolicy(deps: RetainTurnPolicyDeps): RetainTurnPo
             `Hindsight retained ${messageCount} new message${messageCount === 1 ? "" : "s"} to ${targets.join(", ")}${decision ? `; ${decision.reason}` : ""}${remaining > 0 ? `; ${remaining} queued` : ""}`,
             "info",
           );
+        }
+        // Post-retain reflect is opt-in (retain.postRetainReflect, off by default); users who
+        // enable it have opted into this extra visibility, so surface failures like other
+        // opt-in feature failures in this file do, without requiring notifications.retain.
+        if (reflectError) {
+          deps.notify(runtime, `Hindsight post-retain reflect failed: ${reflectError}`, "warning");
         }
         return { queued, sent, remaining };
       } catch (error) {

--- a/extensions/lifecycle/retain.ts
+++ b/extensions/lifecycle/retain.ts
@@ -9,6 +9,7 @@ import type {
 } from "../types.js";
 import { baseTags } from "../banks/banking.js";
 import { projectMessages } from "../utils/messages.js";
+import { redactError } from "../utils/sanitize.js";
 import { contextLabel, liveDocumentId, stableSessionId } from "../utils/session.js";
 import {
   enqueueRetain,
@@ -95,7 +96,7 @@ export async function enqueueRetainFromAgentEnd(args: {
   client: HindsightLikeClient;
   bankId: string;
   extraTags?: string[];
-}): Promise<{ queued: boolean; sent: number; remaining: number }> {
+}): Promise<{ queued: boolean; sent: number; remaining: number; reflectError?: string }> {
   if (!args.config.enabled || !args.config.retain.enabled)
     return { queued: false, sent: 0, remaining: 0 };
   const job = buildRetainJob({
@@ -110,6 +111,7 @@ export async function enqueueRetainFromAgentEnd(args: {
   await enqueueRetain(args.cwd, args.config, job);
   const result = await flushRetain(args.cwd, args.config, args.client);
   await recordRetainDeliveries(args.cwd, args.config, result);
+  let reflectError: string | undefined;
   if (args.config.retain.postRetainReflect) {
     try {
       await args.client.reflect(
@@ -117,11 +119,19 @@ export async function enqueueRetainFromAgentEnd(args: {
         "Reflect on the recently retained session to extract insights",
         { context: "Post-retain reflection" },
       );
-    } catch {
-      /* best-effort reflect after retain */
+    } catch (error) {
+      // Best-effort reflect after retain; the retain itself already succeeded above.
+      // Surface the (redacted) cause to the caller instead of swallowing it silently,
+      // so callers with a notification channel can make it debug-visible.
+      reflectError = redactError(error);
     }
   }
-  return { queued: true, sent: result.sent, remaining: result.remaining };
+  return {
+    queued: true,
+    sent: result.sent,
+    remaining: result.remaining,
+    ...(reflectError ? { reflectError } : {}),
+  };
 }
 
 export type DurableRetainSource = "auto" | "tool" | "command" | "import";

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -1734,4 +1734,42 @@ describe("extension hooks", () => {
       { context: "Post-retain reflection" },
     );
   });
+
+  it("notifies (without failing retain) when postRetainReflect fails", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({ retain: { postRetainReflect: true } }),
+    );
+    mocked.client.reflect.mockRejectedValueOnce(new Error("reflect unavailable"));
+    const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
+    const pi = {
+      on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
+        handlers[name] = [...(handlers[name] ?? []), handler];
+      }),
+      registerTool: vi.fn(),
+      registerCommand: vi.fn(),
+    };
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => join(cwd, "session.jsonl") },
+    };
+
+    const { default: hindsightExtension } = await import("../extensions/index.js");
+    hindsightExtension(pi as any);
+    await handlers.session_start?.[0]?.({}, ctx);
+    await handlers.agent_end?.[0]?.(
+      { messages: [{ role: "assistant", content: "new decision", timestamp: 2 }] },
+      ctx,
+    );
+
+    expect(mocked.client.retain).toHaveBeenCalled();
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringMatching(/^Hindsight post-retain reflect failed: reflect unavailable$/),
+      "warning",
+    );
+  });
 });

--- a/tests/recall-turn-policy.test.ts
+++ b/tests/recall-turn-policy.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRecallTurnPolicy } from "../extensions/lifecycle/memory-lifecycle-recall.js";
+import { readLastRecallSnapshot } from "../extensions/lifecycle/recall-visibility.js";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import type { ResolvedConfig } from "../extensions/types.js";
+import type { RuntimeSnapshot } from "../extensions/lifecycle/memory-lifecycle-runtime.js";
+
+function runtimeFor(cwd: string): RuntimeSnapshot {
+  mkdirSync(join(cwd, ".git"));
+  return { cwd, ui: { setStatus: () => undefined, notify: () => undefined } };
+}
+
+describe("createRecallTurnPolicy unexpected failure", () => {
+  it("writes a debug snapshot when storeLastRecall + storeLastRecallFailures are enabled", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-recall-turn-"));
+    const runtime = runtimeFor(cwd);
+    const statuses: string[] = [];
+    const config: ResolvedConfig = {
+      ...DEFAULT_CONFIG,
+      recall: { ...DEFAULT_CONFIG.recall, storeLastRecall: true, storeLastRecallFailures: true },
+    };
+
+    const policy = createRecallTurnPolicy({
+      getConfig: () => config,
+      getClient: () => {
+        throw new Error("client unavailable");
+      },
+      setMemoryStatus: (_runtime, activity) => {
+        statuses.push(activity);
+      },
+      notify: () => undefined,
+    });
+
+    const result = await policy.recall(
+      { messages: [{ role: "user", content: "hello", timestamp: 1 }] } as never,
+      runtime,
+    );
+
+    expect(result).toBeUndefined();
+    expect(statuses).toEqual(["recalling", "recall-failed"]);
+    const snapshot = await readLastRecallSnapshot(cwd, config.recall.lastRecallPath);
+    expect(snapshot?.failed).toBe(1);
+    expect(snapshot?.failures?.[0]?.error).toContain("client unavailable");
+  });
+
+  it("does not write a snapshot when storeLastRecallFailures is disabled (default)", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-recall-turn-"));
+    const runtime = runtimeFor(cwd);
+    const config: ResolvedConfig = DEFAULT_CONFIG;
+
+    const policy = createRecallTurnPolicy({
+      getConfig: () => config,
+      getClient: () => {
+        throw new Error("client unavailable");
+      },
+      setMemoryStatus: () => undefined,
+      notify: () => undefined,
+    });
+
+    await policy.recall(
+      { messages: [{ role: "user", content: "hello", timestamp: 1 }] } as never,
+      runtime,
+    );
+
+    const snapshot = await readLastRecallSnapshot(cwd, config.recall.lastRecallPath);
+    expect(snapshot).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two best-effort code paths swallowed errors with empty catches, reducing debuggability without being bugs themselves:

- `enqueueRetainFromAgentEnd`'s post-retain reflect call (`retain.postRetainReflect`, opt-in and off by default) now captures and redacts its error and returns it as an optional `reflectError` field instead of a bare catch. The retain turn policy surfaces it via `notify(warning)` after processing all queued targets; since the feature itself is opt-in, only users who already enabled it will ever see this.
- The recall turn policy's outer catch now captures the error. Recall runs every turn, so instead of notifying (which would spam), the redacted cause is written to the existing `last-recall.json` sidecar when the user has already opted into both `recall.storeLastRecall` and `recall.storeLastRecallFailures` (both default `false`). No new config surface; reuses the existing debug-visibility mechanism inspectable via `/hindsight:last-recall`.

Both paths route errors through `redactError()` before they reach any output.

## Linked issue

- Closes #429

## Scope

- `extensions/lifecycle/retain.ts`: capture and redact the post-retain reflect error; return it as `reflectError?: string`.
- `extensions/lifecycle/memory-lifecycle-retain.ts`: collect `reflectError` across bank targets and `notify(warning)` when present.
- `extensions/lifecycle/memory-lifecycle-recall.ts`: capture the outer-catch error; write a redacted debug snapshot via the existing `writeLastRecallSnapshot` sidecar when both opt-in flags are enabled.
- `tests/extension-hooks.test.ts`: integration test that the reflect-failure notification fires.
- `tests/recall-turn-policy.test.ts` (new): unit tests that the debug snapshot is written when opted in, and not written by default.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — skipped because this is a targeted observability fix, not coverage-threshold-sensitive.
- [ ] `npm run typecheck:tsc` — skipped because `npm run typecheck` (tsgo) is part of `npm run check` and passes.
- [ ] full matrix — skipped because this is not release or platform-sensitive work.
- [ ] package verification — skipped because package/release artifacts were not changed.
- [ ] `npm run pack:verify` — skipped because package/release artifacts were not changed.
- [ ] `npm run smoke:hindsight` — skipped because no live Hindsight server is unavailable in this environment; both failure paths are covered by unit/integration tests exercising the actual code paths with a mocked client.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Users who have `retain.postRetainReflect` enabled will now see a warning notification if the post-retain reflect call fails (previously silent). Users who have both `recall.storeLastRecall` and `recall.storeLastRecallFailures` enabled will see unexpected recall failures recorded in their last-recall sidecar (previously silently dropped). Default behavior (both opt-in flags off) is unchanged.

## Risk and rollback

- Risk: Low. Both changes are additive and gated behind existing opt-in config; the retain/recall success paths and their return shapes for non-error cases are unchanged. A reviewer subagent pass confirmed no raw retained/recalled content can leak through either path (`redactError` is applied, and the synthetic recall failure entry has an empty `query`).
- Rollback/revert path: Revert this PR to restore the bare `catch {}` blocks.

## Follow-ups

- None. The three other review items from the `rewrite/slim-core-0.8` review (`observation_scopes .length`, reflect `maxTokens` dual-path, retain-cursor branch-shrink) were assessed and rejected as false positives per #429; not touched here.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] This does not change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

A reviewer subagent pass traced both error paths for potential raw-content leakage (e.g. a Hindsight server echoing request content back in a validation error) and found no risk beyond what `redactError`'s secret-pattern redaction already covers; the synthetic recall failure entry written to the sidecar uses an empty `query` field.