### PR TITLE
feat(config): prefer HINDSIGHT_API_TOKEN over HINDSIGHT_API_KEY

### DIFF
--- a/docs-site/src/content/docs/architecture/diagnostics-and-security.md
+++ b/docs-site/src/content/docs/architecture/diagnostics-and-security.md
@@ -30,7 +30,7 @@ Prefer secret references such as:
 ```json
 {
   "hindsight": {
-    "apiKey": { "source": "env", "name": "HINDSIGHT_API_KEY" }
+    "apiKey": { "source": "env", "name": "HINDSIGHT_API_TOKEN" }
   }
 }
 ```

--- a/docs-site/src/content/docs/development/development.md
+++ b/docs-site/src/content/docs/development/development.md
@@ -90,7 +90,7 @@ For memory-path behavior changes, prove the live path with a configured Hindsigh
 
 ```bash
 export HINDSIGHT_BASE_URL=http://localhost:8888
-# export HINDSIGHT_API_KEY=... # if needed
+# export HINDSIGHT_API_TOKEN=... # if needed (or HINDSIGHT_API_KEY)
 npm run smoke:hindsight
 ```
 
@@ -103,7 +103,7 @@ The GitHub `Hindsight Integration` workflow also runs live smoke when configured
 ```bash
 export HINDSIGHT_INTEGRATION_ENABLED=true
 export HINDSIGHT_BASE_URL=http://localhost:8888
-# export HINDSIGHT_API_KEY=... # if needed
+# export HINDSIGHT_API_TOKEN=... # if needed (or HINDSIGHT_API_KEY)
 npm run bench:memory
 ```
 

--- a/docs-site/src/content/docs/development/release.md
+++ b/docs-site/src/content/docs/development/release.md
@@ -24,7 +24,7 @@ For memory-path changes, also prove the live Hindsight path:
 
 ```bash
 export HINDSIGHT_BASE_URL=http://localhost:8888
-# export HINDSIGHT_API_KEY=... # if needed
+# export HINDSIGHT_API_TOKEN=... # if needed (or HINDSIGHT_API_KEY)
 npm run smoke:hindsight
 ```
 
@@ -112,7 +112,7 @@ Required secret when enabled:
 
 Optional secret and variables:
 
-- `HINDSIGHT_API_KEY`
+- `HINDSIGHT_API_TOKEN` (fallback: `HINDSIGHT_API_KEY`)
 - `HINDSIGHT_SMOKE_ATTEMPTS`, default `20`
 - `HINDSIGHT_SMOKE_CLEANUP_TIMEOUT_MS`, default `5000`
 - `PI_HINDSIGHT_SMOKE_BANK_ID`

--- a/docs-site/src/content/docs/guides/run-local-smoke-test.md
+++ b/docs-site/src/content/docs/guides/run-local-smoke-test.md
@@ -18,7 +18,8 @@ export HINDSIGHT_BASE_URL=http://localhost:8888
 If your server needs a key:
 
 ```bash
-export HINDSIGHT_API_KEY=...
+export HINDSIGHT_API_TOKEN=...
+# or: export HINDSIGHT_API_KEY=...
 ```
 
 ## Run smoke
@@ -35,6 +36,6 @@ The GitHub Actions Hindsight Integration workflow can run the smoke path when co
 
 - `HINDSIGHT_INTEGRATION_ENABLED=true`
 - `HINDSIGHT_BASE_URL`
-- optional `HINDSIGHT_API_KEY`
+- optional `HINDSIGHT_API_TOKEN` (fallback: `HINDSIGHT_API_KEY`)
 
 For memory-path pull requests, an unconfigured skip is not proof. Run local smoke, get a configured workflow pass, or document why live proof is unavailable and which lower-level checks reduce risk.

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -20,9 +20,11 @@ Environment variables win the effective value. Project/user stored values can st
 
 ```bash
 export HINDSIGHT_BASE_URL=http://localhost:8888
-export HINDSIGHT_API_KEY=...
+export HINDSIGHT_API_TOKEN=...
+# Legacy fallback still accepted when TOKEN is unset:
+# export HINDSIGHT_API_KEY=...
 # or point config/env at another env var without storing the raw key:
-export HINDSIGHT_API_KEY_REF=HINDSIGHT_API_KEY
+export HINDSIGHT_API_KEY_REF=HINDSIGHT_API_TOKEN
 
 export PI_HINDSIGHT_ENABLED=true
 export PI_HINDSIGHT_PROJECT_BANK_ID=pi-project-my-repo
@@ -39,7 +41,7 @@ Project config SecretRef shape:
 ```json
 {
   "hindsight": {
-    "apiKey": { "source": "env", "name": "HINDSIGHT_API_KEY" }
+    "apiKey": { "source": "env", "name": "HINDSIGHT_API_TOKEN" }
   }
 }
 ```

--- a/docs-site/src/content/docs/start/setup-tui.md
+++ b/docs-site/src/content/docs/start/setup-tui.md
@@ -35,7 +35,7 @@ Rerun guided setup later with `g`.
 
 Guided setup handles:
 
-1. **server health check** — probe configured URL (fallback `http://localhost:8888`); if unreachable and no API key, offer `HINDSIGHT_API_KEY` env setup (restart required if the env is not in this process); if a key is set, offer an alternate Cloud/self-hosted base URL; docs links shown on this screen. Offline continue skips mental models and import.
+1. **server health check** — probe configured URL (fallback `http://localhost:8888`); if unreachable and no API key, offer `HINDSIGHT_API_TOKEN` (or legacy `HINDSIGHT_API_KEY`) env setup (restart required if the env is not in this process); if a key is set, offer an alternate Cloud/self-hosted base URL; docs links shown on this screen. Offline continue skips mental models and import.
 2. memory profile
 3. **agent use** (coding vs conversation)
 4. project and/or user bank target (existing vs create; one-line `Server: … · Bank: …` status). **Shared coding bank** IDs are saved to **user/global** config and prefilled next time (first keystroke replaces the prefill). **Isolated** bank IDs stay project-local.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,9 +18,11 @@ Environment variables win the effective value. Project/user stored values can st
 
 ```bash
 export HINDSIGHT_BASE_URL=http://localhost:8888
-export HINDSIGHT_API_KEY=...
+export HINDSIGHT_API_TOKEN=...
+# Legacy fallback still accepted when TOKEN is unset:
+# export HINDSIGHT_API_KEY=...
 # or point config/env at another env var without storing the raw key:
-export HINDSIGHT_API_KEY_REF=HINDSIGHT_API_KEY
+export HINDSIGHT_API_KEY_REF=HINDSIGHT_API_TOKEN
 
 export PI_HINDSIGHT_ENABLED=true
 export PI_HINDSIGHT_PROJECT_BANK_ID=pi-project-my-repo
@@ -37,7 +39,7 @@ Project config SecretRef shape:
 ```json
 {
   "hindsight": {
-    "apiKey": { "source": "env", "name": "HINDSIGHT_API_KEY" }
+    "apiKey": { "source": "env", "name": "HINDSIGHT_API_TOKEN" }
   }
 }
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -88,7 +88,7 @@ For memory-path behavior changes, prove the live path with a configured Hindsigh
 
 ```bash
 export HINDSIGHT_BASE_URL=http://localhost:8888
-# export HINDSIGHT_API_KEY=... # if needed
+# export HINDSIGHT_API_TOKEN=... # if needed (or HINDSIGHT_API_KEY)
 npm run smoke:hindsight
 ```
 
@@ -101,7 +101,7 @@ The GitHub `Hindsight Integration` workflow also runs live smoke when configured
 ```bash
 export HINDSIGHT_INTEGRATION_ENABLED=true
 export HINDSIGHT_BASE_URL=http://localhost:8888
-# export HINDSIGHT_API_KEY=... # if needed
+# export HINDSIGHT_API_TOKEN=... # if needed (or HINDSIGHT_API_KEY)
 npm run bench:memory
 ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,7 +22,7 @@ For memory-path changes, also prove the live Hindsight path:
 
 ```bash
 export HINDSIGHT_BASE_URL=http://localhost:8888
-# export HINDSIGHT_API_KEY=... # if needed
+# export HINDSIGHT_API_TOKEN=... # if needed (or HINDSIGHT_API_KEY)
 npm run smoke:hindsight
 ```
 
@@ -110,7 +110,7 @@ Required secret when enabled:
 
 Optional secret and variables:
 
-- `HINDSIGHT_API_KEY`
+- `HINDSIGHT_API_TOKEN` (fallback: `HINDSIGHT_API_KEY`)
 - `HINDSIGHT_SMOKE_ATTEMPTS`, default `20`
 - `HINDSIGHT_SMOKE_CLEANUP_TIMEOUT_MS`, default `5000`
 - `PI_HINDSIGHT_SMOKE_BANK_ID`

--- a/extensions/config/config-editing-registry.ts
+++ b/extensions/config/config-editing-registry.ts
@@ -79,7 +79,7 @@ function apiKeySourceLabel(config: ResolvedConfig): string {
   const envName = apiKeyEnvName(config);
   if (envName !== "not set")
     return config.hindsight.apiKey ? `${envName} (resolved)` : `${envName} (missing)`;
-  return config.hindsight.apiKey ? "set directly or HINDSIGHT_API_KEY env" : "not set";
+  return config.hindsight.apiKey ? "set directly or HINDSIGHT_API_TOKEN/KEY env" : "not set";
 }
 
 type BaseConfigEditingField = Omit<
@@ -658,9 +658,13 @@ export function configEnvValues(env: NodeJS.ProcessEnv): Partial<Record<FieldId,
   return {
     ...(env.PI_HINDSIGHT_ENABLED ? { enabled: env.PI_HINDSIGHT_ENABLED } : {}),
     ...(env.HINDSIGHT_BASE_URL ? { baseUrl: env.HINDSIGHT_BASE_URL } : {}),
-    ...(env.HINDSIGHT_API_KEY || env.HINDSIGHT_API_KEY_REF
-      ? { apiKeyEnv: env.HINDSIGHT_API_KEY_REF ?? "HINDSIGHT_API_KEY" }
-      : {}),
+    ...(env.HINDSIGHT_API_KEY_REF
+      ? { apiKeyEnv: env.HINDSIGHT_API_KEY_REF }
+      : env.HINDSIGHT_API_TOKEN
+        ? { apiKeyEnv: "HINDSIGHT_API_TOKEN" }
+        : env.HINDSIGHT_API_KEY
+          ? { apiKeyEnv: "HINDSIGHT_API_KEY" }
+          : {}),
     ...(env.PI_HINDSIGHT_PROJECT_BANK_ID
       ? { projectBankId: env.PI_HINDSIGHT_PROJECT_BANK_ID }
       : {}),
@@ -824,7 +828,7 @@ export function inputDefaultForConfigEditingField(
 ): string {
   switch (fieldId) {
     case "apiKeyEnv":
-      return apiKeyEnvName(config) === "not set" ? "HINDSIGHT_API_KEY" : apiKeyEnvName(config);
+      return apiKeyEnvName(config) === "not set" ? "HINDSIGHT_API_TOKEN" : apiKeyEnvName(config);
     case "apiKeyDirect":
       return "";
     case "projectBankId":

--- a/extensions/config/config.ts
+++ b/extensions/config/config.ts
@@ -141,9 +141,11 @@ export function resolveConfig(cwd: string, env: NodeJS.ProcessEnv = process.env)
     rawConfig = merge(rawConfig, { hindsight: { apiKey: ref } });
     config = merge(config, { hindsight: { apiKey: ref } });
   }
-  if (env.HINDSIGHT_API_KEY) {
-    rawConfig = merge(rawConfig, { hindsight: { apiKey: env.HINDSIGHT_API_KEY } });
-    config = merge(config, { hindsight: { apiKey: env.HINDSIGHT_API_KEY } });
+  // Prefer HINDSIGHT_API_TOKEN; keep HINDSIGHT_API_KEY as legacy fallback.
+  const apiKeyFromEnv = env.HINDSIGHT_API_TOKEN || env.HINDSIGHT_API_KEY;
+  if (apiKeyFromEnv) {
+    rawConfig = merge(rawConfig, { hindsight: { apiKey: apiKeyFromEnv } });
+    config = merge(config, { hindsight: { apiKey: apiKeyFromEnv } });
   }
   if (env.PI_HINDSIGHT_PROJECT_BANK_ID) {
     const patch = {

--- a/extensions/config/config.ts
+++ b/extensions/config/config.ts
@@ -142,7 +142,7 @@ export function resolveConfig(cwd: string, env: NodeJS.ProcessEnv = process.env)
     config = merge(config, { hindsight: { apiKey: ref } });
   }
   // Prefer HINDSIGHT_API_TOKEN; keep HINDSIGHT_API_KEY as legacy fallback.
-  const apiKeyFromEnv = env.HINDSIGHT_API_TOKEN || env.HINDSIGHT_API_KEY;
+  const apiKeyFromEnv = env.HINDSIGHT_API_TOKEN?.trim() || env.HINDSIGHT_API_KEY?.trim();
   if (apiKeyFromEnv) {
     rawConfig = merge(rawConfig, { hindsight: { apiKey: apiKeyFromEnv } });
     config = merge(config, { hindsight: { apiKey: apiKeyFromEnv } });

--- a/extensions/tui/setup-server-probe.ts
+++ b/extensions/tui/setup-server-probe.ts
@@ -73,7 +73,7 @@ export function formatServerProbeFailure(args: {
     ...lines,
     `API key: ${args.hasApiKey ? "resolved" : `not set (${args.apiKeyEnvLabel})`}`,
     "",
-    "Local embed often needs no key. Cloud / locked APIs need HINDSIGHT_API_KEY (or your env name).",
+    "Local embed often needs no key. Cloud / locked APIs need HINDSIGHT_API_TOKEN (or HINDSIGHT_API_KEY / your env name).",
     "Cloud base URL comes from your Hindsight dashboard after signup — not a fixed public URL.",
   ].join("\n");
 }
@@ -224,7 +224,7 @@ export async function ensureServerConnectionForSetup(args: {
     }
 
     const apiKeyEnvLabel =
-      apiKeyEnvName(config) !== "not set" ? apiKeyEnvName(config) : "HINDSIGHT_API_KEY";
+      apiKeyEnvName(config) !== "not set" ? apiKeyEnvName(config) : "HINDSIGHT_API_TOKEN";
     ctx.ui.notify(
       formatServerProbeFailure({
         results: probeAttempts,

--- a/extensions/tui/setup-tui-actions.ts
+++ b/extensions/tui/setup-tui-actions.ts
@@ -184,7 +184,7 @@ export async function handleDeployment(
   if (value === "Hindsight Cloud") {
     const baseUrl = await ctx.ui.input("Hindsight Cloud base URL", config.hindsight.baseUrl);
     if (baseUrl) await writeAndReload(ctx, deps, { baseUrl: baseUrl.trim() });
-    const envName = await ctx.ui.input("API key env var name", "HINDSIGHT_API_KEY");
+    const envName = await ctx.ui.input("API key env var name", "HINDSIGHT_API_TOKEN");
     if (envName) await writeAndReload(ctx, deps, { apiKeyEnvVar: envName.trim() });
   } else if (value === "Existing local/external API") {
     const baseUrl = await ctx.ui.input("Hindsight API base URL", config.hindsight.baseUrl);

--- a/scripts/smoke-helpers.ts
+++ b/scripts/smoke-helpers.ts
@@ -29,7 +29,7 @@ export function smokeConfig(
   now = Date.now(),
 ): SmokeConfig {
   const configuredBankId = envValue("PI_HINDSIGHT_SMOKE_BANK_ID", env);
-  const apiKey = envValue("HINDSIGHT_API_KEY", env);
+  const apiKey = envValue("HINDSIGHT_API_TOKEN", env) ?? envValue("HINDSIGHT_API_KEY", env);
   return {
     baseUrl: envValue("HINDSIGHT_BASE_URL", env) ?? "http://localhost:8888",
     ...(apiKey ? { apiKey } : {}),

--- a/tests/config-editing-model.test.ts
+++ b/tests/config-editing-model.test.ts
@@ -212,7 +212,7 @@ describe("config editing model", () => {
       importToolResultSummaryMaxChars: 250,
     });
     expect(inputDefaultForConfigEditingField("apiKeyEnv", DEFAULT_CONFIG, "bank")).toBe(
-      "HINDSIGHT_API_KEY",
+      "HINDSIGHT_API_TOKEN",
     );
     expect(inputDefaultForConfigEditingField("projectBankId", DEFAULT_CONFIG, "bank")).toBe("bank");
     expect(parseConfigEditingFieldInput({ id: "recallMaxTokens", kind: "positive-int" }, "5")).toBe(

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -143,6 +143,18 @@ describe("resolveConfig", () => {
     });
     expect(override.hindsight.apiKey).toBe("override-secret");
 
+    const tokenPreferred = resolveConfig(cwd, {
+      PROJECT_KEY: "project-secret",
+      HINDSIGHT_API_TOKEN: "token-secret",
+      HINDSIGHT_API_KEY: "key-secret",
+    });
+    expect(tokenPreferred.hindsight.apiKey).toBe("token-secret");
+
+    const keyFallback = resolveConfig(cwd, {
+      HINDSIGHT_API_KEY: "key-only-secret",
+    });
+    expect(keyFallback.hindsight.apiKey).toBe("key-only-secret");
+
     const refFromEnv = resolveConfig(cwd, {
       HINDSIGHT_API_KEY_REF: "OTHER_KEY",
       OTHER_KEY: "other-secret",

--- a/tests/setup-server-probe.test.ts
+++ b/tests/setup-server-probe.test.ts
@@ -55,9 +55,9 @@ describe("setup server probe", () => {
           },
         ],
         hasApiKey: false,
-        apiKeyEnvLabel: "HINDSIGHT_API_KEY",
+        apiKeyEnvLabel: "HINDSIGHT_API_TOKEN",
       }),
-    ).toMatch(/Could not reach|ECONNREFUSED|HINDSIGHT_API_KEY/s);
+    ).toMatch(/Could not reach|ECONNREFUSED|HINDSIGHT_API_TOKEN/s);
   });
 
   it("returns first healthy candidate", async () => {

--- a/tests/smoke-helpers.test.ts
+++ b/tests/smoke-helpers.test.ts
@@ -48,6 +48,15 @@ describe("smoke helpers", () => {
       cleanupTimeoutMs: 5000,
       cleanupOnFailure: true,
     });
+    expect(
+      smokeConfig(
+        {
+          HINDSIGHT_API_TOKEN: " token ",
+          HINDSIGHT_API_KEY: " key ",
+        },
+        1,
+      ).apiKey,
+    ).toBe("token");
   });
 
   it("creates deterministic markers when clock/random are injected", () => {


### PR DESCRIPTION
## Summary
- Prefer `HINDSIGHT_API_TOKEN` for API credential resolution; keep `HINDSIGHT_API_KEY` as legacy fallback
- Default setup/config UI placeholders to `HINDSIGHT_API_TOKEN`
- Smoke helpers accept TOKEN first, then KEY
- Docs updated for the new preferred env var

Closes #553

## Linked issue
#553

## Scope
Config env resolution, setup TUI defaults, smoke helpers, and related docs/tests only.

## Verification
- [x] `npm run check` (docs, format, lint, typecheck, 577 tests)
- [x] Targeted tests: `config`, `config-editing-model`, `setup-server-probe`, `smoke-helpers`

## Release impact
- [x] patch — bugfix / docs / internal (changelog-visible)

## Risk and rollback
Low risk. Existing `HINDSIGHT_API_KEY` setups keep working. Rollback: revert this PR.

## Follow-ups
None.

## Agent checklist
- [x] Linked issue before implementation
- [x] Focused vertical slice
- [x] Conventional Commit subject
- [x] Hooks not bypassed
- [x] Verification recorded
- [x] No drive-by refactors

## Memory invariants
N/A — env var naming only; retain/recall paths unchanged.

## Guidance sync
Docs updated for preferred env var.

## Notes
GitHub Actions secrets can remain `HINDSIGHT_API_KEY`; process env fallback still covers CI.