### PR TITLE
docs: explain automatic recall quality and score floors

### DIFF
--- a/docs-site/src/content/docs/concepts/memory-behavior.md
+++ b/docs-site/src/content/docs/concepts/memory-behavior.md
@@ -43,9 +43,11 @@ These run for every automatic recall, with no config required:
 You can also drop candidates whose returned per-stage scores fall below configured floors. Supported fields: `semantic`, `reranker`, `final`, `keyword`.
 
 ```json
-"recall": {
-  "minScores": {
-    "reranker": 0.2
+{
+  "recall": {
+    "minScores": {
+      "reranker": 0.2
+    }
   }
 }
 ```

--- a/docs-site/src/content/docs/concepts/memory-behavior.md
+++ b/docs-site/src/content/docs/concepts/memory-behavior.md
@@ -26,6 +26,63 @@ Set `recall.includeSourceFacts: true` (bounded by `recall.maxSourceFactsTokens`)
 
 `recall.queryTimestamp` should normally be omitted. Set it only when recall should be anchored to a specific point in time.
 
+## Recall quality
+
+After Hindsight returns candidates for **automatic** recall, Pi applies a local quality pass before rendering the ephemeral context block. This pass does not change what Hindsight stored; it only decides what gets injected this turn.
+
+### Always-on shape filters
+
+These run for every automatic recall, with no config required:
+
+- **blank-memory** — empty or whitespace-only text
+- **duplicate-memory** — same normalized text already kept in this response
+- **recall-contamination** — payload that looks like a previously injected memory or mental-model block (or related sidecar markers)
+
+### Optional score floors (`recall.minScores`)
+
+You can also drop candidates whose returned per-stage scores fall below configured floors. Supported fields: `semantic`, `reranker`, `final`, `keyword`.
+
+```json
+"recall": {
+  "minScores": {
+    "reranker": 0.2
+  }
+}
+```
+
+Env overrides for the common pair:
+
+- `PI_HINDSIGHT_MIN_RERANKER`
+- `PI_HINDSIGHT_MIN_SEMANTIC`
+
+**Defaults are off.** Score scales depend on embedding model, reranker, budget, bank size, and server version. A floor that separates junk from useful memory on one deploy can over- or under-filter on another. Prefer measuring on your server (see [Last-recall snapshots](#last-recall-snapshots)) before enabling floors.
+
+### Fail-open rules
+
+When floors are set:
+
+| Situation                                       | Result                                                     |
+| ----------------------------------------------- | ---------------------------------------------------------- |
+| Score field is a number **below** its floor     | Drop (`below-score-floor`)                                 |
+| No `scores` object on the result                | **Keep** (BM25-only or older payloads)                     |
+| Floor set for a field that is missing or `null` | **Keep** that field (do not treat as below floor)          |
+| Multiple floors set                             | **AND** — any present field below its floor drops the item |
+
+### Local auto-recall vs tool `minScores`
+
+- Automatic recall floors are a **local** filter after Hindsight returns results.
+- The `hindsight_recall` tool's optional `minScores` argument is a **passthrough to the Hindsight API** on explicit tool calls. The two knobs are independent.
+
+### Suggested starting point
+
+If auto-inject looks noisy and low-rerank junk is obvious, try a soft reranker-only floor first:
+
+```bash
+export PI_HINDSIGHT_MIN_RERANKER=0.2
+```
+
+Exact field names and env wiring: [Configuration](/pi-hindsight/reference/configuration/).
+
 ## Last-recall snapshots
 
 Set `recall.storeLastRecall: true` to write a local visibility snapshot under `.pi/hindsight/` for debugging. Add `recall.storeLastRecallFailures: true` to include failed recall attempts when all recalls fail.

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -148,12 +148,17 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
 }
 ```
 
-`recall.minScores` is optional and defaults to no floors, preserving current automatic-recall
-behavior. When set, automatic recall drops results whose returned `scores.semantic`,
-`scores.reranker`, `scores.final`, or `scores.keyword` is below the configured floor. Results
-with no `scores` object, or with a missing score field, pass through so BM25-only hits and
-passthrough rerankers are not silently discarded. `PI_HINDSIGHT_MIN_SEMANTIC` and
-`PI_HINDSIGHT_MIN_RERANKER` override the matching config floors when set.
+### `recall.minScores` (optional)
 
-This is independent of the `hindsight_recall` tool's optional `minScores` argument, which is
-passed through to the Hindsight API on explicit tool calls.
+Exact fields for automatic-recall score floors. **Defaults: no floors** (inject quality-filtered
+top-k without score thresholds). When set, drop candidates whose returned `scores.semantic` /
+`scores.reranker` /
+`scores.final` / `scores.keyword` is a number strictly below the matching floor. Missing
+`scores` or missing score fields **fail open** (keep the hit).
+
+- Env overrides: `PI_HINDSIGHT_MIN_SEMANTIC`, `PI_HINDSIGHT_MIN_RERANKER` (merge over config for
+  those fields).
+- Independent of the `hindsight_recall` tool `minScores` argument (API passthrough on explicit
+  tool calls).
+
+Behavior, why defaults stay off, and a suggested starting floor: [Memory behavior → Recall quality](/pi-hindsight/concepts/memory-behavior/#recall-quality).

--- a/docs-site/src/content/docs/start/getting-started.md
+++ b/docs-site/src/content/docs/start/getting-started.md
@@ -73,6 +73,8 @@ After setup, `/hindsight` should show:
 - retain queue path
 - import checkpoint/manifest state when imports have run
 
+If automatic recall injects irrelevant noise, see [Recall quality](/pi-hindsight/concepts/memory-behavior/#recall-quality) for always-on filters and optional score floors (off by default).
+
 ## 6. Import old sessions only when useful
 
 Live retain starts after setup. Historical import is optional backfill. Use guided setup's import prompt first when it appears; it previews before writing memory.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,12 +147,17 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
 }
 ```
 
-`recall.minScores` is optional and defaults to no floors, preserving current automatic-recall
-behavior. When set, automatic recall drops results whose returned `scores.semantic`,
-`scores.reranker`, `scores.final`, or `scores.keyword` is below the configured floor. Results
-with no `scores` object, or with a missing score field, pass through so BM25-only hits and
-passthrough rerankers are not silently discarded. `PI_HINDSIGHT_MIN_SEMANTIC` and
-`PI_HINDSIGHT_MIN_RERANKER` override the matching config floors when set.
+### `recall.minScores` (optional)
 
-This is independent of the `hindsight_recall` tool's optional `minScores` argument, which is
-passed through to the Hindsight API on explicit tool calls.
+Exact fields for automatic-recall score floors. **Defaults: no floors** (inject quality-filtered
+top-k without score thresholds). When set, drop candidates whose returned `scores.semantic` /
+`scores.reranker` /
+`scores.final` / `scores.keyword` is a number strictly below the matching floor. Missing
+`scores` or missing score fields **fail open** (keep the hit).
+
+- Env overrides: `PI_HINDSIGHT_MIN_SEMANTIC`, `PI_HINDSIGHT_MIN_RERANKER` (merge over config for
+  those fields).
+- Independent of the `hindsight_recall` tool `minScores` argument (API passthrough on explicit
+  tool calls).
+
+Behavior, why defaults stay off, and a suggested starting floor: [Memory behavior → Recall quality](memory-behavior.md#recall-quality).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,6 +71,8 @@ After setup, `/hindsight` should show:
 - retain queue path
 - import checkpoint/manifest state when imports have run
 
+If automatic recall injects irrelevant noise, see [Recall quality](memory-behavior.md#recall-quality) for always-on filters and optional score floors (off by default).
+
 ## 6. Import old sessions only when useful
 
 Live retain starts after setup. Historical import is optional backfill. Use guided setup's import prompt first when it appears; it previews before writing memory.

--- a/docs/memory-behavior.md
+++ b/docs/memory-behavior.md
@@ -41,9 +41,11 @@ These run for every automatic recall, with no config required:
 You can also drop candidates whose returned per-stage scores fall below configured floors. Supported fields: `semantic`, `reranker`, `final`, `keyword`.
 
 ```json
-"recall": {
-  "minScores": {
-    "reranker": 0.2
+{
+  "recall": {
+    "minScores": {
+      "reranker": 0.2
+    }
   }
 }
 ```

--- a/docs/memory-behavior.md
+++ b/docs/memory-behavior.md
@@ -24,6 +24,63 @@ Set `recall.includeSourceFacts: true` (bounded by `recall.maxSourceFactsTokens`)
 
 `recall.queryTimestamp` should normally be omitted. Set it only when recall should be anchored to a specific point in time.
 
+## Recall quality
+
+After Hindsight returns candidates for **automatic** recall, Pi applies a local quality pass before rendering the ephemeral context block. This pass does not change what Hindsight stored; it only decides what gets injected this turn.
+
+### Always-on shape filters
+
+These run for every automatic recall, with no config required:
+
+- **blank-memory** — empty or whitespace-only text
+- **duplicate-memory** — same normalized text already kept in this response
+- **recall-contamination** — payload that looks like a previously injected memory or mental-model block (or related sidecar markers)
+
+### Optional score floors (`recall.minScores`)
+
+You can also drop candidates whose returned per-stage scores fall below configured floors. Supported fields: `semantic`, `reranker`, `final`, `keyword`.
+
+```json
+"recall": {
+  "minScores": {
+    "reranker": 0.2
+  }
+}
+```
+
+Env overrides for the common pair:
+
+- `PI_HINDSIGHT_MIN_RERANKER`
+- `PI_HINDSIGHT_MIN_SEMANTIC`
+
+**Defaults are off.** Score scales depend on embedding model, reranker, budget, bank size, and server version. A floor that separates junk from useful memory on one deploy can over- or under-filter on another. Prefer measuring on your server (see [Last-recall snapshots](#last-recall-snapshots)) before enabling floors.
+
+### Fail-open rules
+
+When floors are set:
+
+| Situation                                       | Result                                                     |
+| ----------------------------------------------- | ---------------------------------------------------------- |
+| Score field is a number **below** its floor     | Drop (`below-score-floor`)                                 |
+| No `scores` object on the result                | **Keep** (BM25-only or older payloads)                     |
+| Floor set for a field that is missing or `null` | **Keep** that field (do not treat as below floor)          |
+| Multiple floors set                             | **AND** — any present field below its floor drops the item |
+
+### Local auto-recall vs tool `minScores`
+
+- Automatic recall floors are a **local** filter after Hindsight returns results.
+- The `hindsight_recall` tool's optional `minScores` argument is a **passthrough to the Hindsight API** on explicit tool calls. The two knobs are independent.
+
+### Suggested starting point
+
+If auto-inject looks noisy and low-rerank junk is obvious, try a soft reranker-only floor first:
+
+```bash
+export PI_HINDSIGHT_MIN_RERANKER=0.2
+```
+
+Exact field names and env wiring: [Configuration](configuration.md).
+
 ## Last-recall snapshots
 
 Set `recall.storeLastRecall: true` to write a local visibility snapshot under `.pi/hindsight/` for debugging. Add `recall.storeLastRecallFailures: true` to include failed recall attempts when all recalls fail.


### PR DESCRIPTION
## Summary

- Own automatic recall quality policy in **Memory behavior** (shape filters, optional `minScores`, fail-open, why defaults stay off, suggested starting floor).
- Keep **Configuration** as exact field/env reference with a link to that concept.
- Add a start-path pointer from **Getting started** for noisy auto-recall.

## Linked issue

- Closes #481

## Scope

- `docs/memory-behavior.md` + docs-site concepts mirror
- `docs/configuration.md` + docs-site reference mirror
- `docs/getting-started.md` + docs-site start mirror

## Verification

- [x] `npm run check` (via pre-commit; docs-only change)
- [x] `npm run docs:check` (links + site build)
- [ ] `npm run check:coverage` (not run because no source/test changes)
- [ ] `npm run typecheck:tsc` (not run because no TypeScript source changes)
- [ ] full matrix requested/passed (not run because this is not a release/`ci:full` PR)
- [ ] package verification requested/passed (not run because packaging paths are unchanged)
- [ ] `npm run pack:verify` (not run because packaging paths are unchanged)
- [ ] `npm run smoke:hindsight` (not run because no memory-path runtime code changed)

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Docs-site / packaged Markdown explain recall quality and score floors for users.

## Risk and rollback

- Risk: Low — documentation only.
- Rollback/revert path: Revert this PR.

## Follow-ups

- None for this slice. Dual-tree docs consolidation remains a separate hygiene effort.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] Not required: no change to source-of-truth order, contributor workflow, or definition of done.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Tier-1 docs after #480/#473. No runtime change.