### PR TITLE
feat: setup gate pauses memory until bank is configured

### DIFF
--- a/docs-site/src/content/docs/start/getting-started.md
+++ b/docs-site/src/content/docs/start/getting-started.md
@@ -46,6 +46,8 @@ Open Pi in your repository and run:
 
 If no project config exists, guided setup starts automatically. You can rerun it later from the TUI with `g`.
 
+**Setup gate:** until a bank is chosen (guided setup, `banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, or an existing install with prior config/runtime state), automatic bank ensure, recall, and retain stay off. Status warns that setup is required. Existing upgrades with config files or queue/cursor state continue to work without re-onboarding.
+
 Guided setup handles:
 
 1. Hindsight server URL

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,6 +44,8 @@ Open Pi in your repository and run:
 
 If no project config exists, guided setup starts automatically. You can rerun it later from the TUI with `g`.
 
+**Setup gate:** until a bank is chosen (guided setup, `banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, or an existing install with prior config/runtime state), automatic bank ensure, recall, and retain stay off. Status warns that setup is required. Existing upgrades with config files or queue/cursor state continue to work without re-onboarding.
+
 Guided setup handles:
 
 1. Hindsight server URL
@@ -51,7 +53,7 @@ Guided setup handles:
 3. project and/or user bank
 4. optional dry-run-first historical import
 
-Bank templates, mental models, and directives are managed in the Hindsight control-plane web UI, not in Pi.
+Starter mental models can be applied from setup/templates. Ongoing mental-model and mission maintenance is agent-first (ADR-005); the Hindsight web UI remains available for control-plane browsing.
 
 ## 4. Pick the narrowest profile
 

--- a/extensions/config/config-defaults.ts
+++ b/extensions/config/config-defaults.ts
@@ -2,6 +2,7 @@ import type { ResolvedConfig } from "../types.js";
 
 export const DEFAULT_CONFIG: ResolvedConfig = {
   enabled: true,
+  setupComplete: false,
   hindsight: { baseUrl: "http://localhost:8888", timeoutMs: 30_000 },
   agentUse: "coding",
   mentalModels: {

--- a/extensions/config/config-field-paths.ts
+++ b/extensions/config/config-field-paths.ts
@@ -1,5 +1,6 @@
 export type FieldId =
   | "enabled"
+  | "setupComplete"
   | "baseUrl"
   | "apiKeyEnv"
   | "apiKeyDirect"
@@ -46,6 +47,7 @@ export type FieldId =
 
 export const CONFIG_FIELD_PATHS: Record<FieldId, string[]> = {
   enabled: ["enabled"],
+  setupComplete: ["setupComplete"],
   baseUrl: ["hindsight", "baseUrl"],
   apiKeyEnv: ["hindsight", "apiKey"],
   apiKeyDirect: ["hindsight", "apiKey"],
@@ -183,12 +185,14 @@ export const CONFIG_RESET_PATHS = {
   "notifications.startup": [["notifications", "startup"]],
   "notifications.recall": [["notifications", "recall"]],
   "notifications.retain": [["notifications", "retain"]],
+  setupComplete: [["setupComplete"]],
 } as const satisfies Record<string, readonly (readonly string[])[]>;
 
 export type ConfigResetKey = keyof typeof CONFIG_RESET_PATHS;
 
 export const CONFIG_FIELD_RESET_KEYS: Record<FieldId, ConfigResetKey> = {
   enabled: "enabled",
+  setupComplete: "setupComplete",
   baseUrl: "hindsight.baseUrl",
   apiKeyEnv: "hindsight.apiKey",
   apiKeyDirect: "hindsight.apiKey",

--- a/extensions/config/config-normalize.ts
+++ b/extensions/config/config-normalize.ts
@@ -195,6 +195,10 @@ export function normalizeConfig(
   const minScores = scoreFloors(config.recall?.minScores);
   return {
     enabled: bool(config.enabled, DEFAULT_CONFIG.enabled),
+    setupComplete: bool(
+      (config as { setupComplete?: unknown }).setupComplete,
+      DEFAULT_CONFIG.setupComplete,
+    ),
     hindsight: {
       baseUrl: stringValue(config.hindsight?.baseUrl, DEFAULT_CONFIG.hindsight.baseUrl),
       ...(apiKey ? { apiKey } : {}),

--- a/extensions/config/config-writer.ts
+++ b/extensions/config/config-writer.ts
@@ -86,6 +86,7 @@ export function deepMergeConfig(
 
 export interface ProjectConfigPatchInput {
   enabled?: boolean;
+  setupComplete?: boolean;
   baseUrl?: string;
   timeoutMs?: number;
   apiKeyEnvVar?: string;
@@ -141,6 +142,7 @@ export function buildProjectConfigDeletes(input: ProjectConfigPatchInput): strin
 export function buildProjectConfigPatch(input: ProjectConfigPatchInput): Record<string, unknown> {
   const patch: Record<string, unknown> = {};
   if (input.enabled !== undefined) patch.enabled = input.enabled;
+  if (input.setupComplete !== undefined) patch.setupComplete = input.setupComplete;
   if (input.apiKeyEnvVar && !validEnvVarName(input.apiKeyEnvVar)) {
     throw new Error("apiKeyEnvVar must be an environment variable name");
   }

--- a/extensions/config/setup-gate.ts
+++ b/extensions/config/setup-gate.ts
@@ -1,0 +1,46 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { ResolvedConfig } from "../types.js";
+
+/**
+ * Whether automatic Hindsight network memory (ensure bank, auto-recall, auto-retain)
+ * is allowed. False on a true first run until guided/agent setup or explicit bank ids.
+ * Existing installs migrate via bank ids, config files, or local runtime state (ADR-005).
+ */
+export function isMemorySetupComplete(config: ResolvedConfig, cwd: string): boolean {
+  if (config.setupComplete === true) return true;
+  if (config.banks.project.bankId?.trim()) return true;
+  if (config.banks.user.bankId?.trim()) return true;
+  if (config.banks.global.bankId?.trim()) return true;
+  if (hasProjectConfigFile(cwd)) return true;
+  if (hasLocalRuntimeState(cwd, config)) return true;
+  return false;
+}
+
+export function setupRequiredMessage(): string {
+  return (
+    "Hindsight setup required: run /hindsight guided setup, or set banks.project.bankId " +
+    "(or PI_HINDSIGHT_PROJECT_BANK_ID). Memory network I/O is paused until then."
+  );
+}
+
+function hasProjectConfigFile(cwd: string): boolean {
+  return (
+    existsSync(join(cwd, ".pi", "hindsight.json")) ||
+    existsSync(join(cwd, ".pi", "hindsight.jsonc"))
+  );
+}
+
+function hasLocalRuntimeState(cwd: string, config: ResolvedConfig): boolean {
+  const dir = join(cwd, ".pi", "hindsight");
+  if (!existsSync(dir)) return false;
+  const candidates = [
+    join(cwd, config.retain.queuePath),
+    join(cwd, config.retain.queuePath.replace(/\.jsonl$/, ".dead.jsonl")),
+    join(cwd, ".pi", "hindsight", "retain-cursors.json"),
+    join(cwd, config.import.manifestPath),
+    join(cwd, config.import.checkpointPath),
+    join(cwd, config.recall.lastRecallPath),
+  ];
+  return candidates.some((path) => existsSync(path));
+}

--- a/extensions/lifecycle/memory-lifecycle.ts
+++ b/extensions/lifecycle/memory-lifecycle.ts
@@ -1,6 +1,7 @@
 import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
 import { resolveConfig } from "../config/config.js";
 import { consumeLastConfigMigrationResults } from "../config/config.js";
+import { isMemorySetupComplete, setupRequiredMessage } from "../config/setup-gate.js";
 import { deriveProjectBankId } from "../banks/banking.js";
 import { createHindsightClient } from "../client/client.js";
 import { ensureGlobalBank, ensureProjectBank } from "../banks/bank-operations.js";
@@ -74,6 +75,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
   const startPeriodicFlush = (runtime: RuntimeSnapshot) => {
     stopPeriodicFlush();
     if (!config.enabled || !config.retain.enabled || config.retain.flushIntervalMs <= 0) return;
+    if (!isMemorySetupComplete(config, runtime.cwd)) return;
     const queuePath = retainQueuePath(runtime.cwd, config);
     periodicFlush = setInterval(() => {
       if (periodicFlushActive) return;
@@ -157,6 +159,12 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
         );
       }
       if (!config.enabled) return;
+      if (!isMemorySetupComplete(config, runtime.cwd)) {
+        initHealth = { checkedAt: new Date().toISOString(), failures: [] };
+        setMemoryStatus(runtime, "idle");
+        if (config.notifications.startup) notify(runtime, setupRequiredMessage(), "warning");
+        return;
+      }
       const failures: InitHealthFailure[] = [];
       let ensureSucceeded = false;
       if (config.banks.project.enabled) {
@@ -199,6 +207,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       if (!config.enabled || !config.recall.enabled) return undefined;
       const runtime = snapshotRuntime(ctx);
       if (!runtime) return undefined;
+      if (!isMemorySetupComplete(config, runtime.cwd)) return undefined;
       return recallPolicy.recall(event, runtime);
     },
 
@@ -212,6 +221,8 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
         return { queued: false, sent: 0, remaining: 0 };
       const runtime = snapshotRuntime(ctx);
       if (!runtime) return { queued: false, sent: 0, remaining: 0 };
+      if (!isMemorySetupComplete(config, runtime.cwd))
+        return { queued: false, sent: 0, remaining: 0 };
       return retainPolicy.retain(event, runtime);
     },
 
@@ -220,6 +231,7 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
       if (!config.enabled || !config.retain.enabled) return;
       const runtime = snapshotRuntime(ctx);
       if (!runtime) return;
+      if (!isMemorySetupComplete(config, runtime.cwd)) return;
       try {
         const result = await flushRetainQueue(retainQueuePath(runtime.cwd, config), client, {
           maxJobs: config.retain.shutdownFlushMaxJobs,

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -47,6 +47,7 @@ export function buildGuidedSetupPatch(args: {
   const memoryProfile = setupProfileChoiceToMemoryProfile(args.profile);
   return {
     memoryProfile,
+    setupComplete: true,
     ...(profileUsesProject(args.profile) && args.projectBankId?.trim()
       ? { projectBankId: args.projectBankId.trim() }
       : {}),

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -59,6 +59,11 @@ export interface HindsightEntityInput {
 
 export interface ResolvedConfig {
   enabled: boolean;
+  /**
+   * When true, automatic memory network I/O is allowed.
+   * Also treated as complete when bank ids, project config files, or legacy runtime state exist (ADR-005).
+   */
+  setupComplete: boolean;
   hindsight: { baseUrl: string; apiKey?: string; apiKeyRef?: string; timeoutMs: number };
   /** Selects default mental-model sets (coding vs conversation/real-life). */
   agentUse: AgentUseProfile;

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -41,6 +41,15 @@ const mocked = vi.hoisted(() => ({
   checkHindsight: vi.fn(async () => ({ ok: true })),
 }));
 
+/** Minimal project config so setup-gate treats the fixture as configured (ADR-005). */
+function writeSetupCompleteConfig(cwd: string, extra: Record<string, unknown> = {}): void {
+  mkdirSync(join(cwd, ".pi"), { recursive: true });
+  writeFileSync(
+    join(cwd, ".pi", "hindsight.json"),
+    JSON.stringify({ setupComplete: true, hindsight: { baseUrl: "http://unused.test" }, ...extra }),
+  );
+}
+
 vi.mock("../extensions/client/client.js", () => ({
   createHindsightClient: () => mocked.client,
   checkHindsight: mocked.checkHindsight,
@@ -76,6 +85,28 @@ describe("extension hooks", () => {
     } else {
       process.env.HOME = originalHome;
     }
+  });
+
+  it("skips bank ensure and recall when setup is incomplete", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
+    mkdirSync(join(cwd, ".git"));
+    // no .pi/hindsight.json and no runtime state → setup gate closed
+    const { createMemoryLifecycle } = await import("../extensions/lifecycle/memory-lifecycle.js");
+    const ctx = {
+      cwd,
+      ui: { setStatus: vi.fn(), notify: vi.fn() },
+      sessionManager: { getSessionFile: () => join(cwd, "session.jsonl") },
+    };
+    const lifecycle = createMemoryLifecycle(cwd);
+    await lifecycle.initialize(ctx);
+    expect(mocked.ensureProjectBank).not.toHaveBeenCalled();
+    expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringMatching(/setup required/i), "warning");
+    const recall = await lifecycle.recall(
+      { messages: [{ role: "user", content: "q", timestamp: 1 }] } as any,
+      ctx,
+    );
+    expect(recall).toBeUndefined();
+    expect(mocked.client.recall).not.toHaveBeenCalled();
   });
 
   it("marks startup status connected after bank ensure succeeds", async () => {
@@ -340,7 +371,7 @@ describe("extension hooks", () => {
   it("skips automatic retain once for next opt-out and advances retain cursor", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
-    mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const sessionFile = join(cwd, "session.jsonl");
     await setNextSessionRetainMode(cwd, sessionFile, "off");
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
@@ -397,7 +428,7 @@ describe("extension hooks", () => {
   it("still recalls while next opt-out is pending", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
-    mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const sessionFile = join(cwd, "session.jsonl");
     await setNextSessionRetainMode(cwd, sessionFile, "off");
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
@@ -649,6 +680,7 @@ describe("extension hooks", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
       on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
@@ -811,6 +843,7 @@ describe("extension hooks", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
       on: vi.fn((name: string, handler: (event: any, ctx: any) => Promise<any>) => {
@@ -1001,7 +1034,7 @@ describe("extension hooks", () => {
   it("honors session read-only mode and manual tags", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
-    mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const sessionFile = join(cwd, "session.jsonl");
     await setNextSessionRetainMode(cwd, sessionFile, "off");
     await addSessionMemoryTag(cwd, sessionFile, "domain:test");
@@ -1092,6 +1125,7 @@ describe("extension hooks", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const sessionFile = join(cwd, "session.jsonl");
     await setSessionMemoryMode(cwd, sessionFile, "read-only");
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
@@ -1132,6 +1166,7 @@ describe("extension hooks", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const sessionFile = join(cwd, "session.jsonl");
     await setSessionMemoryMode(cwd, sessionFile, "read-only");
     await setNextSessionRetainMode(cwd, sessionFile, "off");
@@ -1167,6 +1202,7 @@ describe("extension hooks", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const sessionFile = join(cwd, "session.jsonl");
     await setSessionMemoryMode(cwd, sessionFile, "ignored");
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
@@ -1203,6 +1239,7 @@ describe("extension hooks", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const sessionFile = join(cwd, "session.jsonl");
     await setSessionMemoryMode(cwd, sessionFile, "ignored");
     await setNextSessionRetainMode(cwd, sessionFile, "off");
@@ -1242,6 +1279,7 @@ describe("extension hooks", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
     mkdirSync(join(cwd, ".pi"));
+    writeSetupCompleteConfig(cwd);
     const sessionFile = join(cwd, "session.jsonl");
     await setSessionRetainEnabled(cwd, sessionFile, false);
     await setNextSessionRetainMode(cwd, sessionFile, "off");

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -56,7 +56,11 @@ describe("guided setup", () => {
         projectBankId: "project-bank",
         config: DEFAULT_CONFIG,
       }),
-    ).toEqual({ memoryProfile: "project-only", projectBankId: "project-bank" });
+    ).toEqual({
+      memoryProfile: "project-only",
+      setupComplete: true,
+      projectBankId: "project-bank",
+    });
 
     expect(
       buildGuidedSetupPatch({
@@ -67,6 +71,7 @@ describe("guided setup", () => {
       }),
     ).toEqual({
       memoryProfile: "project+global",
+      setupComplete: true,
       projectBankId: "project-bank",
       resetDefaults: ["banks.global.bankId"],
     });
@@ -78,7 +83,11 @@ describe("guided setup", () => {
         globalBankId: "global-luxus",
         config: DEFAULT_CONFIG,
       }),
-    ).toEqual({ memoryProfile: "global-only", resetDefaults: ["banks.global.bankId"] });
+    ).toEqual({
+      memoryProfile: "global-only",
+      setupComplete: true,
+      resetDefaults: ["banks.global.bankId"],
+    });
 
     expect(
       buildGuidedSetupPatch({
@@ -87,7 +96,11 @@ describe("guided setup", () => {
         globalBankId: "ignored-user",
         config: DEFAULT_CONFIG,
       }),
-    ).toEqual({ memoryProfile: "recall-only", projectBankId: "project-bank" });
+    ).toEqual({
+      memoryProfile: "recall-only",
+      setupComplete: true,
+      projectBankId: "project-bank",
+    });
   });
 
   it("builds global config patches for user memory profiles", () => {
@@ -270,6 +283,7 @@ describe("guided setup", () => {
       }),
     ).toEqual({
       memoryProfile: "project+global",
+      setupComplete: true,
       projectBankId: "project-bank",
       resetDefaults: ["banks.global.bankId"],
     });

--- a/tests/setup-gate.test.ts
+++ b/tests/setup-gate.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import { isMemorySetupComplete, setupRequiredMessage } from "../extensions/config/setup-gate.js";
+import type { ResolvedConfig } from "../extensions/types.js";
+
+function config(patch: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return { ...DEFAULT_CONFIG, ...patch };
+}
+
+describe("setup gate", () => {
+  it("blocks pure first-run defaults with no config or runtime state", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-fresh-"));
+    expect(isMemorySetupComplete(config(), cwd)).toBe(false);
+    expect(setupRequiredMessage()).toMatch(/setup required/i);
+  });
+
+  it("accepts explicit setupComplete flag", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-flag-"));
+    expect(isMemorySetupComplete(config({ setupComplete: true }), cwd)).toBe(true);
+  });
+
+  it("accepts explicit project bankId", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-bank-"));
+    expect(
+      isMemorySetupComplete(
+        config({
+          banks: {
+            ...DEFAULT_CONFIG.banks,
+            project: { enabled: true, bankId: "my-bank", derive: "manual" },
+          },
+        }),
+        cwd,
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts user bankId as configured", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-user-"));
+    expect(
+      isMemorySetupComplete(
+        config({
+          banks: {
+            ...DEFAULT_CONFIG.banks,
+            project: { enabled: false, derive: "repo" },
+            user: { enabled: true, bankId: "life-bank" },
+            global: { enabled: true, bankId: "life-bank" },
+          },
+        }),
+        cwd,
+      ),
+    ).toBe(true);
+  });
+
+  it("migrates upgrades that already have project config files", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-cfg-"));
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "hindsight.json"), "{}\n");
+    expect(isMemorySetupComplete(config(), cwd)).toBe(true);
+  });
+
+  it("migrates upgrades that have retain runtime state", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-runtime-"));
+    mkdirSync(join(cwd, ".pi", "hindsight"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "hindsight", "retain-cursors.json"), "{}\n");
+    expect(isMemorySetupComplete(config(), cwd)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implement ADR-005 setup gate (#485): automatic bank ensure, recall, retain, and shutdown flush stay off until setup is complete. Completion is `setupComplete: true`, an explicit project/user bank id, a project `.pi/hindsight.json(c)`, or legacy local runtime state (queue/cursors/import/last-recall). Guided setup writes `setupComplete: true`. True first-run installs no longer silently path-derive a bank; upgrades keep working.

## Linked issue

Closes #485

## Scope

Setup-gate helper, lifecycle gates, guided-setup patch, config field `setupComplete`, getting-started note, unit/hook tests. No domain-bank topology flip yet (#488).

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (CI coverage gate passed)
- [x] `npm run typecheck:tsc` (CI TypeScript compiler fallback passed)
- [x] Targeted: `tests/setup-gate.test.ts`, `tests/extension-hooks.test.ts`, `tests/guided-setup.test.ts`
- [x] `npm run smoke:hindsight` skipped as unavailable: live CI hit Cloudflare Tunnel error 1033 on HINDSIGHT_BASE_URL (`h1.luxus.ai` tunnel down). Risk covered by unit/hook tests of ensure/recall/retain gates without network.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

First-run behavior: memory network paused until setup/bank id; upgrades with existing config or runtime state unchanged.

## Risk and rollback

- Risk: users with pure zero-config path-derived banks and no local `.pi` artifacts must run guided setup once.
- Rollback/revert path: revert this PR; or set `setupComplete: true` / `banks.project.bankId` in config.

## Follow-ups

#486 status tones, #487 stable projectId, #488 domain coding bank default, #489 agent tools.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] Getting-started documents the setup gate; ADR-005 already defines the policy.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Live smoke failure is infrastructure (Cloudflare tunnel), not setup-gate logic. Re-run live smoke when the Hindsight host tunnel is healthy.