### PR TITLE
feat: domain-tagged scope mode and coding bank profiles

### DIFF
--- a/docs-site/src/content/docs/concepts/project-identity.md
+++ b/docs-site/src/content/docs/concepts/project-identity.md
@@ -28,19 +28,35 @@ Doctor/status (`/hindsight` doctor, debug report) shows:
 - derivation basis (`pin` / `remote` / `basename`) and source
 - legacy `repo:` tag
 
+## Scope mode (bank topology)
+
+| Mode                          | Bank                                           | Tags                          |
+| ----------------------------- | ---------------------------------------------- | ----------------------------- |
+| **`domain-tagged`** (default) | Shared coding bank (`banks.project.bankId`)    | `project:<id>` isolates repos |
+| **`isolated-bank`**           | Hard wall per repo (path-derived if no bankId) | project tags still written    |
+
+`banks.coding` aliases `banks.project`. `banks.life` aliases `banks.user`.
+
 ## Config
 
 ```jsonc
+// ~/.pi/agent/hindsight.json
+{
+  "setupComplete": true,
+  "scope": { "mode": "domain-tagged", "projectIdStrategy": "remote" },
+  "banks": {
+    "project": { "enabled": true, "bankId": "kai-coding", "derive": "manual" },
+    "user": { "enabled": true, "bankId": "kai-life" }
+  }
+}
+
 // .pi/hindsight.json
 {
-  "scope": {
-    "projectId": "finalform", // optional pin
-    "projectIdStrategy": "remote", // or "basename"
-  },
+  "scope": { "projectId": "finalform" }
 }
 ```
 
-Env: prefer writing the pin into config via guided setup or agent tools. Bank selection remains `banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID` (setup gate).
+Env: `PI_HINDSIGHT_PROJECT_BANK_ID` sets the coding bank id (setup gate).
 
 ## Observation scopes
 

--- a/docs-site/src/content/docs/start/memory-profiles.md
+++ b/docs-site/src/content/docs/start/memory-profiles.md
@@ -4,25 +4,29 @@ title: "Memory profiles"
 
 Choose the narrowest memory route that fits the repository.
 
-## Project + User
+## Coding (shared bank + project tags)
 
-Best for most personal coding.
+Best for most personal coding (ADR-005 **domain-tagged**).
 
-- Recall can read project memory and user memory. Project Bank recall and User Bank recall each have their own token budget (`recall.maxTokens` and `recall.userMaxTokens`), so enabling User Bank recall does not silently grow the total context injected per turn.
-- Automatic retain writes repository session deltas to the Project Bank.
-- User Bank settings are stored once in global Pi config and reused across repositories.
+- One **coding bank** (`banks.project.bankId`) shared across repos.
+- Soft isolation via stable `project:<id>` tags (see [project identity](/pi-hindsight/concepts/project-identity/)).
+- Automatic retain writes to the coding bank with project tags.
 
-Use this when you want repo-specific memory plus durable cross-repo preferences and workflows.
+Use this when you hop between repos and want fewer Hindsight banks.
 
-## Project Only
+## Coding + Life (Project + User)
 
-Best for strict isolation.
+Best for personal coding OS.
 
-- Recall reads the Project Bank.
-- Automatic retain writes session deltas to the Project Bank.
-- User memory is not used by default.
+- Coding bank as above, plus optional **life/user bank** for durable cross-project prefs.
+- Recall can read both; each has its own token budget (`recall.maxTokens` and `recall.userMaxTokens`).
+- Automatic retain is coding-bank only; life/user writes stay explicit.
 
-Use this for sensitive repositories, client work, or any project where memory must stay isolated.
+## Isolated project
+
+Hard wall: dedicated bank for this repo (`scope.mode: isolated-bank`), path-derived if no bank id.
+
+Use for sensitive repositories, client work, or any project where memory must never share a bank.
 
 ## User Only
 

--- a/docs/project-identity.md
+++ b/docs/project-identity.md
@@ -26,19 +26,35 @@ Doctor/status (`/hindsight` doctor, debug report) shows:
 - derivation basis (`pin` / `remote` / `basename`) and source
 - legacy `repo:` tag
 
+## Scope mode (bank topology)
+
+| Mode                          | Bank                                           | Tags                          |
+| ----------------------------- | ---------------------------------------------- | ----------------------------- |
+| **`domain-tagged`** (default) | Shared coding bank (`banks.project.bankId`)    | `project:<id>` isolates repos |
+| **`isolated-bank`**           | Hard wall per repo (path-derived if no bankId) | project tags still written    |
+
+`banks.coding` aliases `banks.project`. `banks.life` aliases `banks.user`.
+
 ## Config
 
 ```jsonc
+// ~/.pi/agent/hindsight.json
+{
+  "setupComplete": true,
+  "scope": { "mode": "domain-tagged", "projectIdStrategy": "remote" },
+  "banks": {
+    "project": { "enabled": true, "bankId": "kai-coding", "derive": "manual" },
+    "user": { "enabled": true, "bankId": "kai-life" }
+  }
+}
+
 // .pi/hindsight.json
 {
-  "scope": {
-    "projectId": "finalform", // optional pin
-    "projectIdStrategy": "remote", // or "basename"
-  },
+  "scope": { "projectId": "finalform" }
 }
 ```
 
-Env: prefer writing the pin into config via guided setup or agent tools. Bank selection remains `banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID` (setup gate).
+Env: `PI_HINDSIGHT_PROJECT_BANK_ID` sets the coding bank id (setup gate).
 
 ## Observation scopes
 

--- a/extensions/banks/banking.ts
+++ b/extensions/banks/banking.ts
@@ -161,10 +161,28 @@ export function legacyRepoScopeTag(legacyKey: string): string {
   return `repo:${legacyKey}`;
 }
 
+/**
+ * Resolve the coding-role bank id.
+ * - Explicit banks.project.bankId always wins (domain coding bank or isolated override).
+ * - isolated-bank mode (or legacy path when no bankId): path/cwd-derived bank.
+ * - domain-tagged without bankId: still path-derived for upgrade safety; setup should set bankId.
+ */
 export function deriveProjectBankId(cwd: string, config: ResolvedConfig): string {
   if (config.banks.project.bankId) return config.banks.project.bankId;
+  // Domain-tagged + explicit bankId is the preferred shared coding bank path.
+  // Without bankId, keep path-derived identity so upgrades do not silently merge banks.
   const basis = config.banks.project.derive === "cwd" ? resolve(cwd) : findRepoRoot(cwd);
   return `pi-project-${slug(basename(basis))}-${hash(basis)}`;
+}
+
+/** True when this repo uses a hard-isolated bank rather than a shared coding domain bank. */
+export function isIsolatedBankMode(config: ResolvedConfig): boolean {
+  return config.scope.mode === "isolated-bank";
+}
+
+/** Coding-role bank id (alias for deriveProjectBankId). */
+export function deriveCodingBankId(cwd: string, config: ResolvedConfig): string {
+  return deriveProjectBankId(cwd, config);
 }
 
 export function selectBanks(cwd: string, config: ResolvedConfig): BankSelection {

--- a/extensions/config/config-defaults.ts
+++ b/extensions/config/config-defaults.ts
@@ -4,6 +4,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
   enabled: true,
   setupComplete: false,
   scope: {
+    mode: "domain-tagged",
     projectIdStrategy: "remote",
   },
   hindsight: { baseUrl: "http://localhost:8888", timeoutMs: 30_000 },

--- a/extensions/config/config-normalize.ts
+++ b/extensions/config/config-normalize.ts
@@ -185,6 +185,26 @@ export function normalizeConfig(
   const apiKey =
     directApiKey(config.hindsight?.apiKey, DEFAULT_CONFIG.hindsight.apiKey) ??
     resolveApiKeyRef(apiKeyRef, env);
+  // banks.coding → project; banks.life → user (ADR-005 role names).
+  const banksRaw = config.banks as
+    | {
+        project?: unknown;
+        coding?: unknown;
+        user?: unknown;
+        global?: unknown;
+        life?: unknown;
+      }
+    | undefined;
+  if (banksRaw && isRecord(banksRaw.coding) && !isRecord(banksRaw.project)) {
+    banksRaw.project = banksRaw.coding;
+  } else if (banksRaw && isRecord(banksRaw.coding) && isRecord(banksRaw.project)) {
+    banksRaw.project = { ...banksRaw.coding, ...banksRaw.project };
+  }
+  if (banksRaw && isRecord(banksRaw.life)) {
+    // life overlays user so alias fields win over defaults merged earlier.
+    if (isRecord(banksRaw.user)) banksRaw.user = { ...banksRaw.user, ...banksRaw.life };
+    else banksRaw.user = banksRaw.life;
+  }
   const projectBankId = optionalString(
     config.banks?.project?.bankId,
     DEFAULT_CONFIG.banks.project.bankId,
@@ -193,8 +213,11 @@ export function normalizeConfig(
   const defaultUserBankConfig = DEFAULT_CONFIG.banks.user;
   const globalBankId = optionalString(userBankConfig?.bankId, defaultUserBankConfig.bankId);
   const minScores = scoreFloors(config.recall?.minScores);
-  const scopeRaw = (config as { scope?: { projectId?: unknown; projectIdStrategy?: unknown } })
-    .scope;
+  const scopeRaw = (
+    config as {
+      scope?: { mode?: unknown; projectId?: unknown; projectIdStrategy?: unknown };
+    }
+  ).scope;
   const projectIdPin = optionalString(scopeRaw?.projectId, DEFAULT_CONFIG.scope.projectId);
   return {
     enabled: bool(config.enabled, DEFAULT_CONFIG.enabled),
@@ -203,6 +226,11 @@ export function normalizeConfig(
       DEFAULT_CONFIG.setupComplete,
     ),
     scope: {
+      mode: enumValue(
+        scopeRaw?.mode,
+        ["domain-tagged", "isolated-bank"] as const,
+        DEFAULT_CONFIG.scope.mode,
+      ),
       ...(projectIdPin ? { projectId: projectIdPin } : {}),
       projectIdStrategy: enumValue(
         scopeRaw?.projectIdStrategy,

--- a/extensions/config/config-writer.ts
+++ b/extensions/config/config-writer.ts
@@ -87,6 +87,7 @@ export function deepMergeConfig(
 export interface ProjectConfigPatchInput {
   enabled?: boolean;
   setupComplete?: boolean;
+  scopeMode?: "domain-tagged" | "isolated-bank";
   projectId?: string;
   projectIdStrategy?: "remote" | "basename";
   baseUrl?: string;
@@ -145,8 +146,13 @@ export function buildProjectConfigPatch(input: ProjectConfigPatchInput): Record<
   const patch: Record<string, unknown> = {};
   if (input.enabled !== undefined) patch.enabled = input.enabled;
   if (input.setupComplete !== undefined) patch.setupComplete = input.setupComplete;
-  if (input.projectId !== undefined || input.projectIdStrategy !== undefined) {
+  if (
+    input.scopeMode !== undefined ||
+    input.projectId !== undefined ||
+    input.projectIdStrategy !== undefined
+  ) {
     patch.scope = {
+      ...(input.scopeMode !== undefined ? { mode: input.scopeMode } : {}),
       ...(input.projectId !== undefined ? { projectId: input.projectId } : {}),
       ...(input.projectIdStrategy !== undefined
         ? { projectIdStrategy: input.projectIdStrategy }

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -27,11 +27,17 @@ export function hasProjectHindsightConfig(cwd: string): boolean {
 export function setupProfileChoiceToMemoryProfile(choice: SetupProfileChoice): MemoryProfile {
   if (choice === "project-user") return "project+global";
   if (choice === "user-only") return "global-only";
+  if (choice === "isolated-only") return "project-only";
   return choice;
 }
 
 function profileUsesProject(profile: SetupProfileChoice): boolean {
-  return profile === "project-user" || profile === "project-only" || profile === "recall-only";
+  return (
+    profile === "project-user" ||
+    profile === "project-only" ||
+    profile === "isolated-only" ||
+    profile === "recall-only"
+  );
 }
 
 function profileUsesUser(profile: SetupProfileChoice): boolean {
@@ -48,6 +54,8 @@ export function buildGuidedSetupPatch(args: {
   return {
     memoryProfile,
     setupComplete: true,
+    // Domain-tagged shares one coding bank + project tags; isolated keeps a hard wall.
+    scopeMode: args.profile === "isolated-only" ? "isolated-bank" : "domain-tagged",
     ...(profileUsesProject(args.profile) && args.projectBankId?.trim()
       ? { projectBankId: args.projectBankId.trim() }
       : {}),
@@ -245,18 +253,20 @@ export async function runGuidedSetup(args: {
   args.ctx.ui.notify(setupDocsHint("Guided setup", "/start/setup-tui/"), "info");
   args.ctx.ui.notify(setupDocsHint("Memory profiles", "/start/memory-profiles/"), "info");
   const profile = await args.ctx.ui.select("Choose memory profile", [
-    "Project + User",
-    "Project Only",
-    "User Only",
-    "Recall Only",
+    "Coding (shared coding bank + project tags)",
+    "Coding + Life (coding bank + user bank)",
+    "Isolated project (hard wall bank per repo)",
+    "Life only (user bank)",
+    "Recall only",
   ]);
   if (!profile) return false;
 
   const setupProfile = {
-    "Project + User": "project-user",
-    "Project Only": "project-only",
-    "User Only": "user-only",
-    "Recall Only": "recall-only",
+    "Coding (shared coding bank + project tags)": "project-only",
+    "Coding + Life (coding bank + user bank)": "project-user",
+    "Isolated project (hard wall bank per repo)": "isolated-only",
+    "Life only (user bank)": "user-only",
+    "Recall only": "recall-only",
   }[profile] as SetupProfileChoice;
 
   const agentUseLabel = await args.ctx.ui.select("How do you use this Pi agent?", [
@@ -272,8 +282,13 @@ export async function runGuidedSetup(args: {
   const projectBankId = profileUsesProject(setupProfile)
     ? await askBankId({
         ctx: args.ctx,
-        title: "Project bank ID",
-        fallback: config.banks.project.bankId ?? args.deps.getProjectBankId(),
+        title:
+          setupProfile === "isolated-only"
+            ? "Isolated project bank ID (optional; leave default for path-derived)"
+            : "Coding bank ID (shared across repos with project tags)",
+        fallback:
+          config.banks.project.bankId ??
+          (setupProfile === "isolated-only" ? args.deps.getProjectBankId() : "pi-coding"),
       })
     : undefined;
   if (profileUsesProject(setupProfile) && projectBankId === undefined) return false;

--- a/extensions/tui/setup-tui-types.ts
+++ b/extensions/tui/setup-tui-types.ts
@@ -18,7 +18,12 @@ export type SetupActionId = FieldId | `reset:${FieldId}` | HubActionId;
 
 export type SetupStep = "config" | "profile" | "banks" | "review" | "done";
 
-export type SetupProfileChoice = "project-user" | "project-only" | "user-only" | "recall-only";
+export type SetupProfileChoice =
+  | "project-user"
+  | "project-only"
+  | "isolated-only"
+  | "user-only"
+  | "recall-only";
 
 export type SetupUiState = {
   step?: SetupStep;

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -57,7 +57,14 @@ export interface HindsightEntityInput {
   type?: string;
 }
 
+export type ScopeMode = "domain-tagged" | "isolated-bank";
+
 export interface ScopeConfig {
+  /**
+   * domain-tagged: shared coding bank (banks.project.bankId) + project tags.
+   * isolated-bank: path-derived or dedicated bank per repo (hard wall).
+   */
+  mode: ScopeMode;
   /** Explicit project id pin (wins over remote/basename). Written as tag project:<slug>. */
   projectId?: string;
   /**

--- a/extensions/utils/diagnostics.ts
+++ b/extensions/utils/diagnostics.ts
@@ -51,13 +51,18 @@ export interface DebugReportArgs {
 export function bankSelectionMessage(projectBankId: string, config: ResolvedConfig): string {
   if (!config.banks.project.enabled) {
     return config.banks.user.enabled && config.banks.user.bankId
-      ? `Hindsight global-only memory: ${config.banks.user.bankId}`
-      : "Hindsight project bank disabled and no global bank configured.";
+      ? `Hindsight life/user bank: ${config.banks.user.bankId}`
+      : "Hindsight coding bank disabled and no life/user bank configured.";
   }
+  const mode = config.scope.mode;
   if (config.banks.project.bankId) {
-    return `Hindsight bank configured: ${projectBankId}`;
+    return mode === "isolated-bank"
+      ? `Hindsight isolated bank: ${projectBankId}`
+      : `Hindsight coding bank (domain-tagged): ${projectBankId}`;
   }
-  return `Hindsight bank auto-selected: ${projectBankId}. Override with PI_HINDSIGHT_PROJECT_BANK_ID or .pi/hindsight.json banks.project.bankId.`;
+  return mode === "isolated-bank"
+    ? `Hindsight isolated bank auto-selected: ${projectBankId}. Set banks.project.bankId to pin.`
+    : `Hindsight coding bank path-derived (set banks.project.bankId for a shared domain bank): ${projectBankId}`;
 }
 
 export function memoryProfile(

--- a/tests/banking.test.ts
+++ b/tests/banking.test.ts
@@ -170,3 +170,20 @@ describe("banking/session identity", () => {
     expect(first).not.toBe(stableSessionId("ephemeral:/repo", "/repo"));
   });
 });
+
+describe("domain coding bank roles", () => {
+  it("uses explicit coding bank id for domain-tagged mode", async () => {
+    const { deriveProjectBankId } = await import("../extensions/banks/banking.js");
+    const { DEFAULT_CONFIG } = await import("../extensions/config/config.js");
+    const config = {
+      ...DEFAULT_CONFIG,
+      scope: { ...DEFAULT_CONFIG.scope, mode: "domain-tagged" as const },
+      banks: {
+        ...DEFAULT_CONFIG.banks,
+        project: { enabled: true, bankId: "kai-coding", derive: "manual" as const },
+      },
+    };
+    expect(deriveProjectBankId("/any/repo", config)).toBe("kai-coding");
+    expect(deriveProjectBankId("/other/repo", config)).toBe("kai-coding");
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -504,4 +504,24 @@ describe("resolveConfig", () => {
     expect(config.notifications.recall).toBe(true);
     expect(config.notifications.retain).toBe(true);
   });
+
+  it("accepts banks.coding and banks.life aliases", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({
+        banks: {
+          coding: { enabled: true, bankId: "coding-bank" },
+          life: { enabled: true, bankId: "life-bank" },
+        },
+      }),
+    );
+    const home = tmp();
+    const config = resolveConfig(cwd, { ...process.env, HOME: home });
+    expect(config.banks.project.bankId).toBe("coding-bank");
+    expect(config.banks.user.bankId).toBe("life-bank");
+    expect(config.banks.user.enabled).toBe(true);
+    expect(config.scope.mode).toBe("domain-tagged");
+  });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -35,10 +35,8 @@ function latestImport(overrides: Partial<ImportManifestEntry> = {}): ImportManif
 
 describe("diagnostics", () => {
   it("explains automatic bank selection and override", () => {
-    expect(bankSelectionMessage("bank-1", DEFAULT_CONFIG)).toContain("auto-selected");
-    expect(bankSelectionMessage("bank-1", DEFAULT_CONFIG)).toContain(
-      "PI_HINDSIGHT_PROJECT_BANK_ID",
-    );
+    expect(bankSelectionMessage("bank-1", DEFAULT_CONFIG)).toContain("path-derived");
+    expect(bankSelectionMessage("bank-1", DEFAULT_CONFIG)).toContain("banks.project.bankId");
   });
 
   it("explains configured bank selection", () => {
@@ -49,7 +47,9 @@ describe("diagnostics", () => {
         project: { ...DEFAULT_CONFIG.banks.project, bankId: "manual" },
       },
     };
-    expect(bankSelectionMessage("manual", config)).toBe("Hindsight bank configured: manual");
+    expect(bankSelectionMessage("manual", config)).toBe(
+      "Hindsight coding bank (domain-tagged): manual",
+    );
   });
 
   it("redacts api key in debug config", () => {

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -59,6 +59,7 @@ describe("guided setup", () => {
     ).toEqual({
       memoryProfile: "project-only",
       setupComplete: true,
+      scopeMode: "domain-tagged",
       projectBankId: "project-bank",
     });
 
@@ -72,6 +73,7 @@ describe("guided setup", () => {
     ).toEqual({
       memoryProfile: "project+global",
       setupComplete: true,
+      scopeMode: "domain-tagged",
       projectBankId: "project-bank",
       resetDefaults: ["banks.global.bankId"],
     });
@@ -86,6 +88,7 @@ describe("guided setup", () => {
     ).toEqual({
       memoryProfile: "global-only",
       setupComplete: true,
+      scopeMode: "domain-tagged",
       resetDefaults: ["banks.global.bankId"],
     });
 
@@ -99,7 +102,23 @@ describe("guided setup", () => {
     ).toEqual({
       memoryProfile: "recall-only",
       setupComplete: true,
+      scopeMode: "domain-tagged",
       projectBankId: "project-bank",
+    });
+  });
+
+  it("marks isolated profile with isolated-bank scope mode", () => {
+    expect(
+      buildGuidedSetupPatch({
+        profile: "isolated-only",
+        projectBankId: "client-acme",
+        config: DEFAULT_CONFIG,
+      }),
+    ).toEqual({
+      memoryProfile: "project-only",
+      setupComplete: true,
+      scopeMode: "isolated-bank",
+      projectBankId: "client-acme",
     });
   });
 
@@ -284,6 +303,7 @@ describe("guided setup", () => {
     ).toEqual({
       memoryProfile: "project+global",
       setupComplete: true,
+      scopeMode: "domain-tagged",
       projectBankId: "project-bank",
       resetDefaults: ["banks.global.bankId"],
     });

--- a/tests/project-identity.test.ts
+++ b/tests/project-identity.test.ts
@@ -9,9 +9,11 @@ import {
   recallScopeTags,
   resolveProjectIdentity,
 } from "../extensions/banks/banking.js";
-import type { ResolvedConfig } from "../extensions/types.js";
+import type { ResolvedConfig, ScopeConfig } from "../extensions/types.js";
 
-function config(patch: Partial<ResolvedConfig> = {}): ResolvedConfig {
+function config(
+  patch: Partial<Omit<ResolvedConfig, "scope">> & { scope?: Partial<ScopeConfig> } = {},
+): ResolvedConfig {
   return {
     ...DEFAULT_CONFIG,
     ...patch,
@@ -60,9 +62,6 @@ describe("stable project identity", () => {
     const identity = resolveProjectIdentity(repo, config());
     expect(identity.basis).toBe("remote");
     expect(identity.projectId).toBe("github-com-luxus-my-app");
-    // Same remote identity if folder is renamed (path hash legacy differs).
-    const moved = join(parent, "my-app-renamed");
-    // Cannot easily rename git root in test without moving; assert dual tags include project.
     const tags = recallScopeTags(repo, config());
     expect(tags).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Summary

Implement ADR-005 domain bank topology (#488): `scope.mode` is `domain-tagged` (default) or `isolated-bank`. Guided setup offers Coding / Coding+Life / Isolated / Life / Recall profiles and writes scope mode plus coding bank id (default `pi-coding` for shared). Config accepts `banks.coding` / `banks.life` aliases. Explicit `banks.project.bankId` is the shared coding bank; without bankId, path-derived remains for upgrade safety.

## Linked issue

Closes #488

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check`
- [x] Unit tests for aliases, guided setup scopeMode, domain bank id reuse

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Guided setup labels and bank selection messages change; default scope.mode is domain-tagged.

## Risk and rollback

- Risk: users must set coding bankId for true multi-repo sharing; path-derived still used if bankId missing (safe upgrade).
- Rollback/revert path: revert PR; set `scope.mode: isolated-bank` for old path-hash banks.

## Follow-ups

#486 status tones, #489 agent tools, #491 MM inject filter.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] memory-profiles + project-identity docs updated.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Live smoke will run in CI if labeled memory-path.