### PR TITLE
feat: filter mental-model inject by project tags

### DIFF
--- a/extensions/banks/bank-templates.ts
+++ b/extensions/banks/bank-templates.ts
@@ -40,8 +40,8 @@ function bankConfigFromMissions(missions: BankMissionDefaults): BankTemplateConf
   };
 }
 
-// Tags must be a subset of tags written at retain time (source:pi, repo:*, session:*)
-// so Hindsight mental-model refresh does not match empty with all_strict.
+// Tags must be a subset of tags written at retain time (source:pi, project:*, session:*, repo:*).
+// Project-tier models get project:<id> stamped at apply time (resolveBankTemplateManifest).
 const RETAIN_COMPAT_TAGS = ["source:pi"] as const;
 
 // Coding project models — durable engineering knowledge (oh-my-pi-shaped core + a few extras).
@@ -240,16 +240,44 @@ function defaultMissionsForTarget(target: BankTemplateTarget): BankMissionDefaul
   return target === "user" ? defaultGlobalBankMissions() : defaultProjectBankMissions();
 }
 
+function slugProjectId(projectId: string): string {
+  return (
+    projectId
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 48) || "project"
+  );
+}
+
+/**
+ * Resolve template manifest for import. For project-target templates with a projectId,
+ * stamp project-tier mental models with project:<id> tags and id suffixes so multi-project
+ * domain banks do not share one architecture model (ADR-005).
+ */
 export function resolveBankTemplateManifest(
   template: BuiltInBankTemplate,
   bankMissionSettings: BankMissionSettings,
+  options?: { projectId?: string },
 ): BankTemplateManifest {
   const missions = resolveBankMissions(
     bankMissionSettings,
     defaultMissionsForTarget(template.target),
   );
+  const projectId = options?.projectId?.trim();
+  let mental_models = template.manifest.mental_models;
+  if (template.target === "project" && projectId && mental_models?.length) {
+    const suffix = slugProjectId(projectId);
+    const projectTag = `project:${projectId}`;
+    mental_models = mental_models.map((model) => ({
+      ...model,
+      id: `${model.id}--${suffix}`,
+      tags: [...new Set([...(model.tags ?? []), "source:pi", projectTag])],
+    }));
+  }
   return {
     ...template.manifest,
+    ...(mental_models ? { mental_models } : {}),
     bank: bankConfigFromMissions(missions),
   };
 }

--- a/extensions/lifecycle/mental-models.ts
+++ b/extensions/lifecycle/mental-models.ts
@@ -146,10 +146,33 @@ export function clearMentalModelListCache(): void {
   mentalModelListCache.clear();
 }
 
+/**
+ * Inject filter for multi-project domain banks (ADR-005).
+ * - User/life bank: all models with content.
+ * - Project/coding bank: bank-global models (no project:* tags) plus models tagged project:<activeId>.
+ */
+export function filterMentalModelsForInject(
+  models: MentalModelSummary[],
+  args: { bankKind: "project" | "user"; projectId?: string },
+): MentalModelSummary[] {
+  if (args.bankKind === "user") return models;
+  const projectId = args.projectId?.trim();
+  const projectTag = projectId ? `project:${projectId}` : undefined;
+  return models.filter((model) => {
+    const tags = model.tags ?? [];
+    const projectTags = tags.filter((t) => t.startsWith("project:"));
+    if (projectTags.length === 0) return true; // bank-global
+    if (!projectTag) return false;
+    return projectTags.includes(projectTag);
+  });
+}
+
 export async function loadMentalModelsBlock(args: {
   client: HindsightLikeClient;
   bankId: string;
   config: ResolvedConfig;
+  bankKind?: "project" | "user";
+  projectId?: string;
 }): Promise<{ rendered: string; modelCount: number; error?: string }> {
   if (!args.config.mentalModels.inject) {
     return { rendered: "", modelCount: 0 };
@@ -160,14 +183,22 @@ export async function loadMentalModelsBlock(args: {
   const listed = await listModelsCached(args);
   if (listed.error) return { rendered: "", modelCount: 0, error: listed.error };
   if (listed.models.length === 0) return { rendered: "", modelCount: 0 };
-  const rendered = renderMentalModelsBlock(listed.models, args.config.mentalModels.maxChars);
-  return { rendered, modelCount: listed.models.length };
+  const filtered = filterMentalModelsForInject(listed.models, {
+    bankKind: args.bankKind ?? "project",
+    ...(args.projectId ? { projectId: args.projectId } : {}),
+  });
+  if (filtered.length === 0) return { rendered: "", modelCount: 0 };
+  const rendered = renderMentalModelsBlock(filtered, args.config.mentalModels.maxChars);
+  return { rendered, modelCount: filtered.length };
 }
 
 export async function loadMentalModelsForScopes(args: {
   client: HindsightLikeClient;
   config: ResolvedConfig;
   bankIds: string[];
+  /** Parallel to bankIds when known; defaults to project for every bank. */
+  bankKinds?: Array<"project" | "user">;
+  projectId?: string;
 }): Promise<{ rendered: string; modelCount: number; failures: number }> {
   if (!args.config.mentalModels.inject || args.bankIds.length === 0) {
     return { rendered: "", modelCount: 0, failures: 0 };
@@ -181,12 +212,16 @@ export async function loadMentalModelsForScopes(args: {
   let failures = 0;
   let remaining = totalBudget;
 
-  for (const bankId of args.bankIds) {
+  for (let i = 0; i < args.bankIds.length; i++) {
+    const bankId = args.bankIds[i]!;
     if (remaining < minBudget) break;
     const budget = equalShare >= minBudget ? Math.min(equalShare, remaining) : remaining;
+    const bankKind = args.bankKinds?.[i] ?? "project";
     const result = await loadMentalModelsBlock({
       client: args.client,
       bankId,
+      bankKind,
+      ...(args.projectId ? { projectId: args.projectId } : {}),
       config: {
         ...args.config,
         mentalModels: { ...args.config.mentalModels, maxChars: budget },

--- a/extensions/lifecycle/recall.ts
+++ b/extensions/lifecycle/recall.ts
@@ -236,10 +236,14 @@ export async function recallForContext(args: {
     }
   }
   const recallRendered = renderRecallBlocks(blocks, args.config.recall.topK);
+  const cwd = args.cwd ?? process.cwd();
+  const identity = createMemoryIdentity(cwd, args.config);
   const mental = await loadMentalModelsForScopes({
     client: args.client,
     config: args.config,
     bankIds: args.scopes.map((scope) => scope.bankId),
+    bankKinds: args.scopes.map((scope) => (scope.kind === "global" ? "user" : "project")),
+    projectId: identity.projectId,
   });
   const rendered = [mental.rendered, recallRendered].filter(Boolean).join("\n\n");
   return {

--- a/extensions/operations/memory-bank-template-operations.ts
+++ b/extensions/operations/memory-bank-template-operations.ts
@@ -4,6 +4,7 @@ import {
   listBuiltInBankTemplates,
   resolveBankTemplateManifest,
 } from "../banks/bank-templates.js";
+import { resolveProjectIdentity } from "../banks/banking.js";
 import { resolveOperationBank } from "../banks/bank-selection.js";
 import type { MemoryOperationsDeps } from "./memory-operation-types.js";
 
@@ -38,7 +39,12 @@ export function createBankTemplateOperations(deps: MemoryOperationsDeps) {
       });
       const bankMissionSettings =
         template.target === "user" ? config.banks.user : config.banks.project;
-      const manifest = resolveBankTemplateManifest(template, bankMissionSettings);
+      const cwd = (deps as { getCwd?: () => string }).getCwd?.() ?? process.cwd();
+      const resolvedProjectId =
+        template.target === "project" ? resolveProjectIdentity(cwd, config).projectId : undefined;
+      const manifest = resolveBankTemplateManifest(template, bankMissionSettings, {
+        ...(resolvedProjectId ? { projectId: resolvedProjectId } : {}),
+      });
       const dryRun = args.dryRun ?? true;
       const result = await client.importBankTemplate(bankId, manifest, { dryRun });
       return { bankId, template, dryRun, result };

--- a/tests/mental-models.test.ts
+++ b/tests/mental-models.test.ts
@@ -44,7 +44,7 @@ describe("use-profile mental model sets", () => {
     expect(getBuiltInBankTemplate("pi-user-preferences")?.id).toBe("pi-coding-user");
   });
 
-  it("uses retain-compatible source:pi tags on seeds", () => {
+  it("uses retain-compatible source:pi tags on seed definitions", () => {
     for (const template of [
       ...listBankTemplatesForAgentUse("coding"),
       ...listBankTemplatesForAgentUse("conversation"),
@@ -53,6 +53,46 @@ describe("use-profile mental model sets", () => {
         expect(model.tags).toEqual(["source:pi"]);
       }
     }
+  });
+
+  it("stamps project tags and id suffixes when resolving project templates", async () => {
+    const { resolveBankTemplateManifest } = await import("../extensions/banks/bank-templates.js");
+    const template = getBuiltInBankTemplate("pi-coding-project");
+    expect(template).toBeTruthy();
+    const manifest = resolveBankTemplateManifest(template!, {}, { projectId: "finalform" });
+    const models = manifest.mental_models ?? [];
+    expect(models.length).toBeGreaterThan(0);
+    for (const model of models) {
+      expect(model.id).toContain("--finalform");
+      expect(model.tags).toEqual(expect.arrayContaining(["source:pi", "project:finalform"]));
+    }
+  });
+});
+
+describe("mental model inject filter", () => {
+  it("keeps bank-global and matching project models only", async () => {
+    const { filterMentalModelsForInject } =
+      await import("../extensions/lifecycle/mental-models.js");
+    const models = [
+      { id: "g", name: "Global prefs", content: "prefs", tags: ["source:pi"] },
+      {
+        id: "a",
+        name: "Arch A",
+        content: "arch a",
+        tags: ["source:pi", "project:alpha"],
+      },
+      {
+        id: "b",
+        name: "Arch B",
+        content: "arch b",
+        tags: ["source:pi", "project:beta"],
+      },
+    ];
+    const filtered = filterMentalModelsForInject(models, {
+      bankKind: "project",
+      projectId: "alpha",
+    });
+    expect(filtered.map((m) => m.id).sort()).toEqual(["a", "g"]);
   });
 });
 


### PR DESCRIPTION
## Summary

MM inject isolation for domain banks (#491): `filterMentalModelsForInject` keeps bank-global + active `project:` models only. Project bank templates stamp `project:<id>` tags and `--project` id suffixes at apply time so refresh matches retain tags.

## Linked issue

Closes #491

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check`
- [x] `tests/mental-models.test.ts` inject filter + template stamp

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Injected context no longer sprays all project MMs; template apply creates per-project model ids.

## Risk and rollback

- Risk: existing untagged project MMs still inject bank-wide (bank-global by design until re-tagged).
- Rollback/revert path: revert PR.

## Follow-ups

#489 agent MM tools; #493 migrate/retag.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] Aligns with ADR-005 MM two-altitude policy.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

None.