### PR TITLE
docs(adr): decide lifeOS dual-bank design in ADR-004

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -116,6 +116,10 @@ export default defineConfig({
                   label: "ADR 003: TUI memory mode vocabulary",
                   slug: "architecture/adr/003-tui-memory-mode-vocabulary",
                 },
+                {
+                  label: "ADR 004: lifeOS dual-bank design",
+                  slug: "architecture/adr/004-lifeos-dual-bank-design",
+                },
               ],
             },
           ],

--- a/docs-site/src/content/docs/architecture/adr/002-explicit-routing-strategy-seam.md
+++ b/docs-site/src/content/docs/architecture/adr/002-explicit-routing-strategy-seam.md
@@ -10,6 +10,8 @@ The typed strategy seam, richer dry-run presenter output, and expanded eval fixt
 
 Amendment (2026-06): the `hindsight_route_memory` dry-run tool was removed in the slim-surface rewrite (#417). The router itself and the strategy seam remain; dry-run inspection would return through the `/hindsight` TUI if needed. References to the tool below are historical.
 
+Amendment (2026-07): [ADR-004](/pi-hindsight/architecture/adr/004-lifeos-dual-bank-design/) decided to remove the heuristic memory router entirely rather than revive its dry-run visibility. Once that removal ships, this ADR's routing-input/output shapes, safety policy, and eval-fixture taxonomy become historical record of a superseded design, not a live contract.
+
 ## Context
 
 Pi Hindsight defaults to safe project-local automatic retain. User Bank automatic retain is disabled unless the user selects a profile or config mode that explicitly enables it. Legacy config/tool aliases still use `global` for this User Bank route.

--- a/docs-site/src/content/docs/architecture/adr/004-lifeos-dual-bank-design.md
+++ b/docs-site/src/content/docs/architecture/adr/004-lifeos-dual-bank-design.md
@@ -15,7 +15,7 @@ Pi Hindsight already supports two kinds of memory: a per-repo **Project Bank** a
 - Dual-bank recall already works. When a repo's config enables `banks.user`, `selectMemoryScopes` returns both a project scope and a user scope; `recallForContext` queries each bank independently and merges the rendered blocks. This is exposed today as the **"Project + User"** guided-setup profile ([Memory profiles](/pi-hindsight/start/memory-profiles/)), alongside "Project Only", "User Only", and "Recall Only".
 - Automatic retain is project-only in every profile except "User Only". Even in "Project + User", the User Bank only receives writes through explicit tools (`hindsight_retain_global`) or commands — never automatically. This is a deliberate safety choice from [ADR-002](/pi-hindsight/architecture/adr/002-explicit-routing-strategy-seam/) ("User Bank writes require high confidence or explicit user action") and is unchanged by this ADR.
 - A heuristic memory router (`extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`) exists to auto-classify candidate retain content as `project`/`global`/`both`/`skip` using regex keyword patterns and mission-term matching. It only auto-engages when `userRetain.mode: "router"`, which the guided-setup writer only sets for the **"User Only"** profile (no project bank to fall back to). Its own dry-run inspection tool (`hindsight_route_memory`) was already removed in the slim-surface rewrite (#417), so it now runs with no user-visible explanation of its decisions. It carries ~580 lines of implementation plus 38 parametrized eval-fixture tests.
-- **Recall token budget is not split across banks.** `recallForContext` requests the full `config.recall.maxTokens` independently for every active scope. Enabling the User Bank alongside the Project Bank silently up to doubles the memory tokens injected into every turn; nothing documents or bounds this today.
+- **Recall token budget is not split across banks.** `recallForContext` requests the full `config.recall.maxTokens` independently for every active scope. Enabling the User Bank alongside the Project Bank can silently double (or more) the memory tokens injected into every turn; nothing documents or bounds this today.
 - Config migration from the legacy `global` naming (`banks.global` → `banks.user`, `globalRetain` → `userRetain`, `globalQueryPreamble` → `userQueryPreamble`) already exists and is unaffected by this ADR.
 
 ## Options considered
@@ -67,11 +67,16 @@ Unchanged from the existing 1.0 support scope ([Surface reference](/pi-hindsight
 
 ## Consequences
 
-- No default behavior changes for existing Project Only, Recall Only, or Project + User users beyond the new `recall.userMaxTokens` cap taking effect for whichever of them already have the User Bank enabled.
-- "User Only" loses automatic classifier-driven retain; those users must use explicit retain (tool or future command) for User Bank writes going forward. This is a narrower, more predictable contract, consistent with every other profile.
-- `extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`, and `tests/memory-router.test.ts` are removed, along with the `"router"` value from `userRetain.mode`/`globalRetain.mode` and the router-eval-fixture taxonomy documented in ADR-002.
-- ADR-002 (explicit routing strategy seam) is superseded by this decision for the router's future; its routing-input/output shape documentation becomes historical context, not a live contract to maintain.
-- A new `recall.userMaxTokens` config field, default value, and normalization ship as part of the follow-up work.
+Once the follow-up implementation issues below land:
+
+- There will be no default behavior changes for existing Project Only, Recall Only, or Project + User users beyond the new `recall.userMaxTokens` cap applying to whichever of them already have the User Bank enabled.
+- "User Only" will lose automatic classifier-driven retain; those users will need to use explicit retain (tool or future command) for User Bank writes going forward. This is a narrower, more predictable contract, consistent with every other profile.
+- `extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`, and `tests/memory-router.test.ts` will be removed, along with the `"router"` value from `userRetain.mode`/`globalRetain.mode` and the router-eval-fixture taxonomy documented in ADR-002.
+- A new `recall.userMaxTokens` config field, default value, and normalization will ship.
+
+Effective immediately with this ADR:
+
+- ADR-002 (explicit routing strategy seam) is superseded by this decision for the router's future; its routing-input/output shape documentation becomes historical context, not a live contract to maintain (see the amendment added to ADR-002).
 
 ## Follow-up implementation issues
 

--- a/docs-site/src/content/docs/architecture/adr/004-lifeos-dual-bank-design.md
+++ b/docs-site/src/content/docs/architecture/adr/004-lifeos-dual-bank-design.md
@@ -1,0 +1,83 @@
+---
+title: "ADR 004: lifeOS dual-bank design"
+---
+
+## Status
+
+Accepted 2026-07-03.
+
+## Context
+
+Pi Hindsight already supports two kinds of memory: a per-repo **Project Bank** and an optional cross-project **User Bank** (the "lifeOS" memory — durable preferences, recurring workflows, coding habits). #420 built tag-group scope isolation specifically so recall could merge both banks safely. This ADR answers the question #424 asked: should the User Bank become a first-class default next to the Project Bank, or stay opt-in, and what should happen to the heuristic memory router along the way.
+
+### Current state
+
+- Dual-bank recall already works. When a repo's config enables `banks.user`, `selectMemoryScopes` returns both a project scope and a user scope; `recallForContext` queries each bank independently and merges the rendered blocks. This is exposed today as the **"Project + User"** guided-setup profile ([Memory profiles](/pi-hindsight/start/memory-profiles/)), alongside "Project Only", "User Only", and "Recall Only".
+- Automatic retain is project-only in every profile except "User Only". Even in "Project + User", the User Bank only receives writes through explicit tools (`hindsight_retain_global`) or commands — never automatically. This is a deliberate safety choice from [ADR-002](/pi-hindsight/architecture/adr/002-explicit-routing-strategy-seam/) ("User Bank writes require high confidence or explicit user action") and is unchanged by this ADR.
+- A heuristic memory router (`extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`) exists to auto-classify candidate retain content as `project`/`global`/`both`/`skip` using regex keyword patterns and mission-term matching. It only auto-engages when `userRetain.mode: "router"`, which the guided-setup writer only sets for the **"User Only"** profile (no project bank to fall back to). Its own dry-run inspection tool (`hindsight_route_memory`) was already removed in the slim-surface rewrite (#417), so it now runs with no user-visible explanation of its decisions. It carries ~580 lines of implementation plus 38 parametrized eval-fixture tests.
+- **Recall token budget is not split across banks.** `recallForContext` requests the full `config.recall.maxTokens` independently for every active scope. Enabling the User Bank alongside the Project Bank silently up to doubles the memory tokens injected into every turn; nothing documents or bounds this today.
+- Config migration from the legacy `global` naming (`banks.global` → `banks.user`, `globalRetain` → `userRetain`, `globalQueryPreamble` → `userQueryPreamble`) already exists and is unaffected by this ADR.
+
+## Options considered
+
+**(a) Dual-bank default.** Enable both banks out of the box for new setups, with merged recall and routed retain.
+**(b) Opt-in User Bank with polished setup.** Keep today's model — User Bank is a deliberate choice via guided setup — and harden the gaps (budget split, router observability) rather than changing the default.
+**(c) Single project bank with user-visibility tags.** Drop the separate User Bank; mark durable facts with a tag inside the project bank instead.
+
+(c) is rejected outright: Hindsight banks are the isolation boundary, not tags. A single project bank is tied to one repo's bank ID (`deriveProjectBankId`); there is no way to recall those tagged facts while working in a _different_ repository without querying a different bank, which defeats the entire cross-project ("lifeOS") purpose. Collapsing to one bank would also regress [ADR-001](/pi-hindsight/architecture/adr/001-memory-lifecycle-and-scope/)'s invariant that project recall is repo-scoped, since "user-visible" facts would need to leak across repo tag boundaries to be found at all.
+
+The real choice is (a) vs (b).
+
+## Decision
+
+**(b): keep the User Bank opt-in; harden the existing design instead of changing the default.**
+
+This repo has a consistent, deliberate pattern of conservative defaults — `postRetainReflect` off, `userRetain.mode` explicit-only, User Bank disabled — and ADR-002 already states "Do not make User Bank automatic retain default" as a standing invariant. Defaulting the User Bank on would also mean every new install needs a second Hindsight bank configured before first use, and would silently increase the default token cost of every recall. Given Pi Hindsight's "Pi-first 1.0" scope and existing safe-by-default posture, that tradeoff is not justified today. Nothing here forecloses revisiting (a) once usage data suggests otherwise — that would be a new ADR, not a reinterpretation of this one.
+
+**The heuristic memory router is removed.** It only ever auto-engaged in the narrow "User Only" profile, its own dry-run visibility was already deleted, and a regex/keyword classifier with no user-facing explanation is exactly the kind of unmonitorable automatic write ADR-002 warned against ("The main safety risk is silent User Bank pollution"). The issue's own framing — "whether the pattern router earns its complexity or is replaced by explicit tools/commands" — is answered: replaced. "User Only" automatic retain falls back to the same explicit-only model every other profile already uses; users write User Bank memory with `hindsight_retain_global` or a command, same as "Project + User" users do today.
+
+## Recall merging and token budget split
+
+Each active scope must have a bounded, independent budget so enabling the User Bank cannot silently balloon per-turn token cost. Concretely:
+
+- `recall.maxTokens` keeps its current meaning and default (800) and continues to bound the **Project Bank** scope only. Existing project-only and project+user users see no change in Project Bank recall behavior.
+- A new `recall.userMaxTokens` (default: half of `recall.maxTokens`, i.e. 400) bounds the **User Bank** scope specifically when it participates in a recall call. User memory is meant to be a smaller, durable supplement to project context, not an equal-weight second corpus.
+- Both caps apply independently per bank query (as today), not as a shared pool — this keeps the change backward compatible and avoids new cross-scope coordination logic. The ceiling that changes is that User Bank recall no longer defaults to the same size as Project Bank recall.
+- This is a new config field with a real default, not a documentation-only fix, so it is implementation work for a follow-up issue, not this ADR.
+
+## Retain routing policy for personal vs. project facts
+
+- Automatic retain stays project-bank-only in every profile. There is no automatic classifier deciding "this fact is personal, route it to the User Bank."
+- Personal/durable facts reach the User Bank only through deliberate action: the `hindsight_retain_global` tool, or a future `/hindsight:retain-global`-style command if usage shows a need for one (not requested by this ADR).
+- `userRetain.mode` drops the `"router"` variant. The type becomes effectively single-valued (`"explicit-only"`) going forward; keeping the field (rather than deleting it outright) preserves config-file compatibility and gives room for a future, better-specified routing strategy without another rename.
+- Migration: existing configs with `userRetain.mode: "router"` (or the legacy `globalRetain.mode: "router"`) must normalize to `"explicit-only"` rather than erroring, consistent with how `enumValue()` already falls back to the default for invalid enum values today.
+
+## Bank missions and dispositions per use case
+
+No changes. `defaultProjectBankMissions()` and `defaultGlobalBankMissions()` (`extensions/banks/bank-operations.ts`) already give the Project Bank a repo-architecture/engineering-decision mission and the User Bank a durable-preferences/cross-project-workflow mission, and both are overridable via bank config. This split already matches "lifeOS vs coding" use cases well and needs no rework here.
+
+## Migration for existing configs
+
+- The existing `banks.global` → `banks.user` / `globalRetain` → `userRetain` / `globalQueryPreamble` → `userQueryPreamble` migration (`migrateUserMemoryConfigFile`) is unaffected.
+- New: `userRetain.mode: "router"` (and the legacy `globalRetain.mode: "router"`) must migrate/normalize to `"explicit-only"` once the router is removed, so existing "User Only" adopters keep working without a config error, just with automatic User Bank writes disabled until they explicitly retain.
+
+## What stays in the web UI
+
+Unchanged from the existing 1.0 support scope ([Surface reference](/pi-hindsight/reference/surface-reference/)'s deferred-surfaces table): cross-bank listing, bank creation/deletion, and template management remain Hindsight control-plane responsibilities. This ADR is only about which already-selected banks participate in a given repo's recall/retain and how routing between them works — not about managing banks themselves.
+
+## Consequences
+
+- No default behavior changes for existing Project Only, Recall Only, or Project + User users beyond the new `recall.userMaxTokens` cap taking effect for whichever of them already have the User Bank enabled.
+- "User Only" loses automatic classifier-driven retain; those users must use explicit retain (tool or future command) for User Bank writes going forward. This is a narrower, more predictable contract, consistent with every other profile.
+- `extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`, and `tests/memory-router.test.ts` are removed, along with the `"router"` value from `userRetain.mode`/`globalRetain.mode` and the router-eval-fixture taxonomy documented in ADR-002.
+- ADR-002 (explicit routing strategy seam) is superseded by this decision for the router's future; its routing-input/output shape documentation becomes historical context, not a live contract to maintain.
+- A new `recall.userMaxTokens` config field, default value, and normalization ship as part of the follow-up work.
+
+## Follow-up implementation issues
+
+Filed from this ADR's acceptance, per #424's acceptance criteria:
+
+- Remove the heuristic memory router (`memory-router.ts`, `routing-strategy.ts`, router eval tests), drop `"router"` from the `userRetain.mode`/`globalRetain.mode` type, and add config migration/normalization so existing `"router"`-mode configs fall back to `"explicit-only"` without erroring.
+- Add `recall.userMaxTokens` (default 400) and apply it to the User Bank recall scope in `recallForContext`, independent of `recall.maxTokens`.
+- Update [Memory profiles](/pi-hindsight/start/memory-profiles/), [Memory Banks](/pi-hindsight/concepts/memory-banks/), and [Compatibility matrix](/pi-hindsight/reference/compatibility/) to reflect the router removal and the per-bank token budget split.
+- Mark ADR-002 as superseded by this ADR for the router-specific sections once the removal ships.

--- a/docs/adr/002-explicit-routing-strategy-seam.md
+++ b/docs/adr/002-explicit-routing-strategy-seam.md
@@ -8,6 +8,8 @@ The typed strategy seam, richer dry-run presenter output, and expanded eval fixt
 
 Amendment (2026-06): the `hindsight_route_memory` dry-run tool was removed in the slim-surface rewrite (#417). The router itself and the strategy seam remain; dry-run inspection would return through the `/hindsight` TUI if needed. References to the tool below are historical.
 
+Amendment (2026-07): [ADR-004](004-lifeos-dual-bank-design.md) decided to remove the heuristic memory router entirely rather than revive its dry-run visibility. Once that removal ships, this ADR's routing-input/output shapes, safety policy, and eval-fixture taxonomy become historical record of a superseded design, not a live contract.
+
 ## Context
 
 Pi Hindsight defaults to safe project-local automatic retain. User Bank automatic retain is disabled unless the user selects a profile or config mode that explicitly enables it. Legacy config/tool aliases still use `global` for this User Bank route.

--- a/docs/adr/004-lifeos-dual-bank-design.md
+++ b/docs/adr/004-lifeos-dual-bank-design.md
@@ -10,10 +10,10 @@ Pi Hindsight already supports two kinds of memory: a per-repo **Project Bank** a
 
 ### Current state
 
-- Dual-bank recall already works. When a repo's config enables `banks.user`, `selectMemoryScopes` returns both a project scope and a user scope; `recallForContext` queries each bank independently and merges the rendered blocks. This is exposed today as the **"Project + User"** guided-setup profile (`docs-site/.../start/memory-profiles.md`), alongside "Project Only", "User Only", and "Recall Only".
+- Dual-bank recall already works. When a repo's config enables `banks.user`, `selectMemoryScopes` returns both a project scope and a user scope; `recallForContext` queries each bank independently and merges the rendered blocks. This is exposed today as the **"Project + User"** guided-setup profile (`docs-site/src/content/docs/start/memory-profiles.md`), alongside "Project Only", "User Only", and "Recall Only".
 - Automatic retain is project-only in every profile except "User Only". Even in "Project + User", the User Bank only receives writes through explicit tools (`hindsight_retain_global`) or commands — never automatically. This is a deliberate safety choice from ADR-002 ("User Bank writes require high confidence or explicit user action") and is unchanged by this ADR.
 - A heuristic memory router (`extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`) exists to auto-classify candidate retain content as `project`/`global`/`both`/`skip` using regex keyword patterns and mission-term matching. It only auto-engages when `userRetain.mode: "router"`, which the guided-setup writer only sets for the **"User Only"** profile (no project bank to fall back to). Its own dry-run inspection tool (`hindsight_route_memory`) was already removed in the slim-surface rewrite (#417), so it now runs with no user-visible explanation of its decisions. It carries ~580 lines of implementation plus 38 parametrized eval-fixture tests.
-- **Recall token budget is not split across banks.** `recallForContext` requests the full `config.recall.maxTokens` independently for every active scope. Enabling the User Bank alongside the Project Bank silently up to doubles the memory tokens injected into every turn; nothing documents or bounds this today.
+- **Recall token budget is not split across banks.** `recallForContext` requests the full `config.recall.maxTokens` independently for every active scope. Enabling the User Bank alongside the Project Bank can silently double (or more) the memory tokens injected into every turn; nothing documents or bounds this today.
 - Config migration from the legacy `global` naming (`banks.global` → `banks.user`, `globalRetain` → `userRetain`, `globalQueryPreamble` → `userQueryPreamble`) already exists and is unaffected by this ADR.
 
 ## Options considered
@@ -65,11 +65,16 @@ Unchanged from the existing 1.0 support scope (`docs/surface-reference.md`'s def
 
 ## Consequences
 
-- No default behavior changes for existing Project Only, Recall Only, or Project + User users beyond the new `recall.userMaxTokens` cap taking effect for whichever of them already have the User Bank enabled.
-- "User Only" loses automatic classifier-driven retain; those users must use explicit retain (tool or future command) for User Bank writes going forward. This is a narrower, more predictable contract, consistent with every other profile.
-- `extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`, and `tests/memory-router.test.ts` are removed, along with the `"router"` value from `userRetain.mode`/`globalRetain.mode` and the router-eval-fixture taxonomy documented in ADR-002.
-- ADR-002 (explicit routing strategy seam) is superseded by this decision for the router's future; its routing-input/output shape documentation becomes historical context, not a live contract to maintain.
-- A new `recall.userMaxTokens` config field, default value, and normalization ship as part of the follow-up work.
+Once the follow-up implementation issues below land:
+
+- There will be no default behavior changes for existing Project Only, Recall Only, or Project + User users beyond the new `recall.userMaxTokens` cap applying to whichever of them already have the User Bank enabled.
+- "User Only" will lose automatic classifier-driven retain; those users will need to use explicit retain (tool or future command) for User Bank writes going forward. This is a narrower, more predictable contract, consistent with every other profile.
+- `extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`, and `tests/memory-router.test.ts` will be removed, along with the `"router"` value from `userRetain.mode`/`globalRetain.mode` and the router-eval-fixture taxonomy documented in ADR-002.
+- A new `recall.userMaxTokens` config field, default value, and normalization will ship.
+
+Effective immediately with this ADR:
+
+- ADR-002 (explicit routing strategy seam) is superseded by this decision for the router's future; its routing-input/output shape documentation becomes historical context, not a live contract to maintain (see the amendment added to ADR-002).
 
 ## Follow-up implementation issues
 
@@ -77,5 +82,5 @@ Filed from this ADR's acceptance, per #424's acceptance criteria:
 
 - Remove the heuristic memory router (`memory-router.ts`, `routing-strategy.ts`, router eval tests), drop `"router"` from the `userRetain.mode`/`globalRetain.mode` type, and add config migration/normalization so existing `"router"`-mode configs fall back to `"explicit-only"` without erroring.
 - Add `recall.userMaxTokens` (default 400) and apply it to the User Bank recall scope in `recallForContext`, independent of `recall.maxTokens`.
-- Update `docs-site/.../start/memory-profiles.md`, `docs-site/.../concepts/memory-banks.md`, and `docs/compatibility.md` to reflect the router removal and the per-bank token budget split.
+- Update `docs-site/src/content/docs/start/memory-profiles.md`, `docs-site/src/content/docs/concepts/memory-banks.md`, and `docs/compatibility.md` to reflect the router removal and the per-bank token budget split.
 - Mark ADR-002 as superseded by this ADR for the router-specific sections once the removal ships.

--- a/docs/adr/004-lifeos-dual-bank-design.md
+++ b/docs/adr/004-lifeos-dual-bank-design.md
@@ -1,0 +1,81 @@
+# ADR 004: lifeOS dual-bank design (project + user memory)
+
+## Status
+
+Accepted 2026-07-03.
+
+## Context
+
+Pi Hindsight already supports two kinds of memory: a per-repo **Project Bank** and an optional cross-project **User Bank** (the "lifeOS" memory — durable preferences, recurring workflows, coding habits). #420 built tag-group scope isolation specifically so recall could merge both banks safely. This ADR answers the question #424 asked: should the User Bank become a first-class default next to the Project Bank, or stay opt-in, and what should happen to the heuristic memory router along the way.
+
+### Current state
+
+- Dual-bank recall already works. When a repo's config enables `banks.user`, `selectMemoryScopes` returns both a project scope and a user scope; `recallForContext` queries each bank independently and merges the rendered blocks. This is exposed today as the **"Project + User"** guided-setup profile (`docs-site/.../start/memory-profiles.md`), alongside "Project Only", "User Only", and "Recall Only".
+- Automatic retain is project-only in every profile except "User Only". Even in "Project + User", the User Bank only receives writes through explicit tools (`hindsight_retain_global`) or commands — never automatically. This is a deliberate safety choice from ADR-002 ("User Bank writes require high confidence or explicit user action") and is unchanged by this ADR.
+- A heuristic memory router (`extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`) exists to auto-classify candidate retain content as `project`/`global`/`both`/`skip` using regex keyword patterns and mission-term matching. It only auto-engages when `userRetain.mode: "router"`, which the guided-setup writer only sets for the **"User Only"** profile (no project bank to fall back to). Its own dry-run inspection tool (`hindsight_route_memory`) was already removed in the slim-surface rewrite (#417), so it now runs with no user-visible explanation of its decisions. It carries ~580 lines of implementation plus 38 parametrized eval-fixture tests.
+- **Recall token budget is not split across banks.** `recallForContext` requests the full `config.recall.maxTokens` independently for every active scope. Enabling the User Bank alongside the Project Bank silently up to doubles the memory tokens injected into every turn; nothing documents or bounds this today.
+- Config migration from the legacy `global` naming (`banks.global` → `banks.user`, `globalRetain` → `userRetain`, `globalQueryPreamble` → `userQueryPreamble`) already exists and is unaffected by this ADR.
+
+## Options considered
+
+**(a) Dual-bank default.** Enable both banks out of the box for new setups, with merged recall and routed retain.
+**(b) Opt-in User Bank with polished setup.** Keep today's model — User Bank is a deliberate choice via guided setup — and harden the gaps (budget split, router observability) rather than changing the default.
+**(c) Single project bank with user-visibility tags.** Drop the separate User Bank; mark durable facts with a tag inside the project bank instead.
+
+(c) is rejected outright: Hindsight banks are the isolation boundary, not tags. A single project bank is tied to one repo's bank ID (`deriveProjectBankId`); there is no way to recall those tagged facts while working in a _different_ repository without querying a different bank, which defeats the entire cross-project ("lifeOS") purpose. Collapsing to one bank would also regress ADR-001's invariant that project recall is repo-scoped, since "user-visible" facts would need to leak across repo tag boundaries to be found at all.
+
+The real choice is (a) vs (b).
+
+## Decision
+
+**(b): keep the User Bank opt-in; harden the existing design instead of changing the default.**
+
+This repo has a consistent, deliberate pattern of conservative defaults — `postRetainReflect` off, `userRetain.mode` explicit-only, User Bank disabled — and ADR-002 already states "Do not make User Bank automatic retain default" as a standing invariant. Defaulting the User Bank on would also mean every new install needs a second Hindsight bank configured before first use, and would silently increase the default token cost of every recall. Given Pi Hindsight's "Pi-first 1.0" scope and existing safe-by-default posture, that tradeoff is not justified today. Nothing here forecloses revisiting (a) once usage data suggests otherwise — that would be a new ADR, not a reinterpretation of this one.
+
+**The heuristic memory router is removed.** It only ever auto-engaged in the narrow "User Only" profile, its own dry-run visibility was already deleted, and a regex/keyword classifier with no user-facing explanation is exactly the kind of unmonitorable automatic write ADR-002 warned against ("The main safety risk is silent User Bank pollution"). The issue's own framing — "whether the pattern router earns its complexity or is replaced by explicit tools/commands" — is answered: replaced. "User Only" automatic retain falls back to the same explicit-only model every other profile already uses; users write User Bank memory with `hindsight_retain_global` or a command, same as "Project + User" users do today.
+
+## Recall merging and token budget split
+
+Each active scope must have a bounded, independent budget so enabling the User Bank cannot silently balloon per-turn token cost. Concretely:
+
+- `recall.maxTokens` keeps its current meaning and default (800) and continues to bound the **Project Bank** scope only. Existing project-only and project+user users see no change in Project Bank recall behavior.
+- A new `recall.userMaxTokens` (default: half of `recall.maxTokens`, i.e. 400) bounds the **User Bank** scope specifically when it participates in a recall call. User memory is meant to be a smaller, durable supplement to project context, not an equal-weight second corpus.
+- Both caps apply independently per bank query (as today), not as a shared pool — this keeps the change backward compatible and avoids new cross-scope coordination logic. The ceiling that changes is that User Bank recall no longer defaults to the same size as Project Bank recall.
+- This is a new config field with a real default, not a documentation-only fix, so it is implementation work for a follow-up issue, not this ADR.
+
+## Retain routing policy for personal vs. project facts
+
+- Automatic retain stays project-bank-only in every profile. There is no automatic classifier deciding "this fact is personal, route it to the User Bank."
+- Personal/durable facts reach the User Bank only through deliberate action: the `hindsight_retain_global` tool, or a future `/hindsight:retain-global`-style command if usage shows a need for one (not requested by this ADR).
+- `userRetain.mode` drops the `"router"` variant. The type becomes effectively single-valued (`"explicit-only"`) going forward; keeping the field (rather than deleting it outright) preserves config-file compatibility and gives room for a future, better-specified routing strategy without another rename.
+- Migration: existing configs with `userRetain.mode: "router"` (or the legacy `globalRetain.mode: "router"`) must normalize to `"explicit-only"` rather than erroring, consistent with how `enumValue()` already falls back to the default for invalid enum values today.
+
+## Bank missions and dispositions per use case
+
+No changes. `defaultProjectBankMissions()` and `defaultGlobalBankMissions()` (`extensions/banks/bank-operations.ts`) already give the Project Bank a repo-architecture/engineering-decision mission and the User Bank a durable-preferences/cross-project-workflow mission, and both are overridable via bank config. This split already matches "lifeOS vs coding" use cases well and needs no rework here.
+
+## Migration for existing configs
+
+- The existing `banks.global` → `banks.user` / `globalRetain` → `userRetain` / `globalQueryPreamble` → `userQueryPreamble` migration (`migrateUserMemoryConfigFile`) is unaffected.
+- New: `userRetain.mode: "router"` (and the legacy `globalRetain.mode: "router"`) must migrate/normalize to `"explicit-only"` once the router is removed, so existing "User Only" adopters keep working without a config error, just with automatic User Bank writes disabled until they explicitly retain.
+
+## What stays in the web UI
+
+Unchanged from the existing 1.0 support scope (`docs/surface-reference.md`'s deferred-surfaces table): cross-bank listing, bank creation/deletion, and template management remain Hindsight control-plane responsibilities. This ADR is only about which already-selected banks participate in a given repo's recall/retain and how routing between them works — not about managing banks themselves.
+
+## Consequences
+
+- No default behavior changes for existing Project Only, Recall Only, or Project + User users beyond the new `recall.userMaxTokens` cap taking effect for whichever of them already have the User Bank enabled.
+- "User Only" loses automatic classifier-driven retain; those users must use explicit retain (tool or future command) for User Bank writes going forward. This is a narrower, more predictable contract, consistent with every other profile.
+- `extensions/operations/memory-router.ts`, `extensions/lifecycle/routing-strategy.ts`, and `tests/memory-router.test.ts` are removed, along with the `"router"` value from `userRetain.mode`/`globalRetain.mode` and the router-eval-fixture taxonomy documented in ADR-002.
+- ADR-002 (explicit routing strategy seam) is superseded by this decision for the router's future; its routing-input/output shape documentation becomes historical context, not a live contract to maintain.
+- A new `recall.userMaxTokens` config field, default value, and normalization ship as part of the follow-up work.
+
+## Follow-up implementation issues
+
+Filed from this ADR's acceptance, per #424's acceptance criteria:
+
+- Remove the heuristic memory router (`memory-router.ts`, `routing-strategy.ts`, router eval tests), drop `"router"` from the `userRetain.mode`/`globalRetain.mode` type, and add config migration/normalization so existing `"router"`-mode configs fall back to `"explicit-only"` without erroring.
+- Add `recall.userMaxTokens` (default 400) and apply it to the User Bank recall scope in `recallForContext`, independent of `recall.maxTokens`.
+- Update `docs-site/.../start/memory-profiles.md`, `docs-site/.../concepts/memory-banks.md`, and `docs/compatibility.md` to reflect the router removal and the per-bank token budget split.
+- Mark ADR-002 as superseded by this ADR for the router-specific sections once the removal ships.


### PR DESCRIPTION
## Summary

Answers #424: should the User Bank (lifeOS / cross-project memory) become a first-class default next to the per-repo Project Bank, and what should happen to the heuristic memory router. This is an ADR-only PR — no code changes, per #424's own scope ("Outcome decides follow-up implementation issues; no code in this issue").

Decision, made with explicit maintainer sign-off on the two open questions before writing this ADR:

- **Keep the User Bank opt-in** (option b in the issue). Dual-bank recall already works today via the "Project + User" guided-setup profile, built on #420's tag-group scope isolation. Defaulting it on would silently double recall token cost and contradicts this repo's consistent conservative-defaults posture and ADR-002's existing "do not make User Bank automatic retain default" invariant. Option (c), a single project bank with user-visibility tags, is rejected outright — Hindsight banks, not tags, are the cross-repo isolation boundary, so it can't deliver real cross-project recall without regressing ADR-001's repo-scoped-recall invariant.
- **Remove the heuristic memory router entirely.** It only ever auto-engaged in the narrow "User Only" profile, its own dry-run tool was already removed in #417, and an unexplainable regex/keyword classifier making automatic User Bank writes is exactly the silent-pollution risk ADR-002 warned about. Personal-fact retain routing becomes explicit tools/commands only — the same model every other profile already uses.
- **New gap found and addressed in the design**: recall today requests the full `recall.maxTokens` independently per active bank scope, so enabling the User Bank silently up to doubles injected context with no documented bound. The ADR specifies a new `recall.userMaxTokens` (default: half of `recall.maxTokens`) to close this.

Also amends ADR-002's Status section with a pointer noting its router-specific sections are superseded by this decision.

## Linked issue

- Closes #424

## Scope

- `docs/adr/004-lifeos-dual-bank-design.md` (new)
- `docs-site/src/content/docs/architecture/adr/004-lifeos-dual-bank-design.md` (new, site mirror)
- `astro.config.mjs`: add ADR-004 to the sidebar
- `docs/adr/002-explicit-routing-strategy-seam.md` + site mirror: amendment note pointing to ADR-004

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — skipped because this is a docs-only change with nothing to cover.
- [ ] `npm run typecheck:tsc` — skipped because there are no source changes; `npm run check` already runs the `tsgo` typecheck.
- [ ] full matrix — skipped because this is not release or platform-sensitive work.
- [ ] package verification — skipped because no package/release artifacts changed.
- [ ] `npm run pack:verify` — skipped because no package/release artifacts changed.
- [ ] `npm run smoke:hindsight` — skipped because no runtime behavior changed.

## Release impact

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

This is a design decision record; no shipped behavior changes until the follow-up implementation issues below land.

## Risk and rollback

- Risk: none — documentation only, no code paths touched.
- Rollback/revert path: revert this PR; ADR-002 reverts to its pre-amendment state and ADR-004 is removed.

## Follow-ups

Filing immediately after this PR is up, per #424's acceptance criteria ("follow-up issues filed for the accepted design"):

- Remove the heuristic memory router (`memory-router.ts`, `routing-strategy.ts`, router eval tests); drop `"router"` from `userRetain.mode`/`globalRetain.mode`; migrate existing `"router"`-mode configs to `"explicit-only"`.
- Add `recall.userMaxTokens` (default 400) and apply it to the User Bank recall scope, independent of `recall.maxTokens`.
- Update `memory-profiles.md`, `memory-banks.md`, and `compatibility.md` once the router removal ships.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries. (unaffected — no code changes)
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight. (unaffected)
- [x] Project Bank and User Bank isolation is preserved. (this ADR reaffirms it as the reason to reject option c)
- [x] Retain Queue behavior remains queue-first and retry-safe. (unaffected)
- [x] Debug output and sidecars remain opt-in and redacted. (unaffected)
- [x] Import behavior remains deterministic and idempotent when touched. (unaffected)

## Guidance sync

- [x] This changes standing architecture guidance (ADR-002's router contract is now superseded) and records a new one (ADR-004). AGENTS.md/PRD.md source-of-truth order, contributor workflow, verification expectations, and definition of done are unaffected — no updates needed there.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice (the ADR and its cross-reference amendment).
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Before drafting, I researched current behavior in depth (dual-bank recall merging, retain routing per profile, the router's actual auto-engagement scope, and token budget handling) and surfaced the two genuinely open, hard-to-reverse product questions to the maintainer for explicit sign-off rather than deciding unilaterally: (1) dual-bank-as-default vs. hardened opt-in, and (2) the router's fate. Both are reflected in the Decision section above.
