### PR TITLE
feat(diagnostics): revive /hindsight:doctor command

### DIFF
--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -113,23 +113,24 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 
 ## Commands
 
-| Command                              | Description                                                                                       |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `/hindsight`                         | Open Hindsight memory TUI.                                                                        |
-| `/hindsight:init`                    | Write .pi/hindsight.json with the currently selected project bank.                                |
-| `/hindsight:import`                  | Import the current Pi session JSONL into Hindsight.                                               |
-| `/hindsight:import-current`          | Import the current Pi session JSONL into Hindsight.                                               |
-| `/hindsight:import-file`             | Import an explicit Pi session JSONL file into Hindsight.                                          |
-| `/hindsight:import-project-sessions` | Import Pi session JSONL files scoped to the current repo/cwd.                                     |
-| `/hindsight:session`                 | Show current Hindsight session memory mode and tags.                                              |
-| `/hindsight:mode`                    | Set session memory mode: normal, read-only, or ignored.                                           |
-| `/hindsight:next-opt-out`            | Skip automatic retain for the next agent run in this session.                                     |
-| `/hindsight:retain`                  | Enable or disable retain for this session.                                                        |
-| `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                   |
-| `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                   |
-| `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript. |
-| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                    |
-| `/hindsight:flush`                   | Flush queued retain jobs.                                                                         |
+| Command                              | Description                                                                                                  |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `/hindsight`                         | Open Hindsight memory TUI.                                                                                   |
+| `/hindsight:init`                    | Write .pi/hindsight.json with the currently selected project bank.                                           |
+| `/hindsight:import`                  | Import the current Pi session JSONL into Hindsight.                                                          |
+| `/hindsight:import-current`          | Import the current Pi session JSONL into Hindsight.                                                          |
+| `/hindsight:import-file`             | Import an explicit Pi session JSONL file into Hindsight.                                                     |
+| `/hindsight:import-project-sessions` | Import Pi session JSONL files scoped to the current repo/cwd.                                                |
+| `/hindsight:session`                 | Show current Hindsight session memory mode and tags.                                                         |
+| `/hindsight:mode`                    | Set session memory mode: normal, read-only, or ignored.                                                      |
+| `/hindsight:next-opt-out`            | Skip automatic retain for the next agent run in this session.                                                |
+| `/hindsight:retain`                  | Enable or disable retain for this session.                                                                   |
+| `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                              |
+| `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                              |
+| `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript.            |
+| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                               |
+| `/hindsight:flush`                   | Flush queued retain jobs.                                                                                    |
+| `/hindsight:doctor`                  | Emit a machine-readable Hindsight diagnostics report (connectivity, queue, imports, config) for bug reports. |
 
 ## Config fields
 

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -44,9 +44,10 @@ Use dry-run before non-dry-run imports. See [Import controls](/pi-hindsight/refe
 /hindsight:last-recall --json
 /hindsight:recall-cleanup
 /hindsight:recall-cleanup <session.jsonl> --prune
+/hindsight:doctor
 ```
 
-`/hindsight:queue` summarizes active and dead-letter retain queues without printing retained payloads. Add `--jobs --json` for redacted job metadata such as job id, bank id, document id, tags, byte counts, retry count, and last error. `/hindsight:flush` flushes queued retain jobs. `/hindsight:last-recall` reads the opt-in local recall snapshot. Recall cleanup reports or prunes accidentally persisted `<hindsight-memory>` transcript lines.
+`/hindsight:queue` summarizes active and dead-letter retain queues without printing retained payloads. Add `--jobs --json` for redacted job metadata such as job id, bank id, document id, tags, byte counts, retry count, and last error. `/hindsight:flush` flushes queued retain jobs. `/hindsight:last-recall` reads the opt-in local recall snapshot. Recall cleanup reports or prunes accidentally persisted `<hindsight-memory>` transcript lines. `/hindsight:doctor` emits a machine-readable JSON diagnostics report (connectivity, queue/dead-letter state, import manifest status, bank routing, and redacted config) for bug reports; it never prints retained/recalled payloads or API keys.
 
 ## Session controls
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -109,23 +109,24 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 
 ## Commands
 
-| Command                              | Description                                                                                       |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `/hindsight`                         | Open Hindsight memory TUI.                                                                        |
-| `/hindsight:init`                    | Write .pi/hindsight.json with the currently selected project bank.                                |
-| `/hindsight:import`                  | Import the current Pi session JSONL into Hindsight.                                               |
-| `/hindsight:import-current`          | Import the current Pi session JSONL into Hindsight.                                               |
-| `/hindsight:import-file`             | Import an explicit Pi session JSONL file into Hindsight.                                          |
-| `/hindsight:import-project-sessions` | Import Pi session JSONL files scoped to the current repo/cwd.                                     |
-| `/hindsight:session`                 | Show current Hindsight session memory mode and tags.                                              |
-| `/hindsight:mode`                    | Set session memory mode: normal, read-only, or ignored.                                           |
-| `/hindsight:next-opt-out`            | Skip automatic retain for the next agent run in this session.                                     |
-| `/hindsight:retain`                  | Enable or disable retain for this session.                                                        |
-| `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                   |
-| `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                   |
-| `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript. |
-| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                    |
-| `/hindsight:flush`                   | Flush queued retain jobs.                                                                         |
+| Command                              | Description                                                                                                  |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `/hindsight`                         | Open Hindsight memory TUI.                                                                                   |
+| `/hindsight:init`                    | Write .pi/hindsight.json with the currently selected project bank.                                           |
+| `/hindsight:import`                  | Import the current Pi session JSONL into Hindsight.                                                          |
+| `/hindsight:import-current`          | Import the current Pi session JSONL into Hindsight.                                                          |
+| `/hindsight:import-file`             | Import an explicit Pi session JSONL file into Hindsight.                                                     |
+| `/hindsight:import-project-sessions` | Import Pi session JSONL files scoped to the current repo/cwd.                                                |
+| `/hindsight:session`                 | Show current Hindsight session memory mode and tags.                                                         |
+| `/hindsight:mode`                    | Set session memory mode: normal, read-only, or ignored.                                                      |
+| `/hindsight:next-opt-out`            | Skip automatic retain for the next agent run in this session.                                                |
+| `/hindsight:retain`                  | Enable or disable retain for this session.                                                                   |
+| `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                              |
+| `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                              |
+| `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript.            |
+| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                               |
+| `/hindsight:flush`                   | Flush queued retain jobs.                                                                                    |
+| `/hindsight:doctor`                  | Emit a machine-readable Hindsight diagnostics report (connectivity, queue, imports, config) for bug reports. |
 
 ## Config fields
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -42,9 +42,10 @@ Use dry-run before non-dry-run imports. See [`import-controls.md`](import-contro
 /hindsight:last-recall --json
 /hindsight:recall-cleanup
 /hindsight:recall-cleanup <session.jsonl> --prune
+/hindsight:doctor
 ```
 
-`/hindsight:queue` summarizes active and dead-letter retain queues without printing retained payloads. Add `--jobs --json` for redacted job metadata such as job id, bank id, document id, tags, byte counts, retry count, and last error. `/hindsight:flush` flushes queued retain jobs. `/hindsight:last-recall` reads the opt-in local recall snapshot. Recall cleanup reports or prunes accidentally persisted `<hindsight-memory>` transcript lines.
+`/hindsight:queue` summarizes active and dead-letter retain queues without printing retained payloads. Add `--jobs --json` for redacted job metadata such as job id, bank id, document id, tags, byte counts, retry count, and last error. `/hindsight:flush` flushes queued retain jobs. `/hindsight:last-recall` reads the opt-in local recall snapshot. Recall cleanup reports or prunes accidentally persisted `<hindsight-memory>` transcript lines. `/hindsight:doctor` emits a machine-readable JSON diagnostics report (connectivity, queue/dead-letter state, import manifest status, bank routing, and redacted config) for bug reports; it never prints retained/recalled payloads or API keys.
 
 ## Session controls
 

--- a/extensions/operations/memory-diagnostics-operations.ts
+++ b/extensions/operations/memory-diagnostics-operations.ts
@@ -1,0 +1,45 @@
+import { checkHindsight } from "../client/client.js";
+import { formatDebugReport } from "../utils/diagnostics.js";
+import { resolveQueuePath, summarizeRetainQueue } from "../queue/queue.js";
+import {
+  importManifestSummary,
+  readImportManifestSafe,
+  resolveImportManifestPath,
+} from "../imports/import-plan.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+
+export function createDiagnosticsOperations(deps: MemoryOperationsDeps) {
+  return {
+    async doctor(cwd: string, sessionFile?: string): Promise<string> {
+      const config = deps.getConfig();
+      const projectBankId = deps.getProjectBankId();
+      const manifestPath = resolveImportManifestPath(cwd, config.import.manifestPath);
+      const [health, queueSummary, manifestResult] = await Promise.all([
+        checkHindsight(deps.getClient(), projectBankId),
+        summarizeRetainQueue(resolveQueuePath(cwd, config.retain.queuePath)),
+        readImportManifestSafe(manifestPath),
+      ]);
+      const imports = importManifestSummary(manifestResult.manifest);
+      return formatDebugReport({
+        cwd,
+        ...(sessionFile ? { sessionFile } : {}),
+        projectBankId,
+        config,
+        queueLength: queueSummary.active.valid,
+        queuePath: queueSummary.active.path,
+        queueMalformedLines: queueSummary.active.malformed,
+        queueReadError: queueSummary.active.error,
+        deadLetterPath: queueSummary.deadLetter.path,
+        deadLetterLength: queueSummary.deadLetter.valid,
+        deadLetterMalformedLines: queueSummary.deadLetter.malformed,
+        deadLetterReadError: queueSummary.deadLetter.error,
+        importManifestPath: manifestPath,
+        importManifestError: manifestResult.error,
+        importManifestAction: manifestResult.action,
+        importCount: imports.count,
+        ...(imports.latest ? { latestImport: imports.latest } : {}),
+        health,
+      });
+    },
+  };
+}

--- a/extensions/operations/memory-operation-service.ts
+++ b/extensions/operations/memory-operation-service.ts
@@ -5,6 +5,7 @@ import {
   importMemorySession,
 } from "../imports/import-sessions.js";
 import { createConfigOperations } from "./memory-config-operations.js";
+import { createDiagnosticsOperations } from "./memory-diagnostics-operations.js";
 import { createQueueOperations } from "../queue/queue-operations.js";
 import { createRecallOperations } from "./memory-recall-operations.js";
 import { createRetainOperations } from "./memory-retain-operations.js";
@@ -59,6 +60,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createImportOperations(deps),
     ...createQueueOperations(deps),
     ...createSessionOperations(),
+    ...createDiagnosticsOperations(deps),
   };
 }
 

--- a/extensions/tui/command-maintenance.ts
+++ b/extensions/tui/command-maintenance.ts
@@ -144,5 +144,21 @@ export function maintenanceCommandOperations(operations: Operations): CommandOpe
         },
       },
     },
+    {
+      name: "hindsight:doctor",
+      spec: {
+        description:
+          "Emit a machine-readable Hindsight diagnostics report (connectivity, queue, imports, config) for bug reports.",
+        handler: async (_args, ctx) => {
+          try {
+            const report = await operations.doctor(ctx.cwd, sessionFile(ctx));
+            const health = (JSON.parse(report) as { health?: string }).health;
+            ctx.ui.notify(report, health === "reachable" ? "info" : "warning");
+          } catch (error) {
+            ctx.ui.notify(`Hindsight doctor report failed: ${redactError(error)}`, "warning");
+          }
+        },
+      },
+    },
   ];
 }

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -181,6 +181,60 @@ describe("hindsight commands", () => {
     expect(message).not.toContain("supersecret123456");
   });
 
+  it("reports the doctor diagnostics report with reachable health", async () => {
+    const operation = maintenanceCommandOperations({
+      doctor: async () => JSON.stringify({ health: "reachable", queueLength: 0 }, null, 2),
+    } as never).find((candidate) => candidate.name === "hindsight:doctor");
+    const ctx = {
+      cwd: mkdtempSync(join(tmpdir(), "pi-hindsight-commands-")),
+      ui: { notify: vi.fn(), setStatus: vi.fn() },
+      sessionManager: {},
+    };
+
+    await operation?.spec.handler("", ctx as never);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      JSON.stringify({ health: "reachable", queueLength: 0 }, null, 2),
+      "info",
+    );
+  });
+
+  it("reports the doctor diagnostics report as a warning when unreachable", async () => {
+    const operation = maintenanceCommandOperations({
+      doctor: async () =>
+        JSON.stringify({ health: "unreachable: connection refused", queueLength: 0 }, null, 2),
+    } as never).find((candidate) => candidate.name === "hindsight:doctor");
+    const ctx = {
+      cwd: mkdtempSync(join(tmpdir(), "pi-hindsight-commands-")),
+      ui: { notify: vi.fn(), setStatus: vi.fn() },
+      sessionManager: {},
+    };
+
+    await operation?.spec.handler("", ctx as never);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("unreachable"), "warning");
+  });
+
+  it("redacts secrets when the doctor report itself fails", async () => {
+    const operation = maintenanceCommandOperations({
+      doctor: async () => {
+        throw new Error("failed to read api_key=supersecret123456");
+      },
+    } as never).find((candidate) => candidate.name === "hindsight:doctor");
+    const ctx = {
+      cwd: mkdtempSync(join(tmpdir(), "pi-hindsight-commands-")),
+      ui: { notify: vi.fn(), setStatus: vi.fn() },
+      sessionManager: {},
+    };
+
+    await operation?.spec.handler("", ctx as never);
+
+    const message = ctx.ui.notify.mock.calls[0]?.[0] as string;
+    expect(message).toContain("Hindsight doctor report failed");
+    expect(message).toContain("api_key=[REDACTED]");
+    expect(message).not.toContain("supersecret123456");
+  });
+
   it("reports last recall snapshot summary", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-commands-"));
     mkdirSync(join(cwd, ".pi", "hindsight"), { recursive: true });
@@ -524,7 +578,7 @@ describe("hindsight commands", () => {
     );
   });
 
-  it("registers /hindsight TUI command and removes legacy status/debug commands", async () => {
+  it("registers /hindsight TUI command and doctor, and removes other legacy status/debug commands", async () => {
     const commands = new Map<string, RegisteredTestCommand>();
     registerCommands(
       {
@@ -540,8 +594,8 @@ describe("hindsight commands", () => {
     );
 
     expect(commands.has("hindsight")).toBe(true);
+    expect(commands.has("hindsight:doctor")).toBe(true);
     expect(commands.has("hindsight:status")).toBe(false);
-    expect(commands.has("hindsight:doctor")).toBe(false);
     expect(commands.has("hindsight:config")).toBe(false);
     expect(commands.has("hindsight:debug")).toBe(false);
     expect(commands.has("hindsight:setup")).toBe(false);

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -264,4 +264,43 @@ describe("memory operations", () => {
       ]),
     );
   });
+
+  it("assembles a doctor report from live health, queue, and import state", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ops-"));
+    const operations = createMemoryOperations({
+      getClient: () => ({ ...client(), health: async () => ({}) }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    const report = JSON.parse(await operations.doctor(cwd, "/tmp/session.jsonl")) as Record<
+      string,
+      unknown
+    >;
+
+    expect(report.health).toBe("reachable");
+    expect(report.projectBankId).toBe("project-bank");
+    expect(report.sessionFile).toBe("/tmp/session.jsonl");
+    expect(report.queueLength).toBe(0);
+    const imports = report.imports as { count: number };
+    expect(imports.count).toBe(0);
+  });
+
+  it("reports doctor health as unreachable when the client health check fails", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ops-"));
+    const operations = createMemoryOperations({
+      getClient: () => ({
+        ...client(),
+        health: async () => {
+          throw new Error("connection refused");
+        },
+      }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    const report = JSON.parse(await operations.doctor(cwd)) as Record<string, unknown>;
+
+    expect(report.health).toBe("unreachable: connection refused");
+  });
 });

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -458,6 +458,7 @@ describe("operation catalog", () => {
       "hindsight:recall-cleanup",
       "hindsight:queue",
       "hindsight:flush",
+      "hindsight:doctor",
     ]);
   });
 });


### PR DESCRIPTION
## Summary

After the slim-core rewrite, `extensions/utils/diagnostics.ts::formatDebugReport` (the rich JSON diagnostics report) had no caller — only its own test file referenced it. Re-adds `/hindsight:doctor` wired to it, per the maintainer decision recorded on #438 ("Revive: re-add a `/hindsight:doctor` command that emits `formatDebugReport`... with a test that exercises the command").

- New `extensions/operations/memory-diagnostics-operations.ts` assembles `DebugReportArgs` from live health (`checkHindsight`), queue/dead-letter state (`summarizeRetainQueue`), and import manifest state (`readImportManifestSafe` + `importManifestSummary`), then calls `formatDebugReport`.
- Wired into `createMemoryOperations` and registered as `hindsight:doctor` in `command-maintenance.ts`, notifying `info`/`warning` based on reachability and redacting unexpected failures, matching sibling commands like `hindsight:last-recall`.
- The report already redacts the API key via `safeConfig()` and never includes retained/recalled content, only metadata (counts, paths, timestamps).

## Linked issue

- Closes #438

## Scope

- `extensions/operations/memory-diagnostics-operations.ts` (new): `doctor(cwd, sessionFile?)` operation.
- `extensions/operations/memory-operation-service.ts`: wire the new operations module in.
- `extensions/tui/command-maintenance.ts`: register `hindsight:doctor`.
- `docs/tools-and-commands.md`, `docs-site/.../tools-and-commands.md`: document the command.
- Generated `docs/surface-reference.md` (and mirror) regenerated.
- Tests: `tests/commands.test.ts` (command handler behavior: reachable/unreachable/throwing), `tests/memory-operations.test.ts` (end-to-end `operations.doctor()` with a fake client), `tests/operation-catalog.test.ts` (exhaustive command list). Updated the existing regression test that asserted `hindsight:doctor` stays unregistered — it and the other legacy commands (`status`/`config`/`debug`/`setup`) remain intentionally removed; only `doctor` is revived per the recorded decision.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — skipped because this is a diagnostics command addition, not coverage-threshold-sensitive.
- [ ] `npm run typecheck:tsc` — skipped because `npm run typecheck` (tsgo) is part of `npm run check` and passes.
- [ ] full matrix — skipped because this is not release or platform-sensitive work.
- [ ] package verification — skipped because package/release artifacts were not changed.
- [ ] `npm run pack:verify` — skipped because package/release artifacts were not changed.
- [ ] `npm run smoke:hindsight` — skipped because no live Hindsight server is unavailable in this environment; health/queue/import assembly is covered by unit and end-to-end tests against a fake client.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds a new `/hindsight:doctor` command. Changelog/release notes should mention the revived diagnostics command for bug reports.

## Risk and rollback

- Risk: Low. `formatDebugReport` already existed and was already tested at the unit level (`tests/diagnostics.test.ts`, unchanged); this PR only adds a caller. A reviewer subagent pass confirmed the underlying operations (`checkHindsight`, `summarizeRetainQueue`, `readImportManifestSafe`) never throw, and the report never includes API keys or raw retained/recalled content — only metadata.
- Rollback/revert path: Revert this PR to remove the command and its operation module; `formatDebugReport` returns to its prior orphaned-but-tested state.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] This does not change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done. `AGENTS.md`/`PRD.md`/`docs/compatibility.md` already referenced `/hindsight:doctor` as an anticipated command (including a "Diagnostics contract" section listing required report fields), so no updates were needed there; this PR makes those existing references accurate.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Verified the report satisfies every field listed in `docs/compatibility.md`'s pre-existing "Diagnostics contract" section (package version/user agent, runtime ranges, base URL without secrets, client package/range, health reachability, server floor + remediation, memory profile/routes/banks, queue state, import state). "Activity" defaults to `idle` since a one-off command invocation has no live in-session turn state to read from — this matches how the original pre-removal implementation worked.