### PR TITLE
docs: align AGENTS bank rules with ADR-005 domain topology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,10 +216,11 @@ Every PR must complete the repository PR template. The PR body gate is intention
 
 ### Bank rules
 
-- Default to one project bank per repo.
-- Optional second User Bank (legacy internal/config name: global bank) is allowed only through explicit config.
-- Do not default to one giant shared bank across unrelated repos.
-- If bank creation/configuration is needed, do it intentionally during initialization or setup, not accidentally on first write.
+- Default topology is **domain-tagged** (ADR-005): one shared **coding** bank for normal repos, soft-isolated by stable `project:<id>` tags (plus dual-tag legacy `repo:` during migration). Role names `coding`/`project` and `life`/`user` stay stable when concrete `bankId` strings change.
+- **isolated-bank** is the hard-wall escape hatch (path-derived or explicit dedicated bankId). Without an explicit `banks.project.bankId`, even domain-tagged mode path-derives a bank for upgrade safety — setup should set the shared coding bankId.
+- Optional second **Life / User Bank** (legacy internal/config name: global bank) is allowed only through explicit config. Automatic retain never writes there.
+- Do not default to one mega-bank for coding + life + sensitive client work.
+- If bank creation/configuration is needed, do it intentionally during initialization or setup, not accidentally on first write (setup gate).
 
 ### Safety rules
 
@@ -272,9 +273,14 @@ Required:
 - `hindsight_retain`
 - `hindsight_reflect`
 
-Suggested human surface:
+Agent control plane (selected banks only; ADR-005):
 
-- `/hindsight` TUI hub (status, mode, next-opt-out, mental models, import, flush, doctor, setup)
+- `hindsight_status`, `hindsight_scope`, `hindsight_bank`, `hindsight_mental_model`
+- `hindsight_scope_migrate` (dry-run dual-tag / legacy guidance + local receipt; never silent rewrite)
+
+Human surface (thin TUI):
+
+- `/hindsight` hub: status, guided setup, emergencies (mode, next-opt-out, flush, doctor); import/templates/advanced demoted
 - `/hindsight:next-opt-out` (skip automatic retain for the next agent run)
 
 ## Implementation priorities


### PR DESCRIPTION
## Summary

Post-merge ADR-005 review found AGENTS.md still said “default to one project bank per repo,” which contradicts domain-tagged defaults. Updated bank rules and explicit tool/TUI surface to match ADR-005/CONTEXT.

## Linked issue

Refs #496 (ADR-005 guidance sync after implementation)

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Docs-only AGENTS.md. Full track verification: npm run check + smoke:hindsight on main (see implementer evidence).

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

Agent/contributor guidance only.

## Risk and rollback

- Risk: none product-wise.
- Rollback/revert path: revert PR.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] AGENTS.md updated to match ADR-005 bank topology (CONTEXT already aligned).

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Review also documented intentional non-bugs: path-derived bank without bankId, empty config file as setup-complete, dual-tag window until manual rebuild.