### PR TITLE
feat: agent control-plane tools for status, bank, mental models

### DIFF
--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -10,12 +10,16 @@ This reference is generated from the operation catalog and config editing regist
 
 Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi workflow tools are part of the stable 1.0 contract. Capability-gated tools are supported when the connected Hindsight server exposes the required upstream endpoint or field; unsupported servers should return a clear capability error.
 
-| Tool                      | Scope    |
-| ------------------------- | -------- |
-| `hindsight_recall`        | core 1.0 |
-| `hindsight_retain`        | core 1.0 |
-| `hindsight_retain_global` | core 1.0 |
-| `hindsight_reflect`       | core 1.0 |
+| Tool                      | Scope                |
+| ------------------------- | -------------------- |
+| `hindsight_recall`        | core 1.0             |
+| `hindsight_retain`        | core 1.0             |
+| `hindsight_retain_global` | core 1.0             |
+| `hindsight_reflect`       | core 1.0             |
+| `hindsight_status`        | supported 1.0        |
+| `hindsight_scope`         | supported 1.0        |
+| `hindsight_bank`          | supported 1.0        |
+| `hindsight_mental_model`  | capability-gated 1.0 |
 
 ## Deferred or non-goal upstream surfaces
 
@@ -110,6 +114,48 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 | `tags`                  | array<string>                                   | no       | Additional tag filter.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `tagsMatch`             | any \| all \| any_strict \| all_strict \| exact | no       | How to match tags. Always enforced together with the automatic Pi project/user scope tag filter. 'exact' folds the automatic scope tags into the exact-match set (memory tags must equal scope tags plus these tags, no more, no less) instead of AND-ing a separate scope group, since scope tags must still be present. Note: 'exact' with empty/omitted tags -- Hindsight's pattern for recalling shared/untagged observations -- is incompatible with scope isolation and will not surface those observations here; see issue #450. |
 | `tagGroups`             | array<object>                                   | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+### `hindsight_status`
+
+Inspect Pi Hindsight status: setup gate, coding/life banks, project scope tags (basis), recall/retain flags, queue. Use before changing memory config. Read-only.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+
+### `hindsight_scope`
+
+Show active project identity: project:<id> tag, derivation (pin/remote/basename), scope.mode (domain-tagged vs isolated-bank), coding/life bank ids. Read-only.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+
+### `hindsight_bank`
+
+Inspect or update the selected coding/life bank. action=get returns profile/stats/config. action=update_mission patches retain/reflect/observations mission (dryRun default true for safety).
+
+| Parameter             | Type                  | Required | Description                                                              |
+| --------------------- | --------------------- | -------- | ------------------------------------------------------------------------ |
+| `action`              | get \| update_mission | yes      |                                                                          |
+| `bank`                | string                | no       | Bank id or alias project\|global\|user. Defaults to coding/project bank. |
+| `retainMission`       | string                | no       |                                                                          |
+| `reflectMission`      | string                | no       |                                                                          |
+| `observationsMission` | string                | no       |                                                                          |
+| `dryRun`              | boolean               | no       | When true (default for update_mission), preview only.                    |
+
+### `hindsight_mental_model`
+
+Agent control plane for mental models on the selected bank. Actions: list|get|create|update|refresh|delete. Project-tier create defaults tags to source:pi + project:<activeId>. delete defaults dryRun=true.
+
+| Parameter     | Type                                                 | Required | Description                                    |
+| ------------- | ---------------------------------------------------- | -------- | ---------------------------------------------- |
+| `action`      | list \| get \| create \| update \| refresh \| delete | yes      |                                                |
+| `bank`        | string                                               | no       | Bank id or alias project\|global\|user.        |
+| `id`          | string                                               | no       | Mental model id for get/update/refresh/delete. |
+| `name`        | string                                               | no       |                                                |
+| `sourceQuery` | string                                               | no       |                                                |
+| `tags`        | array<string>                                        | no       |                                                |
+| `maxTokens`   | integer                                              | no       |                                                |
+| `dryRun`      | boolean                                              | no       |                                                |
 
 ## Commands
 

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -51,6 +51,10 @@ Pi exposes exactly four memory tools:
 - `hindsight_retain`
 - `hindsight_retain_global`
 - `hindsight_reflect`
+- `hindsight_status`
+- `hindsight_scope`
+- `hindsight_bank`
+- `hindsight_mental_model`
 
 Everything else — bank config/profile administration, document/entity/graph/tag browsing, memory inspection, consolidation control, and operation management — lives in the Hindsight control-plane web UI, except for the bundled mental-model templates applied from the hub (`t`).
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -6,12 +6,16 @@ This reference is generated from the operation catalog and config editing regist
 
 Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi workflow tools are part of the stable 1.0 contract. Capability-gated tools are supported when the connected Hindsight server exposes the required upstream endpoint or field; unsupported servers should return a clear capability error.
 
-| Tool                      | Scope    |
-| ------------------------- | -------- |
-| `hindsight_recall`        | core 1.0 |
-| `hindsight_retain`        | core 1.0 |
-| `hindsight_retain_global` | core 1.0 |
-| `hindsight_reflect`       | core 1.0 |
+| Tool                      | Scope                |
+| ------------------------- | -------------------- |
+| `hindsight_recall`        | core 1.0             |
+| `hindsight_retain`        | core 1.0             |
+| `hindsight_retain_global` | core 1.0             |
+| `hindsight_reflect`       | core 1.0             |
+| `hindsight_status`        | supported 1.0        |
+| `hindsight_scope`         | supported 1.0        |
+| `hindsight_bank`          | supported 1.0        |
+| `hindsight_mental_model`  | capability-gated 1.0 |
 
 ## Deferred or non-goal upstream surfaces
 
@@ -106,6 +110,48 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 | `tags`                  | array<string>                                   | no       | Additional tag filter.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | `tagsMatch`             | any \| all \| any_strict \| all_strict \| exact | no       | How to match tags. Always enforced together with the automatic Pi project/user scope tag filter. 'exact' folds the automatic scope tags into the exact-match set (memory tags must equal scope tags plus these tags, no more, no less) instead of AND-ing a separate scope group, since scope tags must still be present. Note: 'exact' with empty/omitted tags -- Hindsight's pattern for recalling shared/untagged observations -- is incompatible with scope isolation and will not surface those observations here; see issue #450. |
 | `tagGroups`             | array<object>                                   | no       | Compound Hindsight tag_groups filter. AND-ed with the automatic Pi project/user scope filter.                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+### `hindsight_status`
+
+Inspect Pi Hindsight status: setup gate, coding/life banks, project scope tags (basis), recall/retain flags, queue. Use before changing memory config. Read-only.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+
+### `hindsight_scope`
+
+Show active project identity: project:<id> tag, derivation (pin/remote/basename), scope.mode (domain-tagged vs isolated-bank), coding/life bank ids. Read-only.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+
+### `hindsight_bank`
+
+Inspect or update the selected coding/life bank. action=get returns profile/stats/config. action=update_mission patches retain/reflect/observations mission (dryRun default true for safety).
+
+| Parameter             | Type                  | Required | Description                                                              |
+| --------------------- | --------------------- | -------- | ------------------------------------------------------------------------ |
+| `action`              | get \| update_mission | yes      |                                                                          |
+| `bank`                | string                | no       | Bank id or alias project\|global\|user. Defaults to coding/project bank. |
+| `retainMission`       | string                | no       |                                                                          |
+| `reflectMission`      | string                | no       |                                                                          |
+| `observationsMission` | string                | no       |                                                                          |
+| `dryRun`              | boolean               | no       | When true (default for update_mission), preview only.                    |
+
+### `hindsight_mental_model`
+
+Agent control plane for mental models on the selected bank. Actions: list|get|create|update|refresh|delete. Project-tier create defaults tags to source:pi + project:<activeId>. delete defaults dryRun=true.
+
+| Parameter     | Type                                                 | Required | Description                                    |
+| ------------- | ---------------------------------------------------- | -------- | ---------------------------------------------- |
+| `action`      | list \| get \| create \| update \| refresh \| delete | yes      |                                                |
+| `bank`        | string                                               | no       | Bank id or alias project\|global\|user.        |
+| `id`          | string                                               | no       | Mental model id for get/update/refresh/delete. |
+| `name`        | string                                               | no       |                                                |
+| `sourceQuery` | string                                               | no       |                                                |
+| `tags`        | array<string>                                        | no       |                                                |
+| `maxTokens`   | integer                                              | no       |                                                |
+| `dryRun`      | boolean                                              | no       |                                                |
 
 ## Commands
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -41,11 +41,15 @@ When mental models exist on active banks and `mentalModels.inject` is true (defa
 
 ## Model-facing tools
 
-These remain available for the agent:
+Available for the agent (control plane is agent-first; TUI is thin):
 
 - `hindsight_recall`
 - `hindsight_retain`
 - `hindsight_retain_global`
 - `hindsight_reflect`
+- `hindsight_status` — setup/banks/scope tones
+- `hindsight_scope` — project id derivation
+- `hindsight_bank` — get bank or update missions (dry-run default)
+- `hindsight_mental_model` — list/get/create/update/refresh/delete (delete dry-run default)
 
 See the generated [surface reference](surface-reference.md) for parameter schemas.

--- a/extensions/client/client.ts
+++ b/extensions/client/client.ts
@@ -247,6 +247,54 @@ export function createHindsightClient(config: ResolvedConfig): HindsightLikeClie
         (signal) => raw.listMentalModels(bankId, { ...options, signal }),
         options?.signal,
       ),
+    getMentalModel: (bankId, mentalModelId, options) =>
+      withTimeout(
+        "hindsight getMentalModel",
+        timeoutMs,
+        (signal) => raw.getMentalModel(bankId, mentalModelId, { ...options, signal }),
+        options?.signal,
+      ),
+    createMentalModel: (bankId, name, sourceQuery, options) =>
+      withTimeout(
+        "hindsight createMentalModel",
+        timeoutMs,
+        (signal) => raw.createMentalModel(bankId, name, sourceQuery, { ...options, signal }),
+        options?.signal,
+      ),
+    updateMentalModel: (bankId, mentalModelId, options) =>
+      withTimeout(
+        "hindsight updateMentalModel",
+        timeoutMs,
+        (signal) => raw.updateMentalModel(bankId, mentalModelId, { ...options, signal }),
+        options?.signal,
+      ),
+    refreshMentalModel: (bankId, mentalModelId, options) =>
+      withTimeout(
+        "hindsight refreshMentalModel",
+        timeoutMs,
+        (signal) => raw.refreshMentalModel(bankId, mentalModelId, { ...options, signal }),
+        options?.signal,
+      ),
+    deleteMentalModel: (bankId, mentalModelId, options) =>
+      withTimeout(
+        "hindsight deleteMentalModel",
+        timeoutMs,
+        async (signal) => {
+          if (options?.dryRun) {
+            return { dryRun: true, bankId, mentalModelId, wouldDelete: true };
+          }
+          await raw.deleteMentalModel(bankId, mentalModelId, { signal });
+          return { deleted: true, bankId, mentalModelId };
+        },
+        options?.signal,
+      ),
+    updateBankConfig: (bankId, options) =>
+      withTimeout(
+        "hindsight updateBankConfig",
+        timeoutMs,
+        (signal) => raw.updateBankConfig(bankId, { ...options, signal }),
+        options?.signal,
+      ),
     health: () =>
       withTimeout("hindsight health", timeoutMs, (signal) =>
         withRetry("health", async () => {

--- a/extensions/operations/memory-control-operations.ts
+++ b/extensions/operations/memory-control-operations.ts
@@ -1,0 +1,192 @@
+import { resolveProjectIdentity } from "../banks/banking.js";
+import { resolveOperationBank } from "../banks/bank-selection.js";
+import { buildStatusFields } from "../utils/status-fields.js";
+import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+import { isMemorySetupComplete, setupRequiredMessage } from "../config/setup-gate.js";
+import type { HindsightLikeClient } from "../types.js";
+
+function clientMethod<K extends keyof HindsightLikeClient>(
+  deps: MemoryOperationsDeps,
+  method: K,
+): NonNullable<HindsightLikeClient[K]> {
+  const client = deps.getClient();
+  const fn = client[method];
+  if (typeof fn !== "function") {
+    throw new Error(`Hindsight client does not support ${String(method)}.`);
+  }
+  // Bind without typing bind's overload union (optional methods vary).
+  return (fn as (...args: never[]) => unknown).bind(client) as NonNullable<HindsightLikeClient[K]>;
+}
+
+export function createControlOperations(deps: MemoryOperationsDeps) {
+  return {
+    status(cwd: string) {
+      const config = deps.getConfig();
+      const fields = buildStatusFields(config, {
+        cwd,
+        projectBankId: deps.getProjectBankId(),
+      });
+      return {
+        setupComplete: isMemorySetupComplete(config, cwd),
+        ...(isMemorySetupComplete(config, cwd) ? {} : { setupHint: setupRequiredMessage() }),
+        project: resolveProjectIdentity(cwd, config),
+        fields,
+      };
+    },
+
+    scopeInfo(cwd: string) {
+      const config = deps.getConfig();
+      const project = resolveProjectIdentity(cwd, config);
+      return {
+        scopeMode: config.scope.mode,
+        projectId: project.projectId,
+        basis: project.basis,
+        source: project.source,
+        projectTag: `project:${project.projectId}`,
+        legacyRepoTag: `repo:${project.legacyRepoKey}`,
+        codingBankId: deps.getProjectBankId(),
+        lifeBankId: config.banks.user.enabled ? config.banks.user.bankId : undefined,
+        dualTagWindow: true,
+      };
+    },
+
+    async bankGet(args: { bank?: string }) {
+      const config = deps.getConfig();
+      const bankId = resolveOperationBank({
+        requestedBank: args.bank,
+        config,
+        projectBankId: deps.getProjectBankId(),
+      });
+      const client = deps.getClient();
+      const [profile, stats, bankConfig] = await Promise.all([
+        client.getBankProfile?.(bankId),
+        client.getBankStats?.(bankId),
+        client.getBankConfig?.(bankId),
+      ]);
+      return { bankId, profile, stats, config: bankConfig };
+    },
+
+    async bankUpdateMission(args: {
+      bank?: string;
+      retainMission?: string;
+      reflectMission?: string;
+      observationsMission?: string;
+      dryRun?: boolean;
+    }) {
+      const config = deps.getConfig();
+      const bankId = resolveOperationBank({
+        requestedBank: args.bank,
+        config,
+        projectBankId: deps.getProjectBankId(),
+      });
+      const patch = {
+        ...(args.retainMission !== undefined ? { retainMission: args.retainMission } : {}),
+        ...(args.reflectMission !== undefined ? { reflectMission: args.reflectMission } : {}),
+        ...(args.observationsMission !== undefined
+          ? { observationsMission: args.observationsMission }
+          : {}),
+      };
+      if (Object.keys(patch).length === 0) {
+        throw new Error(
+          "Provide at least one of retainMission, reflectMission, observationsMission.",
+        );
+      }
+      if (args.dryRun) {
+        return { dryRun: true, bankId, wouldUpdate: patch };
+      }
+      const update = clientMethod(deps, "updateBankConfig");
+      const result = await update(bankId, patch);
+      return { bankId, updated: patch, result };
+    },
+
+    async mentalModel(args: {
+      action: "list" | "get" | "create" | "update" | "refresh" | "delete";
+      bank?: string;
+      id?: string;
+      name?: string;
+      sourceQuery?: string;
+      tags?: string[];
+      maxTokens?: number;
+      dryRun?: boolean;
+      cwd: string;
+    }) {
+      const config = deps.getConfig();
+      const bankId = resolveOperationBank({
+        requestedBank: args.bank,
+        config,
+        projectBankId: deps.getProjectBankId(),
+      });
+      const project = resolveProjectIdentity(args.cwd, config);
+      const isUserBank =
+        args.bank === "global" ||
+        args.bank === "user" ||
+        (config.banks.user.bankId !== undefined && args.bank === config.banks.user.bankId);
+
+      switch (args.action) {
+        case "list": {
+          const list = clientMethod(deps, "listMentalModels");
+          return { bankId, result: await list(bankId) };
+        }
+        case "get": {
+          if (!args.id) throw new Error("id is required for get");
+          const get = clientMethod(deps, "getMentalModel");
+          return { bankId, result: await get(bankId, args.id) };
+        }
+        case "create": {
+          if (!args.name?.trim() || !args.sourceQuery?.trim()) {
+            throw new Error("name and sourceQuery are required for create");
+          }
+          const tags =
+            args.tags ??
+            (isUserBank ? ["source:pi"] : ["source:pi", `project:${project.projectId}`]);
+          if (args.dryRun) {
+            return {
+              dryRun: true,
+              bankId,
+              wouldCreate: { name: args.name, sourceQuery: args.sourceQuery, tags },
+            };
+          }
+          const create = clientMethod(deps, "createMentalModel");
+          const result = await create(bankId, args.name.trim(), args.sourceQuery.trim(), {
+            ...(args.id ? { id: args.id } : {}),
+            tags,
+            ...(args.maxTokens !== undefined ? { maxTokens: args.maxTokens } : {}),
+            trigger: { refreshAfterConsolidation: true },
+          });
+          return { bankId, result };
+        }
+        case "update": {
+          if (!args.id) throw new Error("id is required for update");
+          const options = {
+            ...(args.name !== undefined ? { name: args.name } : {}),
+            ...(args.sourceQuery !== undefined ? { sourceQuery: args.sourceQuery } : {}),
+            ...(args.tags !== undefined ? { tags: args.tags } : {}),
+            ...(args.maxTokens !== undefined ? { maxTokens: args.maxTokens } : {}),
+          };
+          if (Object.keys(options).length === 0) {
+            throw new Error("Provide name, sourceQuery, tags, and/or maxTokens for update");
+          }
+          if (args.dryRun) return { dryRun: true, bankId, id: args.id, wouldUpdate: options };
+          const update = clientMethod(deps, "updateMentalModel");
+          return { bankId, result: await update(bankId, args.id, options) };
+        }
+        case "refresh": {
+          if (!args.id) throw new Error("id is required for refresh");
+          if (args.dryRun) return { dryRun: true, bankId, id: args.id, wouldRefresh: true };
+          const refresh = clientMethod(deps, "refreshMentalModel");
+          return { bankId, result: await refresh(bankId, args.id) };
+        }
+        case "delete": {
+          if (!args.id) throw new Error("id is required for delete");
+          const del = clientMethod(deps, "deleteMentalModel");
+          return {
+            bankId,
+            result: await del(bankId, args.id, { dryRun: args.dryRun ?? true }),
+          };
+        }
+        default:
+          throw new Error(`Unknown mental model action: ${String(args.action)}`);
+      }
+    },
+  };
+}

--- a/extensions/operations/memory-operation-service.ts
+++ b/extensions/operations/memory-operation-service.ts
@@ -6,6 +6,7 @@ import {
 } from "../imports/import-sessions.js";
 import { createBankTemplateOperations } from "./memory-bank-template-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
+import { createControlOperations } from "./memory-control-operations.js";
 import { createDiagnosticsOperations } from "./memory-diagnostics-operations.js";
 import { createQueueOperations } from "../queue/queue-operations.js";
 import { createRecallOperations } from "./memory-recall-operations.js";
@@ -63,6 +64,7 @@ export function createMemoryOperations(deps: MemoryOperationsDeps) {
     ...createSessionOperations(),
     ...createDiagnosticsOperations(deps),
     ...createBankTemplateOperations(deps),
+    ...createControlOperations(deps),
   };
 }
 

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -453,6 +453,132 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       },
       renderResult: renderMemoryToolTextResult,
     }),
+    defineCatalogTool({
+      name: "hindsight_status",
+      label: "Hindsight Status",
+      description:
+        "Inspect Pi Hindsight status: setup gate, coding/life banks, project scope tags (basis), recall/retain flags, queue. Use before changing memory config. Read-only.",
+      parameters: Type.Object({}),
+      async execute(_id, _params, signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        if (signal?.aborted) throw new Error("Aborted");
+        const result = operations.status(ctx.cwd);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+      renderResult: renderMemoryToolTextResult,
+    }),
+    defineCatalogTool({
+      name: "hindsight_scope",
+      label: "Hindsight Scope",
+      description:
+        "Show active project identity: project:<id> tag, derivation (pin/remote/basename), scope.mode (domain-tagged vs isolated-bank), coding/life bank ids. Read-only.",
+      parameters: Type.Object({}),
+      async execute(_id, _params, signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        if (signal?.aborted) throw new Error("Aborted");
+        const result = operations.scopeInfo(ctx.cwd);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+      renderResult: renderMemoryToolTextResult,
+    }),
+    defineCatalogTool({
+      name: "hindsight_bank",
+      label: "Hindsight Bank",
+      description:
+        "Inspect or update the selected coding/life bank. action=get returns profile/stats/config. action=update_mission patches retain/reflect/observations mission (dryRun default true for safety).",
+      parameters: Type.Object({
+        action: Type.Union([Type.Literal("get"), Type.Literal("update_mission")]),
+        bank: Type.Optional(
+          Type.String({
+            description: "Bank id or alias project|global|user. Defaults to coding/project bank.",
+          }),
+        ),
+        retainMission: Type.Optional(Type.String()),
+        reflectMission: Type.Optional(Type.String()),
+        observationsMission: Type.Optional(Type.String()),
+        dryRun: Type.Optional(
+          Type.Boolean({ description: "When true (default for update_mission), preview only." }),
+        ),
+      }),
+      async execute(_id, params, signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        if (signal?.aborted) throw new Error("Aborted");
+        if (params.action === "get") {
+          const result = await operations.bankGet({
+            ...(params.bank ? { bank: params.bank } : {}),
+          });
+          return {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            details: result,
+          };
+        }
+        const result = await operations.bankUpdateMission({
+          ...(params.bank ? { bank: params.bank } : {}),
+          ...(params.retainMission !== undefined ? { retainMission: params.retainMission } : {}),
+          ...(params.reflectMission !== undefined ? { reflectMission: params.reflectMission } : {}),
+          ...(params.observationsMission !== undefined
+            ? { observationsMission: params.observationsMission }
+            : {}),
+          dryRun: params.dryRun ?? true,
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+      renderResult: renderMemoryToolTextResult,
+    }),
+    defineCatalogTool({
+      name: "hindsight_mental_model",
+      label: "Hindsight Mental Model",
+      description:
+        "Agent control plane for mental models on the selected bank. Actions: list|get|create|update|refresh|delete. Project-tier create defaults tags to source:pi + project:<activeId>. delete defaults dryRun=true.",
+      parameters: Type.Object({
+        action: Type.Union([
+          Type.Literal("list"),
+          Type.Literal("get"),
+          Type.Literal("create"),
+          Type.Literal("update"),
+          Type.Literal("refresh"),
+          Type.Literal("delete"),
+        ]),
+        bank: Type.Optional(Type.String({ description: "Bank id or alias project|global|user." })),
+        id: Type.Optional(
+          Type.String({ description: "Mental model id for get/update/refresh/delete." }),
+        ),
+        name: Type.Optional(Type.String()),
+        sourceQuery: Type.Optional(Type.String()),
+        tags: Type.Optional(Type.Array(Type.String())),
+        maxTokens: Type.Optional(Type.Integer({ minimum: 1 })),
+        dryRun: Type.Optional(Type.Boolean()),
+      }),
+      async execute(_id, params, signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        if (signal?.aborted) throw new Error("Aborted");
+        const result = await operations.mentalModel({
+          action: params.action,
+          cwd: ctx.cwd,
+          ...(params.bank ? { bank: params.bank } : {}),
+          ...(params.id ? { id: params.id } : {}),
+          ...(params.name ? { name: params.name } : {}),
+          ...(params.sourceQuery ? { sourceQuery: params.sourceQuery } : {}),
+          ...(params.tags ? { tags: params.tags } : {}),
+          ...(params.maxTokens !== undefined ? { maxTokens: params.maxTokens } : {}),
+          ...(params.dryRun !== undefined ? { dryRun: params.dryRun } : {}),
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+      renderResult: renderMemoryToolTextResult,
+    }),
   ];
 
   // Human surface is TUI-first: `/hindsight` hub plus a few deliberate slash commands.

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -378,6 +378,55 @@ export interface HindsightLikeClient {
     bankId: string,
     options?: { tags?: string[]; signal?: AbortSignal },
   ): Promise<unknown>;
+  getMentalModel?(
+    bankId: string,
+    mentalModelId: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<unknown>;
+  createMentalModel?(
+    bankId: string,
+    name: string,
+    sourceQuery: string,
+    options?: {
+      id?: string;
+      tags?: string[];
+      maxTokens?: number;
+      trigger?: { refreshAfterConsolidation?: boolean };
+      signal?: AbortSignal;
+    },
+  ): Promise<unknown>;
+  updateMentalModel?(
+    bankId: string,
+    mentalModelId: string,
+    options: {
+      name?: string;
+      sourceQuery?: string;
+      tags?: string[];
+      maxTokens?: number;
+      trigger?: { refreshAfterConsolidation?: boolean };
+      signal?: AbortSignal;
+    },
+  ): Promise<unknown>;
+  refreshMentalModel?(
+    bankId: string,
+    mentalModelId: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<unknown>;
+  deleteMentalModel?(
+    bankId: string,
+    mentalModelId: string,
+    options?: { dryRun?: boolean; signal?: AbortSignal },
+  ): Promise<unknown>;
+  updateBankConfig?(
+    bankId: string,
+    options: {
+      reflectMission?: string;
+      retainMission?: string;
+      observationsMission?: string;
+      enableObservations?: boolean;
+      signal?: AbortSignal;
+    },
+  ): Promise<unknown>;
   health?(): Promise<unknown>;
   getVersion?(): Promise<unknown>;
 }

--- a/tests/client-adapter.test.ts
+++ b/tests/client-adapter.test.ts
@@ -6,6 +6,14 @@ const mocks = vi.hoisted(() => ({
   constructor: vi.fn(),
   retain: vi.fn(async () => ({ accepted: true })),
   retainBatch: vi.fn(async () => ({ accepted: true })),
+  listMentalModels: vi.fn(async () => ({ mental_models: [] })),
+  getMentalModel: vi.fn(async () => ({ id: "mm1" })),
+  createMentalModel: vi.fn(async () => ({ id: "mm1" })),
+  updateMentalModel: vi.fn(async () => ({ id: "mm1" })),
+  refreshMentalModel: vi.fn(async () => ({ id: "mm1" })),
+  deleteMentalModel: vi.fn(async () => undefined),
+  updateBankConfig: vi.fn(async () => ({ bank_id: "bank" })),
+  getBankConfig: vi.fn(async () => ({ bank_id: "bank" })),
 }));
 
 vi.mock("@vectorize-io/hindsight-client", async (importOriginal) => {
@@ -17,6 +25,14 @@ vi.mock("@vectorize-io/hindsight-client", async (importOriginal) => {
       return {
         retain: mocks.retain,
         retainBatch: mocks.retainBatch,
+        listMentalModels: mocks.listMentalModels,
+        getMentalModel: mocks.getMentalModel,
+        createMentalModel: mocks.createMentalModel,
+        updateMentalModel: mocks.updateMentalModel,
+        refreshMentalModel: mocks.refreshMentalModel,
+        deleteMentalModel: mocks.deleteMentalModel,
+        updateBankConfig: mocks.updateBankConfig,
+        getBankConfig: mocks.getBankConfig,
       };
     }),
   };
@@ -27,6 +43,14 @@ describe("Hindsight client adapter", () => {
     mocks.constructor.mockClear();
     mocks.retain.mockClear();
     mocks.retainBatch.mockClear();
+    mocks.listMentalModels.mockClear();
+    mocks.getMentalModel.mockClear();
+    mocks.createMentalModel.mockClear();
+    mocks.updateMentalModel.mockClear();
+    mocks.refreshMentalModel.mockClear();
+    mocks.deleteMentalModel.mockClear();
+    mocks.updateBankConfig.mockClear();
+    mocks.getBankConfig.mockClear();
   });
 
   it("uses official retain for single memories when document tags are absent", async () => {
@@ -90,6 +114,69 @@ describe("Hindsight client adapter", () => {
         documentTags: ["doc:tag"],
         signal: expect.any(AbortSignal),
       }),
+    );
+  });
+
+  it("wraps mental-model and bank-config control-plane methods", async () => {
+    const { createHindsightClient } = await import("../extensions/client/client.js");
+    const client = createHindsightClient(DEFAULT_CONFIG);
+
+    await client.listMentalModels!("bank", { tags: ["project:a"] });
+    expect(mocks.listMentalModels).toHaveBeenCalledWith(
+      "bank",
+      expect.objectContaining({ tags: ["project:a"], signal: expect.any(AbortSignal) }),
+    );
+
+    await client.getMentalModel!("bank", "mm1");
+    expect(mocks.getMentalModel).toHaveBeenCalledWith(
+      "bank",
+      "mm1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    await client.createMentalModel!("bank", "Arch", "query", { tags: ["source:pi"] });
+    expect(mocks.createMentalModel).toHaveBeenCalledWith(
+      "bank",
+      "Arch",
+      "query",
+      expect.objectContaining({ tags: ["source:pi"], signal: expect.any(AbortSignal) }),
+    );
+
+    await client.updateMentalModel!("bank", "mm1", { name: "Arch2" });
+    expect(mocks.updateMentalModel).toHaveBeenCalledWith(
+      "bank",
+      "mm1",
+      expect.objectContaining({ name: "Arch2", signal: expect.any(AbortSignal) }),
+    );
+
+    await client.refreshMentalModel!("bank", "mm1");
+    expect(mocks.refreshMentalModel).toHaveBeenCalledWith(
+      "bank",
+      "mm1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    const dry = await client.deleteMentalModel!("bank", "mm1", { dryRun: true });
+    expect(dry).toMatchObject({ dryRun: true, wouldDelete: true });
+    expect(mocks.deleteMentalModel).not.toHaveBeenCalled();
+
+    await client.deleteMentalModel!("bank", "mm1", { dryRun: false });
+    expect(mocks.deleteMentalModel).toHaveBeenCalledWith(
+      "bank",
+      "mm1",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+
+    await client.updateBankConfig!("bank", { retainMission: "code" });
+    expect(mocks.updateBankConfig).toHaveBeenCalledWith(
+      "bank",
+      expect.objectContaining({ retainMission: "code", signal: expect.any(AbortSignal) }),
+    );
+
+    await client.getBankConfig!("bank");
+    expect(mocks.getBankConfig).toHaveBeenCalledWith(
+      "bank",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 });

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -513,10 +513,14 @@ describe("extension hooks", () => {
     hindsightExtension(pi as any);
 
     expect(Object.keys(tools).sort()).toEqual([
+      "hindsight_bank",
+      "hindsight_mental_model",
       "hindsight_recall",
       "hindsight_reflect",
       "hindsight_retain",
       "hindsight_retain_global",
+      "hindsight_scope",
+      "hindsight_status",
     ]);
   });
 

--- a/tests/memory-control-operations.test.ts
+++ b/tests/memory-control-operations.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import { createControlOperations } from "../extensions/operations/memory-control-operations.js";
+
+describe("memory control operations", () => {
+  it("status reports setup required on fresh cwd", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ctrl-"));
+    const ops = createControlOperations({
+      getClient: () => ({
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+      }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "pi-project-x",
+    });
+    const status = ops.status(cwd);
+    expect(status.setupComplete).toBe(false);
+    expect(status.fields.some((f) => f.key === "setup" && f.tone === "warn")).toBe(true);
+  });
+
+  it("mental model create defaults project tags and supports dry-run", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ctrl-mm-"));
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "hindsight.json"), JSON.stringify({ setupComplete: true }));
+    const createMentalModel = vi.fn(async () => ({ mental_model_id: "mm1" }));
+    const ops = createControlOperations({
+      getClient: () => ({
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+        createMentalModel,
+      }),
+      getConfig: () => ({
+        ...DEFAULT_CONFIG,
+        setupComplete: true,
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "coding", derive: "manual" as const },
+        },
+      }),
+      getProjectBankId: () => "coding",
+    });
+
+    const dry = await ops.mentalModel({
+      action: "create",
+      cwd,
+      name: "Architecture",
+      sourceQuery: "What is the architecture?",
+      dryRun: true,
+    });
+    expect(dry).toMatchObject({ dryRun: true, bankId: "coding" });
+    expect((dry as { wouldCreate: { tags: string[] } }).wouldCreate.tags).toEqual(
+      expect.arrayContaining(["source:pi", expect.stringMatching(/^project:/)]),
+    );
+    expect(createMentalModel).not.toHaveBeenCalled();
+
+    await ops.mentalModel({
+      action: "create",
+      cwd,
+      name: "Architecture",
+      sourceQuery: "What is the architecture?",
+      dryRun: false,
+    });
+    expect(createMentalModel).toHaveBeenCalledWith(
+      "coding",
+      "Architecture",
+      "What is the architecture?",
+      expect.objectContaining({
+        tags: expect.arrayContaining(["source:pi"]),
+        trigger: { refreshAfterConsolidation: true },
+      }),
+    );
+  });
+
+  it("delete mental model defaults to dry-run", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ctrl-del-"));
+    const deleteMentalModel = vi.fn(async (_b, _id, opts) => ({ dryRun: opts?.dryRun }));
+    const ops = createControlOperations({
+      getClient: () => ({
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+        deleteMentalModel,
+      }),
+      getConfig: () => ({
+        ...DEFAULT_CONFIG,
+        setupComplete: true,
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "coding", derive: "manual" as const },
+        },
+      }),
+      getProjectBankId: () => "coding",
+    });
+    await ops.mentalModel({ action: "delete", cwd, id: "mm1" });
+    expect(deleteMentalModel).toHaveBeenCalledWith("coding", "mm1", { dryRun: true });
+  });
+});

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -441,6 +441,10 @@ describe("operation catalog", () => {
       "hindsight_retain",
       "hindsight_retain_global",
       "hindsight_reflect",
+      "hindsight_status",
+      "hindsight_scope",
+      "hindsight_bank",
+      "hindsight_mental_model",
     ]);
 
     // Human surface is TUI-first: hub + next-opt-out slash command.


### PR DESCRIPTION
## Summary

Agent-first control plane (#489): tools `hindsight_status`, `hindsight_scope`, `hindsight_bank` (get/update_mission), `hindsight_mental_model` (list/get/create/update/refresh/delete). Selected banks only; delete and mission update default dry-run. Includes status-fields helper for status tool.

## Linked issue

Closes #489

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check`
- [x] `tests/memory-control-operations.test.ts`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

New model-facing tools registered; surface reference updated.

## Risk and rollback

- Risk: more tools in agent context; mitigated by clear descriptions and dry-run defaults on destructive ops.
- Rollback/revert path: revert PR.

## Follow-ups

#490 slim TUI; #492 shared obs; #493 migrate.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] tools-and-commands docs updated.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Stacks conceptually with #500 (status fields) and #501 (MM inject); this branch vendors status-fields if not yet on main.