### PR TITLE
feat: status fields with non-default tone signaling

### DIFF
--- a/extensions/utils/diagnostics.ts
+++ b/extensions/utils/diagnostics.ts
@@ -23,6 +23,7 @@ import {
   formatHindsightStatus,
   type HindsightActivity,
 } from "./status.js";
+import { buildStatusFields } from "./status-fields.js";
 
 export interface DebugReportArgs {
   cwd: string;
@@ -147,6 +148,18 @@ export function formatDebugReport(args: DebugReportArgs): string {
       repoRoot: findRepoRoot(args.cwd),
       sessionFile: args.sessionFile ?? null,
       sessionId,
+      statusFields: buildStatusFields(args.config, {
+        cwd: args.cwd,
+        projectBankId: args.projectBankId,
+        queueLength: args.queueLength,
+        ...(args.deadLetterLength !== undefined ? { deadLetterLength: args.deadLetterLength } : {}),
+        ...(args.health
+          ? {
+              healthOk: args.health.ok,
+              ...(args.health.error ? { healthError: args.health.error } : {}),
+            }
+          : {}),
+      }),
       projectScope: {
         projectId: projectIdentity.projectId,
         basis: projectIdentity.basis,

--- a/extensions/utils/status-fields.ts
+++ b/extensions/utils/status-fields.ts
@@ -1,0 +1,160 @@
+import { isMemorySetupComplete } from "../config/setup-gate.js";
+import { DEFAULT_CONFIG } from "../config/config-defaults.js";
+import { formatProjectIdentityForStatus, resolveProjectIdentity } from "../banks/banking.js";
+import type { ResolvedConfig } from "../types.js";
+
+export type StatusFieldTone = "default" | "custom" | "warn" | "info";
+
+export interface StatusField {
+  key: string;
+  label: string;
+  value: string;
+  tone: StatusFieldTone;
+  source?: string;
+}
+
+export interface StatusFieldContext {
+  cwd: string;
+  projectBankId: string;
+  queueLength?: number;
+  deadLetterLength?: number;
+  healthOk?: boolean;
+  healthError?: string;
+}
+
+function eq(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Build read-only status fields with tone vs defaults (ADR-005).
+ * warn = broken/setup incomplete; custom = non-default valid; info = intentionally off; default = quiet.
+ */
+export function buildStatusFields(config: ResolvedConfig, ctx: StatusFieldContext): StatusField[] {
+  const fields: StatusField[] = [];
+  const setupOk = isMemorySetupComplete(config, ctx.cwd);
+  const project = resolveProjectIdentity(ctx.cwd, config);
+
+  fields.push({
+    key: "setup",
+    label: "Setup",
+    value: setupOk ? "complete" : "required",
+    tone: setupOk ? "default" : "warn",
+  });
+
+  fields.push({
+    key: "enabled",
+    label: "Extension",
+    value: config.enabled ? "enabled" : "disabled",
+    tone:
+      config.enabled === DEFAULT_CONFIG.enabled ? "default" : config.enabled ? "custom" : "info",
+  });
+
+  fields.push({
+    key: "baseUrl",
+    label: "Hindsight URL",
+    value: config.hindsight.baseUrl,
+    tone: config.hindsight.baseUrl === DEFAULT_CONFIG.hindsight.baseUrl ? "default" : "custom",
+  });
+
+  if (ctx.healthOk === false) {
+    fields.push({
+      key: "health",
+      label: "Server",
+      value: ctx.healthError ? `unreachable: ${ctx.healthError}` : "unreachable",
+      tone: "warn",
+    });
+  } else if (ctx.healthOk === true) {
+    fields.push({ key: "health", label: "Server", value: "reachable", tone: "default" });
+  }
+
+  fields.push({
+    key: "scopeMode",
+    label: "Scope mode",
+    value: config.scope.mode,
+    tone: config.scope.mode === DEFAULT_CONFIG.scope.mode ? "default" : "custom",
+  });
+
+  fields.push({
+    key: "projectScope",
+    label: "Project scope",
+    value: formatProjectIdentityForStatus(project),
+    tone: project.basis === "pin" ? "custom" : "default",
+  });
+
+  const codingEnabled = config.banks.project.enabled;
+  fields.push({
+    key: "codingBank",
+    label: "Coding bank",
+    value: codingEnabled
+      ? `${ctx.projectBankId}${config.banks.project.bankId ? "" : " (path-derived)"}`
+      : "disabled",
+    tone: !codingEnabled
+      ? "info"
+      : config.banks.project.bankId
+        ? "custom"
+        : setupOk
+          ? "warn"
+          : "info",
+  });
+
+  const lifeId = config.banks.user.bankId;
+  fields.push({
+    key: "lifeBank",
+    label: "Life bank",
+    value: config.banks.user.enabled ? (lifeId ?? "(no bankId)") : "disabled",
+    tone: !config.banks.user.enabled ? "info" : lifeId ? "custom" : "warn",
+  });
+
+  fields.push({
+    key: "recall",
+    label: "Auto recall",
+    value: config.recall.enabled ? "on" : "off",
+    tone: config.recall.enabled === DEFAULT_CONFIG.recall.enabled ? "default" : "custom",
+  });
+
+  fields.push({
+    key: "retain",
+    label: "Auto retain",
+    value: config.retain.enabled ? "on" : "off",
+    tone: config.retain.enabled === DEFAULT_CONFIG.retain.enabled ? "default" : "custom",
+  });
+
+  if (!eq(config.recall.maxTokens, DEFAULT_CONFIG.recall.maxTokens)) {
+    fields.push({
+      key: "recallMaxTokens",
+      label: "Recall maxTokens",
+      value: String(config.recall.maxTokens),
+      tone: "custom",
+    });
+  }
+
+  const queue = ctx.queueLength ?? 0;
+  const dead = ctx.deadLetterLength ?? 0;
+  fields.push({
+    key: "queue",
+    label: "Retain queue",
+    value: dead > 0 ? `${queue} pending, ${dead} dead-letter` : `${queue} pending`,
+    tone: dead > 0 ? "warn" : queue > 0 ? "custom" : "default",
+  });
+
+  fields.push({
+    key: "mentalModels",
+    label: "Mental model inject",
+    value: config.mentalModels.inject ? "on" : "off",
+    tone: config.mentalModels.inject === DEFAULT_CONFIG.mentalModels.inject ? "default" : "custom",
+  });
+
+  return fields;
+}
+
+/** Render fields for TUI/doctor text (tone as marker; color is TUI's job). */
+export function formatStatusFieldsText(fields: StatusField[]): string {
+  return fields
+    .map((f) => {
+      const mark =
+        f.tone === "warn" ? "!" : f.tone === "custom" ? "*" : f.tone === "info" ? "-" : " ";
+      return `${mark} ${f.label}: ${f.value}`;
+    })
+    .join("\n");
+}

--- a/tests/status-fields.test.ts
+++ b/tests/status-fields.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import { buildStatusFields, formatStatusFieldsText } from "../extensions/utils/status-fields.js";
+import type { ResolvedConfig } from "../extensions/types.js";
+
+function config(patch: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    ...patch,
+    scope: { ...DEFAULT_CONFIG.scope, ...(patch as { scope?: object }).scope },
+    banks: { ...DEFAULT_CONFIG.banks, ...(patch.banks ?? {}) },
+    recall: { ...DEFAULT_CONFIG.recall, ...(patch.recall ?? {}) },
+    retain: { ...DEFAULT_CONFIG.retain, ...(patch.retain ?? {}) },
+  } as ResolvedConfig;
+}
+
+describe("status fields tones", () => {
+  it("warns when setup is incomplete", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-status-fresh-"));
+    const fields = buildStatusFields(config(), {
+      cwd,
+      projectBankId: "pi-project-x",
+    });
+    const setup = fields.find((f) => f.key === "setup");
+    expect(setup?.value).toBe("required");
+    expect(setup?.tone).toBe("warn");
+  });
+
+  it("marks non-default bank id and maxTokens as custom", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-status-cfg-"));
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "hindsight.json"), "{}\n");
+    const fields = buildStatusFields(
+      config({
+        setupComplete: true,
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "kai-coding", derive: "manual" },
+        },
+        recall: { ...DEFAULT_CONFIG.recall, maxTokens: 1200 },
+      }),
+      { cwd, projectBankId: "kai-coding" },
+    );
+    expect(fields.find((f) => f.key === "codingBank")?.tone).toBe("custom");
+    expect(fields.find((f) => f.key === "recallMaxTokens")?.tone).toBe("custom");
+    expect(fields.find((f) => f.key === "setup")?.tone).toBe("default");
+  });
+
+  it("warns on dead-letter queue depth", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-status-dl-"));
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "hindsight.json"), "{}\n");
+    const fields = buildStatusFields(config({ setupComplete: true }), {
+      cwd,
+      projectBankId: "b",
+      queueLength: 1,
+      deadLetterLength: 2,
+    });
+    expect(fields.find((f) => f.key === "queue")?.tone).toBe("warn");
+  });
+
+  it("renders text with tone markers", () => {
+    const text = formatStatusFieldsText([
+      { key: "a", label: "A", value: "ok", tone: "default" },
+      { key: "b", label: "B", value: "custom", tone: "custom" },
+      { key: "c", label: "C", value: "bad", tone: "warn" },
+    ]);
+    expect(text).toContain("  A: ok");
+    expect(text).toContain("* B: custom");
+    expect(text).toContain("! C: bad");
+  });
+});


### PR DESCRIPTION
## Summary

Add `buildStatusFields` / `formatStatusFieldsText` (#486): read-only status snapshot with tones vs defaults (setup required = warn, non-default bank/maxTokens = custom, dead-letter = warn). Embedded in doctor debug report as `statusFields`.

## Linked issue

Closes #486

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check`
- [x] `tests/status-fields.test.ts`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Doctor JSON gains `statusFields`; tone markers for agent/status consumers.

## Risk and rollback

- Risk: low; additive diagnostics.
- Rollback/revert path: revert PR.

## Follow-ups

#489 agent status tool can return same fields; #491 MM inject.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] N/A beyond ADR-005 status tones.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

None.