### PR TITLE
fix: control-plane dry-run defaults, migrate signals, domain bankId gate

### DIFF
--- a/docs-site/src/content/docs/concepts/project-identity.md
+++ b/docs-site/src/content/docs/concepts/project-identity.md
@@ -27,7 +27,7 @@ Doctor/status (`/hindsight` doctor, debug report) shows:
 - active `project:` tag
 - derivation basis (`pin` / `remote` / `basename`) and source
 - legacy `repo:` tag
-- `scopeMigrate` dry-run findings (path-derived bank, path-hash fragility, guidance)
+- `scopeMigrate` dry-run findings (path-derived bank, legacy path-hash tag, weak basename identity, guidance)
 
 ## Scope migrate dry-run (no silent rewrite)
 

--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -135,12 +135,12 @@ Show active project identity: project:<id> tag, derivation (pin/remote/basename)
 
 ### `hindsight_config`
 
-Get or patch allowlisted Pi Hindsight config (project or global file). action=get returns effective values (no secrets) and the allowlist. action=patch updates only allowlisted keys (setupComplete, scopeMode, projectId, projectIdStrategy, includeSharedObservations, projectBankId, enableGlobalBank, globalBankId, agentUse, mentalModelsInject, memoryProfile, recall/retain knobs, baseUrl, apiKeyEnvVar, timeoutMs). dryRun defaults true for patch. Never pass raw API keys — use apiKeyEnvVar. Prefer this over the TUI advanced settings farm for day-to-day edits.
+Get or patch allowlisted Pi Hindsight config (project or global file). action=get returns effective values (no secrets) and the allowlist. action=patch updates only typed allowlisted keys (setupComplete, scopeMode, projectId, projectIdStrategy, includeSharedObservations, projectBankId, enableGlobalBank, globalBankId, agentUse, mentalModelsInject, memoryProfile, recall/retain knobs, baseUrl, apiKeyEnvVar, timeoutMs). dryRun defaults true for patch. Domain-tagged setupComplete requires projectBankId. Never pass raw API keys — use apiKeyEnvVar.
 
 | Parameter | Type              | Required | Description                                                      |
 | --------- | ----------------- | -------- | ---------------------------------------------------------------- |
 | `action`  | get \| patch      | yes      |                                                                  |
-| `patch`   | object/map        | no       | Allowlisted key/value map for action=patch.                      |
+| `patch`   | object            | no       | Typed allowlisted config fields only (no free-form keys).        |
 | `scope`   | project \| global | no       | Which config file to write (default project .pi/hindsight.json). |
 | `dryRun`  | boolean           | no       | When true (default for patch), preview only; set false to write. |
 
@@ -159,18 +159,18 @@ Inspect or update the selected coding/life bank. action=get returns profile/stat
 
 ### `hindsight_mental_model`
 
-Agent control plane for mental models on the selected bank. Actions: list|get|create|update|refresh|delete. Project-tier create defaults tags to source:pi + project:<activeId>. delete defaults dryRun=true.
+Agent control plane for mental models on the selected bank. Actions: list|get|create|update|refresh|delete. Project-tier create defaults tags to source:pi + project:<activeId>. Mutating actions (create/update/refresh/delete) default dryRun=true; set dryRun=false to apply.
 
-| Parameter     | Type                                                 | Required | Description                                    |
-| ------------- | ---------------------------------------------------- | -------- | ---------------------------------------------- |
-| `action`      | list \| get \| create \| update \| refresh \| delete | yes      |                                                |
-| `bank`        | string                                               | no       | Bank id or alias project\|global\|user.        |
-| `id`          | string                                               | no       | Mental model id for get/update/refresh/delete. |
-| `name`        | string                                               | no       |                                                |
-| `sourceQuery` | string                                               | no       |                                                |
-| `tags`        | array<string>                                        | no       |                                                |
-| `maxTokens`   | integer                                              | no       |                                                |
-| `dryRun`      | boolean                                              | no       |                                                |
+| Parameter     | Type                                                 | Required | Description                                                  |
+| ------------- | ---------------------------------------------------- | -------- | ------------------------------------------------------------ |
+| `action`      | list \| get \| create \| update \| refresh \| delete | yes      |                                                              |
+| `bank`        | string                                               | no       | Bank id or alias project\|global\|user.                      |
+| `id`          | string                                               | no       | Mental model id for get/update/refresh/delete.               |
+| `name`        | string                                               | no       |                                                              |
+| `sourceQuery` | string                                               | no       |                                                              |
+| `tags`        | array<string>                                        | no       |                                                              |
+| `maxTokens`   | integer                                              | no       |                                                              |
+| `dryRun`      | boolean                                              | no       | Mutating actions default true (preview). Set false to apply. |
 
 ### `hindsight_scope_migrate`
 

--- a/docs/project-identity.md
+++ b/docs/project-identity.md
@@ -25,7 +25,7 @@ Doctor/status (`/hindsight` doctor, debug report) shows:
 - active `project:` tag
 - derivation basis (`pin` / `remote` / `basename`) and source
 - legacy `repo:` tag
-- `scopeMigrate` dry-run findings (path-derived bank, path-hash fragility, guidance)
+- `scopeMigrate` dry-run findings (path-derived bank, legacy path-hash tag, weak basename identity, guidance)
 
 ## Scope migrate dry-run (no silent rewrite)
 

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -131,12 +131,12 @@ Show active project identity: project:<id> tag, derivation (pin/remote/basename)
 
 ### `hindsight_config`
 
-Get or patch allowlisted Pi Hindsight config (project or global file). action=get returns effective values (no secrets) and the allowlist. action=patch updates only allowlisted keys (setupComplete, scopeMode, projectId, projectIdStrategy, includeSharedObservations, projectBankId, enableGlobalBank, globalBankId, agentUse, mentalModelsInject, memoryProfile, recall/retain knobs, baseUrl, apiKeyEnvVar, timeoutMs). dryRun defaults true for patch. Never pass raw API keys — use apiKeyEnvVar. Prefer this over the TUI advanced settings farm for day-to-day edits.
+Get or patch allowlisted Pi Hindsight config (project or global file). action=get returns effective values (no secrets) and the allowlist. action=patch updates only typed allowlisted keys (setupComplete, scopeMode, projectId, projectIdStrategy, includeSharedObservations, projectBankId, enableGlobalBank, globalBankId, agentUse, mentalModelsInject, memoryProfile, recall/retain knobs, baseUrl, apiKeyEnvVar, timeoutMs). dryRun defaults true for patch. Domain-tagged setupComplete requires projectBankId. Never pass raw API keys — use apiKeyEnvVar.
 
 | Parameter | Type              | Required | Description                                                      |
 | --------- | ----------------- | -------- | ---------------------------------------------------------------- |
 | `action`  | get \| patch      | yes      |                                                                  |
-| `patch`   | object/map        | no       | Allowlisted key/value map for action=patch.                      |
+| `patch`   | object            | no       | Typed allowlisted config fields only (no free-form keys).        |
 | `scope`   | project \| global | no       | Which config file to write (default project .pi/hindsight.json). |
 | `dryRun`  | boolean           | no       | When true (default for patch), preview only; set false to write. |
 
@@ -155,18 +155,18 @@ Inspect or update the selected coding/life bank. action=get returns profile/stat
 
 ### `hindsight_mental_model`
 
-Agent control plane for mental models on the selected bank. Actions: list|get|create|update|refresh|delete. Project-tier create defaults tags to source:pi + project:<activeId>. delete defaults dryRun=true.
+Agent control plane for mental models on the selected bank. Actions: list|get|create|update|refresh|delete. Project-tier create defaults tags to source:pi + project:<activeId>. Mutating actions (create/update/refresh/delete) default dryRun=true; set dryRun=false to apply.
 
-| Parameter     | Type                                                 | Required | Description                                    |
-| ------------- | ---------------------------------------------------- | -------- | ---------------------------------------------- |
-| `action`      | list \| get \| create \| update \| refresh \| delete | yes      |                                                |
-| `bank`        | string                                               | no       | Bank id or alias project\|global\|user.        |
-| `id`          | string                                               | no       | Mental model id for get/update/refresh/delete. |
-| `name`        | string                                               | no       |                                                |
-| `sourceQuery` | string                                               | no       |                                                |
-| `tags`        | array<string>                                        | no       |                                                |
-| `maxTokens`   | integer                                              | no       |                                                |
-| `dryRun`      | boolean                                              | no       |                                                |
+| Parameter     | Type                                                 | Required | Description                                                  |
+| ------------- | ---------------------------------------------------- | -------- | ------------------------------------------------------------ |
+| `action`      | list \| get \| create \| update \| refresh \| delete | yes      |                                                              |
+| `bank`        | string                                               | no       | Bank id or alias project\|global\|user.                      |
+| `id`          | string                                               | no       | Mental model id for get/update/refresh/delete.               |
+| `name`        | string                                               | no       |                                                              |
+| `sourceQuery` | string                                               | no       |                                                              |
+| `tags`        | array<string>                                        | no       |                                                              |
+| `maxTokens`   | integer                                              | no       |                                                              |
+| `dryRun`      | boolean                                              | no       | Mutating actions default true (preview). Set false to apply. |
 
 ### `hindsight_scope_migrate`
 

--- a/extensions/config/setup-gate.ts
+++ b/extensions/config/setup-gate.ts
@@ -6,8 +6,21 @@ import type { ResolvedConfig } from "../types.js";
  * Whether automatic Hindsight network memory (ensure bank, auto-recall, auto-retain)
  * is allowed. False on a true first run until guided/agent setup or explicit bank ids.
  * Existing installs migrate via bank ids, config files, or local runtime state (ADR-005).
+ *
+ * Domain-tagged + project bank enabled additionally requires an explicit coding bankId
+ * so we never auto-operate on a path-derived bank as if it were a shared coding domain.
+ * isolated-bank may still path-derive.
  */
 export function isMemorySetupComplete(config: ResolvedConfig, cwd: string): boolean {
+  if (!hasSetupSignals(config, cwd)) return false;
+  if (requiresExplicitCodingBankId(config) && !config.banks.project.bankId?.trim()) {
+    return false;
+  }
+  return true;
+}
+
+/** Soft signals that this install is not a pure first-run blank slate. */
+function hasSetupSignals(config: ResolvedConfig, cwd: string): boolean {
   if (config.setupComplete === true) return true;
   if (config.banks.project.bankId?.trim()) return true;
   if (config.banks.user.bankId?.trim()) return true;
@@ -17,10 +30,19 @@ export function isMemorySetupComplete(config: ResolvedConfig, cwd: string): bool
   return false;
 }
 
+/**
+ * Domain-tagged coding path needs a real shared bank id before auto network I/O.
+ * isolated-bank (hard wall) may keep path-derived identity.
+ */
+export function requiresExplicitCodingBankId(config: ResolvedConfig): boolean {
+  return config.scope.mode === "domain-tagged" && config.banks.project.enabled;
+}
+
 export function setupRequiredMessage(): string {
   return (
     "Hindsight setup required: run /hindsight guided setup, or set banks.project.bankId " +
-    "(or PI_HINDSIGHT_PROJECT_BANK_ID). Memory network I/O is paused until then."
+    "(or PI_HINDSIGHT_PROJECT_BANK_ID). Domain-tagged mode needs an explicit coding bank id " +
+    "before automatic memory network I/O. Isolated-bank may path-derive."
   );
 }
 

--- a/extensions/operations/memory-control-operations.ts
+++ b/extensions/operations/memory-control-operations.ts
@@ -64,24 +64,93 @@ export function agentConfigView(config: ResolvedConfig): Record<AgentConfigKey, 
   };
 }
 
-/** Keep only allowlisted keys from a tool patch object. Rejects unknown keys. */
-export function pickAgentConfigPatch(
-  raw: Record<string, unknown>,
-): Partial<Record<AgentConfigKey, unknown>> {
+const ENUM_STRINGS: Partial<Record<AgentConfigKey, readonly string[]>> = {
+  scopeMode: ["domain-tagged", "isolated-bank"],
+  projectIdStrategy: ["remote", "basename"],
+  agentUse: ["coding", "conversation"],
+  memoryProfile: ["project-only", "project+global", "global-only", "recall-only"],
+  recallBudget: ["low", "mid", "high"],
+};
+
+const BOOLEAN_KEYS = new Set<AgentConfigKey>([
+  "setupComplete",
+  "includeSharedObservations",
+  "enableGlobalBank",
+  "mentalModelsInject",
+  "recallEnabled",
+  "retainEnabled",
+]);
+
+const NUMBER_KEYS = new Set<AgentConfigKey>(["recallMaxTokens", "timeoutMs"]);
+
+function assertAgentConfigValue(key: AgentConfigKey, value: unknown): unknown {
+  if (BOOLEAN_KEYS.has(key)) {
+    if (typeof value !== "boolean") {
+      throw new Error(`Config field ${key} must be a boolean`);
+    }
+    return value;
+  }
+  if (NUMBER_KEYS.has(key)) {
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+      throw new Error(`Config field ${key} must be a non-negative number`);
+    }
+    return value;
+  }
+  const allowed = ENUM_STRINGS[key];
+  if (allowed) {
+    if (typeof value !== "string" || !allowed.includes(value)) {
+      throw new Error(`Config field ${key} must be one of: ${allowed.join(", ")}`);
+    }
+    return value;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`Config field ${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+/** Keep only allowlisted keys from a tool patch object. Rejects unknown keys and bad types. */
+export function pickAgentConfigPatch(raw: Record<string, unknown>): ProjectConfigPatchInput {
   const unknown = Object.keys(raw).filter((k) => !ALLOWLIST_SET.has(k));
   if (unknown.length) {
     throw new Error(
       `Config keys not allowlisted for agent patch: ${unknown.join(", ")}. Allowed: ${AGENT_CONFIG_ALLOWLIST.join(", ")}`,
     );
   }
-  const out: Partial<Record<AgentConfigKey, unknown>> = {};
+  const out: ProjectConfigPatchInput = {};
   for (const key of AGENT_CONFIG_ALLOWLIST) {
-    if (raw[key] !== undefined) out[key] = raw[key];
+    if (raw[key] === undefined) continue;
+    const value = assertAgentConfigValue(key, raw[key]);
+    (out as Record<string, unknown>)[key] = value;
   }
   if (Object.keys(out).length === 0) {
     throw new Error("Provide at least one allowlisted config field to patch.");
   }
   return out;
+}
+
+/** Domain-tagged coding bank must not mark setup complete without an explicit bankId. */
+export function assertAgentConfigPatchSafe(
+  patch: ProjectConfigPatchInput,
+  current: ResolvedConfig,
+): void {
+  const mode = patch.scopeMode ?? current.scope.mode;
+  const projectEnabled =
+    patch.memoryProfile === "global-only" || patch.memoryProfile === "recall-only"
+      ? false
+      : patch.memoryProfile
+        ? true
+        : current.banks.project.enabled;
+  const bankId =
+    typeof patch.projectBankId === "string" && patch.projectBankId.trim()
+      ? patch.projectBankId.trim()
+      : current.banks.project.bankId?.trim();
+  const wantsSetupComplete = patch.setupComplete === true;
+  if (wantsSetupComplete && mode === "domain-tagged" && projectEnabled && !bankId) {
+    throw new Error(
+      "Cannot set setupComplete=true in domain-tagged mode without projectBankId. Set projectBankId to the shared coding bank first.",
+    );
+  }
 }
 
 function clientMethod<K extends keyof HindsightLikeClient>(
@@ -170,7 +239,8 @@ export function createControlOperations(deps: MemoryOperationsDeps) {
           "Provide at least one of retainMission, reflectMission, observationsMission.",
         );
       }
-      if (args.dryRun) {
+      // Mutating ops default dry-run at the operation layer (not only the tool catalog).
+      if (args.dryRun ?? true) {
         return { dryRun: true, bankId, wouldUpdate: patch };
       }
       const update = clientMethod(deps, "updateBankConfig");
@@ -218,7 +288,7 @@ export function createControlOperations(deps: MemoryOperationsDeps) {
           const tags =
             args.tags ??
             (isUserBank ? ["source:pi"] : ["source:pi", `project:${project.projectId}`]);
-          if (args.dryRun) {
+          if (args.dryRun ?? true) {
             return {
               dryRun: true,
               bankId,
@@ -245,13 +315,14 @@ export function createControlOperations(deps: MemoryOperationsDeps) {
           if (Object.keys(options).length === 0) {
             throw new Error("Provide name, sourceQuery, tags, and/or maxTokens for update");
           }
-          if (args.dryRun) return { dryRun: true, bankId, id: args.id, wouldUpdate: options };
+          if (args.dryRun ?? true)
+            return { dryRun: true, bankId, id: args.id, wouldUpdate: options };
           const update = clientMethod(deps, "updateMentalModel");
           return { bankId, result: await update(bankId, args.id, options) };
         }
         case "refresh": {
           if (!args.id) throw new Error("id is required for refresh");
-          if (args.dryRun) return { dryRun: true, bankId, id: args.id, wouldRefresh: true };
+          if (args.dryRun ?? true) return { dryRun: true, bankId, id: args.id, wouldRefresh: true };
           const refresh = clientMethod(deps, "refreshMentalModel");
           return { bankId, result: await refresh(bankId, args.id) };
         }
@@ -292,8 +363,9 @@ export function createControlOperations(deps: MemoryOperationsDeps) {
         throw new Error("patch object is required for action=patch");
       }
       const picked = pickAgentConfigPatch(args.patch);
+      assertAgentConfigPatchSafe(picked, config);
       const input: ProjectConfigPatchInput = {
-        ...(picked as ProjectConfigPatchInput),
+        ...picked,
         scope: args.scope ?? "project",
       };
       if (args.dryRun ?? true) {

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -509,13 +509,51 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       name: "hindsight_config",
       label: "Hindsight Config",
       description:
-        "Get or patch allowlisted Pi Hindsight config (project or global file). action=get returns effective values (no secrets) and the allowlist. action=patch updates only allowlisted keys (setupComplete, scopeMode, projectId, projectIdStrategy, includeSharedObservations, projectBankId, enableGlobalBank, globalBankId, agentUse, mentalModelsInject, memoryProfile, recall/retain knobs, baseUrl, apiKeyEnvVar, timeoutMs). dryRun defaults true for patch. Never pass raw API keys — use apiKeyEnvVar. Prefer this over the TUI advanced settings farm for day-to-day edits.",
+        "Get or patch allowlisted Pi Hindsight config (project or global file). action=get returns effective values (no secrets) and the allowlist. action=patch updates only typed allowlisted keys (setupComplete, scopeMode, projectId, projectIdStrategy, includeSharedObservations, projectBankId, enableGlobalBank, globalBankId, agentUse, mentalModelsInject, memoryProfile, recall/retain knobs, baseUrl, apiKeyEnvVar, timeoutMs). dryRun defaults true for patch. Domain-tagged setupComplete requires projectBankId. Never pass raw API keys — use apiKeyEnvVar.",
       parameters: Type.Object({
         action: Type.Union([Type.Literal("get"), Type.Literal("patch")]),
         patch: Type.Optional(
-          Type.Record(Type.String(), Type.Unknown(), {
-            description: "Allowlisted key/value map for action=patch.",
-          }),
+          Type.Object(
+            {
+              setupComplete: Type.Optional(Type.Boolean()),
+              scopeMode: Type.Optional(
+                Type.Union([Type.Literal("domain-tagged"), Type.Literal("isolated-bank")]),
+              ),
+              projectId: Type.Optional(Type.String({ minLength: 1 })),
+              projectIdStrategy: Type.Optional(
+                Type.Union([Type.Literal("remote"), Type.Literal("basename")]),
+              ),
+              includeSharedObservations: Type.Optional(Type.Boolean()),
+              projectBankId: Type.Optional(Type.String({ minLength: 1 })),
+              enableGlobalBank: Type.Optional(Type.Boolean()),
+              globalBankId: Type.Optional(Type.String({ minLength: 1 })),
+              agentUse: Type.Optional(
+                Type.Union([Type.Literal("coding"), Type.Literal("conversation")]),
+              ),
+              mentalModelsInject: Type.Optional(Type.Boolean()),
+              memoryProfile: Type.Optional(
+                Type.Union([
+                  Type.Literal("project-only"),
+                  Type.Literal("project+global"),
+                  Type.Literal("global-only"),
+                  Type.Literal("recall-only"),
+                ]),
+              ),
+              recallEnabled: Type.Optional(Type.Boolean()),
+              recallBudget: Type.Optional(
+                Type.Union([Type.Literal("low"), Type.Literal("mid"), Type.Literal("high")]),
+              ),
+              recallMaxTokens: Type.Optional(Type.Number({ minimum: 0 })),
+              retainEnabled: Type.Optional(Type.Boolean()),
+              baseUrl: Type.Optional(Type.String({ minLength: 1 })),
+              apiKeyEnvVar: Type.Optional(Type.String({ minLength: 1 })),
+              timeoutMs: Type.Optional(Type.Number({ minimum: 0 })),
+            },
+            {
+              additionalProperties: false,
+              description: "Typed allowlisted config fields only (no free-form keys).",
+            },
+          ),
         ),
         scope: Type.Optional(
           Type.Union([Type.Literal("project"), Type.Literal("global")], {
@@ -596,7 +634,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       name: "hindsight_mental_model",
       label: "Hindsight Mental Model",
       description:
-        "Agent control plane for mental models on the selected bank. Actions: list|get|create|update|refresh|delete. Project-tier create defaults tags to source:pi + project:<activeId>. delete defaults dryRun=true.",
+        "Agent control plane for mental models on the selected bank. Actions: list|get|create|update|refresh|delete. Project-tier create defaults tags to source:pi + project:<activeId>. Mutating actions (create/update/refresh/delete) default dryRun=true; set dryRun=false to apply.",
       parameters: Type.Object({
         action: Type.Union([
           Type.Literal("list"),
@@ -614,11 +652,20 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         sourceQuery: Type.Optional(Type.String()),
         tags: Type.Optional(Type.Array(Type.String())),
         maxTokens: Type.Optional(Type.Integer({ minimum: 1 })),
-        dryRun: Type.Optional(Type.Boolean()),
+        dryRun: Type.Optional(
+          Type.Boolean({
+            description: "Mutating actions default true (preview). Set false to apply.",
+          }),
+        ),
       }),
       async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         if (signal?.aborted) throw new Error("Aborted");
+        const mutating =
+          params.action === "create" ||
+          params.action === "update" ||
+          params.action === "refresh" ||
+          params.action === "delete";
         const result = await operations.mentalModel({
           action: params.action,
           cwd: ctx.cwd,
@@ -628,7 +675,11 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           ...(params.sourceQuery ? { sourceQuery: params.sourceQuery } : {}),
           ...(params.tags ? { tags: params.tags } : {}),
           ...(params.maxTokens !== undefined ? { maxTokens: params.maxTokens } : {}),
-          ...(params.dryRun !== undefined ? { dryRun: params.dryRun } : {}),
+          ...(mutating
+            ? { dryRun: params.dryRun ?? true }
+            : params.dryRun !== undefined
+              ? { dryRun: params.dryRun }
+              : {}),
         });
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/extensions/operations/scope-migrate.ts
+++ b/extensions/operations/scope-migrate.ts
@@ -21,8 +21,16 @@ export interface ScopeMigratePlan {
   projectIdBasis: "pin" | "remote" | "basename";
   projectIdSource: string;
   dualTagWindow: true;
-  /** True when current path-hash legacy tag would not match another machine's path for same basename. */
-  pathHashFragile: boolean;
+  /**
+   * True while retain still stamps legacy repo:<slug>-<path-hash>.
+   * That legacy tag always depends on absolute path; dual-tag project: is the stable recovery path.
+   */
+  legacyPathHashTag: true;
+  /**
+   * True when project id itself is weak (basename only). Remote/pin identities are stable;
+   * do not conflate them with path-hash legacy tags.
+   */
+  identityBasisWeak: boolean;
   findings: string[];
   guidance: string[];
   /** Optional remote tag sample counts when listTags results were provided. */
@@ -37,17 +45,6 @@ export interface ScopeMigratePlan {
 
 export interface ScopeMigrateReceipt extends ScopeMigratePlan {
   receiptPath: string;
-}
-
-function basenameFragility(legacyRepoKey: string, projectId: string): boolean {
-  // legacy key is typically `<slug>-<12hex>`; path moves change the hash.
-  const dash = legacyRepoKey.lastIndexOf("-");
-  if (dash <= 0) return true;
-  const slug = legacyRepoKey.slice(0, dash);
-  const hash = legacyRepoKey.slice(dash + 1);
-  if (!/^[a-f0-9]{8,}$/i.test(hash)) return true;
-  // Fragile when identity is path-sensitive (basename) or slug only loosely matches project id.
-  return projectId === slug || !projectId.includes("/");
 }
 
 /**
@@ -66,7 +63,7 @@ export function buildScopeMigratePlan(args: {
   const pathDerivedBank = !args.config.banks.project.bankId;
   const projectTag = projectScopeTag(identity.projectId);
   const legacyRepoTag = legacyRepoScopeTag(identity.legacyRepoKey);
-  const pathHashFragile = basenameFragility(identity.legacyRepoKey, identity.projectId);
+  const identityBasisWeak = identity.basis === "basename";
 
   const findings: string[] = [];
   const guidance: string[] = [];
@@ -75,31 +72,29 @@ export function buildScopeMigratePlan(args: {
     `Active dual-tag window: retain writes ${projectTag} and ${legacyRepoTag}; recall any_strict matches either.`,
   );
   findings.push(`Project id basis=${identity.basis} source=${identity.source} → ${projectTag}.`);
+  findings.push(
+    `Legacy tag ${legacyRepoTag} is path-hash based (machine/path moves change the hash). Stable project: tag is the recovery path for new writes.`,
+  );
 
   if (pathDerivedBank) {
     findings.push(
-      `Coding bank is path-derived (${bankId}); domain-tagged mode should set banks.project.bankId to a shared coding bank.`,
+      `Coding bank is path-derived (${bankId}); domain-tagged mode requires banks.project.bankId for a shared coding bank.`,
     );
     guidance.push(
       "Set banks.project.bankId (and setupComplete) so repos share one coding bank; do not rely on path-hash bank ids.",
     );
   }
 
-  if (identity.basis === "basename") {
+  if (identityBasisWeak) {
     findings.push(
       "Project id is basename-derived; remotes or pins are more stable across clones and renames.",
     );
     guidance.push(
       'Prefer scope.projectId pin or projectIdStrategy "remote" when a git origin exists.',
     );
-  }
-
-  if (pathHashFragile) {
+  } else {
     findings.push(
-      "Legacy repo:<slug>-<path-hash> tags break when the absolute path changes (e.g. Mac↔Linux). Dual-tag project: recovers new writes; older repo-only memories may miss.",
-    );
-    guidance.push(
-      "Keep dual-tag until reimport/rebuild. Prefer Hindsight document export/import when available; otherwise reimport Pi transcripts with replace into the coding bank.",
+      `Project id basis is ${identity.basis} (stable across absolute path moves when dual-tag project: is present).`,
     );
   }
 
@@ -157,7 +152,8 @@ export function buildScopeMigratePlan(args: {
     projectIdBasis: identity.basis,
     projectIdSource: identity.source,
     dualTagWindow: true,
-    pathHashFragile,
+    legacyPathHashTag: true,
+    identityBasisWeak,
     findings,
     guidance,
     ...(remoteTagCounts ? { remoteTagCounts } : {}),

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -46,7 +46,13 @@ function writeSetupCompleteConfig(cwd: string, extra: Record<string, unknown> = 
   mkdirSync(join(cwd, ".pi"), { recursive: true });
   writeFileSync(
     join(cwd, ".pi", "hindsight.json"),
-    JSON.stringify({ setupComplete: true, hindsight: { baseUrl: "http://unused.test" }, ...extra }),
+    JSON.stringify({
+      setupComplete: true,
+      hindsight: { baseUrl: "http://unused.test" },
+      // Domain-tagged auto memory requires an explicit coding bank id.
+      banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+      ...extra,
+    }),
   );
 }
 
@@ -115,7 +121,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ hindsight: { baseUrl: "http://unused.test" } }),
+      JSON.stringify({
+        setupComplete: true,
+        hindsight: { baseUrl: "http://unused.test" },
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+      }),
     );
     const { createMemoryLifecycle } = await import("../extensions/lifecycle/memory-lifecycle.js");
     const ctx = {
@@ -140,7 +150,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ hindsight: { baseUrl: "http://unused.test" } }),
+      JSON.stringify({
+        setupComplete: true,
+        hindsight: { baseUrl: "http://unused.test" },
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+      }),
     );
     mocked.ensureProjectBank.mockRejectedValueOnce(new Error("bank ensure exploded"));
     const { createMemoryLifecycle } = await import("../extensions/lifecycle/memory-lifecycle.js");
@@ -202,7 +216,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ hindsight: { baseUrl: "http://unused.test" } }),
+      JSON.stringify({
+        setupComplete: true,
+        hindsight: { baseUrl: "http://unused.test" },
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+      }),
     );
     const { createMemoryLifecycle } = await import("../extensions/lifecycle/memory-lifecycle.js");
     const ctx = {
@@ -229,7 +247,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ hindsight: { baseUrl: "http://unused.test" } }),
+      JSON.stringify({
+        setupComplete: true,
+        hindsight: { baseUrl: "http://unused.test" },
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+      }),
     );
     const sessionFile = join(cwd, "session.jsonl");
 
@@ -299,7 +321,9 @@ describe("extension hooks", () => {
       writeFileSync(
         join(cwd, ".pi", "hindsight.json"),
         JSON.stringify({
+          setupComplete: true,
           hindsight: { baseUrl: "http://unused.test" },
+          banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
           retain: { flushIntervalMs: 1_000, periodicFlushMaxJobs: 1, shutdownFlushMaxJobs: 10 },
         }),
       );
@@ -532,7 +556,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ recall: { storeLastRecall: true } }),
+      JSON.stringify({
+        setupComplete: true,
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+        recall: { storeLastRecall: true },
+      }),
     );
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
@@ -570,7 +598,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ recall: { storeLastRecall: true, lastRecallPath: "." } }),
+      JSON.stringify({
+        setupComplete: true,
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+        recall: { storeLastRecall: true, lastRecallPath: "." },
+      }),
     );
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
@@ -608,7 +640,12 @@ describe("extension hooks", () => {
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
-        banks: { global: { enabled: false } },
+        setupComplete: true,
+        banks: {
+          project: { enabled: true, bankId: "test-coding", derive: "manual" },
+          global: { enabled: false },
+          user: { enabled: false },
+        },
         recall: { storeLastRecall: true, storeLastRecallFailures: true },
       }),
     );
@@ -640,7 +677,7 @@ describe("extension hooks", () => {
     expect(existsSync(snapshotPath)).toBe(true);
     const snapshot = JSON.parse(readFileSync(snapshotPath, "utf8")) as Record<string, any>;
     expect(snapshot.failed).toBe(1);
-    expect(snapshot.failures[0].bankId).toMatch(/^pi-project-/);
+    expect(snapshot.failures[0].bankId).toMatch(/^test-coding/);
     expect(snapshot.failures[0].query).toContain("Why no memory?");
     expect(snapshot.failures[0].error).not.toContain("secret-token");
   });
@@ -652,7 +689,12 @@ describe("extension hooks", () => {
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
-        banks: { global: { enabled: false } },
+        setupComplete: true,
+        banks: {
+          project: { enabled: true, bankId: "test-coding", derive: "manual" },
+          global: { enabled: false },
+          user: { enabled: false },
+        },
         recall: { storeLastRecall: true },
       }),
     );
@@ -718,7 +760,14 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ banks: { global: { enabled: true, bankId: "global-bank" } } }),
+      JSON.stringify({
+        setupComplete: true,
+        banks: {
+          project: { enabled: true, bankId: "test-coding", derive: "manual" },
+          global: { enabled: true, bankId: "global-bank" },
+          user: { enabled: true, bankId: "global-bank" },
+        },
+      }),
     );
     mocked.client.recall.mockImplementation(async (...args: unknown[]) => ({
       results: [{ text: `${String(args[0])} memory` }],
@@ -751,7 +800,7 @@ describe("extension hooks", () => {
     expect(contextResult.messages[0].content).toContain("global-bank memory");
     expect(contextResult.messages.at(-1).content).toBe("What do I know?");
     expect(mocked.client.recall).toHaveBeenCalledTimes(2);
-    expect(mocked.client.recall.mock.calls[0]?.[0]).toMatch(/^pi-project-/);
+    expect(mocked.client.recall.mock.calls[0]?.[0]).toMatch(/^test-coding/);
     expect(mocked.client.recall.mock.calls[0]?.[1]).toContain(
       "Project memory lookup for current repo architecture",
     );
@@ -790,7 +839,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ recall: { injectionPosition: "prepend" } }),
+      JSON.stringify({
+        setupComplete: true,
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+        recall: { injectionPosition: "prepend" },
+      }),
     );
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
@@ -823,7 +876,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ recall: { injectionPosition: "append" } }),
+      JSON.stringify({
+        setupComplete: true,
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+        recall: { injectionPosition: "append" },
+      }),
     );
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
@@ -931,7 +988,14 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ banks: { global: { enabled: true, bankId: "global-bank" } } }),
+      JSON.stringify({
+        setupComplete: true,
+        banks: {
+          project: { enabled: true, bankId: "test-coding", derive: "manual" },
+          global: { enabled: true, bankId: "global-bank" },
+          user: { enabled: true, bankId: "global-bank" },
+        },
+      }),
     );
     mocked.ensureGlobalBank.mockRejectedValueOnce(new Error("global down"));
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
@@ -1094,6 +1158,7 @@ describe("extension hooks", () => {
   it("keeps next opt-out pending when skipped-message cursor update fails", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-hooks-"));
     mkdirSync(join(cwd, ".git"));
+    writeSetupCompleteConfig(cwd);
     mkdirSync(join(cwd, ".pi", "hindsight"), { recursive: true });
     writeFileSync(join(cwd, ".pi", "hindsight", "retain-cursors.json"), "not json");
     const sessionFile = join(cwd, "session.jsonl");
@@ -1364,7 +1429,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ retain: { enabled: false } }),
+      JSON.stringify({
+        setupComplete: true,
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+        retain: { enabled: false },
+      }),
     );
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
@@ -1400,7 +1469,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ hindsight: { baseUrl: "http://unused.test" } }),
+      JSON.stringify({
+        setupComplete: true,
+        hindsight: { baseUrl: "http://unused.test" },
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+      }),
     );
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
@@ -1444,7 +1517,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ hindsight: { baseUrl: "http://unused.test" } }),
+      JSON.stringify({
+        setupComplete: true,
+        hindsight: { baseUrl: "http://unused.test" },
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+      }),
     );
     const sessionFile = join(cwd, "session.jsonl");
     const u1 = { role: "user", content: "u1", timestamp: 1 };
@@ -1486,7 +1563,9 @@ describe("extension hooks", () => {
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
+        setupComplete: true,
         hindsight: { baseUrl: "http://unused.test" },
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
         notifications: { startup: false },
       }),
     );
@@ -1516,7 +1595,7 @@ describe("extension hooks", () => {
     const queued = await readRetainQueue(resolveQueuePath(cwd, ".pi/hindsight/retain-queue.jsonl"));
     expect(queued).toHaveLength(1);
     expect(queued[0]).toMatchObject({
-      bankId: expect.stringMatching(/^pi-project-/),
+      bankId: expect.stringMatching(/^test-coding/),
       documentId: liveDocumentId(sessionFile, cwd),
       updateMode: "append",
       retries: 1,
@@ -1555,6 +1634,9 @@ describe("extension hooks", () => {
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
+        setupComplete: true,
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+
         retain: { shutdownFlushMaxJobs: 2, shutdownFlushTimeoutMs: 1_000 },
         notifications: { startup: false },
       }),
@@ -1596,7 +1678,12 @@ describe("extension hooks", () => {
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
       JSON.stringify({
-        banks: { global: { enabled: false } },
+        setupComplete: true,
+        banks: {
+          project: { enabled: true, bankId: "test-coding", derive: "manual" },
+          global: { enabled: false },
+          user: { enabled: false },
+        },
         notifications: { startup: false, recall: true, retain: true },
       }),
     );
@@ -1627,11 +1714,11 @@ describe("extension hooks", () => {
     );
 
     expect(ctx.ui.notify).toHaveBeenCalledWith(
-      expect.stringMatching(/^Hindsight recalled 1 memory item from pi-project-/),
+      expect.stringMatching(/^Hindsight recalled 1 memory item from test-coding/),
       "info",
     );
     expect(ctx.ui.notify).toHaveBeenCalledWith(
-      expect.stringMatching(/^Hindsight retained 1 new message to pi-project-/),
+      expect.stringMatching(/^Hindsight retained 1 new message to test-coding/),
       "info",
     );
   });
@@ -1642,7 +1729,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ retain: { postRetainReflect: true } }),
+      JSON.stringify({
+        setupComplete: true,
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+        retain: { postRetainReflect: true },
+      }),
     );
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};
     const pi = {
@@ -1667,7 +1758,7 @@ describe("extension hooks", () => {
     );
 
     expect(mocked.client.reflect).toHaveBeenCalledWith(
-      expect.stringMatching(/^pi-project-/),
+      expect.stringMatching(/^test-coding/),
       "Reflect on the recently retained session to extract insights",
       { context: "Post-retain reflection" },
     );
@@ -1679,7 +1770,11 @@ describe("extension hooks", () => {
     mkdirSync(join(cwd, ".pi"));
     writeFileSync(
       join(cwd, ".pi", "hindsight.json"),
-      JSON.stringify({ retain: { postRetainReflect: true } }),
+      JSON.stringify({
+        setupComplete: true,
+        banks: { project: { enabled: true, bankId: "test-coding", derive: "manual" } },
+        retain: { postRetainReflect: true },
+      }),
     );
     mocked.client.reflect.mockRejectedValueOnce(new Error("reflect unavailable"));
     const handlers: Record<string, Array<(event: any, ctx: any) => Promise<any>>> = {};

--- a/tests/memory-control-operations.test.ts
+++ b/tests/memory-control-operations.test.ts
@@ -58,6 +58,7 @@ describe("memory control operations", () => {
     );
     expect(createMentalModel).not.toHaveBeenCalled();
 
+    // Create defaults dry-run; must opt in to write.
     await ops.mentalModel({
       action: "create",
       cwd,
@@ -154,6 +155,18 @@ describe("memory control operations", () => {
       /not allowlisted/i,
     );
 
+    await expect(
+      ops.config({
+        action: "patch",
+        cwd,
+        patch: { includeSharedObservations: "yes" as unknown as boolean },
+      }),
+    ).rejects.toThrow(/must be a boolean/i);
+
+    await expect(
+      ops.config({ action: "patch", cwd, patch: { setupComplete: true } }),
+    ).rejects.toThrow(/projectBankId/i);
+
     const dry = await ops.config({
       action: "patch",
       cwd,
@@ -180,5 +193,42 @@ describe("memory control operations", () => {
     };
     expect(disk.setupComplete).toBe(true);
     expect(disk.banks?.project?.bankId).toBe("kai-coding");
+  });
+
+  it("bank mission and mm create default to dry-run at the op layer", async () => {
+    const updateBankConfig = vi.fn(async () => ({ ok: true }));
+    const createMentalModel = vi.fn(async () => ({ id: "mm1" }));
+    const ops = createControlOperations({
+      getClient: () => ({
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+        updateBankConfig,
+        createMentalModel,
+      }),
+      getConfig: () => ({
+        ...DEFAULT_CONFIG,
+        setupComplete: true,
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "coding", derive: "manual" as const },
+        },
+      }),
+      getProjectBankId: () => "coding",
+    });
+
+    const mission = await ops.bankUpdateMission({ retainMission: "code" });
+    expect(mission).toMatchObject({ dryRun: true });
+    expect(updateBankConfig).not.toHaveBeenCalled();
+
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-mm-dry-"));
+    const created = await ops.mentalModel({
+      action: "create",
+      cwd,
+      name: "X",
+      sourceQuery: "q",
+    });
+    expect(created).toMatchObject({ dryRun: true });
+    expect(createMentalModel).not.toHaveBeenCalled();
   });
 });

--- a/tests/scope-migrate.test.ts
+++ b/tests/scope-migrate.test.ts
@@ -39,8 +39,31 @@ describe("scope migrate dry-run", () => {
     expect(plan.projectTag).toMatch(/^project:/);
     expect(plan.legacyRepoTag).toMatch(/^repo:/);
     expect(plan.pathDerivedBank).toBe(true);
+    expect(plan.legacyPathHashTag).toBe(true);
     expect(plan.findings.some((f) => f.includes("path-derived"))).toBe(true);
     expect(plan.guidance.some((g) => /no silent rewrite/i.test(g))).toBe(true);
+  });
+
+  it("does not mark remote/pin project ids as identity-weak", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-migrate-stable-"));
+    mkdirSync(join(cwd, ".git"));
+    // Pin identity is stable; legacy path-hash still noted separately.
+    const plan = buildScopeMigratePlan({
+      cwd,
+      config: cfg({
+        scope: { ...DEFAULT_CONFIG.scope, projectId: "finalform", projectIdStrategy: "remote" },
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "kai-coding", derive: "manual" },
+        },
+      }),
+      projectBankId: "kai-coding",
+    });
+    expect(plan.projectIdBasis).toBe("pin");
+    expect(plan.identityBasisWeak).toBe(false);
+    expect(plan.legacyPathHashTag).toBe(true);
+    expect(plan.findings.some((f) => /stable across absolute path moves/i.test(f))).toBe(true);
+    expect(plan.findings.some((f) => /basename-derived/i.test(f))).toBe(false);
   });
 
   it("counts remote tag sample and detects other path-hash repo tags", () => {

--- a/tests/setup-gate.test.ts
+++ b/tests/setup-gate.test.ts
@@ -3,11 +3,25 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
-import { isMemorySetupComplete, setupRequiredMessage } from "../extensions/config/setup-gate.js";
+import {
+  isMemorySetupComplete,
+  requiresExplicitCodingBankId,
+  setupRequiredMessage,
+} from "../extensions/config/setup-gate.js";
 import type { ResolvedConfig } from "../extensions/types.js";
 
 function config(patch: Partial<ResolvedConfig> = {}): ResolvedConfig {
-  return { ...DEFAULT_CONFIG, ...patch };
+  return {
+    ...DEFAULT_CONFIG,
+    ...patch,
+    scope: { ...DEFAULT_CONFIG.scope, ...(patch as { scope?: object }).scope },
+    banks: {
+      ...DEFAULT_CONFIG.banks,
+      ...(patch.banks ?? {}),
+      project: { ...DEFAULT_CONFIG.banks.project, ...(patch.banks?.project ?? {}) },
+      user: { ...DEFAULT_CONFIG.banks.user, ...(patch.banks?.user ?? {}) },
+    },
+  } as ResolvedConfig;
 }
 
 describe("setup gate", () => {
@@ -17,9 +31,26 @@ describe("setup gate", () => {
     expect(setupRequiredMessage()).toMatch(/setup required/i);
   });
 
-  it("accepts explicit setupComplete flag", () => {
+  it("rejects setupComplete alone under domain-tagged without coding bankId", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-flag-"));
-    expect(isMemorySetupComplete(config({ setupComplete: true }), cwd)).toBe(true);
+    expect(isMemorySetupComplete(config({ setupComplete: true }), cwd)).toBe(false);
+    expect(requiresExplicitCodingBankId(config())).toBe(true);
+  });
+
+  it("accepts setupComplete with explicit project bankId", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-flag-bank-"));
+    expect(
+      isMemorySetupComplete(
+        config({
+          setupComplete: true,
+          banks: {
+            ...DEFAULT_CONFIG.banks,
+            project: { enabled: true, bankId: "my-bank", derive: "manual" },
+          },
+        }),
+        cwd,
+      ),
+    ).toBe(true);
   });
 
   it("accepts explicit project bankId", () => {
@@ -37,7 +68,7 @@ describe("setup gate", () => {
     ).toBe(true);
   });
 
-  it("accepts user bankId as configured", () => {
+  it("accepts user bankId as configured when project bank disabled", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-user-"));
     expect(
       isMemorySetupComplete(
@@ -54,17 +85,32 @@ describe("setup gate", () => {
     ).toBe(true);
   });
 
-  it("migrates upgrades that already have project config files", () => {
+  it("does not unlock domain-tagged auto memory from empty project config alone", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-cfg-"));
     mkdirSync(join(cwd, ".pi"), { recursive: true });
     writeFileSync(join(cwd, ".pi", "hindsight.json"), "{}\n");
-    expect(isMemorySetupComplete(config(), cwd)).toBe(true);
+    // Soft signal present, but domain-tagged still needs banks.project.bankId.
+    expect(isMemorySetupComplete(config(), cwd)).toBe(false);
   });
 
-  it("migrates upgrades that have retain runtime state", () => {
+  it("does not unlock domain-tagged auto memory from runtime state alone", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-runtime-"));
     mkdirSync(join(cwd, ".pi", "hindsight"), { recursive: true });
     writeFileSync(join(cwd, ".pi", "hindsight", "retain-cursors.json"), "{}\n");
-    expect(isMemorySetupComplete(config(), cwd)).toBe(true);
+    expect(isMemorySetupComplete(config(), cwd)).toBe(false);
+  });
+
+  it("allows isolated-bank path-derived setup via config file or runtime state", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-isolated-"));
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(join(cwd, ".pi", "hindsight.json"), "{}\n");
+    expect(
+      isMemorySetupComplete(
+        config({
+          scope: { ...DEFAULT_CONFIG.scope, mode: "isolated-bank" },
+        }),
+        cwd,
+      ),
+    ).toBe(true);
   });
 });

--- a/tests/status-fields.test.ts
+++ b/tests/status-fields.test.ts
@@ -53,12 +53,21 @@ describe("status fields tones", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-status-dl-"));
     mkdirSync(join(cwd, ".pi"), { recursive: true });
     writeFileSync(join(cwd, ".pi", "hindsight.json"), "{}\n");
-    const fields = buildStatusFields(config({ setupComplete: true }), {
-      cwd,
-      projectBankId: "b",
-      queueLength: 1,
-      deadLetterLength: 2,
-    });
+    const fields = buildStatusFields(
+      config({
+        setupComplete: true,
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "b", derive: "manual" },
+        },
+      }),
+      {
+        cwd,
+        projectBankId: "b",
+        queueLength: 1,
+        deadLetterLength: 2,
+      },
+    );
     expect(fields.find((f) => f.key === "queue")?.tone).toBe("warn");
   });
 
@@ -81,6 +90,10 @@ describe("status fields tones", () => {
       config({
         setupComplete: true,
         scope: { ...DEFAULT_CONFIG.scope, includeSharedObservations: true },
+        banks: {
+          ...DEFAULT_CONFIG.banks,
+          project: { enabled: true, bankId: "kai-coding", derive: "manual" },
+        },
       }),
       { cwd, projectBankId: "kai-coding" },
     );


### PR DESCRIPTION
## Summary

Post-landing review fixes for ADR-005 control plane (#509):

1. **Migrate plan** — replace always-true `pathHashFragile` with `legacyPathHashTag` + `identityBasisWeak` (basename only).
2. **Dry-run defaults** — bank mission + mental-model create/update/refresh/delete default `dryRun=true` at the **operation** layer.
3. **Domain-tagged gate** — auto ensure/recall/retain requires explicit `banks.project.bankId` when project bank is enabled; isolated-bank may still path-derive.
4. **Config patch** — typed TypeBox schema + runtime type checks; reject `setupComplete` without `projectBankId` in domain-tagged mode.

## Linked issue

Closes #509

## Scope

- [x] Single focused vertical slice for this PR
- [x] No drive-by refactors or unrelated cleanup

## Verification

- [x] `npm run check` (538 tests)
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Targeted: setup-gate, scope-migrate, memory-control-operations, extension-hooks. Full suite green. Live smoke deferred to CI when tunnel healthy (behavior is gate/config/local policy).

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Domain-tagged installs without coding bankId stop auto memory until bankId is set (status/setup message). Mutating agent tools default dry-run.

## Risk and rollback

- Risk: upgrades with path-derived banks under domain-tagged need to set `banks.project.bankId` (or switch isolated-bank). Mitigated by clearer setup message and doctor/migrate guidance.
- Rollback/revert path: revert PR.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] project-identity docs; setup message; tool descriptions.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Addresses the extensive post-landing review findings after #502–#508.