### PR TITLE
feat(tui): durable ignore-this-repo option when no config

### DIFF
--- a/docs-site/src/content/docs/start/getting-started.md
+++ b/docs-site/src/content/docs/start/getting-started.md
@@ -44,7 +44,7 @@ Open Pi in your repository and run:
 /hindsight
 ```
 
-If no project config exists, `/hindsight` offers guided setup, open hub, **Ignore this repo** (durable `enabled: false` + `setupComplete: true`), or skip for now. You can rerun guided setup later from the TUI with `g`. Details: [Setup TUI](/pi-hindsight/start/setup-tui/).
+If no project config exists, `/hindsight` offers guided setup, open hub, **Ignore this repo** (durable `enabled: false` + `setupComplete: true` + `status.style: off`; tools refuse calls), or skip for now. You can rerun guided setup later from the TUI with `g`. Details: [Setup TUI](/pi-hindsight/start/setup-tui/).
 
 **Setup gate:** automatic bank ensure, recall, and retain stay off until setup is satisfied. For default **domain-tagged** mode with project memory on, that means an explicit coding bank id (`banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, usually via guided setup). Soft signals alone (empty project config, queue/cursor files, or `setupComplete` without a bank id) do **not** unlock domain-tagged auto memory. **Isolated-bank** may keep path-derived banks after config/runtime signals or guided setup. Status warns when setup is required. Upgrading from path banks: [Upgrading to domain banks](/pi-hindsight/guides/upgrading-to-domain-banks/).
 

--- a/docs-site/src/content/docs/start/getting-started.md
+++ b/docs-site/src/content/docs/start/getting-started.md
@@ -44,7 +44,7 @@ Open Pi in your repository and run:
 /hindsight
 ```
 
-If no project config exists, guided setup starts automatically. You can rerun it later from the TUI with `g`.
+If no project config exists, `/hindsight` offers guided setup, open hub, **Ignore this repo** (durable `enabled: false` + `setupComplete: true`), or skip for now. You can rerun guided setup later from the TUI with `g`. Details: [Setup TUI](/pi-hindsight/start/setup-tui/).
 
 **Setup gate:** automatic bank ensure, recall, and retain stay off until setup is satisfied. For default **domain-tagged** mode with project memory on, that means an explicit coding bank id (`banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, usually via guided setup). Soft signals alone (empty project config, queue/cursor files, or `setupComplete` without a bank id) do **not** unlock domain-tagged auto memory. **Isolated-bank** may keep path-derived banks after config/runtime signals or guided setup. Status warns when setup is required. Upgrading from path banks: [Upgrading to domain banks](/pi-hindsight/guides/upgrading-to-domain-banks/).
 

--- a/docs-site/src/content/docs/start/setup-tui.md
+++ b/docs-site/src/content/docs/start/setup-tui.md
@@ -24,7 +24,14 @@ The hub shows status first (profile, agent use, banks, queue, receipts). Press `
 
 ## Guided setup
 
-If no project config exists, `/hindsight` offers guided setup. Rerun later with `g`.
+If no project config exists, `/hindsight` offers:
+
+- **Guided setup** — configure profile, banks, optional mental models and import
+- **Open hub** — open status/settings without finishing setup first
+- **Ignore this repo** — durable opt-out: writes project config with `enabled: false` and `setupComplete: true` so automatic memory stays off and setup will not keep prompting. Re-enable later from the hub **enabled** field (advanced) or by editing `.pi/hindsight.json`
+- **Skip for now** — dismiss only this prompt; does not write config
+
+Rerun guided setup later with `g`.
 
 Guided setup handles:
 

--- a/docs-site/src/content/docs/start/setup-tui.md
+++ b/docs-site/src/content/docs/start/setup-tui.md
@@ -28,7 +28,7 @@ If no project config exists, `/hindsight` offers:
 
 - **Guided setup** — configure profile, banks, optional mental models and import
 - **Open hub** — open status/settings without finishing setup first
-- **Ignore this repo** — durable opt-out: writes project config with `enabled: false` and `setupComplete: true` so automatic memory stays off and setup will not keep prompting. Re-enable later from the hub **enabled** field (advanced) or by editing `.pi/hindsight.json`
+- **Ignore this repo** — durable opt-out: writes project config with `enabled: false`, `setupComplete: true`, and `status.style: "off"`. Automatic memory, status bar, and tool calls stay off; `/hindsight` remains available to re-enable (hub **enabled** field / edit `.pi/hindsight.json`)
 - **Skip for now** — dismiss only this prompt; does not write config
 
 Rerun guided setup later with `g`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ Open Pi in your repository and run:
 /hindsight
 ```
 
-If no project config exists, `/hindsight` offers guided setup, open hub, **Ignore this repo** (durable `enabled: false` + `setupComplete: true`), or skip for now. You can rerun guided setup later from the TUI with `g`.
+If no project config exists, `/hindsight` offers guided setup, open hub, **Ignore this repo** (durable `enabled: false` + `setupComplete: true` + `status.style: off`; tools refuse calls), or skip for now. You can rerun guided setup later from the TUI with `g`.
 
 **Setup gate:** automatic bank ensure, recall, and retain stay off until setup is satisfied. For default **domain-tagged** mode with project memory on, that means an explicit coding bank id (`banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, usually via guided setup). Soft signals alone (empty project config, queue/cursor files, or `setupComplete` without a bank id) do **not** unlock domain-tagged auto memory. **Isolated-bank** may keep path-derived banks after config/runtime signals or guided setup. Status warns when setup is required. Upgrading from path banks: [Upgrading to domain banks](upgrading-to-domain-banks.md).
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ Open Pi in your repository and run:
 /hindsight
 ```
 
-If no project config exists, guided setup starts automatically. You can rerun it later from the TUI with `g`.
+If no project config exists, `/hindsight` offers guided setup, open hub, **Ignore this repo** (durable `enabled: false` + `setupComplete: true`), or skip for now. You can rerun guided setup later from the TUI with `g`.
 
 **Setup gate:** automatic bank ensure, recall, and retain stay off until setup is satisfied. For default **domain-tagged** mode with project memory on, that means an explicit coding bank id (`banks.project.bankId` / `PI_HINDSIGHT_PROJECT_BANK_ID`, usually via guided setup). Soft signals alone (empty project config, queue/cursor files, or `setupComplete` without a bank id) do **not** unlock domain-tagged auto memory. **Isolated-bank** may keep path-derived banks after config/runtime signals or guided setup. Status warns when setup is required. Upgrading from path banks: [Upgrading to domain banks](upgrading-to-domain-banks.md).
 

--- a/extensions/config/setup-gate.ts
+++ b/extensions/config/setup-gate.ts
@@ -41,15 +41,27 @@ export function requiresExplicitCodingBankId(config: ResolvedConfig): boolean {
 const DOCS_BASE_URL = "https://luxus.github.io/pi-hindsight";
 const CHANGELOG_URL = "https://github.com/luxus/pi-hindsight/blob/main/CHANGELOG.md";
 
+/**
+ * Startup / status hint when automatic memory is blocked by the setup gate.
+ * Keep scannable: primary action first, durable opt-out visible, docs last.
+ */
 export function setupRequiredMessage(): string {
   return [
-    "Hindsight setup required: run /hindsight guided setup, or set banks.project.bankId",
-    "(or PI_HINDSIGHT_PROJECT_BANK_ID). Domain-tagged mode needs an explicit coding bank id",
-    "before automatic memory network I/O. Isolated-bank may path-derive.",
-    `Upgrade paths (soft dual-tag vs shared coding bank vs isolated): ${DOCS_BASE_URL}/guides/upgrading-to-domain-banks/`,
-    `Dual-tag (project: + legacy repo:): ${DOCS_BASE_URL}/concepts/project-identity/`,
+    "Hindsight setup required — automatic memory is off until this repo is configured.",
+    "",
+    "Start here: run  /hindsight",
+    "  • Guided setup — pick a profile, bank IDs, optional mental models / import",
+    "  • Ignore this repo — durable opt-out (no auto memory, tools, or status bar)",
+    "  • Skip for now — dismiss only; this warning can return next session",
+    "",
+    "Or set banks.project.bankId (or PI_HINDSIGHT_PROJECT_BANK_ID).",
+    "Domain-tagged mode needs an explicit coding bank id; isolated-bank may path-derive.",
+    "",
+    `Docs: ${DOCS_BASE_URL}/start/setup-tui/`,
+    `Upgrade: ${DOCS_BASE_URL}/guides/upgrading-to-domain-banks/`,
+    `Identity: ${DOCS_BASE_URL}/concepts/project-identity/`,
     `Changelog: ${CHANGELOG_URL}`,
-  ].join(" ");
+  ].join("\n");
 }
 
 function hasProjectConfigFile(cwd: string): boolean {

--- a/extensions/lifecycle/memory-lifecycle.ts
+++ b/extensions/lifecycle/memory-lifecycle.ts
@@ -158,7 +158,15 @@ export function createMemoryLifecycle(initialCwd: string = process.cwd()): Memor
           "info",
         );
       }
-      if (!config.enabled) return;
+      if (!config.enabled) {
+        // Clear status bar when extension is disabled for this repo.
+        try {
+          runtime.ui.setStatus("hindsight", undefined);
+        } catch {
+          // Session ctx can go stale; status clear is best effort.
+        }
+        return;
+      }
       if (!isMemorySetupComplete(config, runtime.cwd)) {
         initHealth = { checkedAt: new Date().toISOString(), failures: [] };
         setMemoryStatus(runtime, "idle");

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -11,6 +11,9 @@ import { runHindsightSetupTui } from "../tui/setup-tui.js";
 import { renderMemoryToolTextResult, retainToolResponse } from "../tui/tool-presenters.js";
 import { getSessionFile } from "../utils/session.js";
 
+export const HINDSIGHT_DISABLED_TOOL_MESSAGE =
+  "Hindsight is disabled for this repository (enabled=false). Open /hindsight and set enabled=true (and restore status.style if desired), or edit .pi/hindsight.json.";
+
 export type ToolOperation = Parameters<ExtensionAPI["registerTool"]>[0];
 
 const tagMatchSchema = Type.Union(
@@ -132,11 +135,6 @@ function explicitRetainOptions(params: ExplicitRetainOptionParams) {
   };
 }
 
-function defineCatalogTool<TParams extends ToolDefinition["parameters"], TDetails = unknown>(
-  tool: ToolDefinition<TParams, TDetails>,
-): ToolOperation {
-  return defineTool(tool);
-}
 export type CommandOperation = {
   name: string;
   spec: Parameters<ExtensionAPI["registerCommand"]>[1];
@@ -150,6 +148,26 @@ export interface OperationCatalog {
 export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCatalog {
   const operations = createMemoryOperations(deps);
   const useCwd = (cwd: string) => deps.reloadConfig?.(cwd);
+
+  function defineCatalogTool<TParams extends ToolDefinition["parameters"], TDetails = unknown>(
+    tool: ToolDefinition<TParams, TDetails>,
+  ): ToolOperation {
+    const defined = defineTool(tool);
+    const execute = defined.execute.bind(defined);
+    return {
+      ...defined,
+      async execute(id, params, signal, onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        if (!deps.getConfig().enabled) {
+          return {
+            content: [{ type: "text" as const, text: HINDSIGHT_DISABLED_TOOL_MESSAGE }],
+            details: { disabled: true as const },
+          };
+        }
+        return execute(id, params, signal, onUpdate, ctx);
+      },
+    };
+  }
 
   const tools: ToolOperation[] = [
     defineCatalogTool({

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -77,6 +77,14 @@ export function buildGuidedSetupGlobalPatch(args: {
   };
 }
 
+/**
+ * Durable per-repo opt-out: automatic memory stays off and setup gate is satisfied
+ * so `/hindsight` stops re-prompting for guided setup.
+ */
+export function buildIgnoreRepoPatch(): ProjectConfigPatchInput {
+  return { enabled: false, setupComplete: true };
+}
+
 async function askBankId(args: {
   ctx: ExtensionCommandContext;
   title: string;

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -78,11 +78,12 @@ export function buildGuidedSetupGlobalPatch(args: {
 }
 
 /**
- * Durable per-repo opt-out: automatic memory stays off and setup gate is satisfied
- * so `/hindsight` stops re-prompting for guided setup.
+ * Durable per-repo opt-out: automatic memory stays off, setup gate is satisfied
+ * so `/hindsight` stops re-prompting, status bar is cleared (style off), and tools
+ * refuse execution until re-enabled. Hub commands remain available to re-enable.
  */
 export function buildIgnoreRepoPatch(): ProjectConfigPatchInput {
-  return { enabled: false, setupComplete: true };
+  return { enabled: false, setupComplete: true, statusStyle: "off" };
 }
 
 async function askBankId(args: {

--- a/extensions/tui/setup-tui.ts
+++ b/extensions/tui/setup-tui.ts
@@ -179,12 +179,17 @@ async function handleIgnoreRepo(
 ): Promise<boolean> {
   const confirmed = await ctx.ui.confirm(
     "Ignore Hindsight in this repo?",
-    "Writes project config with enabled=false and setupComplete=true so automatic memory stays off and setup will not keep prompting. Re-enable later from the hub (enabled field) or by editing .pi/hindsight.json.",
+    "Writes project config with enabled=false, setupComplete=true, and status.style=off. Automatic memory, status bar, and tool calls stay off; /hindsight remains available to re-enable.",
   );
   if (!confirmed) return false;
   const result = await createMemoryOperations(deps).configure(ctx.cwd, buildIgnoreRepoPatch());
+  try {
+    ctx.ui.setStatus?.("hindsight", undefined);
+  } catch {
+    // Best effort; some hosts may not expose setStatus on command UI.
+  }
   ctx.ui.notify(
-    `Wrote ${result.path}: Hindsight disabled for this repo (enabled=false). Open /hindsight hub to re-enable.`,
+    `Wrote ${result.path}: Hindsight disabled for this repo (enabled=false, status.style=off). Tools refuse calls until re-enabled via /hindsight.`,
     "info",
   );
   return true;

--- a/extensions/tui/setup-tui.ts
+++ b/extensions/tui/setup-tui.ts
@@ -11,6 +11,7 @@ import {
 } from "../queue/flush-presenter.js";
 import { defaultTemplateIdFor, listBankTemplatesForAgentUse } from "../banks/bank-templates.js";
 import {
+  buildIgnoreRepoPatch,
   hasProjectHindsightConfig,
   maybeOfferHistoricalImportForSetup,
   runGuidedSetup,
@@ -172,6 +173,23 @@ async function handleInitConfig(
   );
 }
 
+async function handleIgnoreRepo(
+  ctx: ExtensionCommandContext,
+  deps: MemoryOperationsDeps,
+): Promise<boolean> {
+  const confirmed = await ctx.ui.confirm(
+    "Ignore Hindsight in this repo?",
+    "Writes project config with enabled=false and setupComplete=true so automatic memory stays off and setup will not keep prompting. Re-enable later from the hub (enabled field) or by editing .pi/hindsight.json.",
+  );
+  if (!confirmed) return false;
+  const result = await createMemoryOperations(deps).configure(ctx.cwd, buildIgnoreRepoPatch());
+  ctx.ui.notify(
+    `Wrote ${result.path}: Hindsight disabled for this repo (enabled=false). Open /hindsight hub to re-enable.`,
+    "info",
+  );
+  return true;
+}
+
 export async function runHindsightSetupTui(
   ctx: ExtensionCommandContext,
   deps: MemoryOperationsDeps,
@@ -181,10 +199,14 @@ export async function runHindsightSetupTui(
     const choice = await ctx.ui.select("No project Hindsight config found", [
       "Guided setup",
       "Open hub",
-      "Skip",
+      "Ignore this repo",
+      "Skip for now",
     ]);
     if (choice === "Guided setup") await runGuidedSetup({ ctx, deps, cwd: ctx.cwd });
-    if (choice === "Skip" || !choice) return;
+    else if (choice === "Ignore this repo") {
+      await handleIgnoreRepo(ctx, deps);
+      return;
+    } else if (choice === "Skip for now" || !choice) return;
   }
   while (true) {
     const config = deps.getConfig();

--- a/extensions/utils/status.ts
+++ b/extensions/utils/status.ts
@@ -99,6 +99,7 @@ export function formatHindsightStatus(
   config: ResolvedConfig,
   state: HindsightStatusState,
 ): string | undefined {
+  if (!config.enabled) return undefined;
   const { style, detail, maxLength, showActivity } = config.status;
   if (style === "off") return undefined;
   const p = prefix(style, state.activity);

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -51,7 +51,11 @@ describe("guided setup", () => {
   });
 
   it("builds durable ignore-repo patch", () => {
-    expect(buildIgnoreRepoPatch()).toEqual({ enabled: false, setupComplete: true });
+    expect(buildIgnoreRepoPatch()).toEqual({
+      enabled: false,
+      setupComplete: true,
+      statusStyle: "off",
+    });
   });
 
   it("builds profile and bank patches without inventing global bank IDs", () => {

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -6,6 +6,7 @@ import { DEFAULT_CONFIG } from "../extensions/config/config-defaults.js";
 import {
   buildGuidedSetupGlobalPatch,
   buildGuidedSetupPatch,
+  buildIgnoreRepoPatch,
   hasProjectHindsightConfig,
   importChoicesForSetup,
   maybeOfferHistoricalImportForSetup,
@@ -47,6 +48,10 @@ describe("guided setup", () => {
     expect(setupProfileChoiceToMemoryProfile("project-only")).toBe("project-only");
     expect(setupProfileChoiceToMemoryProfile("user-only")).toBe("global-only");
     expect(setupProfileChoiceToMemoryProfile("recall-only")).toBe("recall-only");
+  });
+
+  it("builds durable ignore-repo patch", () => {
+    expect(buildIgnoreRepoPatch()).toEqual({ enabled: false, setupComplete: true });
   });
 
   it("builds profile and bank patches without inventing global bank IDs", () => {

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -58,6 +58,33 @@ describe("operation catalog", () => {
     }
   });
 
+  it("refuses tool execution when extension is disabled for the repo", async () => {
+    const recall = vi.fn(async () => []);
+    const catalog = createOperationCatalog({
+      getClient: () => ({ ...client(), recall }),
+      getConfig: () => ({ ...DEFAULT_CONFIG, enabled: false }),
+      getProjectBankId: () => "project-bank",
+    });
+    const tool = requireTool(catalog, "hindsight_recall");
+    const result = await tool.execute(
+      "call-1",
+      { query: "what did we decide?" },
+      undefined,
+      undefined,
+      {
+        cwd: mkdtempSync(join(tmpdir(), "pi-hindsight-disabled-tool-")),
+        sessionManager: { getSessionFile: () => undefined },
+      } as never,
+    );
+
+    expect(recall).not.toHaveBeenCalled();
+    expect(result.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("disabled for this repository"),
+    });
+    expect(result.details).toEqual({ disabled: true });
+  });
+
   it("exposes and maps advanced explicit retain options on the project retain tool", async () => {
     const retain = retainMock();
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-catalog-"));

--- a/tests/setup-gate.test.ts
+++ b/tests/setup-gate.test.ts
@@ -31,14 +31,21 @@ describe("setup gate", () => {
     expect(setupRequiredMessage()).toMatch(/setup required/i);
   });
 
-  it("points setup-required copy at upgrade guide, dual-tag docs, and changelog", () => {
+  it("points setup-required copy at /hindsight, ignore-repo, setup docs, and changelog", () => {
     const message = setupRequiredMessage();
     expect(message).toMatch(/setup required/i);
+    expect(message).toContain("/hindsight");
+    expect(message).toMatch(/Ignore this repo/i);
+    expect(message).toMatch(/Guided setup/i);
+    expect(message).toMatch(/Skip for now/i);
+    expect(message).toContain("https://luxus.github.io/pi-hindsight/start/setup-tui/");
     expect(message).toContain(
       "https://luxus.github.io/pi-hindsight/guides/upgrading-to-domain-banks/",
     );
     expect(message).toContain("https://luxus.github.io/pi-hindsight/concepts/project-identity/");
     expect(message).toContain("https://github.com/luxus/pi-hindsight/blob/main/CHANGELOG.md");
+    // Multi-line so the hub options stay scannable in notifications.
+    expect(message.split("\n").length).toBeGreaterThan(4);
   });
 
   it("rejects setupComplete alone under domain-tagged without coding bankId", () => {

--- a/tests/setup-tui.test.ts
+++ b/tests/setup-tui.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
 import { buildConfigEditingTabs } from "../extensions/config/config-editing-model.js";
 import {
   buildRetainReceiptStatusFacts,
   createSetupComponent,
+  runHindsightSetupTui,
 } from "../extensions/tui/setup-tui.js";
 import { HUB_ACTION_HELP } from "../extensions/tui/setup-tui-types.js";
 
@@ -79,5 +83,69 @@ describe("setup TUI receipt facts", () => {
       { showAdvanced: true },
     );
     expect(advanced.map((tab) => tab.id)).toContain("Banks");
+  });
+
+  it("writes durable ignore-repo config from no-config prompt", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ignore-repo-"));
+    const notify = vi.fn();
+    const ctx = {
+      cwd,
+      sessionManager: { getSessionFile: () => undefined },
+      ui: {
+        notify,
+        select: vi.fn().mockResolvedValueOnce("Ignore this repo"),
+        confirm: vi.fn().mockResolvedValueOnce(true),
+        custom: vi.fn(),
+        input: vi.fn(),
+      },
+    } as never;
+
+    await runHindsightSetupTui(ctx, {
+      getClient: () => ({
+        retain: vi.fn(),
+        recall: vi.fn(),
+        reflect: vi.fn(),
+      }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    } as never);
+
+    const written = JSON.parse(readFileSync(join(cwd, ".pi", "hindsight.json"), "utf8")) as {
+      enabled: boolean;
+      setupComplete: boolean;
+    };
+    expect(written.enabled).toBe(false);
+    expect(written.setupComplete).toBe(true);
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Hindsight disabled for this repo"),
+      "info",
+    );
+  });
+
+  it("does not write ignore-repo config when confirm is declined", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ignore-decline-"));
+    const ctx = {
+      cwd,
+      sessionManager: { getSessionFile: () => undefined },
+      ui: {
+        notify: vi.fn(),
+        select: vi.fn().mockResolvedValueOnce("Ignore this repo"),
+        confirm: vi.fn().mockResolvedValueOnce(false),
+        custom: vi.fn(),
+        input: vi.fn(),
+      },
+    } as never;
+
+    await runHindsightSetupTui(ctx, {
+      getClient: () => ({
+        retain: vi.fn(),
+        recall: vi.fn(),
+        reflect: vi.fn(),
+      }),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    } as never);
+
+    expect(() => readFileSync(join(cwd, ".pi", "hindsight.json"), "utf8")).toThrow();
   });
 });

--- a/tests/setup-tui.test.ts
+++ b/tests/setup-tui.test.ts
@@ -113,9 +113,11 @@ describe("setup TUI receipt facts", () => {
     const written = JSON.parse(readFileSync(join(cwd, ".pi", "hindsight.json"), "utf8")) as {
       enabled: boolean;
       setupComplete: boolean;
+      status?: { style?: string };
     };
     expect(written.enabled).toBe(false);
     expect(written.setupComplete).toBe(true);
+    expect(written.status?.style).toBe("off");
     expect(notify).toHaveBeenCalledWith(
       expect.stringContaining("Hindsight disabled for this repo"),
       "info",

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -3,6 +3,15 @@ import { DEFAULT_CONFIG } from "../extensions/config/config.js";
 import { formatHindsightStatus } from "../extensions/utils/status.js";
 
 describe("formatHindsightStatus", () => {
+  it("hides status when extension is disabled", () => {
+    expect(
+      formatHindsightStatus(
+        { ...DEFAULT_CONFIG, enabled: false },
+        { cwd: "/repo", projectBankId: "bank", activity: "connected" },
+      ),
+    ).toBeUndefined();
+  });
+
   it("separates style from detail and truncates length", () => {
     const config = {
       ...DEFAULT_CONFIG,


### PR DESCRIPTION
## Summary

When `/hindsight` opens with no project config, users can now choose **Ignore this repo** to write a durable opt-out (`enabled: false` + `setupComplete: true`) so automatic memory stays off and setup does not keep re-prompting. **Skip for now** remains ephemeral.

## Linked issue

- Closes #515

## Scope

- `extensions/tui/setup-tui.ts`: no-config prompt options + confirm + configure
- `extensions/tui/guided-setup.ts`: `buildIgnoreRepoPatch()`
- tests for patch and write/decline paths
- setup-tui + getting-started docs

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped coverage/tsc/full matrix: TUI setup config write only. Live smoke not required (no retain/recall/transport change).

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

New no-config choice **Ignore this repo**; **Skip** renamed to **Skip for now**.

## Risk and rollback

- Risk: Low. Ignore requires confirm and only writes project config. Re-enable via hub enabled field.
- Rollback/revert path: Revert this PR.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No AGENTS/CONTRIBUTING change required.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Re-enable: hub advanced **enabled** field, or edit `.pi/hindsight.json`.