### PR TITLE
feat(recall): add score floor quality gate

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,9 @@ export PI_HINDSIGHT_PROJECT_BANK_ID=pi-project-my-repo
 export PI_HINDSIGHT_USER_BANK_ID=user-luxus
 # Legacy fallback still works during migration:
 # export PI_HINDSIGHT_GLOBAL_BANK_ID=global-luxus
+# Optional recall quality floors:
+export PI_HINDSIGHT_MIN_RERANKER=0.2
+export PI_HINDSIGHT_MIN_SEMANTIC=0.65
 ```
 
 Project config SecretRef shape:
@@ -105,7 +108,11 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
     "topK": 8,
     "timeoutMs": 40000,
     "cacheTtlMs": 60000,
-    "injectionPosition": "append"
+    "injectionPosition": "append",
+    "minScores": {
+      "reranker": 0.2,
+      "semantic": 0.65
+    }
   },
   "observations": {
     "enabled": true,
@@ -139,3 +146,10 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
   }
 }
 ```
+
+`recall.minScores` is optional and defaults to no floors, preserving current recall behavior.
+When set, automatic recall drops results whose returned `scores.semantic`, `scores.reranker`,
+`scores.final`, or `scores.keyword` is below the configured floor. Results with no `scores`
+object, or with a missing score field, pass through so BM25-only hits and passthrough
+rerankers are not silently discarded. `PI_HINDSIGHT_MIN_SEMANTIC` and
+`PI_HINDSIGHT_MIN_RERANKER` override the matching config floors when set.

--- a/extensions/config/config-normalize.ts
+++ b/extensions/config/config-normalize.ts
@@ -1,4 +1,9 @@
-import type { HindsightEntityInput, ResolvedConfig } from "../types.js";
+import {
+  RECALL_SCORE_FIELDS,
+  type HindsightEntityInput,
+  type RecallMinScores,
+  type ResolvedConfig,
+} from "../types.js";
 import { DEFAULT_CONFIG } from "./config-defaults.js";
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
@@ -132,6 +137,18 @@ function toolNameFilter(
   };
 }
 
+function scoreFloors(value: unknown): RecallMinScores | undefined {
+  if (!isRecord(value)) return undefined;
+  const floors: RecallMinScores = {};
+  for (const field of RECALL_SCORE_FIELDS) {
+    const valueForField = value[field];
+    if (typeof valueForField === "number" && Number.isFinite(valueForField)) {
+      floors[field] = valueForField;
+    }
+  }
+  return Object.keys(floors).length ? floors : undefined;
+}
+
 function hasConfiguredRecallField(rawConfig: unknown, field: string): boolean {
   return isRecord(rawConfig) && isRecord(rawConfig.recall) && field in rawConfig.recall;
 }
@@ -175,6 +192,7 @@ export function normalizeConfig(
   const userBankConfig = config.banks?.user ?? config.banks?.global;
   const defaultUserBankConfig = DEFAULT_CONFIG.banks.user;
   const globalBankId = optionalString(userBankConfig?.bankId, defaultUserBankConfig.bankId);
+  const minScores = scoreFloors(config.recall?.minScores);
   return {
     enabled: bool(config.enabled, DEFAULT_CONFIG.enabled),
     hindsight: {
@@ -306,6 +324,7 @@ export function normalizeConfig(
         config.recall?.preferObservations,
         DEFAULT_CONFIG.recall.preferObservations,
       ),
+      ...(minScores ? { minScores } : {}),
       ...(optionalString(config.recall?.queryTimestamp, DEFAULT_CONFIG.recall.queryTimestamp)
         ? {
             queryTimestamp: stringValue(

--- a/extensions/config/config.ts
+++ b/extensions/config/config.ts
@@ -160,5 +160,21 @@ export function resolveConfig(cwd: string, env: NodeJS.ProcessEnv = process.env)
     rawConfig = merge(rawConfig, patch);
     config = merge(config, patch);
   }
+  const minScores: Record<string, number> = {};
+  const semanticFloor =
+    env.PI_HINDSIGHT_MIN_SEMANTIC?.trim() === ""
+      ? Number.NaN
+      : Number(env.PI_HINDSIGHT_MIN_SEMANTIC);
+  if (Number.isFinite(semanticFloor)) minScores.semantic = semanticFloor;
+  const rerankerFloor =
+    env.PI_HINDSIGHT_MIN_RERANKER?.trim() === ""
+      ? Number.NaN
+      : Number(env.PI_HINDSIGHT_MIN_RERANKER);
+  if (Number.isFinite(rerankerFloor)) minScores.reranker = rerankerFloor;
+  if (Object.keys(minScores).length) {
+    const patch = { recall: { minScores } };
+    rawConfig = merge(rawConfig, patch);
+    config = merge(config, patch);
+  }
   return normalizeConfig(config, rawConfig, env);
 }

--- a/extensions/lifecycle/recall.ts
+++ b/extensions/lifecycle/recall.ts
@@ -1,11 +1,13 @@
 import { basename } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { RECALL_SCORE_FIELDS } from "../types.js";
 import type {
   HindsightLikeClient,
   HindsightTagGroup,
   RecallBlock,
   RecallFailure,
   RecallResultItem,
+  RecallMinScores,
   RecallRole,
   ResolvedConfig,
 } from "../types.js";
@@ -206,7 +208,10 @@ export async function recallForContext(args: {
           ...(scope.tagGroups?.length ? { tagGroups: scope.tagGroups } : {}),
         }),
       );
-      const results = filterRecallQuality(textFromRecallResponse(response)).items;
+      const results = filterRecallQuality(
+        textFromRecallResponse(response),
+        args.config.recall.minScores,
+      ).items;
       blocks.push({
         bankId: scope.bankId,
         query,
@@ -233,7 +238,11 @@ export async function recallForContext(args: {
   };
 }
 
-export type RecallQualityDropReason = "blank-memory" | "recall-contamination" | "duplicate-memory";
+export type RecallQualityDropReason =
+  | "blank-memory"
+  | "recall-contamination"
+  | "duplicate-memory"
+  | "below-score-floor";
 
 export interface RecallQualityDecision {
   item: RecallResultItem;
@@ -251,27 +260,46 @@ function isRecallContamination(text: string): boolean {
   );
 }
 
+function isBelowScoreFloor(item: RecallResultItem, minScores?: RecallMinScores): boolean {
+  if (!minScores) return false;
+  const scores = item.scores;
+  // Fail open when Hindsight omits scores so BM25-only hits and passthrough rerankers
+  // are not silently discarded by local policy.
+  if (!scores) return false;
+  for (const field of RECALL_SCORE_FIELDS) {
+    const floor = minScores[field];
+    const value = scores[field];
+    if (typeof floor === "number" && typeof value === "number" && value < floor) return true;
+  }
+  return false;
+}
+
 export function classifyRecallQuality(
   item: RecallResultItem,
   seen: Set<string>,
+  minScores?: RecallMinScores,
 ): RecallQualityDecision {
   const text = normalizedMemoryText(item);
   const reasons: RecallQualityDropReason[] = [];
   if (!text) reasons.push("blank-memory");
   if (isRecallContamination(itemText(item))) reasons.push("recall-contamination");
   if (text && seen.has(text)) reasons.push("duplicate-memory");
+  if (isBelowScoreFloor(item, minScores)) reasons.push("below-score-floor");
   if (!reasons.length) seen.add(text);
   return { item, decision: reasons.length ? "drop" : "keep", reasons };
 }
 
-export function filterRecallQuality(items: RecallResultItem[]): {
+export function filterRecallQuality(
+  items: RecallResultItem[],
+  minScores?: RecallMinScores,
+): {
   items: RecallResultItem[];
   decisions: RecallQualityDecision[];
   dropped: number;
   reasonCounts: Partial<Record<RecallQualityDropReason, number>>;
 } {
   const seen = new Set<string>();
-  const decisions = items.map((item) => classifyRecallQuality(item, seen));
+  const decisions = items.map((item) => classifyRecallQuality(item, seen, minScores));
   const reasonCounts: Partial<Record<RecallQualityDropReason, number>> = {};
   for (const decision of decisions) {
     for (const reason of decision.reasons) reasonCounts[reason] = (reasonCounts[reason] ?? 0) + 1;

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -37,6 +37,10 @@ export type GlobalRetainMode = "explicit-only";
 export type ImportMode = "curated" | "raw" | "forensic";
 export type ImportQualityProfile = "compatible" | "strict";
 
+export const RECALL_SCORE_FIELDS = ["semantic", "reranker", "final", "keyword"] as const;
+export type RecallScoreField = (typeof RECALL_SCORE_FIELDS)[number];
+export type RecallMinScores = Partial<Record<RecallScoreField, number>>;
+
 export interface BankMissionSettings {
   retainMission?: string;
   reflectMission?: string;
@@ -89,6 +93,7 @@ export interface ResolvedConfig {
     includeFactsInDebug: boolean;
     queryTimestamp?: string;
     preferObservations: boolean;
+    minScores?: RecallMinScores;
   };
   observations: {
     enabled: boolean;
@@ -168,6 +173,14 @@ export interface RecallResultItem {
   occurred_start?: string | null;
   source_fact_ids?: string[];
   sourceFacts?: string[];
+  scores?: RecallResultScores;
+}
+
+export interface RecallResultScores {
+  semantic?: number | null;
+  reranker?: number | null;
+  final?: number | null;
+  keyword?: number | null;
 }
 
 export interface RecallFailure {

--- a/extensions/utils/diagnostics.ts
+++ b/extensions/utils/diagnostics.ts
@@ -260,6 +260,7 @@ export function formatDebugReport(args: DebugReportArgs): string {
         topK: args.config.recall.topK,
         timeoutMs: args.config.recall.timeoutMs,
         injectionPosition: args.config.recall.injectionPosition,
+        minScores: args.config.recall.minScores,
       },
       retain: {
         enabled: args.config.retain.enabled,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -346,6 +346,24 @@ describe("resolveConfig", () => {
     expect(config.recall.preferObservations).toBe(false);
   });
 
+  it("normalizes recall score floors from config and env overrides", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({ recall: { minScores: { semantic: 0.65, reranker: "bad", final: null } } }),
+    );
+
+    const fromConfig = resolveConfig(cwd, {});
+    expect(fromConfig.recall.minScores).toEqual({ semantic: 0.65 });
+
+    const fromEnv = resolveConfig(cwd, {
+      PI_HINDSIGHT_MIN_SEMANTIC: "0.7",
+      PI_HINDSIGHT_MIN_RERANKER: "0.2",
+    });
+    expect(fromEnv.recall.minScores).toEqual({ semantic: 0.7, reranker: 0.2 });
+  });
+
   it("reads JSONC config and release API knobs", () => {
     const cwd = tmp();
     mkdirSync(join(cwd, ".pi"));

--- a/tests/recall-quality-fixtures.test.ts
+++ b/tests/recall-quality-fixtures.test.ts
@@ -31,6 +31,26 @@ describe("recall quality fixtures", () => {
     });
   });
 
+  it("drops recall results below configured score floors and fails open for missing scores", () => {
+    const result = filterRecallQuality(
+      [
+        { text: "Relevant project decision.", scores: { semantic: 0.72, reranker: 0.41 } },
+        { text: "Low semantic candidate.", scores: { semantic: 0.2, reranker: 0.9 } },
+        { text: "Low reranker candidate.", scores: { semantic: 0.9, reranker: 0.03 } },
+        { text: "BM25-only candidate without scores." },
+        { text: "Passthrough reranker candidate.", scores: { semantic: 0.9 } },
+      ],
+      { semantic: 0.65, reranker: 0.2 },
+    );
+
+    expect(result.items.map((item) => item.text)).toEqual([
+      "Relevant project decision.",
+      "BM25-only candidate without scores.",
+      "Passthrough reranker candidate.",
+    ]);
+    expect(result.reasonCounts).toEqual({ "below-score-floor": 2 });
+  });
+
   it("keeps high-signal workflow memories and excludes recalled-memory artifacts in context recall", async () => {
     const client: HindsightLikeClient = {
       retain: async () => undefined,


### PR DESCRIPTION
## Summary

- Adds optional `recall.minScores` floors for automatic Recall quality filtering so per-prompt auto-recall can err toward not injecting low-confidence top-k results.
- Preserves current behavior by default: no floors are applied unless config or env overrides set them.
- Types Hindsight recall result `scores` and keeps score-floor filtering fail-open for BM25-only hits or passthrough rerankers that do not return every score field.

## Linked issue

- Closes #473

## Scope

- Adds `RecallResultScores`/`RecallMinScores` typing and local Recall quality drop reason `below-score-floor`.
- Normalizes `recall.minScores` from config and `PI_HINDSIGHT_MIN_SEMANTIC` / `PI_HINDSIGHT_MIN_RERANKER` env overrides.
- Documents the new config and adds unit coverage for score-floor drops, fail-open missing scores, and config/env normalization.

## Verification

- [x] `npm run check` (ran via the repository pre-commit hook during `git commit`; 58 files, 479 tests passed)
- [ ] `npm run check:coverage` (not run because this focused PR only needed targeted coverage plus the full pre-commit `npm run check`; coverage gate is left for CI/maintainers)
- [x] `npm run typecheck:tsc`
- [ ] full matrix requested/passed (not run; not a release or platform-sensitive change)
- [ ] package verification requested/passed (not run; no package/release path changes)
- [ ] `npm run pack:verify` (not run; no package/release path changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (not run because no configured live Hindsight server is available here; unit tests cover local quality-policy behavior and defaults-off config behavior)

Additional targeted checks run before commit:

- [x] `npm test -- tests/recall-quality-fixtures.test.ts tests/config.test.ts` (25 tests passed)
- [x] `npm run typecheck`
- [x] `npx oxlint --type-aware --type-check extensions/lifecycle/recall.ts extensions/config/config-normalize.ts extensions/config/config.ts extensions/types.ts extensions/utils/diagnostics.ts tests/recall-quality-fixtures.test.ts tests/config.test.ts`
- [x] `npx oxfmt --check extensions/lifecycle/recall.ts extensions/config/config-normalize.ts extensions/config/config.ts extensions/types.ts extensions/utils/diagnostics.ts tests/recall-quality-fixtures.test.ts tests/config.test.ts docs/configuration.md`
- [x] `npm run surface-reference:check && npm run docs:links`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds optional Recall score-floor configuration. Defaults preserve existing behavior; release notes should mention `recall.minScores` and the semantic/reranker env overrides.

## Risk and rollback

- Risk: Misconfigured floors could drop useful Recall candidates before injection. Missing `scores` and missing score fields fail open to avoid silently discarding BM25-only hits or passthrough reranker results.
- Rollback/revert path: Revert this commit, or remove `recall.minScores` / unset `PI_HINDSIGHT_MIN_SEMANTIC` and `PI_HINDSIGHT_MIN_RERANKER` to restore current behavior.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] This does not change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done; `AGENTS.md` and `CONTRIBUTING.md` did not need updates.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation landed in a PR. Direct maintainer assignment arrived without a preexisting issue; I created and linked #473 before opening the PR.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Per-prompt auto-recall injects whatever top-k returns today. A reranker/semantic floor lets deployments choose not to inject low-confidence candidates; in the motivating measurement, junk prompts reranked at 0.00-0.03 while relevant prompts reranked at 0.37-1.0. Defaults keep current behavior unchanged.

