### PR TITLE
chore(ci): exempt dependabot PRs from the PR checklist gate

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -107,6 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       !(github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.event.pull_request.title, 'chore') && contains(github.event.pull_request.title, ': release'))
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

The `pr-body` job ("PR checklist gate") in `.github/workflows/check.yml` already exempts release-please's `github-actions[bot]` PRs from `scripts/check-pr-body.mjs`'s custom template checklist, since bot-generated PR bodies can't follow our agent/human PR template. Dependabot PRs have the exact same problem but weren't exempted, so every dependabot PR permanently fails this check with no way to ever pass it. There's no branch protection configured on `main` today, so this doesn't block merges, but it's misleading, permanently-red CI signal on every dependency-bump PR.

Extend the existing exemption to also skip when the PR author is `dependabot[bot]`.

## Linked issue

- Closes #463

## Scope

- `.github/workflows/check.yml`: one added condition on the `pr-body` job's `if`.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — skipped because this is a CI workflow configuration change with no source code to cover.
- [ ] `npm run typecheck:tsc` — skipped because no source changes; `npm run check` already ran the `tsgo` typecheck.
- [ ] full matrix — skipped because this is not release or platform-sensitive work.
- [ ] package verification — skipped because no package/release artifacts changed.
- [ ] `npm run pack:verify` — skipped because no package/release artifacts changed.
- [ ] `npm run smoke:hindsight` — skipped because no runtime behavior changed.

## Release impact

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

CI-only change; no shipped extension behavior changes.

## Risk and rollback

- Risk: Very low. This only widens an existing, narrowly-scoped exemption (by exact bot username match) to one more known bot account; it does not weaken the check for any human- or agent-authored PR.
- Rollback/revert path: revert this PR; dependabot PRs go back to always failing the PR checklist gate (harmlessly, since there's no branch protection requiring it).

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries. (unaffected)
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight. (unaffected)
- [x] Project Bank and User Bank isolation is preserved. (unaffected)
- [x] Retain Queue behavior remains queue-first and retry-safe. (unaffected)
- [x] Debug output and sidecars remain opt-in and redacted. (unaffected)
- [x] Import behavior remains deterministic and idempotent when touched. (unaffected)

## Guidance sync

- [x] No changes to source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice (a single workflow condition).
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Found while working through merging dependabot PR #436 as part of release finalization — #436's only failing check was this gate.
