### PR TITLE
fix(tui): polish guided setup offline path and bank status

### DIFF
--- a/docs-site/src/content/docs/start/setup-tui.md
+++ b/docs-site/src/content/docs/start/setup-tui.md
@@ -35,12 +35,12 @@ Rerun guided setup later with `g`.
 
 Guided setup handles:
 
-1. **server health check** — probe configured URL (fallback `http://localhost:8888`); if unreachable and no API key, offer `HINDSIGHT_API_KEY` env setup; if a key is set, offer an alternate Cloud/self-hosted base URL; docs links shown on this screen
+1. **server health check** — probe configured URL (fallback `http://localhost:8888`); if unreachable and no API key, offer `HINDSIGHT_API_KEY` env setup (restart required if the env is not in this process); if a key is set, offer an alternate Cloud/self-hosted base URL; docs links shown on this screen. Offline continue skips mental models and import.
 2. memory profile
 3. **agent use** (coding vs conversation)
-4. project and/or user bank target
-5. optional starter mental models (dry-run + confirm)
-6. optional dry-run-first historical import
+4. project and/or user bank target (existing vs create; one-line `Server: … · Bank: …` status)
+5. optional starter mental models (dry-run + confirm; skipped offline / when catalog already present)
+6. optional dry-run-first historical import (skipped offline)
 
 Setup also prints docs links for the current area, such as [memory profiles](/pi-hindsight/start/memory-profiles/) and [imports](/pi-hindsight/guides/importing-sessions/).
 

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -125,10 +125,29 @@ export async function probeBankExistence(
   }
 }
 
+export type SetupBankResolveState = "existing" | "created" | "unverified";
+
+export type ResolvedSetupBank = {
+  bankId: string;
+  state: SetupBankResolveState;
+};
+
+/** One-line status after server + bank resolution. */
+export function formatSetupBankStatusLine(args: {
+  serverReachable: boolean;
+  banks: Array<{ kind: "project" | "user"; bankId: string; state: SetupBankResolveState }>;
+}): string {
+  const server = args.serverReachable ? "Server: reachable" : "Server: offline";
+  if (args.banks.length === 0) return server;
+  const bankParts = args.banks.map((bank) => `${bank.kind} bank ${bank.bankId}: ${bank.state}`);
+  return `${server} · ${bankParts.join(" · ")}`;
+}
+
 /**
  * Collect a bank ID, verify it against Hindsight, and confirm create when missing
  * so typos do not silently mint a new bank.
  * Returns undefined when the user cancels input.
+ * When offline, skips network probe/create and accepts the ID as unverified.
  */
 export async function resolveSetupBankId(args: {
   ctx: ExtensionCommandContext;
@@ -137,7 +156,8 @@ export async function resolveSetupBankId(args: {
   kind: "project" | "user";
   title: string;
   fallback: string;
-}): Promise<string | undefined> {
+  offline?: boolean;
+}): Promise<ResolvedSetupBank | undefined> {
   while (true) {
     const bankId = await askBankId({
       ctx: args.ctx,
@@ -151,13 +171,21 @@ export async function resolveSetupBankId(args: {
         args.ctx.ui.notify("User bank ID is required.", "warning");
         continue;
       }
-      return trimmed;
+      return { bankId: trimmed, state: "unverified" };
+    }
+
+    if (args.offline) {
+      args.ctx.ui.notify(
+        `Offline: accepting ${args.kind} bank ${trimmed} without server verification.`,
+        "info",
+      );
+      return { bankId: trimmed, state: "unverified" };
     }
 
     const existence = await probeBankExistence(args.client, trimmed);
     if (existence.status === "exists") {
       args.ctx.ui.notify(`Using existing ${args.kind} bank ${trimmed}.`, "info");
-      return trimmed;
+      return { bankId: trimmed, state: "existing" };
     }
 
     if (existence.status === "missing") {
@@ -189,7 +217,7 @@ export async function resolveSetupBankId(args: {
           });
         }
         args.ctx.ui.notify(`Created ${args.kind} bank ${trimmed}.`, "info");
-        return trimmed;
+        return { bankId: trimmed, state: "created" };
       } catch (error) {
         args.ctx.ui.notify(
           `Failed to create ${args.kind} bank ${trimmed}: ${error instanceof Error ? error.message : String(error)}`,
@@ -200,13 +228,15 @@ export async function resolveSetupBankId(args: {
     }
 
     // Profile API missing: cannot verify; keep prior behavior.
-    if (existence.error === "getBankProfile unavailable") return trimmed;
+    if (existence.error === "getBankProfile unavailable") {
+      return { bankId: trimmed, state: "unverified" };
+    }
 
     const proceed = await args.ctx.ui.confirm(
       `Could not verify ${args.kind} bank "${trimmed}"`,
       `${existence.error ?? "Unknown error"}. Continue with this ID anyway, or cancel to re-enter?`,
     );
-    if (proceed) return trimmed;
+    if (proceed) return { bankId: trimmed, state: "unverified" };
   }
 }
 
@@ -566,12 +596,13 @@ export async function runGuidedSetup(args: {
   args.ctx.ui.notify(setupDocsHint("Memory profiles", "/start/memory-profiles/"), "info");
 
   // Health-check Hindsight before profile/banks so missing server/key fails early.
-  const serverOk = await ensureServerConnectionForSetup({
+  const connection = await ensureServerConnectionForSetup({
     ctx: args.ctx,
     deps: args.deps,
     cwd: args.cwd,
   });
-  if (!serverOk) return false;
+  if (!connection.continue) return false;
+  const offline = connection.offline;
 
   const profile = await args.ctx.ui.select("Choose memory profile", [
     "Coding (shared coding bank + project tags)",
@@ -601,7 +632,13 @@ export async function runGuidedSetup(args: {
 
   const config = args.deps.getConfig();
   const client = args.deps.getClient();
-  const projectBankId = profileUsesProject(setupProfile)
+  const resolvedBanks: Array<{
+    kind: "project" | "user";
+    bankId: string;
+    state: SetupBankResolveState;
+  }> = [];
+
+  const projectBank = profileUsesProject(setupProfile)
     ? await resolveSetupBankId({
         ctx: args.ctx,
         client,
@@ -614,11 +651,15 @@ export async function runGuidedSetup(args: {
         fallback:
           config.banks.project.bankId ??
           (setupProfile === "isolated-only" ? args.deps.getProjectBankId() : "pi-coding"),
+        offline,
       })
     : undefined;
-  if (profileUsesProject(setupProfile) && projectBankId === undefined) return false;
+  if (profileUsesProject(setupProfile) && projectBank === undefined) return false;
+  if (projectBank?.bankId) {
+    resolvedBanks.push({ kind: "project", bankId: projectBank.bankId, state: projectBank.state });
+  }
 
-  const globalBankId = profileUsesUser(setupProfile)
+  const globalBank = profileUsesUser(setupProfile)
     ? await resolveSetupBankId({
         ctx: args.ctx,
         client,
@@ -626,12 +667,27 @@ export async function runGuidedSetup(args: {
         kind: "user",
         title: "User bank ID",
         fallback: config.banks.user.bankId ?? "",
+        offline,
       })
     : undefined;
-  if (profileUsesUser(setupProfile) && !globalBankId) {
+  if (profileUsesUser(setupProfile) && !globalBank) {
     args.ctx.ui.notify("User bank ID required for user memory profiles.", "warning");
     return false;
   }
+  if (globalBank?.bankId) {
+    resolvedBanks.push({ kind: "user", bankId: globalBank.bankId, state: globalBank.state });
+  }
+
+  args.ctx.ui.notify(
+    formatSetupBankStatusLine({
+      serverReachable: connection.serverReachable,
+      banks: resolvedBanks,
+    }),
+    "info",
+  );
+
+  const projectBankId = projectBank?.bankId;
+  const globalBankId = globalBank?.bankId;
 
   const patch = {
     ...buildGuidedSetupPatch({
@@ -650,11 +706,13 @@ export async function runGuidedSetup(args: {
   const summary = [
     `Profile: ${setupProfileChoiceToMemoryProfile(setupProfile)}`,
     `Agent use: ${agentUse}`,
+    `Server: ${connection.serverReachable ? "reachable" : "offline"}`,
     ...(projectBankId ? [`Project config: project bank ${projectBankId}`] : []),
     ...(globalBankId ? [`Global config: user bank ${globalBankId}`] : []),
     ...(setupProfile === "recall-only"
       ? ["Automatic retain: disabled; automatic recall: enabled"]
       : []),
+    ...(offline ? ["Offline: mental models and import will be skipped"] : []),
   ].join("\n");
   const confirmed = await args.ctx.ui.confirm("Write Pi Hindsight config?", summary);
   if (!confirmed) return false;
@@ -666,6 +724,14 @@ export async function runGuidedSetup(args: {
   }
   const result = await operations.configure(args.cwd, patch);
   args.ctx.ui.notify(`Wrote ${result.path}`, "info");
+
+  if (offline) {
+    args.ctx.ui.notify(
+      "Offline setup complete. Re-run guided setup or use hub (t / i) when the server is reachable for mental models and import.",
+      "info",
+    );
+    return true;
+  }
 
   await maybeOfferMentalModelsForSetup({
     ctx: args.ctx,

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -167,11 +167,14 @@ export async function resolveSetupBankId(args: {
     if (bankId === undefined) return undefined;
     const trimmed = bankId.trim();
     if (!trimmed) {
-      if (args.kind === "user") {
-        args.ctx.ui.notify("User bank ID is required.", "warning");
-        continue;
-      }
-      return { bankId: trimmed, state: "unverified" };
+      // Empty IDs are never valid config values (askBankId already falls back when possible).
+      args.ctx.ui.notify(
+        args.kind === "user"
+          ? "User bank ID is required."
+          : "Project bank ID is required (cannot be empty).",
+        "warning",
+      );
+      continue;
     }
 
     if (args.offline) {

--- a/extensions/tui/setup-server-probe.ts
+++ b/extensions/tui/setup-server-probe.ts
@@ -17,6 +17,16 @@ export type ServerProbeResult = {
   error?: string;
 };
 
+/** Result of the guided-setup server connection step. */
+export type SetupServerConnection = {
+  /** false = cancel guided setup entirely */
+  continue: boolean;
+  /** true when proceeding without a reachable server (skip network offers) */
+  offline: boolean;
+  serverReachable: boolean;
+  baseUrl?: string;
+};
+
 function normalizeBaseUrl(url: string): string {
   return url.trim().replace(/\/$/, "") || LOCAL_DEFAULT_BASE_URL;
 }
@@ -65,6 +75,16 @@ export function formatServerProbeFailure(args: {
     "",
     "Local embed often needs no key. Cloud / locked APIs need HINDSIGHT_API_KEY (or your env name).",
     "Cloud base URL comes from your Hindsight dashboard after signup — not a fixed public URL.",
+  ].join("\n");
+}
+
+export function formatApiKeyRestartRequired(envName: string): string {
+  return [
+    `Saved API key env ref “${envName}”, but it is not set in this Pi process.`,
+    `Export it, then restart Pi so the key is available:`,
+    `  export ${envName}=…`,
+    `  # restart Pi, then re-run /hindsight guided setup`,
+    "Or continue offline now for config-only setup (no mental models / import until online).",
   ].join("\n");
 }
 
@@ -125,15 +145,33 @@ export async function probeHindsightCandidates(args: {
   return { ok: undefined, attempts };
 }
 
+async function chooseOfflineOrCancel(
+  ctx: ExtensionCommandContext,
+  title: string,
+): Promise<SetupServerConnection> {
+  const choice = await ctx.ui.select(title, [
+    "Continue offline (config only)",
+    "Cancel guided setup",
+  ]);
+  if (!choice || choice === "Cancel guided setup") {
+    return { continue: false, offline: false, serverReachable: false };
+  }
+  ctx.ui.notify(
+    "Continuing guided setup offline. Mental models and import are skipped until a server is reachable.",
+    "warning",
+  );
+  return { continue: true, offline: true, serverReachable: false };
+}
+
 /**
  * Guided-setup step: health-check Hindsight, recover base URL / API key env, show docs.
- * Returns false if the user cancels guided setup.
+ * Returns offline=true when continuing without a reachable server (caller should skip MM/import).
  */
 export async function ensureServerConnectionForSetup(args: {
   ctx: ExtensionCommandContext;
   deps: MemoryOperationsDeps;
   cwd: string;
-}): Promise<boolean> {
+}): Promise<SetupServerConnection> {
   const { ctx, deps, cwd } = args;
   ctx.ui.notify(formatServerProbeDocs(), "info");
   ctx.ui.notify("Checking Hindsight server connectivity…", "info");
@@ -141,22 +179,48 @@ export async function ensureServerConnectionForSetup(args: {
   let config = deps.getConfig();
   let attempts = 0;
   const maxAttempts = 4;
+  /** After saving an env ref that is missing in-process, do not re-probe empty. */
+  let pendingKeyRestart = false;
 
   while (attempts < maxAttempts) {
     attempts += 1;
+
+    if (pendingKeyRestart) {
+      ctx.ui.notify(
+        "API key env is configured in project config but not loaded in this process. Restart Pi after exporting the key, or continue offline.",
+        "warning",
+      );
+      const choice = await ctx.ui.select("API key requires restart", [
+        "Cancel guided setup (export key + restart Pi)",
+        "Continue offline (config only)",
+      ]);
+      if (!choice || choice.startsWith("Cancel")) {
+        return { continue: false, offline: false, serverReachable: false };
+      }
+      ctx.ui.notify(
+        "Continuing guided setup offline. Mental models and import are skipped until a server is reachable.",
+        "warning",
+      );
+      return { continue: true, offline: true, serverReachable: false };
+    }
+
     const { ok, attempts: probeAttempts } = await probeHindsightCandidates({
       config,
       configuredClient: deps.getClient(),
     });
     if (ok) {
-      // Persist working base URL when it differs from config (e.g. fallback localhost).
       if (normalizeBaseUrl(config.hindsight.baseUrl) !== ok.baseUrl) {
         await createMemoryOperations(deps).configure(cwd, { baseUrl: ok.baseUrl });
         deps.reloadConfig?.(cwd);
         config = deps.getConfig();
       }
       ctx.ui.notify(formatServerProbeSuccess(ok), "info");
-      return true;
+      return {
+        continue: true,
+        offline: false,
+        serverReachable: true,
+        baseUrl: ok.baseUrl,
+      };
     }
 
     const apiKeyEnvLabel =
@@ -184,11 +248,12 @@ export async function ensureServerConnectionForSetup(args: {
           deps.reloadConfig?.(cwd);
           config = deps.getConfig();
           if (!hasResolvedApiKey(config)) {
-            ctx.ui.notify(
-              `Saved apiKey env ref “${envName.trim()}”, but it is not set in this process. Export it and restart Pi, or continue offline for config-only setup.`,
-              "warning",
-            );
+            ctx.ui.notify(formatApiKeyRestartRequired(envName.trim()), "warning");
+            pendingKeyRestart = true;
+            // Do not empty-reprobe; next loop handles restart vs offline.
+            continue;
           }
+          // Key resolved after reload (unlikely mid-process unless injected) → re-probe.
           continue;
         }
       }
@@ -216,18 +281,19 @@ export async function ensureServerConnectionForSetup(args: {
       "Continue offline (config only)",
       "Cancel guided setup",
     ]);
-    if (!choice || choice === "Cancel guided setup") return false;
+    if (!choice || choice === "Cancel guided setup") {
+      return { continue: false, offline: false, serverReachable: false };
+    }
     if (choice === "Retry health check") continue;
     ctx.ui.notify(
-      "Continuing guided setup offline. Memory network ops will fail until a server is reachable.",
+      "Continuing guided setup offline. Mental models and import are skipped until a server is reachable.",
       "warning",
     );
-    return true;
+    return { continue: true, offline: true, serverReachable: false };
   }
 
-  ctx.ui.notify(
-    "Continuing guided setup after multiple connection attempts. Fix server/key later via /hindsight (d deployment).",
-    "warning",
+  return chooseOfflineOrCancel(
+    ctx,
+    "Still no server after several attempts. Continue offline or cancel?",
   );
-  return true;
 }

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -614,6 +614,32 @@ describe("guided setup", () => {
     expect(getBankProfile).not.toHaveBeenCalled();
   });
 
+  it("re-prompts when project bank id would be empty", async () => {
+    const notify = vi.fn();
+    const input = vi.fn().mockResolvedValueOnce("").mockResolvedValueOnce("pi-coding");
+    const resolved = await resolveSetupBankId({
+      ctx: {
+        ui: { notify, input, confirm: vi.fn() },
+      } as never,
+      client: {
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+        getBankProfile: vi.fn(async () => ({ id: "pi-coding" })),
+      },
+      config: DEFAULT_CONFIG,
+      kind: "project",
+      title: "Coding bank ID",
+      fallback: "",
+    });
+    expect(resolved).toEqual({ bankId: "pi-coding", state: "existing" });
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Project bank ID is required"),
+      "warning",
+    );
+    expect(input).toHaveBeenCalledTimes(2);
+  });
+
   it("skips mental models and import when server probe ends offline", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-guided-offline-"));
     const notify = vi.fn();

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -8,6 +8,7 @@ import {
   buildGuidedSetupPatch,
   buildIgnoreRepoPatch,
   extractMentalModelNames,
+  formatSetupBankStatusLine,
   hasProjectHindsightConfig,
   importChoicesForSetup,
   maybeOfferHistoricalImportForSetup,
@@ -457,6 +458,10 @@ describe("guided setup", () => {
       "info",
     );
     expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Server: reachable · project bank project-bank: existing"),
+      "info",
+    );
+    expect(notify).toHaveBeenCalledWith(
       expect.stringContaining("1 mental model(s) already present"),
       "info",
     );
@@ -509,7 +514,7 @@ describe("guided setup", () => {
       ui: { notify, input, confirm, select: vi.fn() },
     } as never;
 
-    const bankId = await resolveSetupBankId({
+    const resolved = await resolveSetupBankId({
       ctx,
       client,
       config: DEFAULT_CONFIG,
@@ -518,7 +523,7 @@ describe("guided setup", () => {
       fallback: "pi-coding",
     });
 
-    expect(bankId).toBe("pi-coding");
+    expect(resolved).toEqual({ bankId: "pi-coding", state: "existing" });
     expect(createBank).not.toHaveBeenCalled();
     expect(confirm).toHaveBeenCalledWith(
       'Create project bank "typo-bank"?',
@@ -551,7 +556,7 @@ describe("guided setup", () => {
       ui: { notify, input, confirm, select: vi.fn() },
     } as never;
 
-    const bankId = await resolveSetupBankId({
+    const resolved = await resolveSetupBankId({
       ctx,
       client,
       config: DEFAULT_CONFIG,
@@ -560,11 +565,112 @@ describe("guided setup", () => {
       fallback: "pi-coding",
     });
 
-    expect(bankId).toBe("new-coding");
+    expect(resolved).toEqual({ bankId: "new-coding", state: "created" });
     expect(createBank).toHaveBeenCalledWith(
       "new-coding",
       expect.objectContaining({ name: "new-coding" }),
     );
     expect(notify).toHaveBeenCalledWith("Created project bank new-coding.", "info");
+  });
+
+  it("formats server and bank status line", () => {
+    expect(
+      formatSetupBankStatusLine({
+        serverReachable: true,
+        banks: [{ kind: "project", bankId: "pi-coding", state: "existing" }],
+      }),
+    ).toBe("Server: reachable · project bank pi-coding: existing");
+    expect(
+      formatSetupBankStatusLine({
+        serverReachable: false,
+        banks: [{ kind: "project", bankId: "pi-coding", state: "unverified" }],
+      }),
+    ).toBe("Server: offline · project bank pi-coding: unverified");
+  });
+
+  it("accepts bank ids offline without probing", async () => {
+    const getBankProfile = vi.fn();
+    const resolved = await resolveSetupBankId({
+      ctx: {
+        ui: {
+          notify: vi.fn(),
+          input: vi.fn().mockResolvedValueOnce("offline-bank"),
+          confirm: vi.fn(),
+        },
+      } as never,
+      client: {
+        retain: async () => undefined,
+        recall: async () => [],
+        reflect: async () => ({}),
+        getBankProfile,
+      },
+      config: DEFAULT_CONFIG,
+      kind: "project",
+      title: "Coding bank ID",
+      fallback: "pi-coding",
+      offline: true,
+    });
+    expect(resolved).toEqual({ bankId: "offline-bank", state: "unverified" });
+    expect(getBankProfile).not.toHaveBeenCalled();
+  });
+
+  it("skips mental models and import when server probe ends offline", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-guided-offline-"));
+    const notify = vi.fn();
+    const applyBankTemplate = vi.fn();
+    const listMentalModels = vi.fn();
+    const confirm = vi
+      .fn()
+      // Decline API key env setup after failed probe
+      .mockResolvedValueOnce(false)
+      // Write config yes only (no MM / import prompts)
+      .mockResolvedValueOnce(true);
+    const ctx = {
+      cwd,
+      sessionManager: { getSessionFile: () => undefined },
+      ui: {
+        notify,
+        input: vi.fn().mockResolvedValueOnce("project-bank"),
+        select: vi
+          .fn()
+          // After key decline: Server still unreachable → offline
+          .mockResolvedValueOnce("Continue offline (config only)")
+          .mockResolvedValueOnce("Coding (shared coding bank + project tags)")
+          .mockResolvedValueOnce("Coding (architecture, conventions, decisions)"),
+        confirm,
+      },
+    } as never;
+
+    const completed = await runGuidedSetup({
+      ctx,
+      cwd,
+      deps: {
+        getClient: () => ({
+          retain: vi.fn(),
+          recall: vi.fn(),
+          reflect: vi.fn(),
+          // No health → check falls through and fails without network mock
+          getBankProfile: vi.fn(async () => {
+            throw Object.assign(new Error("ECONNREFUSED"), { status: 503 });
+          }),
+          listMentalModels,
+          importBankTemplate: applyBankTemplate,
+        }),
+        getConfig: () => DEFAULT_CONFIG,
+        getProjectBankId: () => "project-bank",
+      } as never,
+    });
+
+    expect(completed).toBe(true);
+    expect(hasProjectHindsightConfig(cwd)).toBe(true);
+    expect(notify).toHaveBeenCalledWith(
+      expect.stringContaining("Server: offline · project bank project-bank: unverified"),
+      "info",
+    );
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining("Offline setup complete"), "info");
+    expect(applyBankTemplate).not.toHaveBeenCalled();
+    expect(listMentalModels).not.toHaveBeenCalled();
+    expect(confirm).toHaveBeenCalledTimes(2);
+    expect(confirm.mock.calls[1]?.[0]).toBe("Write Pi Hindsight config?");
   });
 });

--- a/tests/setup-server-probe.test.ts
+++ b/tests/setup-server-probe.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config/config-defaults.js";
 import {
   buildServerProbeCandidates,
+  formatApiKeyRestartRequired,
   formatServerProbeDocs,
   formatServerProbeFailure,
   formatServerProbeSuccess,
@@ -80,5 +81,12 @@ describe("setup server probe", () => {
     expect(ok?.baseUrl).toBe(LOCAL_DEFAULT_BASE_URL);
     expect(attempts).toHaveLength(2);
     expect(check).toHaveBeenCalledTimes(2);
+  });
+
+  it("formats API key restart guidance after env write without process value", () => {
+    const message = formatApiKeyRestartRequired("HINDSIGHT_API_KEY");
+    expect(message).toContain("export HINDSIGHT_API_KEY=");
+    expect(message).toMatch(/restart Pi/i);
+    expect(message).toMatch(/offline/i);
   });
 });


### PR DESCRIPTION
## Summary

Guided setup polish after the server/bank/ignore work:

1. **Offline flag** — when the probe ends offline, skip mental models and import (config-only finish).
2. **Status line** — after bank resolve: `Server: reachable · project bank X: existing` (or offline/unverified/created).
3. **Key restart path** — if API key env is written but not in this process, stop empty re-probes and force cancel-to-restart vs offline continue.

## Linked issue

- Closes #519

## Scope

- `extensions/tui/setup-server-probe.ts` — connection result shape + key-restart handling
- `extensions/tui/guided-setup.ts` — offline skip, bank state, status line
- tests + setup-tui docs

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped coverage/tsc/full matrix because this is TUI setup flow polish. Live smoke skipped because there is no retain/recall request shape change.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Clearer offline and bank status UX in guided setup.

## Risk and rollback

- Risk: Low. Offline only skips optional network steps; restart path is advisory.
- Rollback/revert path: Revert this PR.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

No AGENTS/CONTRIBUTING change required.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

None.