### PR TITLE
docs: multi-client MCP bank wiring and source tag vocabulary

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -74,6 +74,7 @@ export default defineConfig({
             { label: "Inspect recalls and receipts", slug: "guides/inspect-recalls-and-receipts" },
             { label: "Recover Retain Queue", slug: "guides/recover-retain-queue" },
             { label: "Run local smoke test", slug: "guides/run-local-smoke-test" },
+            { label: "MCP multi-client bank wiring", slug: "guides/mcp-multi-client" },
           ],
         },
         {

--- a/docs-site/src/content/docs/concepts/memory-banks.md
+++ b/docs-site/src/content/docs/concepts/memory-banks.md
@@ -49,9 +49,14 @@ Use tags to filter and isolate memory. Use metadata for provenance.
 
 Examples:
 
-- `source:pi`
-- `repo:pi-hindsight`
+- `source:pi` (always stamp a `source:` for the client that wrote the memory)
+- `project:<stable-id>` (coding bank repo scope; see [project identity](/pi-hindsight/concepts/project-identity/))
+- `repo:<slug>-<hash>` (legacy dual-tag window)
 - `session:<session-id>`
 - `profile:coding`
 
 Do not rely on metadata for filtering behavior when scope isolation matters.
+
+## Multi-client MCP
+
+Other AI tools can share the same banks via Hindsight’s **per-bank** MCP endpoint (`/mcp/<bankId>/`). Keep coding and life banks separate; always stamp `source:`; do not dump web chat into the coding bank. See [MCP multi-client bank wiring](/pi-hindsight/guides/mcp-multi-client/).

--- a/docs-site/src/content/docs/guides/index.mdx
+++ b/docs-site/src/content/docs/guides/index.mdx
@@ -31,4 +31,8 @@ Guides answer “what do I do now?” They avoid repeating the concept model and
   <Card title="Run smoke tests" icon="approve-check-circle">
     Prove the live memory path after memory-path changes. [Run smoke test](./run-local-smoke-test/)
   </Card>
+  <Card title="MCP multi-client" icon="puzzle">
+    Point other AI tools at coding or life banks via per-bank MCP URLs with a clear `source:` tag
+    vocabulary. [MCP guide](./mcp-multi-client/)
+  </Card>
 </CardGrid>

--- a/docs-site/src/content/docs/guides/mcp-multi-client.md
+++ b/docs-site/src/content/docs/guides/mcp-multi-client.md
@@ -1,0 +1,80 @@
+---
+title: "MCP multi-client bank wiring"
+description: "Point other AI tools at the same Hindsight banks as Pi via MCP, with a clear source: tag vocabulary."
+---
+
+Pi Hindsight is one client of a Hindsight bank. Other tools (Claude Desktop, Cursor, web chat agents, custom MCP hosts) can share the **same banks** over Hindsight’s per-bank MCP endpoint without sharing sessions or providers.
+
+## Point clients at a bank
+
+Hindsight MCP is **per bank**, not a single global memory dump. Wire each client to the bank that matches its mission:
+
+| Role             | Typical bank id   | Use for                                                    |
+| ---------------- | ----------------- | ---------------------------------------------------------- |
+| Coding           | e.g. `kai-coding` | Engineering decisions, repo project tags, Pi retain/recall |
+| Life / assistant | e.g. `kai-life`   | Personal preferences, non-repo assistant memory            |
+
+Endpoint shape (see current Hindsight server docs for the exact host path):
+
+```text
+https://<hindsight-host>/mcp/<bankId>/
+```
+
+Examples:
+
+```text
+https://hindsight.example/mcp/kai-coding/
+https://hindsight.example/mcp/kai-life/
+```
+
+Local default:
+
+```text
+http://localhost:8888/mcp/kai-coding/
+```
+
+Configure the client’s MCP server URL to that path. Do **not** point a general-purpose web-chat agent at the coding bank “because it is convenient.”
+
+## Tag vocabulary (always stamp `source:`)
+
+Tags are soft scope inside a bank. Pi and other clients should stay interoperable:
+
+| Tag                  | Who writes it        | Meaning                                                                             |
+| -------------------- | -------------------- | ----------------------------------------------------------------------------------- |
+| `source:pi`          | Pi Hindsight         | Memory originated from Pi                                                           |
+| `source:<client>`    | Other MCP clients    | e.g. `source:claude`, `source:cursor`, `source:web`                                 |
+| `project:<id>`       | Coding bank          | Repo / product scope (stable project identity)                                      |
+| `session:<id>`       | Live tools           | Volatile session id — fine on retains; **do not** put in observation project scopes |
+| `repo:<slug>-<hash>` | Pi (legacy dual-tag) | Path-hash legacy; dual-tag window only                                              |
+
+**Always stamp `source:`** so you can filter “what did Pi write?” vs “what did the web UI write?” when debugging contamination.
+
+## What not to do
+
+- **Do not dump web chat into the coding bank** by default. Web chat is often personal, noisy, and multi-topic. Prefer the life bank, or a dedicated bank with a clear mission.
+- **Do not use one mega-bank** for code + life + medical + random tools. Banks are hard walls; tags are soft scope.
+- **Do not rely on metadata alone** for isolation. Use tags (and bank choice) for filtering.
+- **Do not put volatile `session:` tags into observation scopes** used for consolidation — they fragment beliefs.
+
+## How this fits Pi Hindsight
+
+- Pi’s default domain topology is a **shared coding bank** + `project:<id>` tags (ADR-005).
+- Pi automatic retain stamps `source:pi` and dual-tags `project:` + legacy `repo:`.
+- Optional life/user bank is separate; automatic retain never writes life memory (ADR-004).
+- Shared/untagged observations inside one bank are opt-in (`scope.includeSharedObservations`); they are **not** cross-bank sharing.
+
+## Checklist for a second client
+
+1. Create or pick bank ids that match Pi config (`banks.project.bankId` / life bank).
+2. Point the client MCP URL at `/mcp/<thatBankId>/`.
+3. Set the client’s mission text to match the bank mission (engineering vs personal).
+4. Configure the client to tag retains with `source:<name>` and, for coding, `project:<id>` when applicable.
+5. Verify with a recall from Pi and from the other client that scope isolation still holds.
+
+## Related
+
+- [Memory Banks](/pi-hindsight/concepts/memory-banks/)
+- [Project identity and scope tags](/pi-hindsight/concepts/project-identity/)
+- [Getting started](/pi-hindsight/start/getting-started/)
+- [ADR-005: Domain banks and agent-first surface](/pi-hindsight/architecture/adr/005-domain-banks-and-agent-first-surface/)
+- Hindsight: multi-client / MCP docs and “one memory for every AI tool” product notes (upstream)

--- a/docs-site/src/content/docs/start/getting-started.md
+++ b/docs-site/src/content/docs/start/getting-started.md
@@ -77,6 +77,8 @@ After setup, `/hindsight` should show:
 
 If automatic recall injects irrelevant noise, see [Recall quality](/pi-hindsight/concepts/memory-behavior/#recall-quality) for always-on filters and optional score floors (off by default).
 
+To share the same banks with other AI tools over MCP, see [MCP multi-client bank wiring](/pi-hindsight/guides/mcp-multi-client/).
+
 ## 6. Import old sessions only when useful
 
 Live retain starts after setup. Historical import is optional backfill. Use guided setup's import prompt first when it appears; it previews before writing memory.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,6 +75,8 @@ After setup, `/hindsight` should show:
 
 If automatic recall injects irrelevant noise, see [Recall quality](memory-behavior.md#recall-quality) for always-on filters and optional score floors (off by default).
 
+To share the same banks with other AI tools over MCP (per-bank endpoints, `source:` tags), see the docs-site guide [MCP multi-client bank wiring](https://luxus.github.io/pi-hindsight/guides/mcp-multi-client/).
+
 ## 6. Import old sessions only when useful
 
 Live retain starts after setup. Historical import is optional backfill. Use guided setup's import prompt first when it appears; it previews before writing memory.


### PR DESCRIPTION
## Summary

ADR-005 / #494 docs: guide for multi-client Hindsight MCP wiring (`/mcp/<bankId>/`), tag vocabulary (`source:`, `project:`), and warnings against dumping web chat into the coding bank. Linked from getting-started and memory-banks.

## Linked issue

Closes #494

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Docs-only change.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

New guide + sidebar entry + cross-links.

## Risk and rollback

- Risk: low (documentation only).
- Rollback/revert path: revert PR.

## Follow-ups

None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] Docs-site guide + getting-started/memory-banks links.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

None.