### PR TITLE
feat: scope migrate dry-run for dual-tag / legacy repo tags

### DIFF
--- a/docs-site/src/content/docs/concepts/project-identity.md
+++ b/docs-site/src/content/docs/concepts/project-identity.md
@@ -27,6 +27,25 @@ Doctor/status (`/hindsight` doctor, debug report) shows:
 - active `project:` tag
 - derivation basis (`pin` / `remote` / `basename`) and source
 - legacy `repo:` tag
+- `scopeMigrate` dry-run findings (path-derived bank, path-hash fragility, guidance)
+
+## Scope migrate dry-run (no silent rewrite)
+
+Use the agent tool `hindsight_scope_migrate` (or doctor report) for a **dry-run only** migration plan:
+
+- Confirms dual-tag is active
+- Flags path-derived coding banks under domain-tagged mode
+- Explains when legacy `repo:*` path-hashes miss after path moves
+- Optionally accepts a bank tag sample for hit counts
+- Writes a receipt to `.pi/hindsight/scope-migrate-receipt.json`
+
+It **never** rewrites Hindsight tags or documents. For rebuilds:
+
+1. Prefer Hindsight document/bank export-import when available
+2. Otherwise reimport Pi transcripts with `replace` into the shared coding bank
+3. Keep dual-tag until project-tagged coverage is good enough
+
+When dual-tag can end: every active project memory you care about carries `project:<id>` (or you completed a full export/import rebuild).
 
 ## Scope mode (bank topology)
 

--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -20,6 +20,7 @@ Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi w
 | `hindsight_scope`         | supported 1.0        |
 | `hindsight_bank`          | supported 1.0        |
 | `hindsight_mental_model`  | capability-gated 1.0 |
+| `hindsight_scope_migrate` | supported 1.0        |
 
 ## Deferred or non-goal upstream surfaces
 
@@ -158,6 +159,15 @@ Agent control plane for mental models on the selected bank. Actions: list|get|cr
 | `tags`        | array<string>                                        | no       |                                                |
 | `maxTokens`   | integer                                              | no       |                                                |
 | `dryRun`      | boolean                                              | no       |                                                |
+
+### `hindsight_scope_migrate`
+
+Dry-run only: plan dual-tag / legacy repo:<path-hash> → project:<id> migration. Writes a local receipt under .pi/hindsight/. Never rewrites Hindsight tags or documents. Prefer Hindsight export/import or Pi transcript reimport for actual rebuilds.
+
+| Parameter      | Type          | Required | Description                                                                                           |
+| -------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `bankTags`     | array<string> | no       | Optional tag inventory sample from the coding bank (e.g. listTags). Used only for counts in the plan. |
+| `writeReceipt` | boolean       | no       | Write .pi/hindsight/scope-migrate-receipt.json (default true).                                        |
 
 ## Commands
 

--- a/docs/project-identity.md
+++ b/docs/project-identity.md
@@ -25,6 +25,25 @@ Doctor/status (`/hindsight` doctor, debug report) shows:
 - active `project:` tag
 - derivation basis (`pin` / `remote` / `basename`) and source
 - legacy `repo:` tag
+- `scopeMigrate` dry-run findings (path-derived bank, path-hash fragility, guidance)
+
+## Scope migrate dry-run (no silent rewrite)
+
+Use the agent tool `hindsight_scope_migrate` (or doctor report) for a **dry-run only** migration plan:
+
+- Confirms dual-tag is active
+- Flags path-derived coding banks under domain-tagged mode
+- Explains when legacy `repo:*` path-hashes miss after path moves
+- Optionally accepts a bank tag sample for hit counts
+- Writes a receipt to `.pi/hindsight/scope-migrate-receipt.json`
+
+It **never** rewrites Hindsight tags or documents. For rebuilds:
+
+1. Prefer Hindsight document/bank export-import when available
+2. Otherwise reimport Pi transcripts with `replace` into the shared coding bank
+3. Keep dual-tag until project-tagged coverage is good enough
+
+When dual-tag can end: every active project memory you care about carries `project:<id>` (or you completed a full export/import rebuild).
 
 ## Scope mode (bank topology)
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -16,6 +16,7 @@ Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi w
 | `hindsight_scope`         | supported 1.0        |
 | `hindsight_bank`          | supported 1.0        |
 | `hindsight_mental_model`  | capability-gated 1.0 |
+| `hindsight_scope_migrate` | supported 1.0        |
 
 ## Deferred or non-goal upstream surfaces
 
@@ -154,6 +155,15 @@ Agent control plane for mental models on the selected bank. Actions: list|get|cr
 | `tags`        | array<string>                                        | no       |                                                |
 | `maxTokens`   | integer                                              | no       |                                                |
 | `dryRun`      | boolean                                              | no       |                                                |
+
+### `hindsight_scope_migrate`
+
+Dry-run only: plan dual-tag / legacy repo:<path-hash> → project:<id> migration. Writes a local receipt under .pi/hindsight/. Never rewrites Hindsight tags or documents. Prefer Hindsight export/import or Pi transcript reimport for actual rebuilds.
+
+| Parameter      | Type          | Required | Description                                                                                           |
+| -------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------- |
+| `bankTags`     | array<string> | no       | Optional tag inventory sample from the coding bank (e.g. listTags). Used only for counts in the plan. |
+| `writeReceipt` | boolean       | no       | Write .pi/hindsight/scope-migrate-receipt.json (default true).                                        |
 
 ## Commands
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -53,5 +53,6 @@ Available for the agent (control plane is agent-first; TUI is thin):
 - `hindsight_scope` — project id derivation
 - `hindsight_bank` — get bank or update missions (dry-run default)
 - `hindsight_mental_model` — list/get/create/update/refresh/delete (delete dry-run default)
+- `hindsight_scope_migrate` — dry-run dual-tag / legacy `repo:` migration plan + local receipt (never rewrites)
 
 See the generated [surface reference](surface-reference.md) for parameter schemas.

--- a/extensions/operations/memory-diagnostics-operations.ts
+++ b/extensions/operations/memory-diagnostics-operations.ts
@@ -7,6 +7,11 @@ import {
   resolveImportManifestPath,
 } from "../imports/import-plan.js";
 import type { MemoryOperationsDeps } from "./memory-operation-types.js";
+import {
+  buildScopeMigratePlan,
+  writeScopeMigrateReceipt,
+  type ScopeMigratePlan,
+} from "./scope-migrate.js";
 
 export function createDiagnosticsOperations(deps: MemoryOperationsDeps) {
   return {
@@ -20,6 +25,7 @@ export function createDiagnosticsOperations(deps: MemoryOperationsDeps) {
         readImportManifestSafe(manifestPath),
       ]);
       const imports = importManifestSummary(manifestResult.manifest);
+      const scopeMigrate = buildScopeMigratePlan({ cwd, config, projectBankId });
       return formatDebugReport({
         cwd,
         ...(sessionFile ? { sessionFile } : {}),
@@ -39,7 +45,27 @@ export function createDiagnosticsOperations(deps: MemoryOperationsDeps) {
         importCount: imports.count,
         ...(imports.latest ? { latestImport: imports.latest } : {}),
         health,
+        scopeMigrate,
       });
+    },
+
+    /**
+     * Dry-run only: plan dual-tag / legacy repo-tag migration guidance and write a local receipt.
+     * Never rewrites Hindsight tags or documents.
+     */
+    async scopeMigrateDryRun(
+      cwd: string,
+      options: { bankTags?: string[]; writeReceipt?: boolean } = {},
+    ): Promise<ScopeMigratePlan | import("./scope-migrate.js").ScopeMigrateReceipt> {
+      const config = deps.getConfig();
+      const plan = buildScopeMigratePlan({
+        cwd,
+        config,
+        projectBankId: deps.getProjectBankId(),
+        ...(options.bankTags ? { bankTags: options.bankTags } : {}),
+      });
+      if (options.writeReceipt === false) return plan;
+      return writeScopeMigrateReceipt(cwd, plan);
     },
   };
 }

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -597,6 +597,37 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       },
       renderResult: renderMemoryToolTextResult,
     }),
+    defineCatalogTool({
+      name: "hindsight_scope_migrate",
+      label: "Hindsight Scope Migrate Dry-Run",
+      description:
+        "Dry-run only: plan dual-tag / legacy repo:<path-hash> → project:<id> migration. Writes a local receipt under .pi/hindsight/. Never rewrites Hindsight tags or documents. Prefer Hindsight export/import or Pi transcript reimport for actual rebuilds.",
+      parameters: Type.Object({
+        bankTags: Type.Optional(
+          Type.Array(Type.String(), {
+            description:
+              "Optional tag inventory sample from the coding bank (e.g. listTags). Used only for counts in the plan.",
+          }),
+        ),
+        writeReceipt: Type.Optional(
+          Type.Boolean({
+            description: "Write .pi/hindsight/scope-migrate-receipt.json (default true).",
+          }),
+        ),
+      }),
+      async execute(_id, params, _signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        const result = await operations.scopeMigrateDryRun(ctx.cwd, {
+          ...(params.bankTags ? { bankTags: params.bankTags } : {}),
+          ...(params.writeReceipt !== undefined ? { writeReceipt: params.writeReceipt } : {}),
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: { dryRun: true, rewrite: "none" },
+        };
+      },
+      renderResult: renderMemoryToolTextResult,
+    }),
   ];
 
   // Human surface is TUI-first: `/hindsight` hub plus a few deliberate slash commands.

--- a/extensions/operations/scope-migrate.ts
+++ b/extensions/operations/scope-migrate.ts
@@ -1,0 +1,181 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  deriveProjectBankId,
+  legacyRepoScopeTag,
+  projectScopeTag,
+  resolveProjectIdentity,
+} from "../banks/banking.js";
+import type { ResolvedConfig } from "../types.js";
+
+export interface ScopeMigratePlan {
+  dryRun: true;
+  /** Never rewrites banks/tags from this plan alone. */
+  rewrite: "none";
+  bankId: string;
+  pathDerivedBank: boolean;
+  scopeMode: ResolvedConfig["scope"]["mode"];
+  projectTag: string;
+  legacyRepoTag: string;
+  projectId: string;
+  projectIdBasis: "pin" | "remote" | "basename";
+  projectIdSource: string;
+  dualTagWindow: true;
+  /** True when current path-hash legacy tag would not match another machine's path for same basename. */
+  pathHashFragile: boolean;
+  findings: string[];
+  guidance: string[];
+  /** Optional remote tag sample counts when listTags results were provided. */
+  remoteTagCounts?: {
+    projectTagHits: number;
+    legacyRepoTagHits: number;
+    otherRepoTags: string[];
+    sampleSize: number;
+  };
+  createdAt: string;
+}
+
+export interface ScopeMigrateReceipt extends ScopeMigratePlan {
+  receiptPath: string;
+}
+
+function basenameFragility(legacyRepoKey: string, projectId: string): boolean {
+  // legacy key is typically `<slug>-<12hex>`; path moves change the hash.
+  const dash = legacyRepoKey.lastIndexOf("-");
+  if (dash <= 0) return true;
+  const slug = legacyRepoKey.slice(0, dash);
+  const hash = legacyRepoKey.slice(dash + 1);
+  if (!/^[a-f0-9]{8,}$/i.test(hash)) return true;
+  // Fragile when identity is path-sensitive (basename) or slug only loosely matches project id.
+  return projectId === slug || !projectId.includes("/");
+}
+
+/**
+ * Build a dry-run scope migration plan. Never mutates Hindsight banks or tags.
+ * Dual-tag retain/recall already covers the live window; this plan documents risk and next steps.
+ */
+export function buildScopeMigratePlan(args: {
+  cwd: string;
+  config: ResolvedConfig;
+  projectBankId?: string;
+  bankTags?: string[];
+  now?: Date;
+}): ScopeMigratePlan {
+  const identity = resolveProjectIdentity(args.cwd, args.config);
+  const bankId = args.projectBankId ?? deriveProjectBankId(args.cwd, args.config);
+  const pathDerivedBank = !args.config.banks.project.bankId;
+  const projectTag = projectScopeTag(identity.projectId);
+  const legacyRepoTag = legacyRepoScopeTag(identity.legacyRepoKey);
+  const pathHashFragile = basenameFragility(identity.legacyRepoKey, identity.projectId);
+
+  const findings: string[] = [];
+  const guidance: string[] = [];
+
+  findings.push(
+    `Active dual-tag window: retain writes ${projectTag} and ${legacyRepoTag}; recall any_strict matches either.`,
+  );
+  findings.push(`Project id basis=${identity.basis} source=${identity.source} → ${projectTag}.`);
+
+  if (pathDerivedBank) {
+    findings.push(
+      `Coding bank is path-derived (${bankId}); domain-tagged mode should set banks.project.bankId to a shared coding bank.`,
+    );
+    guidance.push(
+      "Set banks.project.bankId (and setupComplete) so repos share one coding bank; do not rely on path-hash bank ids.",
+    );
+  }
+
+  if (identity.basis === "basename") {
+    findings.push(
+      "Project id is basename-derived; remotes or pins are more stable across clones and renames.",
+    );
+    guidance.push(
+      'Prefer scope.projectId pin or projectIdStrategy "remote" when a git origin exists.',
+    );
+  }
+
+  if (pathHashFragile) {
+    findings.push(
+      "Legacy repo:<slug>-<path-hash> tags break when the absolute path changes (e.g. Mac↔Linux). Dual-tag project: recovers new writes; older repo-only memories may miss.",
+    );
+    guidance.push(
+      "Keep dual-tag until reimport/rebuild. Prefer Hindsight document export/import when available; otherwise reimport Pi transcripts with replace into the coding bank.",
+    );
+  }
+
+  let remoteTagCounts: ScopeMigratePlan["remoteTagCounts"];
+  if (args.bankTags?.length) {
+    const otherRepoTags = [
+      ...new Set(args.bankTags.filter((t) => t.startsWith("repo:") && t !== legacyRepoTag)),
+    ].sort();
+    const projectTagHits = args.bankTags.filter((t) => t === projectTag).length;
+    const legacyRepoTagHits = args.bankTags.filter((t) => t === legacyRepoTag).length;
+    remoteTagCounts = {
+      projectTagHits,
+      legacyRepoTagHits,
+      otherRepoTags,
+      sampleSize: args.bankTags.length,
+    };
+    findings.push(
+      `Remote tag sample (${args.bankTags.length}): project hits=${projectTagHits}, legacy hits=${legacyRepoTagHits}, other repo:* tags=${otherRepoTags.length}.`,
+    );
+    if (legacyRepoTagHits > 0 && projectTagHits === 0) {
+      findings.push(
+        "Sample has legacy repo tags without the stable project tag — reimport or dual-tag new retains before dropping dual-tag.",
+      );
+    }
+    if (otherRepoTags.length > 0) {
+      findings.push(
+        `Other path-hash repo tags present (likely other machines/paths): ${otherRepoTags.slice(0, 5).join(", ")}${otherRepoTags.length > 5 ? "…" : ""}.`,
+      );
+      guidance.push(
+        "Other repo:* path-hashes are expected after path moves; dual-tag project: is the recovery path for new retains.",
+      );
+    }
+  } else {
+    guidance.push(
+      "Optional: pass bank tag inventory (listTags) into dry-run for remote counts; this local plan never rewrites.",
+    );
+  }
+
+  guidance.push(
+    "No silent rewrite: this dry-run only writes a local receipt under .pi/hindsight/.",
+  );
+  guidance.push(
+    "When dual-tag can end: every active project memory carries project:<id> (or you completed export/import rebuild).",
+  );
+
+  return {
+    dryRun: true,
+    rewrite: "none",
+    bankId,
+    pathDerivedBank,
+    scopeMode: args.config.scope.mode,
+    projectTag,
+    legacyRepoTag,
+    projectId: identity.projectId,
+    projectIdBasis: identity.basis,
+    projectIdSource: identity.source,
+    dualTagWindow: true,
+    pathHashFragile,
+    findings,
+    guidance,
+    ...(remoteTagCounts ? { remoteTagCounts } : {}),
+    createdAt: (args.now ?? new Date()).toISOString(),
+  };
+}
+
+export function resolveScopeMigrateReceiptPath(cwd: string): string {
+  return join(cwd, ".pi", "hindsight", "scope-migrate-receipt.json");
+}
+
+export async function writeScopeMigrateReceipt(
+  cwd: string,
+  plan: ScopeMigratePlan,
+): Promise<ScopeMigrateReceipt> {
+  const receiptPath = resolveScopeMigrateReceiptPath(cwd);
+  await mkdir(dirname(receiptPath), { recursive: true });
+  const receipt: ScopeMigrateReceipt = { ...plan, receiptPath };
+  await writeFile(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+  return receipt;
+}

--- a/extensions/utils/diagnostics.ts
+++ b/extensions/utils/diagnostics.ts
@@ -24,6 +24,7 @@ import {
   type HindsightActivity,
 } from "./status.js";
 import { buildStatusFields } from "./status-fields.js";
+import type { ScopeMigratePlan } from "../operations/scope-migrate.js";
 
 export interface DebugReportArgs {
   cwd: string;
@@ -47,6 +48,7 @@ export interface DebugReportArgs {
   activity?: HindsightActivity;
   memoryCount?: number;
   queueRemaining?: number;
+  scopeMigrate?: ScopeMigratePlan;
 }
 
 export function bankSelectionMessage(projectBankId: string, config: ResolvedConfig): string {
@@ -170,6 +172,7 @@ export function formatDebugReport(args: DebugReportArgs): string {
         dualTagWindow:
           "Retain and recall dual-tag project:<id> and legacy repo:<path-hash> so path moves and older banks stay recoverable.",
       },
+      scopeMigrate: args.scopeMigrate ?? null,
       memoryProfile: memoryProfile(args.config),
       projectBankId: args.projectBankId,
       projectBankSelection: args.config.banks.project.bankId

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -520,6 +520,7 @@ describe("extension hooks", () => {
       "hindsight_retain",
       "hindsight_retain_global",
       "hindsight_scope",
+      "hindsight_scope_migrate",
       "hindsight_status",
     ]);
   });

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -445,6 +445,7 @@ describe("operation catalog", () => {
       "hindsight_scope",
       "hindsight_bank",
       "hindsight_mental_model",
+      "hindsight_scope_migrate",
     ]);
 
     // Human surface is TUI-first: hub + next-opt-out slash command.

--- a/tests/scope-migrate.test.ts
+++ b/tests/scope-migrate.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import {
+  buildScopeMigratePlan,
+  writeScopeMigrateReceipt,
+} from "../extensions/operations/scope-migrate.js";
+import type { ResolvedConfig } from "../extensions/types.js";
+
+function cfg(patch: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    ...patch,
+    scope: { ...DEFAULT_CONFIG.scope, ...(patch.scope ?? {}) },
+    banks: {
+      ...DEFAULT_CONFIG.banks,
+      ...(patch.banks ?? {}),
+      project: { ...DEFAULT_CONFIG.banks.project, ...(patch.banks?.project ?? {}) },
+    },
+  };
+}
+
+describe("scope migrate dry-run", () => {
+  it("plans dual-tag guidance without rewrite and flags path-derived banks", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-migrate-"));
+    mkdirSync(join(cwd, ".git"));
+    const plan = buildScopeMigratePlan({
+      cwd,
+      config: cfg(),
+      projectBankId: "pi-project-demo-abc",
+      now: new Date("2026-07-10T00:00:00.000Z"),
+    });
+
+    expect(plan.dryRun).toBe(true);
+    expect(plan.rewrite).toBe("none");
+    expect(plan.dualTagWindow).toBe(true);
+    expect(plan.projectTag).toMatch(/^project:/);
+    expect(plan.legacyRepoTag).toMatch(/^repo:/);
+    expect(plan.pathDerivedBank).toBe(true);
+    expect(plan.findings.some((f) => f.includes("path-derived"))).toBe(true);
+    expect(plan.guidance.some((g) => /no silent rewrite/i.test(g))).toBe(true);
+  });
+
+  it("counts remote tag sample and detects other path-hash repo tags", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-migrate-tags-"));
+    mkdirSync(join(cwd, ".git"));
+    const base = buildScopeMigratePlan({
+      cwd,
+      config: cfg({
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "kai-coding", derive: "manual" },
+        },
+      }),
+      projectBankId: "kai-coding",
+    });
+
+    const plan = buildScopeMigratePlan({
+      cwd,
+      config: cfg({
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "kai-coding", derive: "manual" },
+        },
+      }),
+      projectBankId: "kai-coding",
+      bankTags: [
+        base.projectTag,
+        base.legacyRepoTag,
+        "repo:otherhost-deadbeef1234",
+        "source:pi",
+        base.projectTag,
+      ],
+    });
+
+    expect(plan.pathDerivedBank).toBe(false);
+    expect(plan.remoteTagCounts).toEqual({
+      projectTagHits: 2,
+      legacyRepoTagHits: 1,
+      otherRepoTags: ["repo:otherhost-deadbeef1234"],
+      sampleSize: 5,
+    });
+    expect(plan.findings.some((f) => f.includes("Other path-hash"))).toBe(true);
+  });
+
+  it("writes a receipt under .pi/hindsight/", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-migrate-rcpt-"));
+    mkdirSync(join(cwd, ".git"));
+    const plan = buildScopeMigratePlan({
+      cwd,
+      config: cfg({ setupComplete: true }),
+      projectBankId: "kai-coding",
+    });
+    const receipt = await writeScopeMigrateReceipt(cwd, plan);
+    expect(receipt.receiptPath).toContain(".pi/hindsight/scope-migrate-receipt.json");
+    const raw = JSON.parse(readFileSync(receipt.receiptPath, "utf8")) as { rewrite: string };
+    expect(raw.rewrite).toBe("none");
+  });
+});


### PR DESCRIPTION
## Summary

ADR-005 / #493 scope migrate **dry-run**: local plan + doctor `scopeMigrate` findings + optional bank tag sample counts + receipt at `.pi/hindsight/scope-migrate-receipt.json`. Tool `hindsight_scope_migrate`. **Never** rewrites Hindsight tags/documents; guidance points at export/import or transcript reimport.

## Linked issue

Closes #493

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Unit tests cover plan + receipt. CI coverage + tsc ran on the PR. Live smoke skipped in CI classification (dry-run local only; no rewrite path). Full matrix/package not required.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

New dry-run tool + doctor field + docs.

## Risk and rollback

- Risk: operators may expect automatic retag; mitigated by rewrite:none and docs.
- Rollback/revert path: revert PR.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] project-identity docs updated.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Dual-tag remains the live migration window; this PR documents and dry-runs only. Optional remote listTags inventory can land later without blocking.