### PR TITLE
docs: upgrade guide and setup-required links for domain banks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For local checkout installs, see [Development](#development).
 4. Choose the narrowest memory profile that fits the repo: **Project + User**, **Project Only**, **User Only**, or **Recall Only**.
 5. Start coding. Recall happens before provider calls; retain happens after completed agent runs when the selected profile allows automatic retain.
 
-See the [getting started guide](https://luxus.github.io/pi-hindsight/start/getting-started/) for setup details.
+See the [getting started guide](https://luxus.github.io/pi-hindsight/start/getting-started/) for setup details. Upgrading from older path-bank installs: [Upgrading to domain banks](https://luxus.github.io/pi-hindsight/guides/upgrading-to-domain-banks/).
 
 ## Safety defaults
 
@@ -60,7 +60,7 @@ See [memory behavior](https://luxus.github.io/pi-hindsight/concepts/memory-behav
 
 - [Start](https://luxus.github.io/pi-hindsight/start/) — install and first setup
 - [Concepts](https://luxus.github.io/pi-hindsight/concepts/) — memory model, banks, queue, imports, safety
-- [Guides](https://luxus.github.io/pi-hindsight/guides/) — task workflows for setup, diagnostics, imports, and recovery
+- [Guides](https://luxus.github.io/pi-hindsight/guides/) — task workflows for setup, diagnostics, imports, recovery, and [domain-bank upgrades](https://luxus.github.io/pi-hindsight/guides/upgrading-to-domain-banks/)
 - [Reference](https://luxus.github.io/pi-hindsight/reference/) — tools, commands, config, hooks, generated surface
 - [Development](https://luxus.github.io/pi-hindsight/development/) — contributor setup, checks, release, docs workflow
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -75,6 +75,7 @@ export default defineConfig({
             { label: "Recover Retain Queue", slug: "guides/recover-retain-queue" },
             { label: "Run local smoke test", slug: "guides/run-local-smoke-test" },
             { label: "MCP multi-client bank wiring", slug: "guides/mcp-multi-client" },
+            { label: "Upgrading to domain banks", slug: "guides/upgrading-to-domain-banks" },
           ],
         },
         {

--- a/docs-site/src/content/docs/concepts/project-identity.md
+++ b/docs-site/src/content/docs/concepts/project-identity.md
@@ -4,6 +4,8 @@ title: "Project identity and scope tags"
 
 Pi Hindsight tags project memories so recall stays scoped to the current repository. Identity is **stable across absolute path moves** when possible (ADR-005).
 
+Upgrading from older path-bank installs: see [Upgrading to domain banks](/pi-hindsight/guides/upgrading-to-domain-banks/) (soft dual-tag vs shared coding bank vs isolated-bank).
+
 ## Resolution order
 
 1. **Pin** — `scope.projectId` in `.pi/hindsight.json` or global config

--- a/docs-site/src/content/docs/development/release.md
+++ b/docs-site/src/content/docs/development/release.md
@@ -39,11 +39,12 @@ npm run check:release
 1. Merge feature and fix PRs into `main` with Conventional Commit subjects.
 2. The `Release Please` workflow opens or updates a release PR.
 3. Review the release PR changelog, version bump, and manifest update.
-4. Confirm release/package verification passes. Use the `ci:package` or `ci:full` labels if additional gates are needed.
-5. Merge the release PR.
-6. Release-please creates the `v*.*.*` tag and GitHub release.
-7. Release Please dispatches the trusted `Release` workflow at the release tag. It verifies the tagged release commit, and publishes to npm through trusted publishing only if the dispatch's `publish` input is `true` (currently held at `false`; see above).
-8. If publish was held, a maintainer runs `gh workflow run release.yml --ref vX.Y.Z -f publish=true` to publish once ready.
+4. For user-visible topology or setup-gate changes (domain banks, dual-tag, bankId requirements), add a short **Migration** note on the release PR / GitHub Release body linking [Upgrading to domain banks](/pi-hindsight/guides/upgrading-to-domain-banks/) and the dual-tag section of [project identity](/pi-hindsight/concepts/project-identity/). Do not hand-edit generated `CHANGELOG.md` entries as source of truth; put narrative migration guidance in the guide and the release body.
+5. Confirm release/package verification passes. Use the `ci:package` or `ci:full` labels if additional gates are needed.
+6. Merge the release PR.
+7. Release-please creates the `v*.*.*` tag and GitHub release.
+8. Release Please dispatches the trusted `Release` workflow at the release tag. It verifies the tagged release commit, and publishes to npm through trusted publishing only if the dispatch's `publish` input is `true` (currently held at `false`; see above).
+9. If publish was held, a maintainer runs `gh workflow run release.yml --ref vX.Y.Z -f publish=true` to publish once ready.
 
 Manual `Release Please` workflow dispatch can refresh the release PR if needed.
 

--- a/docs-site/src/content/docs/guides/index.mdx
+++ b/docs-site/src/content/docs/guides/index.mdx
@@ -35,4 +35,8 @@ Guides answer “what do I do now?” They avoid repeating the concept model and
     Point other AI tools at coding or life banks via per-bank MCP URLs with a clear `source:` tag
     vocabulary. [MCP guide](./mcp-multi-client/)
   </Card>
+  <Card title="Upgrading to domain banks" icon="rocket">
+    Soft dual-tag update, shared coding bank, or isolated-bank after ADR-005. [Upgrade
+    guide](./upgrading-to-domain-banks/)
+  </Card>
 </CardGrid>

--- a/docs-site/src/content/docs/guides/upgrading-to-domain-banks.md
+++ b/docs-site/src/content/docs/guides/upgrading-to-domain-banks.md
@@ -1,0 +1,86 @@
+---
+title: "Upgrading to domain banks"
+description: "Soft dual-tag path vs shared coding bank vs isolated-bank after ADR-005."
+---
+
+Pi Hindsight’s default bank topology changed under ADR-005: most repos share a **coding bank** and isolate with stable `project:<id>` tags, instead of one path-hash bank per folder. This guide is for people upgrading an existing install (or anyone who sees **Setup: required** after an update).
+
+## What changed
+
+| Before (path banks)                         | After (domain banks)                                                          |
+| ------------------------------------------- | ----------------------------------------------------------------------------- |
+| Bank id derived from absolute path          | Explicit coding bank id for shared domain mode                                |
+| Isolation mostly by separate banks          | Isolation by `project:<id>` tags (plus dual-tag legacy `repo:`)               |
+| Auto memory could run on path-derived banks | **Domain-tagged** auto memory needs `banks.project.bankId` before network I/O |
+
+You do **not** need a bulk tag rewrite to keep working. Soft update is dual-tag + choose a bank model.
+
+## Choose a path
+
+### 1. Soft update (recommended first)
+
+Stay on your current bank content. New retains write **both**:
+
+- stable `project:<id>` (prefer git remote or a pin — see [project identity](/pi-hindsight/concepts/project-identity/))
+- legacy `repo:<slug>-<path-hash>`
+
+Recall matches **either** tag, so older memories still surface while new ones get stable tags.
+
+**Unlock auto memory under domain-tagged:** set an explicit coding bank id (even if you keep using a dedicated bank for now), **or** switch to isolated-bank (path C).
+
+Practical steps:
+
+1. Open `/hindsight` → guided setup (`g`) **or** set `banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`.
+2. Prefer `scope.projectIdStrategy: "remote"` (default) or pin `scope.projectId` for weak basename-only repos.
+3. Optional: ask the agent to run `hindsight_scope_migrate` (dry-run only) for a local plan/receipt. It never rewrites Hindsight tags.
+
+### 2. Full adopt: shared coding bank
+
+Use one coding bank across normal repos; isolate with tags.
+
+1. `/hindsight` guided setup → **Coding** or **Coding + Life**.
+2. Set a shared coding bank id (example: `pi-coding` or your own `kai-coding`).
+3. Confirm `scope.mode` is `domain-tagged` and `setupComplete` is satisfied.
+4. Optional later: reimport Pi sessions into that bank if you want history consolidated ([importing sessions](/pi-hindsight/guides/importing-sessions/)).
+
+Dual-tag stays on until coverage is good enough; drop it only after project-tagged memory is what you rely on (or after a full export/import rebuild).
+
+### 3. Keep hard isolation (closest to older path banks)
+
+```jsonc
+{
+  "scope": { "mode": "isolated-bank" },
+  "banks": { "project": { "enabled": true } },
+}
+```
+
+Path-derived bank ids remain valid. Pin `banks.project.bankId` if you want a fixed hard-wall bank. Dual-tag still helps after path moves.
+
+### 4. Freeze on a previous package version
+
+If you must not change topology yet, pin the previous published release of `@luxusai/pi-hindsight` and read the [changelog](https://github.com/luxus/pi-hindsight/blob/main/CHANGELOG.md). Prefer path 1–3 when you can; pin is for temporary freezes, not the long-term product path.
+
+## Setup gate (why auto memory paused)
+
+Automatic bank ensure, recall, and retain stay off until setup is satisfied:
+
+- **Domain-tagged** + project bank enabled → requires explicit `banks.project.bankId` (or env). Soft signals alone (empty project config, queue files, `setupComplete` without bank id) do **not** unlock auto memory.
+- **Isolated-bank** → may use path-derived banks once config/runtime signals show an existing install, or after guided setup.
+
+Status shows **Setup: required** and startup can warn with this guide’s URL when notifications are on.
+
+## Inspect without rewriting
+
+| Tool / surface               | Role                                                               |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `/hindsight` status / doctor | Shows project tag, bank selection, path-derived warnings           |
+| `hindsight_scope_migrate`    | Dry-run plan + local receipt; **never** rewrites tags or documents |
+| Guided setup                 | Writes bank ids, profile, and setup completion                     |
+
+## Related
+
+- [Project identity and scope tags](/pi-hindsight/concepts/project-identity/) — dual-tag window, remote vs pin
+- [Getting started](/pi-hindsight/start/getting-started/) — first setup and profiles
+- [Memory profiles](/pi-hindsight/start/memory-profiles/)
+- [ADR-005: Domain banks and agent-first surface](/pi-hindsight/architecture/adr/005-domain-banks-and-agent-first-surface/)
+- [Changelog](https://github.com/luxus/pi-hindsight/blob/main/CHANGELOG.md)

--- a/docs-site/src/content/docs/start/getting-started.md
+++ b/docs-site/src/content/docs/start/getting-started.md
@@ -46,7 +46,7 @@ Open Pi in your repository and run:
 
 If no project config exists, guided setup starts automatically. You can rerun it later from the TUI with `g`.
 
-**Setup gate:** until a bank is chosen (guided setup, `banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, or an existing install with prior config/runtime state), automatic bank ensure, recall, and retain stay off. Status warns that setup is required. Existing upgrades with config files or queue/cursor state continue to work without re-onboarding.
+**Setup gate:** automatic bank ensure, recall, and retain stay off until setup is satisfied. For default **domain-tagged** mode with project memory on, that means an explicit coding bank id (`banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, usually via guided setup). Soft signals alone (empty project config, queue/cursor files, or `setupComplete` without a bank id) do **not** unlock domain-tagged auto memory. **Isolated-bank** may keep path-derived banks after config/runtime signals or guided setup. Status warns when setup is required. Upgrading from path banks: [Upgrading to domain banks](/pi-hindsight/guides/upgrading-to-domain-banks/).
 
 Guided setup handles:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,7 @@ Open Pi in your repository and run:
 
 If no project config exists, guided setup starts automatically. You can rerun it later from the TUI with `g`.
 
-**Setup gate:** until a bank is chosen (guided setup, `banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, or an existing install with prior config/runtime state), automatic bank ensure, recall, and retain stay off. Status warns that setup is required. Existing upgrades with config files or queue/cursor state continue to work without re-onboarding.
+**Setup gate:** automatic bank ensure, recall, and retain stay off until setup is satisfied. For default **domain-tagged** mode with project memory on, that means an explicit coding bank id (`banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, usually via guided setup). Soft signals alone (empty project config, queue/cursor files, or `setupComplete` without a bank id) do **not** unlock domain-tagged auto memory. **Isolated-bank** may keep path-derived banks after config/runtime signals or guided setup. Status warns when setup is required. Upgrading from path banks: [Upgrading to domain banks](upgrading-to-domain-banks.md).
 
 Guided setup handles:
 

--- a/docs/project-identity.md
+++ b/docs/project-identity.md
@@ -2,6 +2,8 @@
 
 Pi Hindsight tags project memories so recall stays scoped to the current repository. Identity is **stable across absolute path moves** when possible (ADR-005).
 
+Upgrading from older path-bank installs: see [Upgrading to domain banks](upgrading-to-domain-banks.md) (soft dual-tag vs shared coding bank vs isolated-bank).
+
 ## Resolution order
 
 1. **Pin** — `scope.projectId` in `.pi/hindsight.json` or global config

--- a/docs/release.md
+++ b/docs/release.md
@@ -37,11 +37,12 @@ npm run check:release
 1. Merge feature and fix PRs into `main` with Conventional Commit subjects.
 2. The `Release Please` workflow opens or updates a release PR.
 3. Review the release PR changelog, version bump, and manifest update.
-4. Confirm release/package verification passes. Use the `ci:package` or `ci:full` labels if additional gates are needed.
-5. Merge the release PR.
-6. Release-please creates the `v*.*.*` tag and GitHub release.
-7. Release Please dispatches the trusted `Release` workflow at the release tag. It verifies the tagged release commit, and publishes to npm through trusted publishing only if the dispatch's `publish` input is `true` (currently held at `false`; see above).
-8. If publish was held, a maintainer runs `gh workflow run release.yml --ref vX.Y.Z -f publish=true` to publish once ready.
+4. For user-visible topology or setup-gate changes (domain banks, dual-tag, bankId requirements), add a short **Migration** note on the release PR / GitHub Release body linking [Upgrading to domain banks](https://luxus.github.io/pi-hindsight/guides/upgrading-to-domain-banks/) and the dual-tag section of [project identity](https://luxus.github.io/pi-hindsight/concepts/project-identity/). Do not hand-edit generated `CHANGELOG.md` entries as source of truth; put narrative migration guidance in the guide and the release body.
+5. Confirm release/package verification passes. Use the `ci:package` or `ci:full` labels if additional gates are needed.
+6. Merge the release PR.
+7. Release-please creates the `v*.*.*` tag and GitHub release.
+8. Release Please dispatches the trusted `Release` workflow at the release tag. It verifies the tagged release commit, and publishes to npm through trusted publishing only if the dispatch's `publish` input is `true` (currently held at `false`; see above).
+9. If publish was held, a maintainer runs `gh workflow run release.yml --ref vX.Y.Z -f publish=true` to publish once ready.
 
 Manual `Release Please` workflow dispatch can refresh the release PR if needed.
 

--- a/docs/upgrading-to-domain-banks.md
+++ b/docs/upgrading-to-domain-banks.md
@@ -1,0 +1,68 @@
+# Upgrading to domain banks
+
+Pi Hindsight’s default bank topology changed under ADR-005: most repos share a **coding bank** and isolate with stable `project:<id>` tags, instead of one path-hash bank per folder. This guide is for people upgrading an existing install (or anyone who sees **Setup: required** after an update).
+
+Published docs: <https://luxus.github.io/pi-hindsight/guides/upgrading-to-domain-banks/>
+
+## What changed
+
+| Before (path banks)                         | After (domain banks)                                                          |
+| ------------------------------------------- | ----------------------------------------------------------------------------- |
+| Bank id derived from absolute path          | Explicit coding bank id for shared domain mode                                |
+| Isolation mostly by separate banks          | Isolation by `project:<id>` tags (plus dual-tag legacy `repo:`)               |
+| Auto memory could run on path-derived banks | **Domain-tagged** auto memory needs `banks.project.bankId` before network I/O |
+
+You do **not** need a bulk tag rewrite to keep working. Soft update is dual-tag + choose a bank model.
+
+## Choose a path
+
+### 1. Soft update (recommended first)
+
+Stay on your current bank content. New retains write **both**:
+
+- stable `project:<id>` (prefer git remote or a pin — see [project identity](project-identity.md))
+- legacy `repo:<slug>-<path-hash>`
+
+Recall matches **either** tag, so older memories still surface while new ones get stable tags.
+
+**Unlock auto memory under domain-tagged:** set an explicit coding bank id (even if you keep using a dedicated bank for now), **or** switch to isolated-bank (path 3).
+
+Practical steps:
+
+1. Open `/hindsight` → guided setup (`g`) **or** set `banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`.
+2. Prefer `scope.projectIdStrategy: "remote"` (default) or pin `scope.projectId` for weak basename-only repos.
+3. Optional: run `hindsight_scope_migrate` (dry-run only) for a local plan/receipt. It never rewrites Hindsight tags.
+
+### 2. Full adopt: shared coding bank
+
+1. `/hindsight` guided setup → **Coding** or **Coding + Life**.
+2. Set a shared coding bank id (example: `pi-coding` or your own `kai-coding`).
+3. Confirm `scope.mode` is `domain-tagged` and setup is complete.
+4. Optional later: reimport Pi sessions into that bank ([importing sessions](importing-sessions.md)).
+
+### 3. Keep hard isolation (closest to older path banks)
+
+```jsonc
+{
+  "scope": { "mode": "isolated-bank" },
+  "banks": { "project": { "enabled": true } },
+}
+```
+
+Path-derived bank ids remain valid. Pin `banks.project.bankId` if you want a fixed hard-wall bank.
+
+### 4. Freeze on a previous package version
+
+Pin the previous published release of `@luxusai/pi-hindsight` and read the [changelog](https://github.com/luxus/pi-hindsight/blob/main/CHANGELOG.md). Prefer paths 1–3 when you can.
+
+## Setup gate
+
+- **Domain-tagged** + project bank enabled → requires explicit `banks.project.bankId` (or env). Soft signals alone do **not** unlock auto memory.
+- **Isolated-bank** → may use path-derived banks once config/runtime signals show an existing install, or after guided setup.
+
+## Related
+
+- [Project identity](project-identity.md)
+- [Getting started](getting-started.md)
+- [ADR-005](adr/005-domain-banks-and-agent-first-surface.md)
+- [Changelog](https://github.com/luxus/pi-hindsight/blob/main/CHANGELOG.md)

--- a/extensions/config/setup-gate.ts
+++ b/extensions/config/setup-gate.ts
@@ -38,12 +38,18 @@ export function requiresExplicitCodingBankId(config: ResolvedConfig): boolean {
   return config.scope.mode === "domain-tagged" && config.banks.project.enabled;
 }
 
+const DOCS_BASE_URL = "https://luxus.github.io/pi-hindsight";
+const CHANGELOG_URL = "https://github.com/luxus/pi-hindsight/blob/main/CHANGELOG.md";
+
 export function setupRequiredMessage(): string {
-  return (
-    "Hindsight setup required: run /hindsight guided setup, or set banks.project.bankId " +
-    "(or PI_HINDSIGHT_PROJECT_BANK_ID). Domain-tagged mode needs an explicit coding bank id " +
-    "before automatic memory network I/O. Isolated-bank may path-derive."
-  );
+  return [
+    "Hindsight setup required: run /hindsight guided setup, or set banks.project.bankId",
+    "(or PI_HINDSIGHT_PROJECT_BANK_ID). Domain-tagged mode needs an explicit coding bank id",
+    "before automatic memory network I/O. Isolated-bank may path-derive.",
+    `Upgrade paths (soft dual-tag vs shared coding bank vs isolated): ${DOCS_BASE_URL}/guides/upgrading-to-domain-banks/`,
+    `Dual-tag (project: + legacy repo:): ${DOCS_BASE_URL}/concepts/project-identity/`,
+    `Changelog: ${CHANGELOG_URL}`,
+  ].join(" ");
 }
 
 function hasProjectConfigFile(cwd: string): boolean {

--- a/tests/setup-gate.test.ts
+++ b/tests/setup-gate.test.ts
@@ -31,6 +31,16 @@ describe("setup gate", () => {
     expect(setupRequiredMessage()).toMatch(/setup required/i);
   });
 
+  it("points setup-required copy at upgrade guide, dual-tag docs, and changelog", () => {
+    const message = setupRequiredMessage();
+    expect(message).toMatch(/setup required/i);
+    expect(message).toContain(
+      "https://luxus.github.io/pi-hindsight/guides/upgrading-to-domain-banks/",
+    );
+    expect(message).toContain("https://luxus.github.io/pi-hindsight/concepts/project-identity/");
+    expect(message).toContain("https://github.com/luxus/pi-hindsight/blob/main/CHANGELOG.md");
+  });
+
   it("rejects setupComplete alone under domain-tagged without coding bankId", () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-setup-flag-"));
     expect(isMemorySetupComplete(config({ setupComplete: true }), cwd)).toBe(false);


### PR DESCRIPTION
## Summary

Add a user-facing upgrade guide for ADR-005 domain banks and point the setup-required startup warning at that guide, dual-tag project identity docs, and the changelog. Align getting-started setup-gate wording with the domain-tagged bankId requirement.

## Linked issue

- Closes #511

## Scope

- New guide: soft dual-tag path vs shared coding bank vs isolated-bank (no bulk tag rewrite for soft update)
- `setupRequiredMessage()` includes stable URLs for upgrade guide, project-identity, and CHANGELOG
- Getting started / project identity / README / release maintainer notes updated
- Sidebar + guides index entry

## Verification

- [x] `npm run check` (539 tests, docs:check, format, lint, typecheck)
- [ ] `npm run check:coverage` — not needed because docs-focused with only setup-gate warning-string change
- [ ] `npm run typecheck:tsc` — not needed because `tsgo` already ran in `npm run check`
- [ ] full matrix requested/passed — not needed because not release/platform-sensitive
- [ ] package verification requested/passed — not needed because no package/release path change
- [ ] `npm run pack:verify` — not needed because no package/release path change
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass — not needed because no memory-path behavior change (message copy + docs only)

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Explain: user-visible setup-required warning gains docs/changelog links; new upgrade guide. Changelog-friendly as docs improvement. Release maintainers should link the guide from the next release body when domain-bank topology ships (see release.md migration note).

## Risk and rollback

- Risk: low — docs + warning copy only; no bank topology or gate logic change
- Rollback/revert path: revert this PR

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. (N/A — docs/setup copy only; release.md notes maintainer migration blurb practice.)

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Primary guide URL after publish: https://luxus.github.io/pi-hindsight/guides/upgrading-to-domain-banks/
Soft path: dual-tag keeps `project:` + legacy `repo:`; full path: shared coding bankId; hard wall: isolated-bank.