### PR TITLE
chore(ci): hold automatic npm publish dispatch from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,4 +36,8 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${RELEASE_TAG}"
-          gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=true
+          # publish is held at false for now (see docs/release.md); a maintainer
+          # runs `gh workflow run release.yml --ref "$RELEASE_TAG" -f publish=true`
+          # to actually publish once ready. Flip back to true to resume
+          # auto-publish on every release-please merge.
+          gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=false

--- a/docs-site/src/content/docs/development/release.md
+++ b/docs-site/src/content/docs/development/release.md
@@ -4,7 +4,9 @@ title: "Release"
 
 Release automation uses [`release-please`](https://github.com/googleapis/release-please) to turn Conventional Commits on `main` into a release PR. The release PR updates `package.json`, `package-lock.json`, `.release-please-manifest.json`, and `CHANGELOG.md`.
 
-After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. Release Please then dispatches the trusted `Release` workflow at the immutable release tag with `publish=true`; that workflow verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
+After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. Release Please then dispatches the trusted `Release` workflow at the immutable release tag; that workflow always verifies the release, and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC only when dispatched with `publish=true`. The workflow does not use `NPM_TOKEN`.
+
+The `publish` value release-please dispatches with is currently held at `false` in `.github/workflows/release-please.yml` (see the comment on the dispatch step), so merging a release PR creates the tag/GitHub release and runs verification without publishing. A maintainer publishes explicitly with `gh workflow run release.yml --ref vX.Y.Z -f publish=true` once ready. Flip the dispatch step back to `publish=true` to resume automatic publish-on-merge for future releases.
 
 ## Release checks
 
@@ -40,8 +42,8 @@ npm run check:release
 4. Confirm release/package verification passes. Use the `ci:package` or `ci:full` labels if additional gates are needed.
 5. Merge the release PR.
 6. Release-please creates the `v*.*.*` tag and GitHub release.
-7. Release Please dispatches the trusted `Release` workflow at the release tag with `publish=true`.
-8. The `Release` workflow verifies the tagged release commit and publishes to npm through trusted publishing.
+7. Release Please dispatches the trusted `Release` workflow at the release tag. It verifies the tagged release commit, and publishes to npm through trusted publishing only if the dispatch's `publish` input is `true` (currently held at `false`; see above).
+8. If publish was held, a maintainer runs `gh workflow run release.yml --ref vX.Y.Z -f publish=true` to publish once ready.
 
 Manual `Release Please` workflow dispatch can refresh the release PR if needed.
 
@@ -116,6 +118,6 @@ Optional secret and variables:
 
 An unconfigured workflow skip is not release proof for memory-path changes. Capability-gated smoke steps are evidence only for the server capabilities that actually ran; skipped advanced steps must be called out in PR verification notes.
 
-## Manual publish fallback
+## Manual publish
 
-Manual workflow dispatch of the `Release` workflow can verify only, or publish when `publish=true`. Use this fallback only when the normal release-please tag flow is blocked and a maintainer explicitly approves the manual release.
+Manual workflow dispatch of the `Release` workflow can verify only, or publish when `publish=true`. While automatic publish is held (see above), this manual dispatch is the normal way to publish after a release-please merge, not just a fallback. It is also available if the normal release-please tag flow is blocked and a maintainer explicitly approves a manual release.

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,7 +2,9 @@
 
 Release automation uses [`release-please`](https://github.com/googleapis/release-please) to turn Conventional Commits on `main` into a release PR. The release PR updates `package.json`, `package-lock.json`, `.release-please-manifest.json`, and `CHANGELOG.md`.
 
-After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. Release Please then dispatches the trusted `Release` workflow at the immutable release tag with `publish=true`; that workflow verifies and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC. The workflow does not use `NPM_TOKEN`.
+After the release PR merges, release-please creates the tag and GitHub release. The release-please config intentionally disables component tag prefixes so generated tags stay in the `vX.Y.Z` namespace used by the release workflow, rather than `pi-hindsight-vX.Y.Z`. Release Please then dispatches the trusted `Release` workflow at the immutable release tag; that workflow always verifies the release, and publishes `@luxusai/pi-hindsight` through npm trusted publishing with GitHub OIDC only when dispatched with `publish=true`. The workflow does not use `NPM_TOKEN`.
+
+The `publish` value release-please dispatches with is currently held at `false` in `.github/workflows/release-please.yml` (see the comment on the dispatch step), so merging a release PR creates the tag/GitHub release and runs verification without publishing. A maintainer publishes explicitly with `gh workflow run release.yml --ref vX.Y.Z -f publish=true` once ready. Flip the dispatch step back to `publish=true` to resume automatic publish-on-merge for future releases.
 
 ## Release checks
 
@@ -38,8 +40,8 @@ npm run check:release
 4. Confirm release/package verification passes. Use the `ci:package` or `ci:full` labels if additional gates are needed.
 5. Merge the release PR.
 6. Release-please creates the `v*.*.*` tag and GitHub release.
-7. Release Please dispatches the trusted `Release` workflow at the release tag with `publish=true`.
-8. The `Release` workflow verifies the tagged release commit and publishes to npm through trusted publishing.
+7. Release Please dispatches the trusted `Release` workflow at the release tag. It verifies the tagged release commit, and publishes to npm through trusted publishing only if the dispatch's `publish` input is `true` (currently held at `false`; see above).
+8. If publish was held, a maintainer runs `gh workflow run release.yml --ref vX.Y.Z -f publish=true` to publish once ready.
 
 Manual `Release Please` workflow dispatch can refresh the release PR if needed.
 
@@ -114,6 +116,6 @@ Optional secret and variables:
 
 An unconfigured workflow skip is not release proof for memory-path changes. Capability-gated smoke steps are evidence only for the server capabilities that actually ran; skipped advanced steps must be called out in PR verification notes.
 
-## Manual publish fallback
+## Manual publish
 
-Manual workflow dispatch of the `Release` workflow can verify only, or publish when `publish=true`. Use this fallback only when the normal release-please tag flow is blocked and a maintainer explicitly approves the manual release.
+Manual workflow dispatch of the `Release` workflow can verify only, or publish when `publish=true`. While automatic publish is held (see above), this manual dispatch is the normal way to publish after a release-please merge, not just a fallback. It is also available if the normal release-please tag flow is blocked and a maintainer explicitly approves a manual release.

--- a/tests/release-workflows.test.mjs
+++ b/tests/release-workflows.test.mjs
@@ -8,7 +8,9 @@ describe(".github/workflows/release-please.yml", () => {
     expect(content).toContain("Dispatch trusted release workflow");
     expect(content).toContain("RELEASE_TAG: ${{ steps.release.outputs.tag_name }}");
     expect(content).toContain('test -n "${RELEASE_TAG}"');
-    expect(content).toContain('gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=');
+    expect(content).toMatch(
+      /gh workflow run release\.yml --ref "\$\{RELEASE_TAG\}" -f publish=(true|false)\b/,
+    );
     expect(content).not.toContain("npm publish --provenance --access public");
   });
 });

--- a/tests/release-workflows.test.mjs
+++ b/tests/release-workflows.test.mjs
@@ -8,7 +8,7 @@ describe(".github/workflows/release-please.yml", () => {
     expect(content).toContain("Dispatch trusted release workflow");
     expect(content).toContain("RELEASE_TAG: ${{ steps.release.outputs.tag_name }}");
     expect(content).toContain('test -n "${RELEASE_TAG}"');
-    expect(content).toContain('gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=true');
+    expect(content).toContain('gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=');
     expect(content).not.toContain("npm publish --provenance --access public");
   });
 });

--- a/tests/verify-release.test.mjs
+++ b/tests/verify-release.test.mjs
@@ -89,8 +89,8 @@ describe("verify-release", () => {
     expect(releasePlease).toContain("actions: write");
     expect(releasePlease).toContain("steps.release.outputs.release_created == 'true'");
     expect(releasePlease).toContain("RELEASE_TAG: ${{ steps.release.outputs.tag_name }}");
-    expect(releasePlease).toContain(
-      'gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=',
+    expect(releasePlease).toMatch(
+      /gh workflow run release\.yml --ref "\$\{RELEASE_TAG\}" -f publish=(true|false)\b/,
     );
     expect(releasePlease).not.toContain("npm publish --provenance --access public");
     expect(release).toContain("id-token: write");

--- a/tests/verify-release.test.mjs
+++ b/tests/verify-release.test.mjs
@@ -90,7 +90,7 @@ describe("verify-release", () => {
     expect(releasePlease).toContain("steps.release.outputs.release_created == 'true'");
     expect(releasePlease).toContain("RELEASE_TAG: ${{ steps.release.outputs.tag_name }}");
     expect(releasePlease).toContain(
-      'gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=true',
+      'gh workflow run release.yml --ref "${RELEASE_TAG}" -f publish=',
     );
     expect(releasePlease).not.toContain("npm publish --provenance --access public");
     expect(release).toContain("id-token: write");


### PR DESCRIPTION
## Summary

`release-please.yml` currently dispatches `release.yml` with `publish=true` immediately and automatically whenever a release-please PR is merged, with no manual approval gate before the actual `npm publish`. For the upcoming v0.7.0 release, the maintainer wants to merge the release PR (finalizing tag/CHANGELOG/version) but review before the actual publish happens.

- Changed the auto-dispatch to `publish=false`, so merging release-please only creates the tag/GitHub release and runs the `verify` matrix (build/test/pack verification) without publishing.
- Actual publish becomes an explicit manual step: `gh workflow run release.yml --ref vX.Y.Z -f publish=true`.
- Documented the current held state and the manual publish command in `docs/release.md` (+ site mirror).
- Relaxed the two tests that hard-coded the literal `-f publish=true` dispatch string so they check the dispatch shape without pinning the toggle value, since it's now a deliberately mutable policy switch (flip back to `true` to resume auto-publish for future releases).

## Linked issue

- Closes #465

## Scope

- `.github/workflows/release-please.yml`: dispatch value + explanatory comment.
- `docs/release.md` + `docs-site/.../development/release.md`: describe current held state, manual publish command, renamed "Manual publish fallback" section to "Manual publish" since it's now the normal path while held.
- `tests/release-workflows.test.mjs`, `tests/verify-release.test.mjs`: relax the hard-coded `publish=true` assertions.

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` — skipped because this is a CI workflow + docs change with no new source lines to cover.
- [ ] `npm run typecheck:tsc` — skipped because no source changes; `npm run check` already ran the `tsgo` typecheck.
- [ ] full matrix — skipped because this is not platform-sensitive work.
- [ ] package verification — skipped because no package/release artifacts changed (this only changes when publish happens, not what gets published).
- [ ] `npm run pack:verify` — skipped because no package contents changed.
- [ ] `npm run smoke:hindsight` — skipped because no runtime extension behavior changed.

## Release impact

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

This changes the release *process* (manual publish approval instead of automatic), not the published package's behavior.

## Risk and rollback

- Risk: Very low. Worst case if forgotten: a merged release-please PR creates a tag/GitHub release but never gets published to npm until someone notices and runs the manual dispatch — a safe failure mode (under-publishing, not accidentally over-publishing).
- Rollback/revert path: revert this PR, or simply flip `-f publish=false` back to `-f publish=true` in `release-please.yml`, to resume automatic publish-on-merge.

## Follow-ups

- None required. Revisit whether to restore auto-publish in a future release once the maintainer is comfortable with the release cadence (noted in #465).

## Memory invariants

- [x] Retain still stores raw rich content, not summaries. (unaffected)
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight. (unaffected)
- [x] Project Bank and User Bank isolation is preserved. (unaffected)
- [x] Retain Queue behavior remains queue-first and retry-safe. (unaffected)
- [x] Debug output and sidecars remain opt-in and redacted. (unaffected)
- [x] Import behavior remains deterministic and idempotent when touched. (unaffected)

## Guidance sync

- [x] This changes the documented release process (`docs/release.md`), which I updated in the same PR per AGENTS.md's requirement to keep contributor-facing docs aligned with actual behavior.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice (the publish-hold switch and its docs/tests).
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Requested directly by the maintainer as part of preparing to merge release-please PR #431 for v0.7.0: merge the release PR to finalize versioning, but hold the actual npm publish for manual review first.
