### PR TITLE
refactor(tui): slim hub to status, setup, and emergencies

### DIFF
--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -13,24 +13,26 @@ Pi Hindsight is **TUI-first**. Public slash commands:
 /hindsight:next-opt-out
 ```
 
-`/hindsight` opens the memory hub for status, guided setup, session mode, mental models, import, flush, doctor, init, and advanced settings.  
+`/hindsight` opens a **thin** memory hub: status, short guided setup, and emergency actions (mode, next-opt-out, flush, doctor). Day-to-day mission/mental-model/config edits belong to agent tools, not a TUI field farm.  
 `/hindsight:next-opt-out` skips automatic retain for the next agent run (also hub key `x`).
 
 ### Hub keys
 
-| Key | Action                                                                                       |
-| --- | -------------------------------------------------------------------------------------------- |
-| `g` | Guided setup (profile, agent use, banks, optional mental models + import)                    |
-| `m` | Session mode: `normal` / `read-only` / `ignored`                                             |
-| `x` | Next-opt-out: skip automatic retain for the next agent run                                   |
-| `t` | Apply mental-model set for current **agent use** (coding vs conversation); dry-run + confirm |
-| `i` | Historical import (dry-run first)                                                            |
-| `f` | Flush retain queue                                                                           |
-| `o` | Doctor diagnostics report                                                                    |
-| `n` | Write `.pi/hindsight.json` with the selected project bank                                    |
-| `d` | Deployment / connection helpers                                                              |
-| `a` | Toggle advanced settings tabs                                                                |
-| `q` | Close                                                                                        |
+| Key | Action                                                                |
+| --- | --------------------------------------------------------------------- |
+| `g` | Guided setup (profile, agent use, banks, optional templates + import) |
+| `m` | Session mode: `normal` / `read-only` / `ignored`                      |
+| `x` | Next-opt-out: skip automatic retain for the next agent run            |
+| `f` | Flush retain queue                                                    |
+| `o` | Doctor diagnostics report (includes status tones)                     |
+| `n` | Write `.pi/hindsight.json` with the selected project bank             |
+| `d` | Deployment / connection helpers                                       |
+| `i` | Historical import (dry-run first)                                     |
+| `t` | Apply starter bank template / mental-model set (dry-run first)        |
+| `a` | Toggle advanced settings (prefer agent tools for day-to-day edits)    |
+| `q` | Close                                                                 |
+
+Day-to-day mission, mental-model, and config edits: prefer agent control-plane tools (ADR-005); the advanced TUI farm is an escape hatch, not the primary surface.
 
 ### Agent use and mental models
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -9,24 +9,26 @@ Pi Hindsight is **TUI-first**. Public slash commands:
 /hindsight:next-opt-out
 ```
 
-- `/hindsight` opens the memory hub for status, guided setup, session mode, mental models, import, flush, doctor, init, and advanced settings.
+- `/hindsight` opens a **thin** memory hub: status, short guided setup, and emergency actions (mode, next-opt-out, flush, doctor). Day-to-day mission/mental-model/config edits belong to agent tools, not a TUI field farm.
 - `/hindsight:next-opt-out` skips automatic retain for the next agent run only (also available as hub key `x`).
 
 ### Hub keys
 
-| Key | Action                                                                                       |
-| --- | -------------------------------------------------------------------------------------------- |
-| `g` | Guided setup (profile, agent use, banks, optional mental models + import)                    |
-| `m` | Session mode: `normal` / `read-only` / `ignored`                                             |
-| `x` | Next-opt-out: skip automatic retain for the next agent run                                   |
-| `t` | Apply mental-model set for current **agent use** (coding vs conversation); dry-run + confirm |
-| `i` | Historical import (dry-run first)                                                            |
-| `f` | Flush retain queue                                                                           |
-| `o` | Doctor diagnostics report                                                                    |
-| `n` | Write `.pi/hindsight.json` with the selected project bank                                    |
-| `d` | Deployment / connection helpers                                                              |
-| `a` | Toggle advanced settings tabs                                                                |
-| `q` | Close                                                                                        |
+| Key | Action                                                                |
+| --- | --------------------------------------------------------------------- |
+| `g` | Guided setup (profile, agent use, banks, optional templates + import) |
+| `m` | Session mode: `normal` / `read-only` / `ignored`                      |
+| `x` | Next-opt-out: skip automatic retain for the next agent run            |
+| `f` | Flush retain queue                                                    |
+| `o` | Doctor diagnostics report (includes status tones)                     |
+| `n` | Write `.pi/hindsight.json` with the selected project bank             |
+| `d` | Deployment / connection helpers                                       |
+| `i` | Historical import (dry-run first)                                     |
+| `t` | Apply starter bank template / mental-model set (dry-run first)        |
+| `a` | Toggle advanced settings (prefer agent tools for day-to-day edits)    |
+| `q` | Close                                                                 |
+
+Day-to-day mission, mental-model, and config edits: prefer agent control-plane tools (ADR-005 / `hindsight_status`, `hindsight_bank`, `hindsight_mental_model` when registered); the advanced TUI farm is an escape hatch, not the primary surface.
 
 ### Agent use and mental models
 

--- a/extensions/tui/setup-tui-types.ts
+++ b/extensions/tui/setup-tui-types.ts
@@ -45,5 +45,6 @@ export type ThemeLike = {
 export const RECEIPT_FACT_LIMIT = 3;
 export const CANCEL = "Cancel";
 
+/** Hub footer: status/setup/emergency first; import/templates/advanced demoted (agent tools own day-to-day edits). */
 export const HUB_ACTION_HELP =
-  " g guided · m mode · x next-opt-out · t mental models · i import · f flush · o doctor · n init · d deployment · a advanced · q close ";
+  " g guided · m mode · x next-opt-out · f flush · o doctor · n init · d deployment · i import · t templates · a advanced · q close ";

--- a/tests/setup-tui.test.ts
+++ b/tests/setup-tui.test.ts
@@ -5,6 +5,7 @@ import {
   buildRetainReceiptStatusFacts,
   createSetupComponent,
 } from "../extensions/tui/setup-tui.js";
+import { HUB_ACTION_HELP } from "../extensions/tui/setup-tui-types.js";
 
 const theme = {
   fg: (_name: string, text: string) => text,
@@ -53,9 +54,14 @@ describe("setup TUI receipt facts", () => {
     const rendered = component.render(100).join("\n");
     expect(rendered).toContain("Docs: https://luxus.github.io/pi-hindsight/concepts/memory-banks/");
     expect(rendered).toContain("Allows cross-project recall");
+    // Footer is width-truncated; assert the full hub help string and visible prefix.
+    expect(HUB_ACTION_HELP).toContain("f flush");
+    expect(HUB_ACTION_HELP).toContain("t templates");
+    expect(HUB_ACTION_HELP).toContain("a advanced");
+    expect(HUB_ACTION_HELP.indexOf("f flush")).toBeLessThan(HUB_ACTION_HELP.indexOf("t templates"));
     expect(rendered).toContain("g guided");
     expect(rendered).toContain("m mode");
-    expect(rendered).toContain("t mental models");
+    expect(rendered).toContain("x next-opt-out");
   });
 
   it("default hub shows Status only until advanced is enabled", () => {


### PR DESCRIPTION
## Summary

ADR-005 thin TUI (#490): hub help and docs reorder so status/setup/emergency actions lead; import, templates, and advanced settings are demoted. Advanced remains available as an escape hatch; day-to-day mission/MM/config edits prefer agent control-plane tools.

## Linked issue

Closes #490

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Not memory-path; docs + hub footer string + setup-tui tests.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Hub key order/help text and tools-and-commands docs.

## Risk and rollback

- Risk: operators looking for `t mental models` label need `t templates` wording; keys unchanged.
- Rollback/revert path: revert PR.

## Follow-ups

Agent control-plane tools (#489 / #502) complete the agent-first surface.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] tools-and-commands docs (packaged + docs-site) updated.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

None.