### PR TITLE
fix(tui): skip guided mental-model offer for existing banks

### DIFF
--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -10,7 +10,7 @@ import { importDocumentSummary } from "../imports/import-presentation.js";
 import type { ImportProgressEvent } from "../imports/import-sessions.js";
 import type { MemoryProfile, ProjectConfigPatchInput } from "../config/config-writer.js";
 import type { SetupProfileChoice } from "./setup-tui-types.js";
-import type { AgentUseProfile, ResolvedConfig } from "../types.js";
+import type { AgentUseProfile, HindsightLikeClient, ResolvedConfig } from "../types.js";
 import { defaultTemplateIdFor } from "../banks/bank-templates.js";
 import {
   renderBankTemplateApplyResult,
@@ -122,25 +122,214 @@ function setupImportProgressMessage(event: ImportProgressEvent): string {
   return `Hindsight import progress: ${event.message}`;
 }
 
+function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== "object" || !error) return false;
+  const fields = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    message?: unknown;
+  };
+  return (
+    fields.status === 404 ||
+    fields.statusCode === 404 ||
+    fields.code === 404 ||
+    fields.code === "404" ||
+    (typeof fields.message === "string" && /\b404\b|not found/i.test(fields.message))
+  );
+}
+
+/** Setup-time snapshot of a bank's mental-model catalog from the API. */
+export interface SetupBankMentalModelProbe {
+  target: "project" | "user";
+  bankId: string;
+  /** False when getBankProfile reports not found (or no profile API). */
+  bankExists: boolean;
+  modelNames: string[];
+  error?: string;
+}
+
+/** Extract mental-model names from a listMentalModels response body. */
+export function extractMentalModelNames(response: unknown): string[] {
+  if (!response || typeof response !== "object") return [];
+  const body = response as { items?: unknown; mental_models?: unknown };
+  const rows = Array.isArray(body.items)
+    ? body.items
+    : Array.isArray(body.mental_models)
+      ? body.mental_models
+      : [];
+  const names: string[] = [];
+  for (const entry of rows) {
+    if (!entry || typeof entry !== "object") continue;
+    const row = entry as { name?: unknown; id?: unknown };
+    if (typeof row.name === "string" && row.name.trim()) names.push(row.name.trim());
+    else if (typeof row.id === "string" && row.id.trim()) names.push(row.id.trim());
+  }
+  return names;
+}
+
+/**
+ * Decide which setup targets should be offered starter mental models.
+ * Existing banks that already have models are not offered by default.
+ * Probe failures are not auto-offered (hub remains the intentional path).
+ */
+export function selectMentalModelTargetsToOffer(probes: SetupBankMentalModelProbe[]): {
+  toOffer: SetupBankMentalModelProbe[];
+  alreadyProvisioned: SetupBankMentalModelProbe[];
+  unknown: SetupBankMentalModelProbe[];
+} {
+  const toOffer: SetupBankMentalModelProbe[] = [];
+  const alreadyProvisioned: SetupBankMentalModelProbe[] = [];
+  const unknown: SetupBankMentalModelProbe[] = [];
+  for (const probe of probes) {
+    if (probe.error) {
+      unknown.push(probe);
+      continue;
+    }
+    if (probe.bankExists && probe.modelNames.length > 0) {
+      alreadyProvisioned.push(probe);
+      continue;
+    }
+    // New bank or existing empty catalog → offer starter provision.
+    toOffer.push(probe);
+  }
+  return { toOffer, alreadyProvisioned, unknown };
+}
+
+export async function probeBankMentalModels(args: {
+  client: HindsightLikeClient;
+  target: "project" | "user";
+  bankId: string;
+}): Promise<SetupBankMentalModelProbe> {
+  const bankId = args.bankId.trim();
+  if (!bankId) {
+    return {
+      target: args.target,
+      bankId: "",
+      bankExists: false,
+      modelNames: [],
+      error: "missing bank id",
+    };
+  }
+
+  let bankExists = false;
+  if (args.client.getBankProfile) {
+    try {
+      await args.client.getBankProfile(bankId);
+      bankExists = true;
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return { target: args.target, bankId, bankExists: false, modelNames: [] };
+      }
+      return {
+        target: args.target,
+        bankId,
+        bankExists: false,
+        modelNames: [],
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  } else {
+    // Without profile API, assume the bank may exist and still list models.
+    bankExists = true;
+  }
+
+  if (!args.client.listMentalModels) {
+    return {
+      target: args.target,
+      bankId,
+      bankExists,
+      modelNames: [],
+      ...(bankExists ? { error: "listMentalModels unavailable" } : {}),
+    };
+  }
+
+  try {
+    const response = await args.client.listMentalModels(bankId);
+    return {
+      target: args.target,
+      bankId,
+      bankExists,
+      modelNames: extractMentalModelNames(response),
+    };
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return { target: args.target, bankId, bankExists: false, modelNames: [] };
+    }
+    return {
+      target: args.target,
+      bankId,
+      bankExists,
+      modelNames: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function formatExistingMentalModelsSummary(probe: SetupBankMentalModelProbe): string {
+  const preview = probe.modelNames.slice(0, 6).join(", ");
+  const more = probe.modelNames.length > 6 ? ` (+${probe.modelNames.length - 6} more)` : "";
+  return `${probe.target} bank ${probe.bankId}: ${probe.modelNames.length} mental model(s) already present (${preview}${more}). Skipping starter provision; use hub (t) to re-apply intentionally.`;
+}
+
 async function maybeOfferMentalModelsForSetup(args: {
   ctx: ExtensionCommandContext;
   operations: MemoryOperations;
+  client: HindsightLikeClient;
   agentUse: AgentUseProfile;
   setupProfile: SetupProfileChoice;
+  projectBankId?: string;
+  globalBankId?: string;
 }): Promise<void> {
-  const targets: Array<"project" | "user"> = [];
-  if (profileUsesProject(args.setupProfile)) targets.push("project");
-  if (profileUsesUser(args.setupProfile)) targets.push("user");
+  const targets: Array<{ target: "project" | "user"; bankId: string }> = [];
+  if (profileUsesProject(args.setupProfile) && args.projectBankId?.trim()) {
+    targets.push({ target: "project", bankId: args.projectBankId.trim() });
+  }
+  if (profileUsesUser(args.setupProfile) && args.globalBankId?.trim()) {
+    targets.push({ target: "user", bankId: args.globalBankId.trim() });
+  }
   if (targets.length === 0) return;
 
+  const probes: SetupBankMentalModelProbe[] = [];
+  for (const entry of targets) {
+    probes.push(
+      await probeBankMentalModels({
+        client: args.client,
+        target: entry.target,
+        bankId: entry.bankId,
+      }),
+    );
+  }
+
+  const { toOffer, alreadyProvisioned, unknown } = selectMentalModelTargetsToOffer(probes);
+
+  for (const probe of alreadyProvisioned) {
+    args.ctx.ui.notify(formatExistingMentalModelsSummary(probe), "info");
+  }
+  for (const probe of unknown) {
+    args.ctx.ui.notify(
+      `Could not inspect ${probe.target} bank ${probe.bankId || "(missing id)"} for mental models: ${probe.error}. Skipping automatic starter provision; use hub (t) if needed.`,
+      "warning",
+    );
+  }
+
+  if (toOffer.length === 0) return;
+
+  const bankSummary = toOffer
+    .map((probe) =>
+      probe.bankExists
+        ? `${probe.target}=${probe.bankId} (exists, empty catalog)`
+        : `${probe.target}=${probe.bankId} (new or missing)`,
+    )
+    .join("; ");
   const proceed = await args.ctx.ui.confirm(
     "Provision starter mental models?",
-    `Agent use: ${args.agentUse}. Dry-run preview first; nothing is written without confirmation. Mental models become part of automatic context when present.`,
+    `Agent use: ${args.agentUse}. Targets: ${bankSummary}. Dry-run preview first; nothing is written without confirmation. Mental models become part of automatic context when present.`,
   );
   if (!proceed) return;
 
-  for (const target of targets) {
-    const templateId = defaultTemplateIdFor(target, args.agentUse);
+  for (const probe of toOffer) {
+    const templateId = defaultTemplateIdFor(probe.target, args.agentUse);
     try {
       const dryRun = await args.operations.applyBankTemplate({ templateId, dryRun: true });
       const details = renderBankTemplateMentalModelDetails(dryRun.template);
@@ -361,8 +550,11 @@ export async function runGuidedSetup(args: {
   await maybeOfferMentalModelsForSetup({
     ctx: args.ctx,
     operations,
+    client: args.deps.getClient(),
     agentUse,
     setupProfile,
+    ...(projectBankId !== undefined ? { projectBankId } : {}),
+    ...(globalBankId !== undefined ? { globalBankId } : {}),
   });
 
   await maybeOfferHistoricalImportForSetup({

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { ensureGlobalBank, ensureProjectBank } from "../banks/bank-operations.js";
 import {
   createMemoryOperations,
   type MemoryOperations,
@@ -95,6 +96,118 @@ async function askBankId(args: {
   const value = await args.ctx.ui.input(args.title, args.fallback);
   if (value === undefined) return undefined;
   return value.trim() || args.fallback;
+}
+
+export type BankExistence =
+  | { status: "exists" }
+  | { status: "missing" }
+  | { status: "unknown"; error?: string };
+
+/** Check whether a bank ID already exists in Hindsight (typo protection for setup). */
+export async function probeBankExistence(
+  client: HindsightLikeClient,
+  bankId: string,
+): Promise<BankExistence> {
+  const id = bankId.trim();
+  if (!id) return { status: "unknown", error: "missing bank id" };
+  if (!client.getBankProfile) {
+    return { status: "unknown", error: "getBankProfile unavailable" };
+  }
+  try {
+    await client.getBankProfile(id);
+    return { status: "exists" };
+  } catch (error) {
+    if (isNotFoundError(error)) return { status: "missing" };
+    return {
+      status: "unknown",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Collect a bank ID, verify it against Hindsight, and confirm create when missing
+ * so typos do not silently mint a new bank.
+ * Returns undefined when the user cancels input.
+ */
+export async function resolveSetupBankId(args: {
+  ctx: ExtensionCommandContext;
+  client: HindsightLikeClient;
+  config: ResolvedConfig;
+  kind: "project" | "user";
+  title: string;
+  fallback: string;
+}): Promise<string | undefined> {
+  while (true) {
+    const bankId = await askBankId({
+      ctx: args.ctx,
+      title: args.title,
+      fallback: args.fallback,
+    });
+    if (bankId === undefined) return undefined;
+    const trimmed = bankId.trim();
+    if (!trimmed) {
+      if (args.kind === "user") {
+        args.ctx.ui.notify("User bank ID is required.", "warning");
+        continue;
+      }
+      return trimmed;
+    }
+
+    const existence = await probeBankExistence(args.client, trimmed);
+    if (existence.status === "exists") {
+      args.ctx.ui.notify(`Using existing ${args.kind} bank ${trimmed}.`, "info");
+      return trimmed;
+    }
+
+    if (existence.status === "missing") {
+      const create = await args.ctx.ui.confirm(
+        `Create ${args.kind} bank "${trimmed}"?`,
+        `No bank with this ID was found in Hindsight. Confirm create, or cancel to re-enter the ID (typo protection).`,
+      );
+      if (!create) {
+        args.ctx.ui.notify("Bank ID not created. Re-enter the correct bank ID.", "info");
+        continue;
+      }
+      if (!args.client.createBank) {
+        args.ctx.ui.notify(
+          "Hindsight client cannot create banks. Re-enter an existing bank ID or fix client support.",
+          "error",
+        );
+        continue;
+      }
+      try {
+        if (args.kind === "project") {
+          await ensureProjectBank(args.client, trimmed, {
+            ...args.config.banks.project,
+            enableObservations: args.config.observations.enabled,
+          });
+        } else {
+          await ensureGlobalBank(args.client, trimmed, {
+            ...args.config.banks.user,
+            enableObservations: args.config.observations.enabled,
+          });
+        }
+        args.ctx.ui.notify(`Created ${args.kind} bank ${trimmed}.`, "info");
+        return trimmed;
+      } catch (error) {
+        args.ctx.ui.notify(
+          `Failed to create ${args.kind} bank ${trimmed}: ${error instanceof Error ? error.message : String(error)}`,
+          "error",
+        );
+        continue;
+      }
+    }
+
+    // Profile API missing: cannot verify; keep prior behavior.
+    if (existence.error === "getBankProfile unavailable") return trimmed;
+
+    const proceed = await args.ctx.ui.confirm(
+      `Could not verify ${args.kind} bank "${trimmed}"`,
+      `${existence.error ?? "Unknown error"}. Continue with this ID anyway, or cancel to re-enter?`,
+    );
+    if (proceed) return trimmed;
+  }
 }
 
 export function importChoicesForSetup(args: {
@@ -487,9 +600,13 @@ export async function runGuidedSetup(args: {
     : ("coding" as const);
 
   const config = args.deps.getConfig();
+  const client = args.deps.getClient();
   const projectBankId = profileUsesProject(setupProfile)
-    ? await askBankId({
+    ? await resolveSetupBankId({
         ctx: args.ctx,
+        client,
+        config,
+        kind: "project",
         title:
           setupProfile === "isolated-only"
             ? "Isolated project bank ID (optional; leave default for path-derived)"
@@ -502,8 +619,11 @@ export async function runGuidedSetup(args: {
   if (profileUsesProject(setupProfile) && projectBankId === undefined) return false;
 
   const globalBankId = profileUsesUser(setupProfile)
-    ? await askBankId({
+    ? await resolveSetupBankId({
         ctx: args.ctx,
+        client,
+        config,
+        kind: "user",
         title: "User bank ID",
         fallback: config.banks.user.bankId ?? "",
       })
@@ -550,7 +670,7 @@ export async function runGuidedSetup(args: {
   await maybeOfferMentalModelsForSetup({
     ctx: args.ctx,
     operations,
-    client: args.deps.getClient(),
+    client,
     agentUse,
     setupProfile,
     ...(projectBankId !== undefined ? { projectBankId } : {}),

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -7,10 +7,13 @@ import {
   buildGuidedSetupGlobalPatch,
   buildGuidedSetupPatch,
   buildIgnoreRepoPatch,
+  extractMentalModelNames,
   hasProjectHindsightConfig,
   importChoicesForSetup,
   maybeOfferHistoricalImportForSetup,
+  probeBankMentalModels,
   runGuidedSetup,
+  selectMentalModelTargetsToOffer,
   setupProfileChoiceToMemoryProfile,
 } from "../extensions/tui/guided-setup.js";
 
@@ -323,5 +326,134 @@ describe("guided setup", () => {
         config: configuredGlobal,
       }),
     ).toEqual({ scope: "global", enableGlobalBank: true, globalBankId: "global-luxus" });
+  });
+
+  it("extracts mental model names from list responses", () => {
+    expect(
+      extractMentalModelNames({
+        items: [{ id: "a", name: "Architecture" }, { id: "b", name: "  " }, { id: "c" }],
+      }),
+    ).toEqual(["Architecture", "b", "c"]);
+    expect(extractMentalModelNames({ mental_models: [{ name: "Goals" }] })).toEqual(["Goals"]);
+    expect(extractMentalModelNames(null)).toEqual([]);
+  });
+
+  it("skips starter mental-model offer when banks already have models", () => {
+    const decision = selectMentalModelTargetsToOffer([
+      {
+        target: "project",
+        bankId: "pi-coding",
+        bankExists: true,
+        modelNames: ["Architecture decisions"],
+      },
+      {
+        target: "user",
+        bankId: "life",
+        bankExists: false,
+        modelNames: [],
+      },
+      {
+        target: "user",
+        bankId: "broken",
+        bankExists: true,
+        modelNames: [],
+        error: "timeout",
+      },
+    ]);
+    expect(decision.toOffer.map((probe) => probe.bankId)).toEqual(["life"]);
+    expect(decision.alreadyProvisioned.map((probe) => probe.bankId)).toEqual(["pi-coding"]);
+    expect(decision.unknown.map((probe) => probe.bankId)).toEqual(["broken"]);
+  });
+
+  it("probes bank existence and existing mental models from the API", async () => {
+    const getBankProfile = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "pi-coding" })
+      .mockRejectedValueOnce(Object.assign(new Error("not found"), { status: 404 }));
+    const listMentalModels = vi.fn().mockResolvedValueOnce({
+      items: [{ id: "mm1", name: "Project architecture" }],
+    });
+    const client = {
+      retain: async () => undefined,
+      recall: async () => [],
+      reflect: async () => ({}),
+      getBankProfile,
+      listMentalModels,
+    };
+
+    await expect(
+      probeBankMentalModels({ client, target: "project", bankId: "pi-coding" }),
+    ).resolves.toEqual({
+      target: "project",
+      bankId: "pi-coding",
+      bankExists: true,
+      modelNames: ["Project architecture"],
+    });
+    await expect(
+      probeBankMentalModels({ client, target: "project", bankId: "new-bank" }),
+    ).resolves.toEqual({
+      target: "project",
+      bankId: "new-bank",
+      bankExists: false,
+      modelNames: [],
+    });
+    expect(listMentalModels).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not prompt for starter mental models when the bank already has them", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-guided-existing-mm-"));
+    const notify = vi.fn();
+    const confirm = vi
+      .fn()
+      // Write config yes; import no. No mental-model confirm should appear.
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const applyBankTemplate = vi.fn();
+    const listMentalModels = vi.fn(async () => ({
+      items: [{ id: "mm1", name: "Architecture decisions" }],
+    }));
+    const getBankProfile = vi.fn(async () => ({ id: "project-bank" }));
+    const ctx = {
+      cwd,
+      sessionManager: { getSessionFile: () => undefined },
+      ui: {
+        notify,
+        input: vi.fn().mockResolvedValueOnce("project-bank"),
+        select: vi
+          .fn()
+          .mockResolvedValueOnce("Coding (shared coding bank + project tags)")
+          .mockResolvedValueOnce("Coding (architecture, conventions, decisions)"),
+        confirm,
+      },
+    } as never;
+
+    const completed = await runGuidedSetup({
+      ctx,
+      cwd,
+      deps: {
+        getClient: () => ({
+          retain: vi.fn(),
+          recall: vi.fn(),
+          reflect: vi.fn(),
+          getBankProfile,
+          listMentalModels,
+          importBankTemplate: applyBankTemplate,
+        }),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "project-bank",
+      } as never,
+    });
+
+    expect(completed).toBe(true);
+    expect(getBankProfile).toHaveBeenCalledWith("project-bank");
+    expect(listMentalModels).toHaveBeenCalledWith("project-bank");
+    expect(confirm).toHaveBeenCalledTimes(2);
+    expect(confirm.mock.calls[0]?.[0]).toBe("Write Pi Hindsight config?");
+    expect(confirm.mock.calls[1]?.[0]).toBe("Preview historical import now?");
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("1 mental model(s) already present"),
+      "info",
+    );
+    expect(applyBankTemplate).not.toHaveBeenCalled();
   });
 });

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -11,7 +11,9 @@ import {
   hasProjectHindsightConfig,
   importChoicesForSetup,
   maybeOfferHistoricalImportForSetup,
+  probeBankExistence,
   probeBankMentalModels,
+  resolveSetupBankId,
   runGuidedSetup,
   selectMentalModelTargetsToOffer,
   setupProfileChoiceToMemoryProfile,
@@ -451,9 +453,118 @@ describe("guided setup", () => {
     expect(confirm.mock.calls[0]?.[0]).toBe("Write Pi Hindsight config?");
     expect(confirm.mock.calls[1]?.[0]).toBe("Preview historical import now?");
     expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Using existing project bank project-bank"),
+      "info",
+    );
+    expect(notify).toHaveBeenCalledWith(
       expect.stringContaining("1 mental model(s) already present"),
       "info",
     );
     expect(applyBankTemplate).not.toHaveBeenCalled();
+  });
+
+  it("probes bank existence for typo protection", async () => {
+    const getBankProfile = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "ok" })
+      .mockRejectedValueOnce(Object.assign(new Error("not found"), { status: 404 }))
+      .mockRejectedValueOnce(new Error("timeout"));
+    const client = {
+      retain: async () => undefined,
+      recall: async () => [],
+      reflect: async () => ({}),
+      getBankProfile,
+    };
+    await expect(probeBankExistence(client, "ok")).resolves.toEqual({ status: "exists" });
+    await expect(probeBankExistence(client, "missing")).resolves.toEqual({ status: "missing" });
+    await expect(probeBankExistence(client, "broken")).resolves.toEqual({
+      status: "unknown",
+      error: "timeout",
+    });
+    await expect(
+      probeBankExistence(
+        { retain: async () => undefined, recall: async () => [], reflect: async () => ({}) },
+        "x",
+      ),
+    ).resolves.toEqual({ status: "unknown", error: "getBankProfile unavailable" });
+  });
+
+  it("confirms create for missing banks and re-prompts on decline", async () => {
+    const notify = vi.fn();
+    const input = vi.fn().mockResolvedValueOnce("typo-bank").mockResolvedValueOnce("pi-coding");
+    const confirm = vi.fn().mockResolvedValueOnce(false);
+    const getBankProfile = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("not found"), { status: 404 }))
+      .mockResolvedValueOnce({ id: "pi-coding" });
+    const createBank = vi.fn();
+    const client = {
+      retain: async () => undefined,
+      recall: async () => [],
+      reflect: async () => ({}),
+      getBankProfile,
+      createBank,
+    };
+    const ctx = {
+      ui: { notify, input, confirm, select: vi.fn() },
+    } as never;
+
+    const bankId = await resolveSetupBankId({
+      ctx,
+      client,
+      config: DEFAULT_CONFIG,
+      kind: "project",
+      title: "Coding bank ID",
+      fallback: "pi-coding",
+    });
+
+    expect(bankId).toBe("pi-coding");
+    expect(createBank).not.toHaveBeenCalled();
+    expect(confirm).toHaveBeenCalledWith(
+      'Create project bank "typo-bank"?',
+      expect.stringContaining("typo protection"),
+    );
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Using existing project bank pi-coding"),
+      "info",
+    );
+  });
+
+  it("creates a missing bank after confirmation", async () => {
+    const notify = vi.fn();
+    const input = vi.fn().mockResolvedValueOnce("new-coding");
+    const confirm = vi.fn().mockResolvedValueOnce(true);
+    const getBankProfile = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("not found"), { status: 404 }))
+      // ensureProjectBank re-checks existence before create
+      .mockRejectedValueOnce(Object.assign(new Error("not found"), { status: 404 }));
+    const createBank = vi.fn(async () => ({ id: "new-coding" }));
+    const client = {
+      retain: async () => undefined,
+      recall: async () => [],
+      reflect: async () => ({}),
+      getBankProfile,
+      createBank,
+    };
+    const ctx = {
+      ui: { notify, input, confirm, select: vi.fn() },
+    } as never;
+
+    const bankId = await resolveSetupBankId({
+      ctx,
+      client,
+      config: DEFAULT_CONFIG,
+      kind: "project",
+      title: "Coding bank ID",
+      fallback: "pi-coding",
+    });
+
+    expect(bankId).toBe("new-coding");
+    expect(createBank).toHaveBeenCalledWith(
+      "new-coding",
+      expect.objectContaining({ name: "new-coding" }),
+    );
+    expect(notify).toHaveBeenCalledWith("Created project bank new-coding.", "info");
   });
 });


### PR DESCRIPTION
## Summary

Guided setup now inspects Hindsight before accepting bank IDs and before offering starter mental models:

1. **Missing bank ID** → confirm create (typo protection); decline re-prompts for the ID
2. **Existing bank with mental models** → report catalog and skip auto-offer of starter templates
3. **New/empty bank** → keep dry-run → confirm apply flow for starters

## Linked issue

- Closes #513

## Scope

- `extensions/tui/guided-setup.ts`: `probeBankExistence` / `resolveSetupBankId` create confirm; mental-model catalog probe + skip
- `tests/guided-setup.test.ts`: coverage for existence, create confirm, decline re-entry, and no-prompt when models exist

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped coverage/tsc/full matrix: TUI setup decision path only. Live smoke not required for this PR: setup UI gating against existing profile/list/create bank APIs; no retain/recall request shape change.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Guided setup confirms create for unknown bank IDs and no longer prompts to add starter mental models when the bank already has them.

## Risk and rollback

- Risk: Low. Create is explicit; decline re-enters the ID. Probe failures for mental models skip auto-offer. Hub `t` remains intentional re-apply.
- Rollback/revert path: Revert this PR.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No guidance-doc change required.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Hub action `t` remains the intentional path to re-apply starter mental-model templates.