### PR TITLE
fix(operations): declare type on tagGroups.match enum for MFJS compatibility

### DIFF
--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -43,7 +43,7 @@ const tagGroupJsonSchema = {
   required: ["tags"],
   properties: {
     tags: { type: "array", items: { type: "string" } },
-    match: { enum: ["any", "all", "any_strict", "all_strict"] },
+    match: { type: "string", enum: ["any", "all", "any_strict", "all_strict"] },
   },
   additionalProperties: false,
 };

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -12,6 +12,7 @@ type ReflectOptions = Parameters<HindsightLikeClient["reflect"]>[2];
 
 type JsonSchema = {
   type?: string;
+  enum?: unknown[];
   properties?: Record<string, JsonSchema>;
   patternProperties?: Record<string, JsonSchema>;
   items?: JsonSchema;
@@ -315,6 +316,37 @@ describe("operation catalog", () => {
         ]),
       }),
     );
+  });
+
+  it("declares a type on every tagGroups.match enum so strict JSON schema validators (Moonshot MFJS) accept the tool", () => {
+    // Regression: Moonshot's "Moonshot Flavored JSON Schema" (MFJS) rejects any
+    // property schema that omits `type`, even when `enum` is present. The
+    // tagGroups.match field is a hand-written JSON schema literal wrapped in
+    // Type.Unsafe, so TypeBox cannot add `type` automatically. Without an
+    // explicit `type: "string"`, every request carrying hindsight_recall /
+    // hindsight_reflect is rejected by api.kimi.com/coding/v1 with:
+    //   tools.function.parameters is not a valid moonshot flavored json schema,
+    //   details: <At path 'properties.tagGroups.items.properties.match': type is not defined>
+    // See https://github.com/MoonshotAI/kimi-cli/issues/1595
+    const catalog = createOperationCatalog({
+      getClient: () => client(),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "project-bank",
+    });
+
+    for (const name of ["hindsight_recall", "hindsight_reflect"] as const) {
+      const tool = requireTool(catalog, name);
+      const properties = (tool.parameters as JsonSchema).properties ?? {};
+      const tagGroupsItems = properties.tagGroups?.items as JsonSchema | undefined;
+      const matchSchema = tagGroupsItems?.properties?.match;
+
+      expect(matchSchema, `${name} should declare tagGroups.items.properties.match`).toBeDefined();
+      expect(
+        matchSchema?.type,
+        `${name}.tagGroups.items.properties.match must declare type for MFJS`,
+      ).toBe("string");
+      expect(matchSchema?.enum).toEqual(["any", "all", "any_strict", "all_strict"]);
+    }
   });
 
   it("folds automatic scope tags into an exact tagsMatch filter for recall", async () => {


### PR DESCRIPTION
## Summary

`hindsight_recall` and `hindsight_reflect` tool schemas are rejected by strict JSON-schema validators because `tagGroups.items.properties.match` declares `enum` without `type`. The schema is a hand-written JSON literal wrapped in `Type.Unsafe`, so TypeBox cannot inject `type` the way it does for every other property in the catalog. Add `type: "string"` to the `match` enum so the schema is valid standard JSON Schema and valid Moonshot Flavored JSON Schema (MFJS).

## Linked issue

- Closes #550

## Scope

One-line schema fix in `extensions/operations/operation-catalog.ts` plus a focused regression test in `tests/operation-catalog.test.ts` that asserts `tagGroups.items.properties.match.type === "string"` for both `hindsight_recall` and `hindsight_reflect`. No other tools, no behavior change, no config touch.

## Verification

- [x] `npm run check` (docs:check + format + lint + typecheck + 577 tests, all green)
- [x] Regression test confirmed red on the unpatched schema (`expected undefined to be 'string'`) and green after the one-line fix
- [x] End-to-end wire check against `api.kimi.com/coding/v1`: the patched schema is accepted by `kimi-for-coding` (K2.7), `k3`, and `k3-256k`; the unpatched schema is rejected by all three with the MFJS error
- [x] `npm run check:coverage` skipped because no coverage-sensitive code paths are touched (one-line schema declaration + one focused test; coverage delta is meaningless here)
- [x] `npm run typecheck:tsc` passed as part of `npm run check`
- [ ] full matrix / package / smoke not run because they are unavailable for this change: no release path, no memory-path behavior change, no Hindsight server interaction touched

## Release impact

- [x] User-visible change

Fixes a hard 400 failure for any user pointing pi-hindsight at a Moonshot strict endpoint (`api.kimi.com/coding/v1`) or a Volcengine relay that enforces its own schema validation. Changelog-worthy as a bug fix.

## Risk and rollback

- Risk: Near zero. `type: "string"` on an enum is valid standard JSON Schema; lenient providers (OpenAI, Anthropic, MiniMax, JDCloud) already accept it. No runtime logic change, no parameter shape change, no stored-data change.
- Rollback/revert path: Revert this single commit. The regression test will go red and the original MFJS 400 will return for strict validators.

## Follow-ups

- None. The companion issue (#550) tracks the broader schema-hygiene question (avoiding `Type.Unsafe` for hand-written literals), which is out of scope for this fix.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries. (untouched)
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight. (untouched)
- [x] Project Bank and User Bank isolation is preserved. (untouched)
- [x] Retain Queue behavior remains queue-first and retry-safe. (untouched)
- [x] Debug output and sidecars remain opt-in and redacted. (untouched)
- [x] Import behavior remains deterministic and idempotent when touched. (untouched)

## Guidance sync

- [x] No source-of-truth order, contributor workflow, verification expectation, memory policy, or definition-of-done change. `AGENTS.md` and `CONTRIBUTING.md` need no update.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Reproducer against the real Moonshot coding endpoint (with a valid Kimi coding-plan key):

```bash
# Unpatched schema -> 400
curl -s https://api.kimi.com/coding/v1/chat/completions \
  -H "Authorization: Bearer $KIMI_API_KEY" -H "Content-Type: application/json" \
  -d '{"model":"kimi-for-coding","max_tokens":20,"messages":[{"role":"user","content":"Hi"}],
       "tools":[{"type":"function","function":{"name":"get_weather","parameters":{
         "type":"object","properties":{"unit":{"enum":["celsius","fahrenheit"]}},
         "required":[]}}}]}'
# -> tools.function.parameters is not a valid moonshot flavored json schema,
#    details: <At path 'properties.unit': type is not defined>

# Patched schema (add "type":"string") -> 200
```

Same MFJS rejection hits all three models on `api.kimi.com/coding/v1` (`kimi-for-coding`, `k3`, `k3-256k`). MiniMax (`api.minimaxi.com`) and JDCloud relays accept the unpatched schema, which is why the bug was not caught earlier against lenient providers.
