### PR TITLE
feat(recall): add optional score-floor gate for auto-inject

### DIFF
--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -29,6 +29,9 @@ export PI_HINDSIGHT_PROJECT_BANK_ID=pi-project-my-repo
 export PI_HINDSIGHT_USER_BANK_ID=user-luxus
 # Legacy fallback still works during migration:
 # export PI_HINDSIGHT_GLOBAL_BANK_ID=global-luxus
+# Optional automatic-recall quality floors (local drop before inject):
+# export PI_HINDSIGHT_MIN_RERANKER=0.2
+# export PI_HINDSIGHT_MIN_SEMANTIC=0.65
 ```
 
 Project config SecretRef shape:
@@ -107,7 +110,11 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
     "topK": 8,
     "timeoutMs": 40000,
     "cacheTtlMs": 60000,
-    "injectionPosition": "append"
+    "injectionPosition": "append",
+    "minScores": {
+      "reranker": 0.2,
+      "semantic": 0.65
+    }
   },
   "observations": {
     "enabled": true,
@@ -140,3 +147,13 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
   }
 }
 ```
+
+`recall.minScores` is optional and defaults to no floors, preserving current automatic-recall
+behavior. When set, automatic recall drops results whose returned `scores.semantic`,
+`scores.reranker`, `scores.final`, or `scores.keyword` is below the configured floor. Results
+with no `scores` object, or with a missing score field, pass through so BM25-only hits and
+passthrough rerankers are not silently discarded. `PI_HINDSIGHT_MIN_SEMANTIC` and
+`PI_HINDSIGHT_MIN_RERANKER` override the matching config floors when set.
+
+This is independent of the `hindsight_recall` tool's optional `minScores` argument, which is
+passed through to the Hindsight API on explicit tool calls.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,9 @@ export PI_HINDSIGHT_PROJECT_BANK_ID=pi-project-my-repo
 export PI_HINDSIGHT_USER_BANK_ID=user-luxus
 # Legacy fallback still works during migration:
 # export PI_HINDSIGHT_GLOBAL_BANK_ID=global-luxus
+# Optional automatic-recall quality floors (local drop before inject):
+# export PI_HINDSIGHT_MIN_RERANKER=0.2
+# export PI_HINDSIGHT_MIN_SEMANTIC=0.65
 ```
 
 Project config SecretRef shape:
@@ -105,7 +108,11 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
     "topK": 8,
     "timeoutMs": 40000,
     "cacheTtlMs": 60000,
-    "injectionPosition": "append"
+    "injectionPosition": "append",
+    "minScores": {
+      "reranker": 0.2,
+      "semantic": 0.65
+    }
   },
   "observations": {
     "enabled": true,
@@ -139,3 +146,13 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
   }
 }
 ```
+
+`recall.minScores` is optional and defaults to no floors, preserving current automatic-recall
+behavior. When set, automatic recall drops results whose returned `scores.semantic`,
+`scores.reranker`, `scores.final`, or `scores.keyword` is below the configured floor. Results
+with no `scores` object, or with a missing score field, pass through so BM25-only hits and
+passthrough rerankers are not silently discarded. `PI_HINDSIGHT_MIN_SEMANTIC` and
+`PI_HINDSIGHT_MIN_RERANKER` override the matching config floors when set.
+
+This is independent of the `hindsight_recall` tool's optional `minScores` argument, which is
+passed through to the Hindsight API on explicit tool calls.

--- a/extensions/config/config-normalize.ts
+++ b/extensions/config/config-normalize.ts
@@ -1,4 +1,9 @@
-import type { HindsightEntityInput, ResolvedConfig } from "../types.js";
+import {
+  RECALL_SCORE_FIELDS,
+  type HindsightEntityInput,
+  type RecallMinScores,
+  type ResolvedConfig,
+} from "../types.js";
 import { DEFAULT_CONFIG } from "./config-defaults.js";
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
@@ -132,6 +137,18 @@ function toolNameFilter(
   };
 }
 
+function scoreFloors(value: unknown): RecallMinScores | undefined {
+  if (!isRecord(value)) return undefined;
+  const floors: RecallMinScores = {};
+  for (const field of RECALL_SCORE_FIELDS) {
+    const valueForField = value[field];
+    if (typeof valueForField === "number" && Number.isFinite(valueForField)) {
+      floors[field] = valueForField;
+    }
+  }
+  return Object.keys(floors).length ? floors : undefined;
+}
+
 function hasConfiguredRecallField(rawConfig: unknown, field: string): boolean {
   return isRecord(rawConfig) && isRecord(rawConfig.recall) && field in rawConfig.recall;
 }
@@ -175,6 +192,7 @@ export function normalizeConfig(
   const userBankConfig = config.banks?.user ?? config.banks?.global;
   const defaultUserBankConfig = DEFAULT_CONFIG.banks.user;
   const globalBankId = optionalString(userBankConfig?.bankId, defaultUserBankConfig.bankId);
+  const minScores = scoreFloors(config.recall?.minScores);
   return {
     enabled: bool(config.enabled, DEFAULT_CONFIG.enabled),
     hindsight: {
@@ -325,6 +343,7 @@ export function normalizeConfig(
         config.recall?.preferObservations,
         DEFAULT_CONFIG.recall.preferObservations,
       ),
+      ...(minScores ? { minScores } : {}),
       ...(optionalString(config.recall?.queryTimestamp, DEFAULT_CONFIG.recall.queryTimestamp)
         ? {
             queryTimestamp: stringValue(

--- a/extensions/config/config.ts
+++ b/extensions/config/config.ts
@@ -160,5 +160,21 @@ export function resolveConfig(cwd: string, env: NodeJS.ProcessEnv = process.env)
     rawConfig = merge(rawConfig, patch);
     config = merge(config, patch);
   }
+  const minScores: Record<string, number> = {};
+  const semanticFloor =
+    env.PI_HINDSIGHT_MIN_SEMANTIC?.trim() === ""
+      ? Number.NaN
+      : Number(env.PI_HINDSIGHT_MIN_SEMANTIC);
+  if (Number.isFinite(semanticFloor)) minScores.semantic = semanticFloor;
+  const rerankerFloor =
+    env.PI_HINDSIGHT_MIN_RERANKER?.trim() === ""
+      ? Number.NaN
+      : Number(env.PI_HINDSIGHT_MIN_RERANKER);
+  if (Number.isFinite(rerankerFloor)) minScores.reranker = rerankerFloor;
+  if (Object.keys(minScores).length) {
+    const patch = { recall: { minScores } };
+    rawConfig = merge(rawConfig, patch);
+    config = merge(config, patch);
+  }
   return normalizeConfig(config, rawConfig, env);
 }

--- a/extensions/lifecycle/recall.ts
+++ b/extensions/lifecycle/recall.ts
@@ -1,13 +1,15 @@
 import { basename } from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type {
-  HindsightLikeClient,
-  HindsightTagGroup,
-  RecallBlock,
-  RecallFailure,
-  RecallResultItem,
-  RecallRole,
-  ResolvedConfig,
+import {
+  RECALL_SCORE_FIELDS,
+  type HindsightLikeClient,
+  type HindsightTagGroup,
+  type RecallBlock,
+  type RecallFailure,
+  type RecallMinScores,
+  type RecallResultItem,
+  type RecallRole,
+  type ResolvedConfig,
 } from "../types.js";
 import { isInjectedHindsightMemory, projectMessageText } from "../utils/messages.js";
 import { createMemoryIdentity } from "../operations/memory-identity.js";
@@ -207,7 +209,10 @@ export async function recallForContext(args: {
           ...(scope.tagGroups?.length ? { tagGroups: scope.tagGroups } : {}),
         }),
       );
-      const results = filterRecallQuality(textFromRecallResponse(response)).items;
+      const results = filterRecallQuality(
+        textFromRecallResponse(response),
+        args.config.recall.minScores,
+      ).items;
       blocks.push({
         bankId: scope.bankId,
         query,
@@ -240,7 +245,11 @@ export async function recallForContext(args: {
   };
 }
 
-export type RecallQualityDropReason = "blank-memory" | "recall-contamination" | "duplicate-memory";
+export type RecallQualityDropReason =
+  | "blank-memory"
+  | "recall-contamination"
+  | "duplicate-memory"
+  | "below-score-floor";
 
 export interface RecallQualityDecision {
   item: RecallResultItem;
@@ -258,27 +267,46 @@ function isRecallContamination(text: string): boolean {
   );
 }
 
+function isBelowScoreFloor(item: RecallResultItem, minScores?: RecallMinScores): boolean {
+  if (!minScores) return false;
+  const scores = item.scores;
+  // Fail open when Hindsight omits scores so BM25-only hits and passthrough rerankers
+  // are not silently discarded by local policy.
+  if (!scores) return false;
+  for (const field of RECALL_SCORE_FIELDS) {
+    const floor = minScores[field];
+    const value = scores[field];
+    if (typeof floor === "number" && typeof value === "number" && value < floor) return true;
+  }
+  return false;
+}
+
 export function classifyRecallQuality(
   item: RecallResultItem,
   seen: Set<string>,
+  minScores?: RecallMinScores,
 ): RecallQualityDecision {
   const text = normalizedMemoryText(item);
   const reasons: RecallQualityDropReason[] = [];
   if (!text) reasons.push("blank-memory");
   if (isRecallContamination(itemText(item))) reasons.push("recall-contamination");
   if (text && seen.has(text)) reasons.push("duplicate-memory");
+  if (isBelowScoreFloor(item, minScores)) reasons.push("below-score-floor");
   if (!reasons.length) seen.add(text);
   return { item, decision: reasons.length ? "drop" : "keep", reasons };
 }
 
-export function filterRecallQuality(items: RecallResultItem[]): {
+export function filterRecallQuality(
+  items: RecallResultItem[],
+  minScores?: RecallMinScores,
+): {
   items: RecallResultItem[];
   decisions: RecallQualityDecision[];
   dropped: number;
   reasonCounts: Partial<Record<RecallQualityDropReason, number>>;
 } {
   const seen = new Set<string>();
-  const decisions = items.map((item) => classifyRecallQuality(item, seen));
+  const decisions = items.map((item) => classifyRecallQuality(item, seen, minScores));
   const reasonCounts: Partial<Record<RecallQualityDropReason, number>> = {};
   for (const decision of decisions) {
     for (const reason of decision.reasons) reasonCounts[reason] = (reasonCounts[reason] ?? 0) + 1;

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -40,6 +40,11 @@ export type ImportQualityProfile = "compatible" | "strict";
 /** Agent use profile selects mental-model seed sets (coding vs conversation/life). */
 export type AgentUseProfile = "coding" | "conversation";
 
+/** Score fields Hindsight may return on recall results; used for optional local floors. */
+export const RECALL_SCORE_FIELDS = ["semantic", "reranker", "final", "keyword"] as const;
+export type RecallScoreField = (typeof RECALL_SCORE_FIELDS)[number];
+export type RecallMinScores = Partial<Record<RecallScoreField, number>>;
+
 export interface BankMissionSettings {
   retainMission?: string;
   reflectMission?: string;
@@ -102,6 +107,8 @@ export interface ResolvedConfig {
     includeFactsInDebug: boolean;
     queryTimestamp?: string;
     preferObservations: boolean;
+    /** Optional local floors for automatic recall injection. Omitted by default. */
+    minScores?: RecallMinScores;
   };
   observations: {
     enabled: boolean;
@@ -181,6 +188,14 @@ export interface RecallResultItem {
   occurred_start?: string | null;
   source_fact_ids?: string[];
   sourceFacts?: string[];
+  scores?: RecallResultScores;
+}
+
+export interface RecallResultScores {
+  semantic?: number | null;
+  reranker?: number | null;
+  final?: number | null;
+  keyword?: number | null;
 }
 
 export interface RecallFailure {

--- a/extensions/utils/diagnostics.ts
+++ b/extensions/utils/diagnostics.ts
@@ -260,6 +260,7 @@ export function formatDebugReport(args: DebugReportArgs): string {
         topK: args.config.recall.topK,
         timeoutMs: args.config.recall.timeoutMs,
         injectionPosition: args.config.recall.injectionPosition,
+        minScores: args.config.recall.minScores,
       },
       retain: {
         enabled: args.config.retain.enabled,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -346,6 +346,24 @@ describe("resolveConfig", () => {
     expect(config.recall.preferObservations).toBe(false);
   });
 
+  it("normalizes recall score floors from config and env overrides", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"));
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({ recall: { minScores: { semantic: 0.65, reranker: "bad", final: null } } }),
+    );
+
+    const fromConfig = resolveConfig(cwd, {});
+    expect(fromConfig.recall.minScores).toEqual({ semantic: 0.65 });
+
+    const fromEnv = resolveConfig(cwd, {
+      PI_HINDSIGHT_MIN_SEMANTIC: "0.7",
+      PI_HINDSIGHT_MIN_RERANKER: "0.2",
+    });
+    expect(fromEnv.recall.minScores).toEqual({ semantic: 0.7, reranker: 0.2 });
+  });
+
   it("reads JSONC config and release API knobs", () => {
     const cwd = tmp();
     mkdirSync(join(cwd, ".pi"));

--- a/tests/recall-quality-fixtures.test.ts
+++ b/tests/recall-quality-fixtures.test.ts
@@ -31,6 +31,26 @@ describe("recall quality fixtures", () => {
     });
   });
 
+  it("drops recall results below configured score floors and fails open for missing scores", () => {
+    const result = filterRecallQuality(
+      [
+        { text: "Relevant project decision.", scores: { semantic: 0.72, reranker: 0.41 } },
+        { text: "Low semantic candidate.", scores: { semantic: 0.2, reranker: 0.9 } },
+        { text: "Low reranker candidate.", scores: { semantic: 0.9, reranker: 0.03 } },
+        { text: "BM25-only candidate without scores." },
+        { text: "Passthrough reranker candidate.", scores: { semantic: 0.9 } },
+      ],
+      { semantic: 0.65, reranker: 0.2 },
+    );
+
+    expect(result.items.map((item) => item.text)).toEqual([
+      "Relevant project decision.",
+      "BM25-only candidate without scores.",
+      "Passthrough reranker candidate.",
+    ]);
+    expect(result.reasonCounts).toEqual({ "below-score-floor": 2 });
+  });
+
   it("keeps high-signal workflow memories and excludes recalled-memory artifacts in context recall", async () => {
     const client: HindsightLikeClient = {
       retain: async () => undefined,
@@ -62,6 +82,34 @@ describe("recall quality fixtures", () => {
     expect(result.rendered).toContain("Blocker: Hindsight server unavailable");
     expect(result.rendered).not.toContain("last-recall.json");
     expect(result.rendered).not.toContain("previous block");
+  });
+
+  it("applies configured score floors during automatic context recall", async () => {
+    const client: HindsightLikeClient = {
+      retain: async () => undefined,
+      reflect: async () => ({}),
+      recall: async () => [
+        { text: "High confidence decision.", scores: { semantic: 0.9, reranker: 0.8 } },
+        { text: "Junk low rerank hit.", scores: { semantic: 0.9, reranker: 0.01 } },
+        { text: "No scores BM25 hit." },
+      ],
+    };
+
+    const result = await recallForContext({
+      client,
+      config: {
+        ...DEFAULT_CONFIG,
+        recall: { ...DEFAULT_CONFIG.recall, minScores: { reranker: 0.2 } },
+      },
+      scopes: [{ kind: "project", bankId: "project-bank" }],
+      messages: [user("What did we decide?")],
+    });
+
+    expect(result.blocks[0]!.results.map((item) => item.text)).toEqual([
+      "High confidence decision.",
+      "No scores BM25 hit.",
+    ]);
+    expect(result.rendered).not.toContain("Junk low rerank hit.");
   });
 
   it("renders nothing when only low-quality recall artifacts remain", () => {


### PR DESCRIPTION
## Summary

- Adds optional `recall.minScores` floors for **automatic** recall quality filtering so low-confidence top-k hits can be dropped before ephemeral context injection.
- Defaults preserve current behavior (no floors). Missing `scores` / missing score fields **fail open**.
- Env overrides: `PI_HINDSIGHT_MIN_SEMANTIC`, `PI_HINDSIGHT_MIN_RERANKER`.
- Distinct from the existing `hindsight_recall` tool `minScores` API passthrough.

## Linked issue

- Closes #473

## Scope

- Types: `RecallResultScores`, `RecallMinScores`, drop reason `below-score-floor`
- Local filter in `filterRecallQuality` + wiring from `recallForContext`
- Config normalize + env merge; diagnostics dump; docs

## Verification

- [x] `npm run check` (pre-commit; 501 tests)
- [x] `npm run check:coverage`
- [x] `npm run typecheck:tsc`
- [ ] full matrix requested/passed (not run because this is not a release PR and matrix is reserved for release/`ci:full`)
- [ ] package verification requested/passed (not run because package/release packaging paths are unchanged)
- [ ] `npm run pack:verify` (not run because package/release packaging paths are unchanged)
- [ ] `npm run smoke:hindsight` (not run because live Hindsight is unavailable for this local quality-policy path; unit tests cover floors, fail-open, and config/env normalization)

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Optional `recall.minScores` and env floor overrides for automatic recall.

## Risk and rollback

- Risk: Misconfigured floors can drop useful candidates. Fail-open for missing scores reduces false drops for BM25-only / passthrough reranker results.
- Rollback/revert path: Revert this PR, or remove `recall.minScores` / unset the env vars.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] Not required: no change to source-of-truth order, contributor workflow, or definition of done.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Re-lands the closed #474 design cleanly on current main (post #478). Does not change the four-tool surface.

Copilot review on this PR generated no code comments.