### PR TITLE
feat(tui): probe Hindsight server health in guided setup

### DIFF
--- a/docs-site/src/content/docs/start/setup-tui.md
+++ b/docs-site/src/content/docs/start/setup-tui.md
@@ -35,11 +35,12 @@ Rerun guided setup later with `g`.
 
 Guided setup handles:
 
-1. memory profile
-2. **agent use** (coding vs conversation)
-3. project and/or user bank target
-4. optional starter mental models (dry-run + confirm)
-5. optional dry-run-first historical import
+1. **server health check** — probe configured URL (fallback `http://localhost:8888`); if unreachable and no API key, offer `HINDSIGHT_API_KEY` env setup; if a key is set, offer an alternate Cloud/self-hosted base URL; docs links shown on this screen
+2. memory profile
+3. **agent use** (coding vs conversation)
+4. project and/or user bank target
+5. optional starter mental models (dry-run + confirm)
+6. optional dry-run-first historical import
 
 Setup also prints docs links for the current area, such as [memory profiles](/pi-hindsight/start/memory-profiles/) and [imports](/pi-hindsight/guides/importing-sessions/).
 

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -16,6 +16,7 @@ import {
   renderBankTemplateApplyResult,
   renderBankTemplateMentalModelDetails,
 } from "./bank-template-presentation.js";
+import { ensureServerConnectionForSetup } from "./setup-server-probe.js";
 
 export function hasProjectHindsightConfig(cwd: string): boolean {
   return (
@@ -261,6 +262,15 @@ export async function runGuidedSetup(args: {
 }): Promise<boolean> {
   args.ctx.ui.notify(setupDocsHint("Guided setup", "/start/setup-tui/"), "info");
   args.ctx.ui.notify(setupDocsHint("Memory profiles", "/start/memory-profiles/"), "info");
+
+  // Health-check Hindsight before profile/banks so missing server/key fails early.
+  const serverOk = await ensureServerConnectionForSetup({
+    ctx: args.ctx,
+    deps: args.deps,
+    cwd: args.cwd,
+  });
+  if (!serverOk) return false;
+
   const profile = await args.ctx.ui.select("Choose memory profile", [
     "Coding (shared coding bank + project tags)",
     "Coding + Life (coding bank + user bank)",

--- a/extensions/tui/setup-server-probe.ts
+++ b/extensions/tui/setup-server-probe.ts
@@ -1,0 +1,233 @@
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { checkHindsight, createHindsightClient } from "../client/client.js";
+import type { MemoryOperationsDeps } from "../operations/memory-operation-service.js";
+import { createMemoryOperations } from "../operations/memory-operation-service.js";
+import type { HindsightLikeClient, ResolvedConfig } from "../types.js";
+import { apiKeyEnvName } from "../config/config-editing-registry.js";
+
+export const LOCAL_DEFAULT_BASE_URL = "http://localhost:8888";
+const DOCS_BASE_URL = "https://luxus.github.io/pi-hindsight";
+const CLOUD_SIGNUP_URL = "https://ui.hindsight.vectorize.io/signup";
+const INSTALL_URL = "https://hindsight.vectorize.io/developer/installation";
+
+export type ServerProbeResult = {
+  ok: boolean;
+  baseUrl: string;
+  usedApiKey: boolean;
+  error?: string;
+};
+
+function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/$/, "") || LOCAL_DEFAULT_BASE_URL;
+}
+
+/** Ordered unique base URLs to try during guided setup. */
+export function buildServerProbeCandidates(config: ResolvedConfig): string[] {
+  const configured = normalizeBaseUrl(config.hindsight.baseUrl);
+  const candidates = [configured];
+  if (configured !== LOCAL_DEFAULT_BASE_URL) candidates.push(LOCAL_DEFAULT_BASE_URL);
+  return [...new Set(candidates)];
+}
+
+export function hasResolvedApiKey(config: ResolvedConfig): boolean {
+  return Boolean(config.hindsight.apiKey?.trim());
+}
+
+export function formatServerProbeDocs(): string {
+  return [
+    "Pi Hindsight docs:",
+    `  Setup TUI: ${DOCS_BASE_URL}/start/setup-tui/`,
+    `  Getting started: ${DOCS_BASE_URL}/start/getting-started/`,
+    `  Minimal config: ${DOCS_BASE_URL}/start/minimal-config/`,
+    `Hindsight server: ${INSTALL_URL}`,
+    `Hindsight Cloud signup: ${CLOUD_SIGNUP_URL}`,
+  ].join("\n");
+}
+
+export function formatServerProbeSuccess(result: ServerProbeResult): string {
+  const key = result.usedApiKey ? "with API key" : "without API key";
+  return `Hindsight server reachable at ${result.baseUrl} (${key}).`;
+}
+
+export function formatServerProbeFailure(args: {
+  results: ServerProbeResult[];
+  hasApiKey: boolean;
+  apiKeyEnvLabel: string;
+}): string {
+  const lines = args.results.map((result) => {
+    const key = result.usedApiKey ? "with key" : "no key";
+    return `  • ${result.baseUrl} (${key}): ${result.error ?? "unreachable"}`;
+  });
+  return [
+    "Could not reach a Hindsight server yet.",
+    ...lines,
+    `API key: ${args.hasApiKey ? "resolved" : `not set (${args.apiKeyEnvLabel})`}`,
+    "",
+    "Local embed often needs no key. Cloud / locked APIs need HINDSIGHT_API_KEY (or your env name).",
+    "Cloud base URL comes from your Hindsight dashboard after signup — not a fixed public URL.",
+  ].join("\n");
+}
+
+export async function probeHindsightBaseUrl(args: {
+  config: ResolvedConfig;
+  baseUrl: string;
+  createClient?: (config: ResolvedConfig) => HindsightLikeClient;
+  check?: typeof checkHindsight;
+}): Promise<ServerProbeResult> {
+  const baseUrl = normalizeBaseUrl(args.baseUrl);
+  const createClient = args.createClient ?? createHindsightClient;
+  const check = args.check ?? checkHindsight;
+  const probeConfig: ResolvedConfig = {
+    ...args.config,
+    hindsight: { ...args.config.hindsight, baseUrl },
+  };
+  const client = createClient(probeConfig);
+  const health = await check(client, "setup-probe");
+  return {
+    ok: health.ok,
+    baseUrl,
+    usedApiKey: hasResolvedApiKey(probeConfig),
+    ...(health.error ? { error: health.error } : {}),
+  };
+}
+
+export async function probeHindsightCandidates(args: {
+  config: ResolvedConfig;
+  /** When probing the configured URL, prefer the live runtime client (tests/hooks). */
+  configuredClient?: HindsightLikeClient;
+  createClient?: (config: ResolvedConfig) => HindsightLikeClient;
+  check?: typeof checkHindsight;
+}): Promise<{ ok: ServerProbeResult | undefined; attempts: ServerProbeResult[] }> {
+  const attempts: ServerProbeResult[] = [];
+  const check = args.check ?? checkHindsight;
+  const configured = normalizeBaseUrl(args.config.hindsight.baseUrl);
+  for (const baseUrl of buildServerProbeCandidates(args.config)) {
+    let result: ServerProbeResult;
+    if (baseUrl === configured && args.configuredClient) {
+      const health = await check(args.configuredClient, "setup-probe");
+      result = {
+        ok: health.ok,
+        baseUrl,
+        usedApiKey: hasResolvedApiKey(args.config),
+        ...(health.error ? { error: health.error } : {}),
+      };
+    } else {
+      result = await probeHindsightBaseUrl({
+        config: args.config,
+        baseUrl,
+        ...(args.createClient ? { createClient: args.createClient } : {}),
+        ...(args.check ? { check: args.check } : {}),
+      });
+    }
+    attempts.push(result);
+    if (result.ok) return { ok: result, attempts };
+  }
+  return { ok: undefined, attempts };
+}
+
+/**
+ * Guided-setup step: health-check Hindsight, recover base URL / API key env, show docs.
+ * Returns false if the user cancels guided setup.
+ */
+export async function ensureServerConnectionForSetup(args: {
+  ctx: ExtensionCommandContext;
+  deps: MemoryOperationsDeps;
+  cwd: string;
+}): Promise<boolean> {
+  const { ctx, deps, cwd } = args;
+  ctx.ui.notify(formatServerProbeDocs(), "info");
+  ctx.ui.notify("Checking Hindsight server connectivity…", "info");
+
+  let config = deps.getConfig();
+  let attempts = 0;
+  const maxAttempts = 4;
+
+  while (attempts < maxAttempts) {
+    attempts += 1;
+    const { ok, attempts: probeAttempts } = await probeHindsightCandidates({
+      config,
+      configuredClient: deps.getClient(),
+    });
+    if (ok) {
+      // Persist working base URL when it differs from config (e.g. fallback localhost).
+      if (normalizeBaseUrl(config.hindsight.baseUrl) !== ok.baseUrl) {
+        await createMemoryOperations(deps).configure(cwd, { baseUrl: ok.baseUrl });
+        deps.reloadConfig?.(cwd);
+        config = deps.getConfig();
+      }
+      ctx.ui.notify(formatServerProbeSuccess(ok), "info");
+      return true;
+    }
+
+    const apiKeyEnvLabel =
+      apiKeyEnvName(config) !== "not set" ? apiKeyEnvName(config) : "HINDSIGHT_API_KEY";
+    ctx.ui.notify(
+      formatServerProbeFailure({
+        results: probeAttempts,
+        hasApiKey: hasResolvedApiKey(config),
+        apiKeyEnvLabel,
+      }),
+      "warning",
+    );
+
+    if (!hasResolvedApiKey(config)) {
+      const setKey = await ctx.ui.confirm(
+        "Configure API key env var?",
+        `No API key is resolved. Local servers often work without one. Cloud needs export ${apiKeyEnvLabel}=… then restart Pi. Save env var name to project config?`,
+      );
+      if (setKey) {
+        const envName = await ctx.ui.input("API key environment variable name", apiKeyEnvLabel);
+        if (envName?.trim()) {
+          await createMemoryOperations(deps).configure(cwd, {
+            apiKeyEnvVar: envName.trim(),
+          });
+          deps.reloadConfig?.(cwd);
+          config = deps.getConfig();
+          if (!hasResolvedApiKey(config)) {
+            ctx.ui.notify(
+              `Saved apiKey env ref “${envName.trim()}”, but it is not set in this process. Export it and restart Pi, or continue offline for config-only setup.`,
+              "warning",
+            );
+          }
+          continue;
+        }
+      }
+    } else {
+      const alt = await ctx.ui.confirm(
+        "Try a different base URL?",
+        "API key is set but the server was unreachable. Paste a Cloud/self-hosted API base URL from your Hindsight dashboard?",
+      );
+      if (alt) {
+        const url = await ctx.ui.input(
+          "Hindsight API base URL",
+          config.hindsight.baseUrl || LOCAL_DEFAULT_BASE_URL,
+        );
+        if (url?.trim()) {
+          await createMemoryOperations(deps).configure(cwd, { baseUrl: url.trim() });
+          deps.reloadConfig?.(cwd);
+          config = deps.getConfig();
+          continue;
+        }
+      }
+    }
+
+    const choice = await ctx.ui.select("Server still unreachable", [
+      "Retry health check",
+      "Continue offline (config only)",
+      "Cancel guided setup",
+    ]);
+    if (!choice || choice === "Cancel guided setup") return false;
+    if (choice === "Retry health check") continue;
+    ctx.ui.notify(
+      "Continuing guided setup offline. Memory network ops will fail until a server is reachable.",
+      "warning",
+    );
+    return true;
+  }
+
+  ctx.ui.notify(
+    "Continuing guided setup after multiple connection attempts. Fix server/key later via /hindsight (d deployment).",
+    "warning",
+  );
+  return true;
+}

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -184,6 +184,7 @@ describe("guided setup", () => {
           retain: vi.fn(),
           recall: vi.fn(),
           reflect: vi.fn(),
+          health: vi.fn(async () => ({ status: "ok" })),
         }),
         getConfig: () => DEFAULT_CONFIG,
         getProjectBankId: () => "project-bank",

--- a/tests/setup-server-probe.test.ts
+++ b/tests/setup-server-probe.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config/config-defaults.js";
+import {
+  buildServerProbeCandidates,
+  formatServerProbeDocs,
+  formatServerProbeFailure,
+  formatServerProbeSuccess,
+  hasResolvedApiKey,
+  LOCAL_DEFAULT_BASE_URL,
+  probeHindsightCandidates,
+} from "../extensions/tui/setup-server-probe.js";
+
+describe("setup server probe", () => {
+  it("prefers configured URL and falls back to localhost when different", () => {
+    expect(
+      buildServerProbeCandidates({
+        ...DEFAULT_CONFIG,
+        hindsight: { ...DEFAULT_CONFIG.hindsight, baseUrl: "https://api.example.com/" },
+      }),
+    ).toEqual(["https://api.example.com", LOCAL_DEFAULT_BASE_URL]);
+    expect(buildServerProbeCandidates(DEFAULT_CONFIG)).toEqual([LOCAL_DEFAULT_BASE_URL]);
+  });
+
+  it("detects resolved API keys", () => {
+    expect(hasResolvedApiKey(DEFAULT_CONFIG)).toBe(false);
+    expect(
+      hasResolvedApiKey({
+        ...DEFAULT_CONFIG,
+        hindsight: { ...DEFAULT_CONFIG.hindsight, apiKey: "secret" },
+      }),
+    ).toBe(true);
+  });
+
+  it("formats success, failure, and docs copy", () => {
+    expect(
+      formatServerProbeSuccess({
+        ok: true,
+        baseUrl: LOCAL_DEFAULT_BASE_URL,
+        usedApiKey: false,
+      }),
+    ).toContain("reachable");
+    expect(formatServerProbeDocs()).toContain(
+      "https://luxus.github.io/pi-hindsight/start/setup-tui/",
+    );
+    expect(formatServerProbeDocs()).toContain("ui.hindsight.vectorize.io/signup");
+    expect(
+      formatServerProbeFailure({
+        results: [
+          {
+            ok: false,
+            baseUrl: LOCAL_DEFAULT_BASE_URL,
+            usedApiKey: false,
+            error: "ECONNREFUSED",
+          },
+        ],
+        hasApiKey: false,
+        apiKeyEnvLabel: "HINDSIGHT_API_KEY",
+      }),
+    ).toMatch(/Could not reach|ECONNREFUSED|HINDSIGHT_API_KEY/s);
+  });
+
+  it("returns first healthy candidate", async () => {
+    const check = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, error: "down" })
+      .mockResolvedValueOnce({ ok: true });
+    const createClient = vi.fn(() => ({
+      retain: async () => undefined,
+      recall: async () => [],
+      reflect: async () => ({}),
+    }));
+    const { ok, attempts } = await probeHindsightCandidates({
+      config: {
+        ...DEFAULT_CONFIG,
+        hindsight: { ...DEFAULT_CONFIG.hindsight, baseUrl: "https://api.example.com" },
+      },
+      createClient,
+      check,
+    });
+    expect(ok?.baseUrl).toBe(LOCAL_DEFAULT_BASE_URL);
+    expect(attempts).toHaveLength(2);
+    expect(check).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Guided setup now health-checks the Hindsight server before profile/bank steps: configured URL first (fallback `http://localhost:8888`), docs links on the probe screen, API key env recovery when no key, alternate base URL when a key is set but the host is down, with offline continue or cancel.

## Linked issue

- Closes #517

## Scope

- `extensions/tui/setup-server-probe.ts` — candidates, probe, recovery UI
- `extensions/tui/guided-setup.ts` — run probe first
- unit tests + setup-tui docs

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped coverage/tsc/full matrix because this is TUI setup connectivity UX reusing existing `checkHindsight`/`health`. Live smoke skipped because there is no retain/recall request shape change.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Guided setup starts with a server health step and clearer recovery for missing key/URL.

## Risk and rollback

- Risk: Low. Probe failures allow offline continue; successful fallback localhost may write baseUrl.
- Rollback/revert path: Revert this PR.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No AGENTS/CONTRIBUTING change required.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Cloud has no single fixed public API URL in-repo; when a key is present and health fails, setup asks for the dashboard base URL.