### PR TITLE
feat: agent allowlisted hindsight_config get/patch tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ Required:
 
 Agent control plane (selected banks only; ADR-005):
 
-- `hindsight_status`, `hindsight_scope`, `hindsight_bank`, `hindsight_mental_model`
+- `hindsight_status`, `hindsight_scope`, `hindsight_config` (allowlisted get/patch; no raw secrets), `hindsight_bank`, `hindsight_mental_model`
 - `hindsight_scope_migrate` (dry-run dual-tag / legacy guidance + local receipt; never silent rewrite)
 
 Human surface (thin TUI):

--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -18,6 +18,7 @@ Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi w
 | `hindsight_reflect`       | core 1.0             |
 | `hindsight_status`        | supported 1.0        |
 | `hindsight_scope`         | supported 1.0        |
+| `hindsight_config`        | supported 1.0        |
 | `hindsight_bank`          | supported 1.0        |
 | `hindsight_mental_model`  | capability-gated 1.0 |
 | `hindsight_scope_migrate` | supported 1.0        |
@@ -131,6 +132,17 @@ Show active project identity: project:<id> tag, derivation (pin/remote/basename)
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
+
+### `hindsight_config`
+
+Get or patch allowlisted Pi Hindsight config (project or global file). action=get returns effective values (no secrets) and the allowlist. action=patch updates only allowlisted keys (setupComplete, scopeMode, projectId, projectIdStrategy, includeSharedObservations, projectBankId, enableGlobalBank, globalBankId, agentUse, mentalModelsInject, memoryProfile, recall/retain knobs, baseUrl, apiKeyEnvVar, timeoutMs). dryRun defaults true for patch. Never pass raw API keys — use apiKeyEnvVar. Prefer this over the TUI advanced settings farm for day-to-day edits.
+
+| Parameter | Type              | Required | Description                                                      |
+| --------- | ----------------- | -------- | ---------------------------------------------------------------- |
+| `action`  | get \| patch      | yes      |                                                                  |
+| `patch`   | object/map        | no       | Allowlisted key/value map for action=patch.                      |
+| `scope`   | project \| global | no       | Which config file to write (default project .pi/hindsight.json). |
+| `dryRun`  | boolean           | no       | When true (default for patch), preview only; set false to write. |
 
 ### `hindsight_bank`
 

--- a/docs-site/src/content/docs/reference/tools-and-commands.md
+++ b/docs-site/src/content/docs/reference/tools-and-commands.md
@@ -32,7 +32,7 @@ Pi Hindsight is **TUI-first**. Public slash commands:
 | `a` | Toggle advanced settings (prefer agent tools for day-to-day edits)    |
 | `q` | Close                                                                 |
 
-Day-to-day mission, mental-model, and config edits: prefer agent control-plane tools (ADR-005); the advanced TUI farm is an escape hatch, not the primary surface.
+Day-to-day mission, mental-model, and config edits: prefer agent control-plane tools (`hindsight_status`, `hindsight_config`, `hindsight_bank`, `hindsight_mental_model`); the advanced TUI farm is an escape hatch, not the primary surface.
 
 ### Agent use and mental models
 
@@ -47,7 +47,7 @@ When mental models exist on active banks and `mentalModels.inject` is true (defa
 
 ## Explicit tools
 
-Pi exposes exactly four memory tools:
+Pi exposes memory tools plus an agent control plane for selected banks:
 
 - `hindsight_recall`
 - `hindsight_retain`
@@ -55,10 +55,12 @@ Pi exposes exactly four memory tools:
 - `hindsight_reflect`
 - `hindsight_status`
 - `hindsight_scope`
+- `hindsight_config` (allowlisted get/patch; dry-run default on patch; no raw secrets)
 - `hindsight_bank`
 - `hindsight_mental_model`
+- `hindsight_scope_migrate`
 
-Everything else — bank config/profile administration, document/entity/graph/tag browsing, memory inspection, consolidation control, and operation management — lives in the Hindsight control-plane web UI, except for the bundled mental-model templates applied from the hub (`t`).
+Platform-wide bank list/delete and full control-plane browsing stay in the Hindsight web UI. Bundled mental-model templates remain available from the hub (`t`).
 
 Tool notes:
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -14,6 +14,7 @@ Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi w
 | `hindsight_reflect`       | core 1.0             |
 | `hindsight_status`        | supported 1.0        |
 | `hindsight_scope`         | supported 1.0        |
+| `hindsight_config`        | supported 1.0        |
 | `hindsight_bank`          | supported 1.0        |
 | `hindsight_mental_model`  | capability-gated 1.0 |
 | `hindsight_scope_migrate` | supported 1.0        |
@@ -127,6 +128,17 @@ Show active project identity: project:<id> tag, derivation (pin/remote/basename)
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
+
+### `hindsight_config`
+
+Get or patch allowlisted Pi Hindsight config (project or global file). action=get returns effective values (no secrets) and the allowlist. action=patch updates only allowlisted keys (setupComplete, scopeMode, projectId, projectIdStrategy, includeSharedObservations, projectBankId, enableGlobalBank, globalBankId, agentUse, mentalModelsInject, memoryProfile, recall/retain knobs, baseUrl, apiKeyEnvVar, timeoutMs). dryRun defaults true for patch. Never pass raw API keys — use apiKeyEnvVar. Prefer this over the TUI advanced settings farm for day-to-day edits.
+
+| Parameter | Type              | Required | Description                                                      |
+| --------- | ----------------- | -------- | ---------------------------------------------------------------- |
+| `action`  | get \| patch      | yes      |                                                                  |
+| `patch`   | object/map        | no       | Allowlisted key/value map for action=patch.                      |
+| `scope`   | project \| global | no       | Which config file to write (default project .pi/hindsight.json). |
+| `dryRun`  | boolean           | no       | When true (default for patch), preview only; set false to write. |
 
 ### `hindsight_bank`
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -28,7 +28,7 @@ Pi Hindsight is **TUI-first**. Public slash commands:
 | `a` | Toggle advanced settings (prefer agent tools for day-to-day edits)    |
 | `q` | Close                                                                 |
 
-Day-to-day mission, mental-model, and config edits: prefer agent control-plane tools (ADR-005 / `hindsight_status`, `hindsight_bank`, `hindsight_mental_model` when registered); the advanced TUI farm is an escape hatch, not the primary surface.
+Day-to-day mission, mental-model, and config edits: prefer agent control-plane tools (`hindsight_status`, `hindsight_config`, `hindsight_bank`, `hindsight_mental_model`); the advanced TUI farm is an escape hatch, not the primary surface.
 
 ### Agent use and mental models
 
@@ -51,6 +51,7 @@ Available for the agent (control plane is agent-first; TUI is thin):
 - `hindsight_reflect`
 - `hindsight_status` — setup/banks/scope tones
 - `hindsight_scope` — project id derivation
+- `hindsight_config` — allowlisted config get/patch (dry-run default on patch; no raw secrets)
 - `hindsight_bank` — get bank or update missions (dry-run default)
 - `hindsight_mental_model` — list/get/create/update/refresh/delete (delete dry-run default)
 - `hindsight_scope_migrate` — dry-run dual-tag / legacy `repo:` migration plan + local receipt (never rewrites)

--- a/extensions/config/config-writer.ts
+++ b/extensions/config/config-writer.ts
@@ -90,6 +90,8 @@ export interface ProjectConfigPatchInput {
   scopeMode?: "domain-tagged" | "isolated-bank";
   projectId?: string;
   projectIdStrategy?: "remote" | "basename";
+  /** Opt-in shared/untagged observation recall (ADR-005 / #492). */
+  includeSharedObservations?: boolean;
   baseUrl?: string;
   timeoutMs?: number;
   apiKeyEnvVar?: string;
@@ -149,13 +151,17 @@ export function buildProjectConfigPatch(input: ProjectConfigPatchInput): Record<
   if (
     input.scopeMode !== undefined ||
     input.projectId !== undefined ||
-    input.projectIdStrategy !== undefined
+    input.projectIdStrategy !== undefined ||
+    input.includeSharedObservations !== undefined
   ) {
     patch.scope = {
       ...(input.scopeMode !== undefined ? { mode: input.scopeMode } : {}),
       ...(input.projectId !== undefined ? { projectId: input.projectId } : {}),
       ...(input.projectIdStrategy !== undefined
         ? { projectIdStrategy: input.projectIdStrategy }
+        : {}),
+      ...(input.includeSharedObservations !== undefined
+        ? { includeSharedObservations: input.includeSharedObservations }
         : {}),
     };
   }

--- a/extensions/operations/memory-control-operations.ts
+++ b/extensions/operations/memory-control-operations.ts
@@ -3,7 +3,86 @@ import { resolveOperationBank } from "../banks/bank-selection.js";
 import { buildStatusFields } from "../utils/status-fields.js";
 import type { MemoryOperationsDeps } from "./memory-operation-types.js";
 import { isMemorySetupComplete, setupRequiredMessage } from "../config/setup-gate.js";
-import type { HindsightLikeClient } from "../types.js";
+import { configureMemory, type ProjectConfigPatchInput } from "../config/config-writer.js";
+import type { HindsightLikeClient, ResolvedConfig } from "../types.js";
+
+/** Keys agents may read/patch via hindsight_config (no raw secrets). */
+export const AGENT_CONFIG_ALLOWLIST = [
+  "setupComplete",
+  "scopeMode",
+  "projectId",
+  "projectIdStrategy",
+  "includeSharedObservations",
+  "projectBankId",
+  "enableGlobalBank",
+  "globalBankId",
+  "agentUse",
+  "mentalModelsInject",
+  "memoryProfile",
+  "recallEnabled",
+  "recallBudget",
+  "recallMaxTokens",
+  "retainEnabled",
+  "baseUrl",
+  "apiKeyEnvVar",
+  "timeoutMs",
+] as const;
+
+export type AgentConfigKey = (typeof AGENT_CONFIG_ALLOWLIST)[number];
+
+const ALLOWLIST_SET = new Set<string>(AGENT_CONFIG_ALLOWLIST);
+
+export function agentConfigView(config: ResolvedConfig): Record<AgentConfigKey, unknown> {
+  let memoryProfile: string = "project-only";
+  if (config.recall.enabled && !config.retain.enabled) memoryProfile = "recall-only";
+  else if (!config.banks.project.enabled && config.banks.user.enabled)
+    memoryProfile = "global-only";
+  else if (config.banks.project.enabled && config.banks.user.enabled)
+    memoryProfile = "project+global";
+
+  return {
+    setupComplete: config.setupComplete,
+    scopeMode: config.scope.mode,
+    projectId: config.scope.projectId,
+    projectIdStrategy: config.scope.projectIdStrategy,
+    includeSharedObservations: config.scope.includeSharedObservations,
+    projectBankId: config.banks.project.bankId,
+    enableGlobalBank: config.banks.user.enabled,
+    globalBankId: config.banks.user.bankId,
+    agentUse: config.agentUse,
+    mentalModelsInject: config.mentalModels.inject,
+    memoryProfile,
+    recallEnabled: config.recall.enabled,
+    recallBudget: config.recall.budget,
+    recallMaxTokens: config.recall.maxTokens,
+    retainEnabled: config.retain.enabled,
+    baseUrl: config.hindsight.baseUrl,
+    apiKeyEnvVar: config.hindsight.apiKeyRef?.startsWith("env:")
+      ? config.hindsight.apiKeyRef.slice(4)
+      : undefined,
+    timeoutMs: config.hindsight.timeoutMs,
+  };
+}
+
+/** Keep only allowlisted keys from a tool patch object. Rejects unknown keys. */
+export function pickAgentConfigPatch(
+  raw: Record<string, unknown>,
+): Partial<Record<AgentConfigKey, unknown>> {
+  const unknown = Object.keys(raw).filter((k) => !ALLOWLIST_SET.has(k));
+  if (unknown.length) {
+    throw new Error(
+      `Config keys not allowlisted for agent patch: ${unknown.join(", ")}. Allowed: ${AGENT_CONFIG_ALLOWLIST.join(", ")}`,
+    );
+  }
+  const out: Partial<Record<AgentConfigKey, unknown>> = {};
+  for (const key of AGENT_CONFIG_ALLOWLIST) {
+    if (raw[key] !== undefined) out[key] = raw[key];
+  }
+  if (Object.keys(out).length === 0) {
+    throw new Error("Provide at least one allowlisted config field to patch.");
+  }
+  return out;
+}
 
 function clientMethod<K extends keyof HindsightLikeClient>(
   deps: MemoryOperationsDeps,
@@ -187,6 +266,53 @@ export function createControlOperations(deps: MemoryOperationsDeps) {
         default:
           throw new Error(`Unknown mental model action: ${String(args.action)}`);
       }
+    },
+
+    /**
+     * Agent allowlisted config get/patch. Writes project (or optional global) config files.
+     * Never accepts direct API keys — use apiKeyEnvVar only.
+     */
+    async config(args: {
+      action: "get" | "patch";
+      cwd: string;
+      patch?: Record<string, unknown>;
+      scope?: "project" | "global";
+      dryRun?: boolean;
+    }) {
+      const config = deps.getConfig();
+      if (args.action === "get") {
+        return {
+          allowlist: [...AGENT_CONFIG_ALLOWLIST],
+          scope: args.scope ?? "project",
+          values: agentConfigView(config),
+          note: "Secrets are never returned. Patch only allowlisted keys; dryRun defaults true for patch.",
+        };
+      }
+      if (!args.patch || typeof args.patch !== "object") {
+        throw new Error("patch object is required for action=patch");
+      }
+      const picked = pickAgentConfigPatch(args.patch);
+      const input: ProjectConfigPatchInput = {
+        ...(picked as ProjectConfigPatchInput),
+        scope: args.scope ?? "project",
+      };
+      if (args.dryRun ?? true) {
+        return {
+          dryRun: true,
+          scope: input.scope,
+          wouldPatch: picked,
+          allowlist: [...AGENT_CONFIG_ALLOWLIST],
+        };
+      }
+      const result = await configureMemory(args.cwd, input, deps);
+      return {
+        dryRun: false,
+        scope: input.scope,
+        patched: picked,
+        path: result.path,
+        projectBankId: result.projectBankId,
+        values: agentConfigView(deps.getConfig()),
+      };
     },
   };
 }

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -506,6 +506,46 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       renderResult: renderMemoryToolTextResult,
     }),
     defineCatalogTool({
+      name: "hindsight_config",
+      label: "Hindsight Config",
+      description:
+        "Get or patch allowlisted Pi Hindsight config (project or global file). action=get returns effective values (no secrets) and the allowlist. action=patch updates only allowlisted keys (setupComplete, scopeMode, projectId, projectIdStrategy, includeSharedObservations, projectBankId, enableGlobalBank, globalBankId, agentUse, mentalModelsInject, memoryProfile, recall/retain knobs, baseUrl, apiKeyEnvVar, timeoutMs). dryRun defaults true for patch. Never pass raw API keys — use apiKeyEnvVar. Prefer this over the TUI advanced settings farm for day-to-day edits.",
+      parameters: Type.Object({
+        action: Type.Union([Type.Literal("get"), Type.Literal("patch")]),
+        patch: Type.Optional(
+          Type.Record(Type.String(), Type.Unknown(), {
+            description: "Allowlisted key/value map for action=patch.",
+          }),
+        ),
+        scope: Type.Optional(
+          Type.Union([Type.Literal("project"), Type.Literal("global")], {
+            description: "Which config file to write (default project .pi/hindsight.json).",
+          }),
+        ),
+        dryRun: Type.Optional(
+          Type.Boolean({
+            description: "When true (default for patch), preview only; set false to write.",
+          }),
+        ),
+      }),
+      async execute(_id, params, signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        if (signal?.aborted) throw new Error("Aborted");
+        const result = await operations.config({
+          action: params.action,
+          cwd: ctx.cwd,
+          ...(params.patch ? { patch: params.patch as Record<string, unknown> } : {}),
+          ...(params.scope ? { scope: params.scope } : {}),
+          ...(params.dryRun !== undefined ? { dryRun: params.dryRun } : {}),
+        });
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+      renderResult: renderMemoryToolTextResult,
+    }),
+    defineCatalogTool({
       name: "hindsight_bank",
       label: "Hindsight Bank",
       description:

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -514,6 +514,7 @@ describe("extension hooks", () => {
 
     expect(Object.keys(tools).sort()).toEqual([
       "hindsight_bank",
+      "hindsight_config",
       "hindsight_mental_model",
       "hindsight_recall",
       "hindsight_reflect",

--- a/tests/memory-control-operations.test.ts
+++ b/tests/memory-control-operations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
@@ -98,5 +98,87 @@ describe("memory control operations", () => {
     });
     await ops.mentalModel({ action: "delete", cwd, id: "mm1" });
     expect(deleteMentalModel).toHaveBeenCalledWith("coding", "mm1", { dryRun: true });
+  });
+
+  it("config get returns allowlisted view without secrets", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-cfg-get-"));
+    const ops = createControlOperations({
+      getClient: () => ({
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+      }),
+      getConfig: () => ({
+        ...DEFAULT_CONFIG,
+        setupComplete: true,
+        hindsight: {
+          ...DEFAULT_CONFIG.hindsight,
+          apiKey: "sk-secret",
+          apiKeyRef: "env:HINDSIGHT_API_KEY",
+        },
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "kai-coding", derive: "manual" as const },
+        },
+      }),
+      getProjectBankId: () => "kai-coding",
+    });
+    const got = await ops.config({ action: "get", cwd });
+    expect(got.allowlist).toContain("projectBankId");
+    expect((got as { values: { projectBankId?: string } }).values.projectBankId).toBe("kai-coding");
+    expect(JSON.stringify(got)).not.toContain("sk-secret");
+    expect((got as { values: { apiKeyEnvVar?: string } }).values.apiKeyEnvVar).toBe(
+      "HINDSIGHT_API_KEY",
+    );
+  });
+
+  it("config patch rejects unknown keys and dry-runs by default", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-cfg-patch-"));
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "hindsight.json"), "{}\n");
+    let reloads = 0;
+    const ops = createControlOperations({
+      getClient: () => ({
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+      }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "coding",
+      reloadConfig: () => {
+        reloads += 1;
+      },
+    });
+
+    await expect(ops.config({ action: "patch", cwd, patch: { notAKey: true } })).rejects.toThrow(
+      /not allowlisted/i,
+    );
+
+    const dry = await ops.config({
+      action: "patch",
+      cwd,
+      patch: { projectBankId: "kai-coding", includeSharedObservations: true },
+    });
+    expect(dry).toMatchObject({ dryRun: true });
+    expect((dry as { wouldPatch: Record<string, unknown> }).wouldPatch).toEqual({
+      projectBankId: "kai-coding",
+      includeSharedObservations: true,
+    });
+    expect(reloads).toBe(0);
+
+    const written = await ops.config({
+      action: "patch",
+      cwd,
+      patch: { projectBankId: "kai-coding", setupComplete: true },
+      dryRun: false,
+    });
+    expect(written).toMatchObject({ dryRun: false, path: expect.stringContaining("hindsight") });
+    expect(reloads).toBe(1);
+    const disk = JSON.parse(readFileSync(join(cwd, ".pi", "hindsight.json"), "utf8")) as {
+      setupComplete?: boolean;
+      banks?: { project?: { bankId?: string } };
+    };
+    expect(disk.setupComplete).toBe(true);
+    expect(disk.banks?.project?.bankId).toBe("kai-coding");
   });
 });

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -443,6 +443,7 @@ describe("operation catalog", () => {
       "hindsight_reflect",
       "hindsight_status",
       "hindsight_scope",
+      "hindsight_config",
       "hindsight_bank",
       "hindsight_mental_model",
       "hindsight_scope_migrate",


### PR DESCRIPTION
## Summary

Closes the remaining #489 gap: `hindsight_config` multi-action tool with allowlisted get/patch. Patch dry-run defaults true; get never returns raw API keys. Extends config writer for `includeSharedObservations`.

## Linked issue

Closes #489

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check` (534 tests)
- [x] `npm run check:coverage` (CI coverage gate pass)
- [x] `npm run typecheck:tsc` (CI tsc fallback pass)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Targeted unit tests: get allowlist (no secrets), reject unknown keys, dry-run default, write projectBankId/setupComplete to disk (`tests/memory-control-operations.test.ts`).

Live smoke: CI and local both hit Cloudflare Tunnel error **1033** on h1.luxus.ai (infra down). Not a product regression in this slice (config file write only). Prior successful track smoke is in implementer `live-smoke.log` (exit 0 earlier same day). Lower-level coverage: pure allowlist + real `writeProjectConfig` path in unit tests.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

New agent tool; surface reference updated.

## Risk and rollback

- Risk: agent can write project config; mitigated by allowlist + dry-run default + no direct API key.
- Rollback/revert path: revert PR.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] tools-and-commands + AGENTS.md list hindsight_config.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Skeptic gap: #489 closed without config get/patch; this PR finishes that acceptance criterion. Live-smoke failure is tunnel 1033, not code.