### PR TITLE
fix(test): make scope-migrate receipt path assertion Windows-safe

### DIFF
--- a/tests/scope-migrate.test.ts
+++ b/tests/scope-migrate.test.ts
@@ -117,7 +117,7 @@ describe("scope migrate dry-run", () => {
       projectBankId: "kai-coding",
     });
     const receipt = await writeScopeMigrateReceipt(cwd, plan);
-    expect(receipt.receiptPath).toContain(".pi/hindsight/scope-migrate-receipt.json");
+    expect(receipt.receiptPath).toBe(join(cwd, ".pi", "hindsight", "scope-migrate-receipt.json"));
     const raw = JSON.parse(readFileSync(receipt.receiptPath, "utf8")) as { rewrite: string };
     expect(raw.rewrite).toBe("none");
   });


### PR DESCRIPTION
## Summary

Fix Windows full-matrix failure where `tests/scope-migrate.test.ts` asserted a POSIX receipt path substring.

## Linked issue

- Closes #521

## Scope

- Update receipt path assertion to use `path.join` so separators match the platform.

## Verification

- [x] `npm run check` (via pre-commit hook; 560 tests passed)
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — skipped: one-line test assertion only; no coverage surface change
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — skipped: pre-commit already ran `tsgo` typecheck; no production source change
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — platform-sensitive assertion; CI PR matrix will cover windows when labeled/triggered; local Linux path-join assertion is equivalent
- [ ] package verification requested/passed (release/package changes or `ci:package`) — skipped: no package change
- [ ] `npm run pack:verify` (release/package changes) — skipped: no package change
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — skipped: test-only, no memory-path runtime change

Failed CI evidence: https://github.com/luxus/pi-hindsight/actions/runs/29167850994/job/86584083087

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

None — test assertion only.

## Risk and rollback

- Risk: low; only tightens the path assertion to the real joined absolute path.
- Rollback/revert path: revert this commit.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. (N/A)

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Root cause: `expect(receipt.receiptPath).toContain(".pi/hindsight/...")` fails when Windows returns `.pi\\hindsight\\...`. Production path construction already uses `path.join`; only the test was separator-sensitive.