### PR TITLE
feat(banks): bundle starter bank templates with browse/apply commands

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,14 @@ An optional shared bank for durable user-level preferences, recurring workflows,
 
 A stable name that resolves to a real bank ID. `project` means the selected Project Bank. `global` is the legacy/internal alias for the configured User Bank. Prefer **User Bank** in user-facing docs when the exact bank ID is not important.
 
+### Bank Template
+
+A Hindsight manifest (bank config overrides, mental models, directives) that provisions a bank in one call. `pi-hindsight` bundles a small, fixed set of built-in templates (`/hindsight:templates`, `/hindsight:template-apply`) targeted at its own Project Bank and User Bank missions; browsing, editing, and exporting arbitrary templates remains a Hindsight control-plane responsibility.
+
+### Mental Model
+
+A Hindsight-synthesized, reusable answer to a recurring question over stored memory, refreshed via Reflect rather than recalled raw. `pi-hindsight` does not expose ad hoc mental model creation, editing, or refresh; the Hindsight control-plane web UI owns that lifecycle. The bundled Bank Templates are the one explicit, dry-run-gated exception: applying one creates or updates its fixed set of starter mental models.
+
 ### Retain
 
 A write to Hindsight. Retain stores raw rich content, not summaries. Automatic retain writes structured session deltas after turns; explicit retain writes user-provided content through tools or commands.

--- a/docs-site/src/content/docs/architecture/adr/004-lifeos-dual-bank-design.md
+++ b/docs-site/src/content/docs/architecture/adr/004-lifeos-dual-bank-design.md
@@ -6,6 +6,8 @@ title: "ADR 004: lifeOS dual-bank design"
 
 Accepted 2026-07-03.
 
+Amendment (2026-07): the "What stays in the web UI" section below cited the generated surface reference's deferred-surfaces table for "template management remains a Hindsight control-plane responsibility." That table (generated from the operation catalog) never actually listed template management as a row; the citation was inaccurate, not a decision this ADR made. Separately, #467 narrowed the underlying claim: `pi-hindsight` now bundles a small, fixed set of starter bank templates (`/hindsight:templates`, `/hindsight:template-apply`) applied via the official Hindsight client's bank-template import endpoint. Arbitrary template authoring, editing, export, and cross-bank template catalog browsing remain control-plane-only; applying one of the two bundled, reviewed templates to the already-selected bank does not.
+
 ## Context
 
 Pi Hindsight already supports two kinds of memory: a per-repo **Project Bank** and an optional cross-project **User Bank** (the "lifeOS" memory — durable preferences, recurring workflows, coding habits). #420 built tag-group scope isolation specifically so recall could merge both banks safely. This ADR answers the question #424 asked: should the User Bank become a first-class default next to the Project Bank, or stay opt-in, and what should happen to the heuristic memory router along the way.
@@ -63,7 +65,7 @@ No changes. `defaultProjectBankMissions()` and `defaultGlobalBankMissions()` (`e
 
 ## What stays in the web UI
 
-Unchanged from the existing 1.0 support scope ([Surface reference](/pi-hindsight/reference/surface-reference/)'s deferred-surfaces table): cross-bank listing, bank creation/deletion, and template management remain Hindsight control-plane responsibilities. This ADR is only about which already-selected banks participate in a given repo's recall/retain and how routing between them works — not about managing banks themselves.
+Unchanged from the existing 1.0 support scope ([Surface reference](/pi-hindsight/reference/surface-reference/)'s "Deferred or non-goal upstream surfaces" table): cross-bank listing and bank deletion remain Hindsight control-plane responsibilities. Template management is narrower after #467: `pi-hindsight` bundles a small, fixed set of reviewed starter templates and can apply one to the already-selected bank, but arbitrary template authoring, editing, export, and a general template catalog stay control-plane-only. This ADR is only about which already-selected banks participate in a given repo's recall/retain and how routing between them works — not about managing banks themselves.
 
 ## Consequences
 

--- a/docs-site/src/content/docs/concepts/starter-mental-model-suggestions.md
+++ b/docs-site/src/content/docs/concepts/starter-mental-model-suggestions.md
@@ -6,7 +6,9 @@ Mental models should start as explicit, inspectable user choices. Pi Hindsight m
 
 ## Placement decision
 
-Starter suggestions live in docs only. Mental models are created and managed in the Hindsight control-plane web UI; Pi does not expose mental model creation. Use the suggestions below as copy-paste material when creating models in the web UI.
+Starter suggestions live in docs only, and ad hoc mental models are created and managed in the Hindsight control-plane web UI; Pi does not expose general-purpose mental model creation. Use the suggestions below as copy-paste material when creating custom models in the web UI.
+
+The one exception: the suggestions on this page are also the exact content of pi-hindsight's bundled [bank templates](/pi-hindsight/reference/tools-and-commands/#bank-templates) (`/hindsight:templates`, `/hindsight:template-apply`). Applying one of those two fixed, reviewed templates does create these specific mental models via Hindsight's bank-template import endpoint — a curated, dry-run-gated, explicit-command action, not the general mental-model editor described below. This page is the source of truth for what those bundled mental models ask and why; keep `extensions/banks/bank-templates.ts` in sync with it, not the other way around.
 
 ## Product rules
 
@@ -55,4 +57,6 @@ Avoid starter mental models for:
 
 ## Web UI handoff
 
-Pi intentionally does not recreate Hindsight's mental model editor. All create/edit/refresh/delete happens in the Hindsight control-plane web UI. If Pi ever surfaces these suggestions interactively, it must stay read-only with a web interface handoff, and it should not hide source queries behind friendly labels.
+Pi intentionally does not recreate Hindsight's mental model editor. Custom mental models — anything beyond the two bundled bank templates above — are create/edit/refresh/delete only in the Hindsight control-plane web UI. If Pi ever surfaces these suggestions interactively outside of applying a bundled template, it must stay read-only with a web interface handoff, and it should not hide source queries behind friendly labels.
+
+The bundled bank templates are held to a narrower, still-conservative bar: they are exactly the fixed content on this page (no free-form model authoring), applying one is always an explicit command with a dry-run preview, and the preview always shows each model's name, source query, and tags before the user is asked to confirm.

--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -113,24 +113,26 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 
 ## Commands
 
-| Command                              | Description                                                                                                  |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `/hindsight`                         | Open Hindsight memory TUI.                                                                                   |
-| `/hindsight:init`                    | Write .pi/hindsight.json with the currently selected project bank.                                           |
-| `/hindsight:import`                  | Import the current Pi session JSONL into Hindsight.                                                          |
-| `/hindsight:import-current`          | Import the current Pi session JSONL into Hindsight.                                                          |
-| `/hindsight:import-file`             | Import an explicit Pi session JSONL file into Hindsight.                                                     |
-| `/hindsight:import-project-sessions` | Import Pi session JSONL files scoped to the current repo/cwd.                                                |
-| `/hindsight:session`                 | Show current Hindsight session memory mode and tags.                                                         |
-| `/hindsight:mode`                    | Set session memory mode: normal, read-only, or ignored.                                                      |
-| `/hindsight:next-opt-out`            | Skip automatic retain for the next agent run in this session.                                                |
-| `/hindsight:retain`                  | Enable or disable retain for this session.                                                                   |
-| `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                              |
-| `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                              |
-| `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript.            |
-| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                               |
-| `/hindsight:flush`                   | Flush queued retain jobs.                                                                                    |
-| `/hindsight:doctor`                  | Emit a machine-readable Hindsight diagnostics report (connectivity, queue, imports, config) for bug reports. |
+| Command                              | Description                                                                                                                                                    |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/hindsight`                         | Open Hindsight memory TUI.                                                                                                                                     |
+| `/hindsight:init`                    | Write .pi/hindsight.json with the currently selected project bank.                                                                                             |
+| `/hindsight:import`                  | Import the current Pi session JSONL into Hindsight.                                                                                                            |
+| `/hindsight:import-current`          | Import the current Pi session JSONL into Hindsight.                                                                                                            |
+| `/hindsight:import-file`             | Import an explicit Pi session JSONL file into Hindsight.                                                                                                       |
+| `/hindsight:import-project-sessions` | Import Pi session JSONL files scoped to the current repo/cwd.                                                                                                  |
+| `/hindsight:session`                 | Show current Hindsight session memory mode and tags.                                                                                                           |
+| `/hindsight:mode`                    | Set session memory mode: normal, read-only, or ignored.                                                                                                        |
+| `/hindsight:next-opt-out`            | Skip automatic retain for the next agent run in this session.                                                                                                  |
+| `/hindsight:retain`                  | Enable or disable retain for this session.                                                                                                                     |
+| `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                                                                                |
+| `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                                                                                |
+| `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript.                                                              |
+| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                                                                                 |
+| `/hindsight:flush`                   | Flush queued retain jobs.                                                                                                                                      |
+| `/hindsight:doctor`                  | Emit a machine-readable Hindsight diagnostics report (connectivity, queue, imports, config) for bug reports.                                                   |
+| `/hindsight:templates`               | List bundled Hindsight bank templates.                                                                                                                         |
+| `/hindsight:template-apply`          | Apply a bundled Hindsight bank template: writes bank config and creates/updates mental models. Defaults to a dry-run preview with confirmation before writing. |
 
 ## Config fields
 

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -12,7 +12,7 @@ For a generated reference of registered tools, commands, and editable config fie
 /hindsight
 ```
 
-Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. Status activity can distinguish recall, retain, and import work, including `importing`, `imported`, `import-queued`, and `import-failed`. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Mental models and directives are managed in the Hindsight control-plane web UI.
+Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. Status activity can distinguish recall, retain, and import work, including `importing`, `imported`, `import-queued`, and `import-failed`. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Directives, and arbitrary/custom mental models, are managed in the Hindsight control-plane web UI; see [Bank templates](#bank-templates) below for the one exception (a small bundled set of starter mental models).
 
 ## Setup and config
 
@@ -69,6 +69,16 @@ Use dry-run before non-dry-run imports. See [Import controls](/pi-hindsight/refe
 - `next-opt-out`: skips automatic retain once, then clears itself.
 - manual tags are merged into automatic retain jobs.
 
+## Bank templates
+
+```text
+/hindsight:templates
+/hindsight:template-apply <id>
+/hindsight:template-apply <id> --dry-run
+```
+
+`/hindsight:templates` lists pi-hindsight's small, fixed set of bundled bank templates (see [Starter mental model suggestions](/pi-hindsight/concepts/starter-mental-model-suggestions/) for the mental models they create). `/hindsight:template-apply <id>` writes bank config overrides and creates/updates the template's mental models via Hindsight's bank-template import endpoint, targeting whichever bank (Project or User) the template declares. Bank config falls back to Pi's default missions the same way `ensureProjectBank`/`ensureGlobalBank` do — any mission you've already customized in config is kept, never overwritten by the template default. It previews with `dryRun` and asks for confirmation before writing unless `--dry-run` is passed. This is the one place pi-hindsight creates mental models directly; everything beyond these bundled templates — arbitrary template authoring, editing, export, and directive management — stays in the Hindsight control-plane web UI.
+
 ## Explicit tools
 
 Pi exposes exactly four memory tools:
@@ -78,7 +88,7 @@ Pi exposes exactly four memory tools:
 - `hindsight_retain_global`
 - `hindsight_reflect`
 
-Everything else — bank config/profile administration, document/entity/graph/tag browsing, memory inspection, consolidation control, and operation management — lives in the Hindsight control-plane web UI.
+Everything else — bank config/profile administration, document/entity/graph/tag browsing, memory inspection, consolidation control, and operation management — lives in the Hindsight control-plane web UI, except for the bundled [Bank templates](#bank-templates) commands above.
 
 Tool notes:
 

--- a/docs/adr/004-lifeos-dual-bank-design.md
+++ b/docs/adr/004-lifeos-dual-bank-design.md
@@ -4,6 +4,8 @@
 
 Accepted 2026-07-03.
 
+Amendment (2026-07): the "What stays in the web UI" section below cited `docs/surface-reference.md`'s deferred-surfaces table for "template management remains a Hindsight control-plane responsibility." That table (generated from the operation catalog) never actually listed template management as a row; the citation was inaccurate, not a decision this ADR made. Separately, #467 narrowed the underlying claim: `pi-hindsight` now bundles a small, fixed set of starter bank templates (`/hindsight:templates`, `/hindsight:template-apply`) applied via the official Hindsight client's bank-template import endpoint. Arbitrary template authoring, editing, export, and cross-bank template catalog browsing remain control-plane-only; applying one of the two bundled, reviewed templates to the already-selected bank does not.
+
 ## Context
 
 Pi Hindsight already supports two kinds of memory: a per-repo **Project Bank** and an optional cross-project **User Bank** (the "lifeOS" memory — durable preferences, recurring workflows, coding habits). #420 built tag-group scope isolation specifically so recall could merge both banks safely. This ADR answers the question #424 asked: should the User Bank become a first-class default next to the Project Bank, or stay opt-in, and what should happen to the heuristic memory router along the way.
@@ -61,7 +63,7 @@ No changes. `defaultProjectBankMissions()` and `defaultGlobalBankMissions()` (`e
 
 ## What stays in the web UI
 
-Unchanged from the existing 1.0 support scope (`docs/surface-reference.md`'s deferred-surfaces table): cross-bank listing, bank creation/deletion, and template management remain Hindsight control-plane responsibilities. This ADR is only about which already-selected banks participate in a given repo's recall/retain and how routing between them works — not about managing banks themselves.
+Unchanged from the existing 1.0 support scope (`docs/surface-reference.md`'s "Deferred or non-goal upstream surfaces" table): cross-bank listing and bank deletion remain Hindsight control-plane responsibilities. Template management is narrower after #467: `pi-hindsight` bundles a small, fixed set of reviewed starter templates and can apply one to the already-selected bank, but arbitrary template authoring, editing, export, and a general template catalog stay control-plane-only. This ADR is only about which already-selected banks participate in a given repo's recall/retain and how routing between them works — not about managing banks themselves.
 
 ## Consequences
 

--- a/docs/starter-mental-model-suggestions.md
+++ b/docs/starter-mental-model-suggestions.md
@@ -4,7 +4,9 @@ Mental models should start as explicit, inspectable user choices. Pi Hindsight m
 
 ## Placement decision
 
-Starter suggestions live in docs only. Mental models are created and managed in the Hindsight control-plane web UI; Pi does not expose mental model creation. Use the suggestions below as copy-paste material when creating models in the web UI.
+Starter suggestions live in docs only, and ad hoc mental models are created and managed in the Hindsight control-plane web UI; Pi does not expose general-purpose mental model creation. Use the suggestions below as copy-paste material when creating custom models in the web UI.
+
+The one exception: the suggestions on this page are also the exact content of pi-hindsight's bundled [bank templates](https://luxus.github.io/pi-hindsight/reference/tools-and-commands/#bank-templates) (`/hindsight:templates`, `/hindsight:template-apply`). Applying one of those two fixed, reviewed templates does create these specific mental models via Hindsight's bank-template import endpoint — a curated, dry-run-gated, explicit-command action, not the general mental-model editor described below. This page is the source of truth for what those bundled mental models ask and why; keep `extensions/banks/bank-templates.ts` in sync with it, not the other way around.
 
 ## Product rules
 
@@ -53,4 +55,6 @@ Avoid starter mental models for:
 
 ## Web UI handoff
 
-Pi intentionally does not recreate Hindsight's mental model editor. All create/edit/refresh/delete happens in the Hindsight control-plane web UI. If Pi ever surfaces these suggestions interactively, it must stay read-only with a web interface handoff, and it should not hide source queries behind friendly labels.
+Pi intentionally does not recreate Hindsight's mental model editor. Custom mental models — anything beyond the two bundled bank templates above — are create/edit/refresh/delete only in the Hindsight control-plane web UI. If Pi ever surfaces these suggestions interactively outside of applying a bundled template, it must stay read-only with a web interface handoff, and it should not hide source queries behind friendly labels.
+
+The bundled bank templates are held to a narrower, still-conservative bar: they are exactly the fixed content on this page (no free-form model authoring), applying one is always an explicit command with a dry-run preview, and the preview always shows each model's name, source query, and tags before the user is asked to confirm.

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -109,24 +109,26 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 
 ## Commands
 
-| Command                              | Description                                                                                                  |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `/hindsight`                         | Open Hindsight memory TUI.                                                                                   |
-| `/hindsight:init`                    | Write .pi/hindsight.json with the currently selected project bank.                                           |
-| `/hindsight:import`                  | Import the current Pi session JSONL into Hindsight.                                                          |
-| `/hindsight:import-current`          | Import the current Pi session JSONL into Hindsight.                                                          |
-| `/hindsight:import-file`             | Import an explicit Pi session JSONL file into Hindsight.                                                     |
-| `/hindsight:import-project-sessions` | Import Pi session JSONL files scoped to the current repo/cwd.                                                |
-| `/hindsight:session`                 | Show current Hindsight session memory mode and tags.                                                         |
-| `/hindsight:mode`                    | Set session memory mode: normal, read-only, or ignored.                                                      |
-| `/hindsight:next-opt-out`            | Skip automatic retain for the next agent run in this session.                                                |
-| `/hindsight:retain`                  | Enable or disable retain for this session.                                                                   |
-| `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                              |
-| `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                              |
-| `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript.            |
-| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                               |
-| `/hindsight:flush`                   | Flush queued retain jobs.                                                                                    |
-| `/hindsight:doctor`                  | Emit a machine-readable Hindsight diagnostics report (connectivity, queue, imports, config) for bug reports. |
+| Command                              | Description                                                                                                                                                    |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/hindsight`                         | Open Hindsight memory TUI.                                                                                                                                     |
+| `/hindsight:init`                    | Write .pi/hindsight.json with the currently selected project bank.                                                                                             |
+| `/hindsight:import`                  | Import the current Pi session JSONL into Hindsight.                                                                                                            |
+| `/hindsight:import-current`          | Import the current Pi session JSONL into Hindsight.                                                                                                            |
+| `/hindsight:import-file`             | Import an explicit Pi session JSONL file into Hindsight.                                                                                                       |
+| `/hindsight:import-project-sessions` | Import Pi session JSONL files scoped to the current repo/cwd.                                                                                                  |
+| `/hindsight:session`                 | Show current Hindsight session memory mode and tags.                                                                                                           |
+| `/hindsight:mode`                    | Set session memory mode: normal, read-only, or ignored.                                                                                                        |
+| `/hindsight:next-opt-out`            | Skip automatic retain for the next agent run in this session.                                                                                                  |
+| `/hindsight:retain`                  | Enable or disable retain for this session.                                                                                                                     |
+| `/hindsight:tag`                     | Add or remove a Hindsight tag for this session.                                                                                                                |
+| `/hindsight:last-recall`             | Show the last opt-in persisted recall snapshot.                                                                                                                |
+| `/hindsight:recall-cleanup`          | Scan or prune accidentally persisted Hindsight recall blocks from the current session transcript.                                                              |
+| `/hindsight:queue`                   | Inspect local retain queue and dead-letter metadata without printing payloads.                                                                                 |
+| `/hindsight:flush`                   | Flush queued retain jobs.                                                                                                                                      |
+| `/hindsight:doctor`                  | Emit a machine-readable Hindsight diagnostics report (connectivity, queue, imports, config) for bug reports.                                                   |
+| `/hindsight:templates`               | List bundled Hindsight bank templates.                                                                                                                         |
+| `/hindsight:template-apply`          | Apply a bundled Hindsight bank template: writes bank config and creates/updates mental models. Defaults to a dry-run preview with confirmation before writing. |
 
 ## Config fields
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -10,7 +10,7 @@ For a generated reference of registered tools, commands, and editable config fie
 /hindsight
 ```
 
-Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. Status activity can distinguish recall, retain, and import work, including `importing`, `imported`, `import-queued`, and `import-failed`. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Mental models and directives are managed in the Hindsight control-plane web UI.
+Shows memory status, selected banks, config facts, retain queue status, import status, and recent retain receipts. Status activity can distinguish recall, retain, and import work, including `importing`, `imported`, `import-queued`, and `import-failed`. It also exposes setup/config editing actions. Press `f` to flush queued retain jobs from the TUI. Directives, and arbitrary/custom mental models, are managed in the Hindsight control-plane web UI; see [Bank templates](#bank-templates) below for the one exception (a small bundled set of starter mental models).
 
 ## Setup and config
 
@@ -67,6 +67,16 @@ Use dry-run before non-dry-run imports. See [`import-controls.md`](import-contro
 - `next-opt-out`: skips automatic retain once, then clears itself.
 - manual tags are merged into automatic retain jobs.
 
+## Bank templates
+
+```text
+/hindsight:templates
+/hindsight:template-apply <id>
+/hindsight:template-apply <id> --dry-run
+```
+
+`/hindsight:templates` lists pi-hindsight's small, fixed set of bundled bank templates (see [`starter-mental-model-suggestions.md`](starter-mental-model-suggestions.md) for the mental models they create). `/hindsight:template-apply <id>` writes bank config overrides and creates/updates the template's mental models via Hindsight's bank-template import endpoint, targeting whichever bank (Project or User) the template declares. Bank config falls back to Pi's default missions the same way `ensureProjectBank`/`ensureGlobalBank` do — any mission you've already customized in config is kept, never overwritten by the template default. It previews with `dryRun` and asks for confirmation before writing unless `--dry-run` is passed. This is the one place pi-hindsight creates mental models directly; everything beyond these bundled templates — arbitrary template authoring, editing, export, and directive management — stays in the Hindsight control-plane web UI.
+
 ## Explicit tools
 
 Pi exposes exactly four memory tools:
@@ -76,7 +86,7 @@ Pi exposes exactly four memory tools:
 - `hindsight_retain_global`
 - `hindsight_reflect`
 
-Everything else — bank config/profile administration, document/entity/graph/tag browsing, memory inspection, consolidation control, and operation management — lives in the Hindsight control-plane web UI.
+Everything else — bank config/profile administration, document/entity/graph/tag browsing, memory inspection, consolidation control, and operation management — lives in the Hindsight control-plane web UI, except for the bundled [Bank templates](#bank-templates) commands above.
 
 Tool notes:
 

--- a/extensions/banks/bank-operations.ts
+++ b/extensions/banks/bank-operations.ts
@@ -44,7 +44,10 @@ export interface BankMissionConfig extends BankMissionSettings {
   enableObservations?: boolean;
 }
 
-function resolveBankMissions(config: BankMissionSettings, defaults: BankMissionDefaults) {
+export function resolveBankMissions(
+  config: BankMissionSettings,
+  defaults: BankMissionDefaults,
+): BankMissionDefaults {
   return {
     reflectMission: config.reflectMission ?? defaults.reflectMission,
     retainMission: config.retainMission ?? defaults.retainMission,

--- a/extensions/banks/bank-templates.ts
+++ b/extensions/banks/bank-templates.ts
@@ -1,0 +1,170 @@
+import type {
+  BankTemplateConfig,
+  BankTemplateManifest,
+  BankTemplateMentalModel,
+} from "@vectorize-io/hindsight-client";
+import {
+  defaultGlobalBankMissions,
+  defaultProjectBankMissions,
+  resolveBankMissions,
+} from "./bank-operations.js";
+import type { BankMissionDefaults } from "./bank-operations.js";
+import type { BankMissionSettings } from "../types.js";
+
+export type BankTemplateProfileId = "pi-coding-project" | "pi-user-preferences";
+export type BankTemplateTarget = "project" | "user";
+
+export interface BuiltInBankTemplate {
+  id: BankTemplateProfileId;
+  label: string;
+  target: BankTemplateTarget;
+  description: string;
+  manifest: BankTemplateManifest;
+}
+
+function bankConfigFromMissions(missions: BankMissionDefaults): BankTemplateConfig {
+  return {
+    reflect_mission: missions.reflectMission,
+    retain_mission: missions.retainMission,
+    enable_observations: true,
+    observations_mission: missions.observationsMission,
+  };
+}
+
+// Mirrors docs/starter-mental-model-suggestions.md's project-bank suggestions. Keep in sync;
+// that doc is the source of truth for what these mental models ask and why. No refresh
+// trigger is set: refresh stays explicit per that doc's product rules.
+const PROJECT_MENTAL_MODELS: BankTemplateMentalModel[] = [
+  {
+    id: "project-architecture-and-seams",
+    name: "Project architecture and seams",
+    source_query:
+      "What are the stable architecture boundaries, modules, and seams in this project?",
+    tags: ["project", "architecture", "stable"],
+    max_tokens: 2048,
+  },
+  {
+    id: "testing-and-release-process",
+    name: "Testing and release process",
+    source_query: "What test, CI, release, and verification practices does this project use?",
+    tags: ["project", "workflow", "release"],
+    max_tokens: 2048,
+  },
+  {
+    id: "memory-safety-policy",
+    name: "Memory safety policy",
+    source_query:
+      "What memory rules, safety constraints, and anti-patterns matter in this project?",
+    tags: ["project", "memory-policy", "safety"],
+    max_tokens: 2048,
+  },
+  {
+    id: "current-roadmap-and-priorities",
+    name: "Current roadmap and priorities",
+    source_query:
+      "What roadmap themes, active priorities, and deferred non-goals recur for this project?",
+    tags: ["project", "roadmap", "priority"],
+    max_tokens: 2048,
+  },
+  {
+    id: "code-style-and-naming-conventions",
+    name: "Code style and naming conventions",
+    source_query: "What code style, naming, module, and testing conventions recur in this project?",
+    tags: ["project", "conventions", "style"],
+    max_tokens: 2048,
+  },
+];
+
+// Mirrors docs/starter-mental-model-suggestions.md's global-bank suggestions. Keep in sync.
+const USER_MENTAL_MODELS: BankTemplateMentalModel[] = [
+  {
+    id: "user-collaboration-preferences",
+    name: "User collaboration preferences",
+    source_query:
+      "What durable preferences has the user shown for collaboration, review, autonomy, and communication?",
+    tags: ["global", "user-preference", "collaboration"],
+    max_tokens: 2048,
+  },
+  {
+    id: "coding-assistant-operating-preferences",
+    name: "Coding assistant operating preferences",
+    source_query:
+      "What durable preferences has the user shown for how coding assistants should plan, verify, commit, and use tools?",
+    tags: ["global", "assistant-workflow", "preference"],
+    max_tokens: 2048,
+  },
+  {
+    id: "cross-project-workflow-habits",
+    name: "Cross-project workflow habits",
+    source_query:
+      "What workflow habits recur across the user's repositories, issue tracking, PR review, and release process?",
+    tags: ["global", "workflow", "cross-project"],
+    max_tokens: 2048,
+  },
+  {
+    id: "tooling-and-review-preferences",
+    name: "Tooling and review preferences",
+    source_query:
+      "What tools, checks, review loops, and quality gates does the user repeatedly prefer?",
+    tags: ["global", "tooling", "review"],
+    max_tokens: 2048,
+  },
+];
+
+export const BUILT_IN_BANK_TEMPLATES: readonly BuiltInBankTemplate[] = [
+  {
+    id: "pi-coding-project",
+    label: "Pi Coding Project",
+    target: "project",
+    description:
+      "Repo-focused memory for architecture, decisions, conventions, and recurring issues. Bank config falls back to Pi Hindsight's default project-bank missions, keeping any mission you've already customized; adds starter mental models from docs/starter-mental-model-suggestions.md.",
+    manifest: {
+      version: "1",
+      bank: bankConfigFromMissions(defaultProjectBankMissions()),
+      mental_models: PROJECT_MENTAL_MODELS,
+    },
+  },
+  {
+    id: "pi-user-preferences",
+    label: "Pi User Preferences",
+    target: "user",
+    description:
+      "Cross-project durable preferences, workflow habits, and assistant behavior guidance. Bank config falls back to Pi Hindsight's default user-bank missions, keeping any mission you've already customized; adds starter mental models from docs/starter-mental-model-suggestions.md.",
+    manifest: {
+      version: "1",
+      bank: bankConfigFromMissions(defaultGlobalBankMissions()),
+      mental_models: USER_MENTAL_MODELS,
+    },
+  },
+] as const;
+
+export function listBuiltInBankTemplates(): readonly BuiltInBankTemplate[] {
+  return BUILT_IN_BANK_TEMPLATES;
+}
+
+export function getBuiltInBankTemplate(id: string): BuiltInBankTemplate | undefined {
+  return BUILT_IN_BANK_TEMPLATES.find((template) => template.id === id);
+}
+
+function defaultMissionsForTarget(target: BankTemplateTarget): BankMissionDefaults {
+  return target === "user" ? defaultGlobalBankMissions() : defaultProjectBankMissions();
+}
+
+// Resolves the manifest actually sent for a template against the caller's current bank
+// mission settings, so applying a bundled template never clobbers a mission the user already
+// customized away from Pi's defaults -- the same fallback ensureProjectBank/ensureGlobalBank
+// use for bank creation. Falls back to the template's own default-based manifest.bank when the
+// caller hasn't customized anything.
+export function resolveBankTemplateManifest(
+  template: BuiltInBankTemplate,
+  bankMissionSettings: BankMissionSettings,
+): BankTemplateManifest {
+  const missions = resolveBankMissions(
+    bankMissionSettings,
+    defaultMissionsForTarget(template.target),
+  );
+  return {
+    ...template.manifest,
+    bank: bankConfigFromMissions(missions),
+  };
+}

--- a/extensions/client/client.ts
+++ b/extensions/client/client.ts
@@ -6,7 +6,7 @@ import {
   createConfig,
   sdk,
 } from "@vectorize-io/hindsight-client";
-import type { Client, ReflectRequest } from "@vectorize-io/hindsight-client";
+import type { BankTemplateManifest, Client, ReflectRequest } from "@vectorize-io/hindsight-client";
 import { redactError } from "../utils/sanitize.js";
 import type { HindsightLikeClient, ResolvedConfig } from "../types.js";
 import { PI_HINDSIGHT_USER_AGENT } from "../version.js";
@@ -144,6 +144,26 @@ async function reflect(
   return args.raw.reflect(args.bankId, args.query, { ...args.options, signal });
 }
 
+async function importBankTemplate(
+  lowLevel: Client,
+  bankId: string,
+  manifest: BankTemplateManifest,
+  options: { dryRun?: boolean } | undefined,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const response = await sdk.importBankTemplate({
+    client: lowLevel,
+    path: { bank_id: bankId },
+    ...(options?.dryRun ? { query: { dry_run: true } } : {}),
+    // The generated SDK types `body` as `never` for this endpoint: the OpenAPI schema
+    // declares a raw JSON object rather than a typed model. The request body is still the
+    // documented BankTemplateManifest shape (Hindsight's Bank Templates API docs).
+    body: manifest as never,
+    signal,
+  });
+  return unwrapSdkResponse(response, "importBankTemplate");
+}
+
 export function createHindsightClient(config: ResolvedConfig): HindsightLikeClient {
   installFetchRequestCompat();
 
@@ -212,6 +232,13 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
     getBankConfig: (bankId) =>
       withTimeout("hindsight getBankConfig", timeoutMs, (signal) =>
         withRetry("getBankConfig", () => raw.getBankConfig(bankId, { signal })),
+      ),
+    importBankTemplate: (bankId, manifest, options) =>
+      withTimeout(
+        "hindsight importBankTemplate",
+        timeoutMs,
+        (signal) => importBankTemplate(lowLevel, bankId, manifest, options, signal),
+        options?.signal,
       ),
     health: () =>
       withTimeout("hindsight health", timeoutMs, (signal) =>

--- a/extensions/operations/memory-bank-template-operations.ts
+++ b/extensions/operations/memory-bank-template-operations.ts
@@ -1,0 +1,42 @@
+import {
+  getBuiltInBankTemplate,
+  listBuiltInBankTemplates,
+  resolveBankTemplateManifest,
+} from "../banks/bank-templates.js";
+import { resolveOperationBank } from "../banks/bank-selection.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+
+export function createBankTemplateOperations(deps: MemoryOperationsDeps) {
+  return {
+    listBankTemplates() {
+      return listBuiltInBankTemplates();
+    },
+
+    async applyBankTemplate(args: { templateId: string; dryRun?: boolean }) {
+      const template = getBuiltInBankTemplate(args.templateId);
+      if (!template) {
+        throw new Error(
+          `Unknown bank template id: ${args.templateId}. Run /hindsight:templates to list ids.`,
+        );
+      }
+      const client = deps.getClient();
+      if (!client.importBankTemplate) {
+        throw new Error("Hindsight client does not support bank template import.");
+      }
+      const config = deps.getConfig();
+      // Each bundled template already declares which bank kind it targets, so apply resolves
+      // that bank directly instead of taking a separate --bank override.
+      const bankId = resolveOperationBank({
+        requestedBank: template.target === "user" ? "global" : undefined,
+        config,
+        projectBankId: deps.getProjectBankId(),
+      });
+      const bankMissionSettings =
+        template.target === "user" ? config.banks.user : config.banks.project;
+      const manifest = resolveBankTemplateManifest(template, bankMissionSettings);
+      const dryRun = args.dryRun ?? true;
+      const result = await client.importBankTemplate(bankId, manifest, { dryRun });
+      return { bankId, template, dryRun, result };
+    },
+  };
+}

--- a/extensions/operations/memory-operation-service.ts
+++ b/extensions/operations/memory-operation-service.ts
@@ -4,6 +4,7 @@ import {
   importMemoryProjectSessions,
   importMemorySession,
 } from "../imports/import-sessions.js";
+import { createBankTemplateOperations } from "./memory-bank-template-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
 import { createDiagnosticsOperations } from "./memory-diagnostics-operations.js";
 import { createQueueOperations } from "../queue/queue-operations.js";
@@ -61,6 +62,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createQueueOperations(deps),
     ...createSessionOperations(),
     ...createDiagnosticsOperations(deps),
+    ...createBankTemplateOperations(deps),
   };
 }
 

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -7,6 +7,7 @@ import {
 import { importCommandOperations } from "../tui/command-imports.js";
 import { maintenanceCommandOperations } from "../tui/command-maintenance.js";
 import { sessionCommandOperations } from "../tui/command-session.js";
+import { templateCommandOperations } from "../tui/command-templates.js";
 import type { MemoryOperationsDeps } from "./memory-operation-service.js";
 import { createMemoryOperations } from "./memory-operation-service.js";
 import { formatReflectResult } from "./reflect-presenter.js";
@@ -483,6 +484,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
     ...importCommandOperations(operations),
     ...sessionCommandOperations(operations),
     ...maintenanceCommandOperations(operations),
+    ...templateCommandOperations(operations),
   ];
 
   return { tools, commands };

--- a/extensions/tui/bank-template-presentation.ts
+++ b/extensions/tui/bank-template-presentation.ts
@@ -1,0 +1,45 @@
+import type { BankTemplateImportResponse } from "@vectorize-io/hindsight-client";
+import type { BuiltInBankTemplate } from "../banks/bank-templates.js";
+
+export function renderBankTemplateList(templates: readonly BuiltInBankTemplate[]): string {
+  const lines = templates.map((template) => {
+    const mentalModels = template.manifest.mental_models?.length ?? 0;
+    const directives = template.manifest.directives?.length ?? 0;
+    return `- ${template.id} (${template.target}): ${template.label} — ${template.description} mentalModels=${mentalModels} directives=${directives}`;
+  });
+  return ["Hindsight bank templates:", ...lines].join("\n");
+}
+
+function summarizeImportResponse(result: unknown): string {
+  if (typeof result !== "object" || !result) return JSON.stringify(result);
+  const response = result as BankTemplateImportResponse;
+  const created = response.mental_models_created?.length ?? 0;
+  const updated = response.mental_models_updated?.length ?? 0;
+  const directivesCreated = response.directives_created?.length ?? 0;
+  const directivesUpdated = response.directives_updated?.length ?? 0;
+  return `configApplied=${response.config_applied}; mentalModels created=${created}/updated=${updated}; directives created=${directivesCreated}/updated=${directivesUpdated}`;
+}
+
+export function renderBankTemplateApplyResult(args: {
+  bankId: string;
+  template: BuiltInBankTemplate;
+  dryRun: boolean;
+  result: unknown;
+}): string {
+  const prefix = args.dryRun
+    ? `Bank template preview: ${args.template.id} -> ${args.bankId}`
+    : `Applied bank template: ${args.template.id} -> ${args.bankId}`;
+  return `${prefix}; ${summarizeImportResponse(args.result)}; write=${args.dryRun ? "no" : "yes"}`;
+}
+
+// Shows each mental model's name, source query, and tags before submission, per
+// docs/starter-mental-model-suggestions.md's product rules.
+export function renderBankTemplateMentalModelDetails(template: BuiltInBankTemplate): string {
+  const models = template.manifest.mental_models ?? [];
+  if (!models.length) return "";
+  const lines = models.map(
+    (model) =>
+      `- ${model.name} (${model.id}); tags=${model.tags?.join(",") || "none"}; query=${model.source_query}`,
+  );
+  return [`Mental models for ${template.id} (${template.target} bank):`, ...lines].join("\n");
+}

--- a/extensions/tui/command-templates.ts
+++ b/extensions/tui/command-templates.ts
@@ -1,0 +1,85 @@
+import { listBuiltInBankTemplates } from "../banks/bank-templates.js";
+import type { createMemoryOperations } from "../operations/memory-operation-service.js";
+import type { CommandOperation } from "../operations/operation-catalog.js";
+import { redactError } from "../utils/sanitize.js";
+import {
+  renderBankTemplateApplyResult,
+  renderBankTemplateList,
+  renderBankTemplateMentalModelDetails,
+} from "./bank-template-presentation.js";
+import { argList, completeFlags, completeValues, firstNonFlagArg } from "./command-utils.js";
+
+type Operations = ReturnType<typeof createMemoryOperations>;
+type ApplyBankTemplateResult = Awaited<ReturnType<Operations["applyBankTemplate"]>>;
+
+function templateIds(): string[] {
+  return listBuiltInBankTemplates().map((template) => template.id);
+}
+
+async function confirmTemplateApply(
+  ctx: { ui: { select: (prompt: string, options: string[]) => Promise<string | undefined> } },
+  preview: ApplyBankTemplateResult,
+): Promise<boolean> {
+  // Show the model name, source query, and tags before submission, per
+  // docs/starter-mental-model-suggestions.md's product rules.
+  const details = renderBankTemplateMentalModelDetails(preview.template);
+  const summary = renderBankTemplateApplyResult(preview);
+  const action = await ctx.ui.select(
+    `${details ? `${details}\n\n` : ""}${summary}\n\nThis will write bank config and create/update mental models in Hindsight. Continue?`,
+    ["Apply", "Cancel"],
+  );
+  return action === "Apply";
+}
+
+export function templateCommandOperations(operations: Operations): CommandOperation[] {
+  return [
+    {
+      name: "hindsight:templates",
+      spec: {
+        description: "List bundled Hindsight bank templates.",
+        handler: async (_args, ctx) => {
+          ctx.ui.notify(renderBankTemplateList(operations.listBankTemplates()), "info");
+        },
+      },
+    },
+    {
+      name: "hindsight:template-apply",
+      spec: {
+        description:
+          "Apply a bundled Hindsight bank template: writes bank config and creates/updates mental models. Defaults to a dry-run preview with confirmation before writing.",
+        getArgumentCompletions: (prefix) =>
+          completeValues(prefix, templateIds()) ?? completeFlags(prefix, ["--dry-run"]),
+        handler: async (args, ctx) => {
+          const templateId = firstNonFlagArg(args);
+          if (!templateId) {
+            ctx.ui.notify(
+              `Usage: /hindsight:template-apply <id> [--dry-run]. Known ids: ${templateIds().join(", ")}`,
+              "warning",
+            );
+            return;
+          }
+          const dryRun = argList(args).some((flag) => flag === "--dry-run" || flag === "--preview");
+          try {
+            const preview = await operations.applyBankTemplate({ templateId, dryRun: true });
+            if (dryRun) {
+              const details = renderBankTemplateMentalModelDetails(preview.template);
+              ctx.ui.notify(
+                `${details ? `${details}\n\n` : ""}${renderBankTemplateApplyResult(preview)}`,
+                "info",
+              );
+              return;
+            }
+            if (!(await confirmTemplateApply(ctx, preview))) {
+              ctx.ui.notify("Hindsight bank template apply cancelled.", "warning");
+              return;
+            }
+            const result = await operations.applyBankTemplate({ templateId, dryRun: false });
+            ctx.ui.notify(renderBankTemplateApplyResult(result), "info");
+          } catch (error) {
+            ctx.ui.notify(`Hindsight bank template apply failed: ${redactError(error)}`, "warning");
+          }
+        },
+      },
+    },
+  ];
+}

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -1,4 +1,5 @@
 import type {
+  BankTemplateManifest,
   MinScores,
   TagGroupAndInput,
   TagGroupLeaf,
@@ -310,6 +311,11 @@ export interface HindsightLikeClient {
   getBankProfile?(bankId: string): Promise<unknown>;
   getBankStats?(bankId: string): Promise<unknown>;
   getBankConfig?(bankId: string): Promise<unknown>;
+  importBankTemplate?(
+    bankId: string,
+    manifest: BankTemplateManifest,
+    options?: { dryRun?: boolean; signal?: AbortSignal },
+  ): Promise<unknown>;
   health?(): Promise<unknown>;
   getVersion?(): Promise<unknown>;
 }

--- a/tests/bank-templates.test.ts
+++ b/tests/bank-templates.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultGlobalBankMissions,
+  defaultProjectBankMissions,
+} from "../extensions/banks/bank-operations.js";
+import {
+  BUILT_IN_BANK_TEMPLATES,
+  getBuiltInBankTemplate,
+  listBuiltInBankTemplates,
+  resolveBankTemplateManifest,
+} from "../extensions/banks/bank-templates.js";
+
+describe("bank templates", () => {
+  it("has unique lowercase-hyphenated ids for every built-in template", () => {
+    const ids = BUILT_IN_BANK_TEMPLATES.map((template) => template.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it("declares a valid version-1 manifest with unique mental model ids for every template", () => {
+    for (const template of BUILT_IN_BANK_TEMPLATES) {
+      expect(template.manifest.version).toBe("1");
+      const mentalModelIds = template.manifest.mental_models?.map((model) => model.id) ?? [];
+      expect(mentalModelIds.length).toBeGreaterThan(0);
+      expect(new Set(mentalModelIds).size).toBe(mentalModelIds.length);
+      for (const id of mentalModelIds) expect(id).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
+  it("matches Pi's own default project-bank missions for the project template", () => {
+    const template = getBuiltInBankTemplate("pi-coding-project");
+    const defaults = defaultProjectBankMissions();
+
+    expect(template?.target).toBe("project");
+    expect(template?.manifest.bank).toMatchObject({
+      reflect_mission: defaults.reflectMission,
+      retain_mission: defaults.retainMission,
+      observations_mission: defaults.observationsMission,
+      enable_observations: true,
+    });
+  });
+
+  it("matches Pi's own default user-bank missions for the user template", () => {
+    const template = getBuiltInBankTemplate("pi-user-preferences");
+    const defaults = defaultGlobalBankMissions();
+
+    expect(template?.target).toBe("user");
+    expect(template?.manifest.bank).toMatchObject({
+      reflect_mission: defaults.reflectMission,
+      retain_mission: defaults.retainMission,
+      observations_mission: defaults.observationsMission,
+      enable_observations: true,
+    });
+  });
+
+  it("does not set an auto-refresh trigger on bundled mental models", () => {
+    for (const template of BUILT_IN_BANK_TEMPLATES) {
+      for (const model of template.manifest.mental_models ?? []) {
+        expect(model.trigger).toBeUndefined();
+      }
+    }
+  });
+
+  it("returns undefined for an unknown template id", () => {
+    expect(getBuiltInBankTemplate("does-not-exist")).toBeUndefined();
+  });
+
+  it("resolves default missions when the caller has not customized any bank mission", () => {
+    const template = getBuiltInBankTemplate("pi-coding-project")!;
+    const defaults = defaultProjectBankMissions();
+
+    const manifest = resolveBankTemplateManifest(template, {});
+
+    expect(manifest.bank).toMatchObject({
+      reflect_mission: defaults.reflectMission,
+      retain_mission: defaults.retainMission,
+      observations_mission: defaults.observationsMission,
+    });
+  });
+
+  it("keeps the caller's customized mission instead of the template default", () => {
+    const template = getBuiltInBankTemplate("pi-coding-project")!;
+    const defaults = defaultProjectBankMissions();
+
+    const manifest = resolveBankTemplateManifest(template, { retainMission: "Custom retain" });
+
+    expect(manifest.bank?.retain_mission).toBe("Custom retain");
+    expect(manifest.bank?.reflect_mission).toBe(defaults.reflectMission);
+  });
+
+  it("does not mutate the template's own mental models when resolving a customized manifest", () => {
+    const template = getBuiltInBankTemplate("pi-coding-project")!;
+
+    const manifest = resolveBankTemplateManifest(template, { retainMission: "Custom retain" });
+
+    expect(manifest.mental_models).toBe(template.manifest.mental_models);
+  });
+
+  it("lists all built-in templates", () => {
+    expect(listBuiltInBankTemplates()).toHaveLength(BUILT_IN_BANK_TEMPLATES.length);
+  });
+});

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -600,4 +600,183 @@ describe("hindsight commands", () => {
     expect(commands.has("hindsight:debug")).toBe(false);
     expect(commands.has("hindsight:setup")).toBe(false);
   });
+
+  it("lists bundled bank templates", async () => {
+    const commands = new Map<string, RegisteredTestCommand>();
+    registerCommands(
+      {
+        registerCommand: (name: string, command: RegisteredTestCommand) => {
+          commands.set(name, command);
+        },
+      } as any,
+      {
+        getClient: () => client(),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "bank",
+      },
+    );
+    const ctx = { cwd: "/tmp", ui: { notify: vi.fn(), setStatus: vi.fn() }, sessionManager: {} };
+
+    await commands.get("hindsight:templates")?.handler([], ctx);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringMatching(/pi-coding-project[\s\S]*pi-user-preferences/),
+      "info",
+    );
+  });
+
+  it("shows usage when template-apply is called without an id", async () => {
+    const commands = new Map<string, RegisteredTestCommand>();
+    registerCommands(
+      {
+        registerCommand: (name: string, command: RegisteredTestCommand) => {
+          commands.set(name, command);
+        },
+      } as any,
+      {
+        getClient: () => client(),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "bank",
+      },
+    );
+    const ctx = { cwd: "/tmp", ui: { notify: vi.fn(), setStatus: vi.fn() }, sessionManager: {} };
+
+    await commands.get("hindsight:template-apply")?.handler([], ctx);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("Usage:"), "warning");
+  });
+
+  it("shows a bank template dry-run preview without asking for confirmation", async () => {
+    const importBankTemplate = vi.fn(async () => ({ bank_id: "bank", config_applied: true }));
+    const commands = new Map<string, RegisteredTestCommand>();
+    registerCommands(
+      {
+        registerCommand: (name: string, command: RegisteredTestCommand) => {
+          commands.set(name, command);
+        },
+      } as any,
+      {
+        getClient: () => ({ ...client(), importBankTemplate }),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "bank",
+      },
+    );
+    const ctx = {
+      cwd: "/tmp",
+      ui: { notify: vi.fn(), setStatus: vi.fn(), select: vi.fn() },
+      sessionManager: {},
+    };
+
+    await commands
+      .get("hindsight:template-apply")
+      ?.handler(["pi-coding-project", "--dry-run"], ctx);
+
+    expect(importBankTemplate).toHaveBeenCalledTimes(1);
+    expect(importBankTemplate).toHaveBeenCalledWith("bank", expect.any(Object), { dryRun: true });
+    expect(ctx.ui.select).not.toHaveBeenCalled();
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("Bank template preview: pi-coding-project -> bank"),
+      "info",
+    );
+  });
+
+  it("asks before applying a bank template and cancels safely", async () => {
+    const importBankTemplate = vi.fn(async () => ({ bank_id: "bank", config_applied: true }));
+    const commands = new Map<string, RegisteredTestCommand>();
+    registerCommands(
+      {
+        registerCommand: (name: string, command: RegisteredTestCommand) => {
+          commands.set(name, command);
+        },
+      } as any,
+      {
+        getClient: () => ({ ...client(), importBankTemplate }),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "bank",
+      },
+    );
+    const ctx = {
+      cwd: "/tmp",
+      ui: { notify: vi.fn(), setStatus: vi.fn(), select: vi.fn(async () => "Cancel") },
+      sessionManager: {},
+    };
+
+    await commands.get("hindsight:template-apply")?.handler(["pi-coding-project"], ctx);
+
+    expect(importBankTemplate).toHaveBeenCalledTimes(1);
+    expect(importBankTemplate).toHaveBeenCalledWith("bank", expect.any(Object), { dryRun: true });
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      "Hindsight bank template apply cancelled.",
+      "warning",
+    );
+  });
+
+  it("applies a bank template after confirmation", async () => {
+    const importBankTemplate = vi.fn(async () => ({ bank_id: "bank", config_applied: true }));
+    const commands = new Map<string, RegisteredTestCommand>();
+    registerCommands(
+      {
+        registerCommand: (name: string, command: RegisteredTestCommand) => {
+          commands.set(name, command);
+        },
+      } as any,
+      {
+        getClient: () => ({ ...client(), importBankTemplate }),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "bank",
+      },
+    );
+    const ctx = {
+      cwd: "/tmp",
+      ui: { notify: vi.fn(), setStatus: vi.fn(), select: vi.fn(async () => "Apply") },
+      sessionManager: {},
+    };
+
+    await commands.get("hindsight:template-apply")?.handler(["pi-coding-project"], ctx);
+
+    expect(importBankTemplate).toHaveBeenCalledTimes(2);
+    expect(importBankTemplate).toHaveBeenNthCalledWith(1, "bank", expect.any(Object), {
+      dryRun: true,
+    });
+    expect(importBankTemplate).toHaveBeenNthCalledWith(2, "bank", expect.any(Object), {
+      dryRun: false,
+    });
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("Applied bank template: pi-coding-project -> bank"),
+      "info",
+    );
+  });
+
+  it("redacts secrets when bank template apply fails", async () => {
+    const importBankTemplate = vi.fn(async () => {
+      throw new Error("failed to reach api_key=supersecret123456");
+    });
+    const commands = new Map<string, RegisteredTestCommand>();
+    registerCommands(
+      {
+        registerCommand: (name: string, command: RegisteredTestCommand) => {
+          commands.set(name, command);
+        },
+      } as any,
+      {
+        getClient: () => ({ ...client(), importBankTemplate }),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "bank",
+      },
+    );
+    const ctx = {
+      cwd: "/tmp",
+      ui: { notify: vi.fn(), setStatus: vi.fn(), select: vi.fn() },
+      sessionManager: {},
+    };
+
+    await commands
+      .get("hindsight:template-apply")
+      ?.handler(["pi-coding-project", "--dry-run"], ctx);
+
+    const message = ctx.ui.notify.mock.calls[0]?.[0] as string;
+    expect(message).toContain("Hindsight bank template apply failed");
+    expect(message).toContain("api_key=[REDACTED]");
+    expect(message).not.toContain("supersecret123456");
+  });
 });

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -46,10 +46,14 @@ vi.mock("../extensions/client/client.js", () => ({
   checkHindsight: mocked.checkHindsight,
 }));
 
-vi.mock("../extensions/banks/bank-operations.js", () => ({
-  ensureGlobalBank: mocked.ensureGlobalBank,
-  ensureProjectBank: mocked.ensureProjectBank,
-}));
+vi.mock("../extensions/banks/bank-operations.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../extensions/banks/bank-operations.js")>();
+  return {
+    ...actual,
+    ensureGlobalBank: mocked.ensureGlobalBank,
+    ensureProjectBank: mocked.ensureProjectBank,
+  };
+});
 
 describe("extension hooks", () => {
   const originalHome = process.env.HOME;

--- a/tests/memory-operations.test.ts
+++ b/tests/memory-operations.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { defaultProjectBankMissions } from "../extensions/banks/bank-operations.js";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
 import { createMemoryOperations } from "../extensions/operations/memory-operation-service.js";
 import type { HindsightLikeClient } from "../extensions/types.js";
@@ -302,5 +303,160 @@ describe("memory operations", () => {
     const report = JSON.parse(await operations.doctor(cwd)) as Record<string, unknown>;
 
     expect(report.health).toBe("unreachable: connection refused");
+  });
+
+  it("lists the bundled bank templates", () => {
+    const operations = createMemoryOperations({
+      getClient: () => client(),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    const templates = operations.listBankTemplates();
+
+    expect(templates.map((template) => template.id)).toEqual(
+      expect.arrayContaining(["pi-coding-project", "pi-user-preferences"]),
+    );
+  });
+
+  it("applies a project-targeted bank template to the resolved project bank", async () => {
+    const importBankTemplate = vi.fn(async () => ({
+      bank_id: "project-bank",
+      config_applied: true,
+    }));
+    const operations = createMemoryOperations({
+      getClient: () => ({ ...client(), importBankTemplate }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    const result = await operations.applyBankTemplate({
+      templateId: "pi-coding-project",
+      dryRun: true,
+    });
+
+    expect(result.bankId).toBe("project-bank");
+    expect(importBankTemplate).toHaveBeenCalledWith(
+      "project-bank",
+      expect.objectContaining({ version: "1" }),
+      { dryRun: true },
+    );
+  });
+
+  it("applies a user-targeted bank template to the configured user bank", async () => {
+    const importBankTemplate = vi.fn(async () => ({
+      bank_id: "global-luxus",
+      config_applied: true,
+    }));
+    const config = {
+      ...DEFAULT_CONFIG,
+      banks: { ...DEFAULT_CONFIG.banks, user: { enabled: true, bankId: "global-luxus" } },
+    };
+    const operations = createMemoryOperations({
+      getClient: () => ({ ...client(), importBankTemplate }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    });
+
+    const result = await operations.applyBankTemplate({ templateId: "pi-user-preferences" });
+
+    expect(result.bankId).toBe("global-luxus");
+    expect(result.dryRun).toBe(true);
+    expect(importBankTemplate).toHaveBeenCalledWith(
+      "global-luxus",
+      expect.objectContaining({ version: "1" }),
+      { dryRun: true },
+    );
+  });
+
+  it("keeps a customized project mission instead of overwriting it with the template default", async () => {
+    const importBankTemplate = vi.fn(async () => ({
+      bank_id: "project-bank",
+      config_applied: true,
+    }));
+    const config = {
+      ...DEFAULT_CONFIG,
+      banks: {
+        ...DEFAULT_CONFIG.banks,
+        project: { ...DEFAULT_CONFIG.banks.project, retainMission: "Custom retain mission" },
+      },
+    };
+    const operations = createMemoryOperations({
+      getClient: () => ({ ...client(), importBankTemplate }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    });
+
+    await operations.applyBankTemplate({ templateId: "pi-coding-project" });
+
+    const manifest = (importBankTemplate.mock.calls as unknown[][])[0]?.[1] as {
+      bank?: { retain_mission?: string; reflect_mission?: string };
+    };
+    expect(manifest.bank?.retain_mission).toBe("Custom retain mission");
+    expect(manifest.bank?.reflect_mission).toBe(defaultProjectBankMissions().reflectMission);
+  });
+
+  it("keeps a customized user mission instead of overwriting it with the template default", async () => {
+    const importBankTemplate = vi.fn(async () => ({
+      bank_id: "global-luxus",
+      config_applied: true,
+    }));
+    const config = {
+      ...DEFAULT_CONFIG,
+      banks: {
+        ...DEFAULT_CONFIG.banks,
+        user: { enabled: true, bankId: "global-luxus", reflectMission: "Custom reflect mission" },
+      },
+    };
+    const operations = createMemoryOperations({
+      getClient: () => ({ ...client(), importBankTemplate }),
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    });
+
+    await operations.applyBankTemplate({ templateId: "pi-user-preferences" });
+
+    const manifest = (importBankTemplate.mock.calls as unknown[][])[0]?.[1] as {
+      bank?: { reflect_mission?: string };
+    };
+    expect(manifest.bank?.reflect_mission).toBe("Custom reflect mission");
+  });
+
+  it("rejects applying a user-targeted template when the user bank is disabled", async () => {
+    const importBankTemplate = vi.fn(async () => ({}));
+    const operations = createMemoryOperations({
+      getClient: () => ({ ...client(), importBankTemplate }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    await expect(
+      operations.applyBankTemplate({ templateId: "pi-user-preferences" }),
+    ).rejects.toThrow("User Hindsight bank is disabled");
+    expect(importBankTemplate).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown bank template id", async () => {
+    const operations = createMemoryOperations({
+      getClient: () => client(),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    await expect(operations.applyBankTemplate({ templateId: "does-not-exist" })).rejects.toThrow(
+      "Unknown bank template id",
+    );
+  });
+
+  it("rejects applying a bank template when the client does not support import", async () => {
+    const operations = createMemoryOperations({
+      getClient: () => client(),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    await expect(operations.applyBankTemplate({ templateId: "pi-coding-project" })).rejects.toThrow(
+      "does not support bank template import",
+    );
   });
 });

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -459,6 +459,8 @@ describe("operation catalog", () => {
       "hindsight:queue",
       "hindsight:flush",
       "hindsight:doctor",
+      "hindsight:templates",
+      "hindsight:template-apply",
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- Bundle two fixed, reviewed Hindsight bank templates: `pi-coding-project` (Project Bank) and `pi-user-preferences` (User Bank), built from the existing `defaultProjectBankMissions()`/`defaultGlobalBankMissions()` plus the starter mental models already documented in `docs/starter-mental-model-suggestions.md` (no auto-refresh triggers, per that doc's product rules).
- Add `/hindsight:templates` (list) and `/hindsight:template-apply <id> [--dry-run]` (dry-run preview showing each mental model's name/source query/tags, then explicit confirmation before writing) targeting whichever bank the template declares.
- Add `client.importBankTemplate` using the official `@vectorize-io/hindsight-client@0.8.4` generated `sdk.importBankTemplate` (with a narrow, documented `body as never` cast for a known SDK codegen gap) — no hand-rolled REST shim.
- Amend ADR-004's stale deferred-surfaces citation and narrow the "template management stays in the web UI" policy to exclude these bundled templates; update `starter-mental-model-suggestions.md`'s placement/Web-UI-handoff sections, `tools-and-commands.md`, `CONTEXT.md` glossary (`Bank Template`, `Mental Model`), and all docs-site mirrors; regenerate `surface-reference.md`.
- Resolve each template's bank config (`reflect_mission`/`retain_mission`/`observations_mission`) against the caller's current config the same way `ensureProjectBank`/`ensureGlobalBank` already do, so applying a template never overwrites a mission the user already customized in `.pi/hindsight.json` — only unset missions fall back to the template default. Exported `resolveBankMissions` from `bank-operations.ts` to share this logic instead of duplicating it.

## Linked issue

- Closes #467

## Scope

- One vertical slice: bundled bank-template browse/apply. No general template catalog, editor, export, or schema-fetch tooling (those stay control-plane-only per #410); no new agent-invokable tools (the slim four-tool surface is unchanged — these are user-invoked commands only).

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Changelog: adds `/hindsight:templates` and `/hindsight:template-apply` commands for applying bundled starter bank templates (bank config + starter mental models).

## Risk and rollback

- Risk: Low. New code paths only run via the two new explicit commands; the automatic recall/retain lifecycle, queue, and tool surface are untouched. Template apply is dry-run-first with explicit confirmation, error output is redacted via `redactError`, and the User Bank path refuses to run when `banks.user` is disabled/unconfigured (existing `resolveOperationBank` behavior, covered by tests).
- Rollback/revert path: revert this single commit; no config migration, storage format, or queue changes to unwind.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

- ADR conflict handling: this deliberately narrows a position taken in #410/#411 and reaffirmed in ADR-004. ADR-004 carries an explicit Amendment (2026-07) in this diff documenting the narrowing and correcting its stale citation of the generated deferred-surfaces table (which never actually listed template management). `docs/starter-mental-model-suggestions.md` is amended as the source of truth for the bundled mental-model content; mental-model creation beyond these two fixed templates remains web-UI-only.
- Skipped checks: `npm run smoke:hindsight` not run locally — no live Hindsight server available in this environment — but CI's `live-smoke` job did run against a real Hindsight instance on the initial push and passed, giving live coverage of the new `importBankTemplate` path this local environment couldn't provide. Full matrix / package verification / `pack:verify` not applicable (no release or packaging changes; `docs/starter-mental-model-suggestions.md`, the only packaged doc touched, passes `docs:check` packaged-link validation).
- Review: a pre-PR subagent review pass found no blockers; its one "major" finding (missing user-bank-disabled test) was already covered by `tests/memory-operations.test.ts` ("rejects applying a user-targeted template when the user bank is disabled", which uses a client that does support `importBankTemplate` and asserts it is never called). The `--preview` alias intentionally mirrors the existing `command-imports.ts` convention (accepted flag, only `--dry-run` completed).
- Post-review fix: after the first push (CI green), a second critical pass caught that the bundled `bank` config was being sent unconditionally from `defaultProjectBankMissions()`/`defaultGlobalBankMissions()`, which would silently overwrite a mission a user had already customized in config — `ensureProjectBank`/`ensureGlobalBank` don't have this problem because they resolve config first, defaults second. Fixed by exporting and reusing that same resolution order (`resolveBankMissions`), added dedicated tests in both `tests/bank-templates.test.ts` (unit-level) and `tests/memory-operations.test.ts` (operation-level, for both Project and User Bank), and amended the one commit in place (force-pushed) rather than leaving a "fix bug from own review" commit in the history.
- Memory policy note: this is the one place Pi creates mental models directly. Guardrails: fixed bundled content only, explicit command, dry-run preview listing each model's name/source query/tags, confirmation before write, no auto-refresh triggers.

