### PR TITLE
feat: multi-strategy retain + knowledge entity_labels

### DIFF
--- a/docs/memory-behavior.md
+++ b/docs/memory-behavior.md
@@ -130,6 +130,8 @@ The retain projection is controlled by:
 
 Defaults keep user/assistant text, assistant tool calls, tool result errors, and per-message timestamps while excluding recursive Hindsight tool output and noisy read/search results.
 
+Live session retains set the named bank strategy `conversation` (coding project templates define multi-strategy maps: `git`, `gitlog`, `conversation`, `document`, `survey`, plus knowledge `entity_labels` for page routing). Default bank mission text prefers final-state-wins extraction when a conversation amends itself.
+
 Explicit retain tool tags are merged with base `source:pi`, repo, and session tags so manually retained memories remain visible to default project recall.
 
 ## Queue-first durability

--- a/extensions/banks/bank-operations.ts
+++ b/extensions/banks/bank-operations.ts
@@ -4,7 +4,9 @@ const DEFAULT_PROJECT_REFLECT_MISSION =
   "You are a senior developer helping a Pi coding agent. Prefer past technical decisions, architecture trade-offs, conventions, and constraints. Be direct and opinionated when memory supports it; do not invent facts not grounded in memory.";
 
 const DEFAULT_PROJECT_RETAIN_MISSION =
-  "Always extract technical decisions, API/architecture trade-offs, blockers, error resolutions, repo conventions, and durable project-local preferences. Ignore greetings, small talk, scheduling logistics, secrets, probe/bait harness instructions (e.g. temporary 'do not ask questions' test rules), and resurfaced recalled memory unless it adds a new correction or decision.";
+  "Always extract technical decisions, API/architecture trade-offs, blockers, error resolutions, repo conventions, and durable project-local preferences. " +
+  "CRITICAL for conversations: record ONLY the FINAL settled state as what is in effect — when the same rule is amended, keep only the LAST choice; superseded proposals appear only as rejected alternatives, never as active decisions. " +
+  "Ignore greetings, small talk, scheduling logistics, secrets, probe/bait harness instructions (e.g. temporary 'do not ask questions' test rules), and resurfaced recalled memory unless it adds a new correction or decision.";
 
 const DEFAULT_PROJECT_OBSERVATIONS_MISSION =
   "Identify evolving durable project patterns, recurring constraints, architectural preferences, and contradictions with prior knowledge. Focus on stable repo-relevant knowledge — not transient task state, one-off plans, or test-harness noise.";

--- a/extensions/banks/bank-templates.ts
+++ b/extensions/banks/bank-templates.ts
@@ -10,6 +10,7 @@ import {
   resolveBankMissions,
 } from "./bank-operations.js";
 import type { BankMissionDefaults } from "./bank-operations.js";
+import { KNOWLEDGE_ENTITY_LABELS, PI_RETAIN_STRATEGIES } from "./retain-strategies.js";
 import type { AgentUseProfile, BankMissionSettings } from "../types.js";
 
 export type BankTemplateProfileId =
@@ -32,12 +33,26 @@ export interface BuiltInBankTemplate {
   manifest: BankTemplateManifest;
 }
 
-function bankConfigFromMissions(missions: BankMissionDefaults): BankTemplateConfig {
-  return {
+function bankConfigFromMissions(
+  missions: BankMissionDefaults,
+  options?: { codingStrategies?: boolean },
+): BankTemplateConfig {
+  const base: BankTemplateConfig = {
     reflect_mission: missions.reflectMission,
     retain_mission: missions.retainMission,
     enable_observations: true,
     observations_mission: missions.observationsMission,
+  };
+  if (!options?.codingStrategies) return base;
+  // Coding-agents-aligned multi-strategy retain + knowledge entity labels for page routing.
+  // Default strategy is conversation (live Pi sessions); git/gitlog used by opt-in seed paths.
+  return {
+    ...base,
+    retain_extraction_mode: "verbose",
+    retain_default_strategy: "conversation",
+    retain_strategies: { ...PI_RETAIN_STRATEGIES },
+    entity_labels: [KNOWLEDGE_ENTITY_LABELS],
+    entities_allow_free_form: true,
   };
 }
 
@@ -215,7 +230,7 @@ export const BUILT_IN_BANK_TEMPLATES: readonly BuiltInBankTemplate[] = [
     description: "Repo-focused mental models for architecture, conventions, and durable decisions.",
     manifest: {
       version: "1",
-      bank: bankConfigFromMissions(defaultProjectBankMissions()),
+      bank: bankConfigFromMissions(defaultProjectBankMissions(), { codingStrategies: true }),
       mental_models: CODING_PROJECT_MENTAL_MODELS,
     },
   },
@@ -342,10 +357,11 @@ export function resolveBankTemplateManifest(
     const bankGlobal = bankGlobalMentalModelsForTemplate(template.id);
     mental_models = bankGlobal.length > 0 ? [...bankGlobal, ...stamped] : stamped;
   }
+  const codingStrategies = template.id === "pi-coding-project";
   return {
     ...template.manifest,
     ...(mental_models ? { mental_models } : {}),
-    bank: bankConfigFromMissions(missions),
+    bank: bankConfigFromMissions(missions, { codingStrategies }),
   };
 }
 

--- a/extensions/banks/retain-strategies.ts
+++ b/extensions/banks/retain-strategies.ts
@@ -1,0 +1,171 @@
+/**
+ * Named retain strategies and knowledge entity-label taxonomy.
+ *
+ * Aligned with @vectorize-io/hindsight-coding-agents bank-template practices, adapted for Pi:
+ * default strategy is conversation (live Pi sessions), not git.
+ * Pages are seeded separately (knowledge-base API) — not as bare mental_models in the template.
+ */
+
+/** Per-strategy retain config accepted by BankTemplateConfig.retain_strategies. */
+export type RetainStrategyConfig = {
+  retain_mission?: string;
+  retain_extraction_mode?: string;
+  retain_chunk_size?: number;
+  retain_custom_instructions?: string;
+};
+
+export const GIT_RETAIN_MISSION =
+  "You are ingesting a single git commit: its message and its full diff. Extract the concrete " +
+  "technical DECISION and the CAUSE/INVARIANT it encodes, bound to the specific code entities " +
+  "(functions, methods, files) and behaviors it changes. Preserve exact identifiers, paths, and " +
+  "literal values verbatim. Capture both WHAT changed and WHY. Issue/PR references (#123, GH-123) " +
+  "are load-bearing: keep them VERBATIM in the fact text and emit each as an ENTITY.";
+
+export const GITLOG_RETAIN_MISSION =
+  "You are ingesting an aggregated block of git commit MESSAGES ONLY (no diffs) — the project's " +
+  "recent commit-message history, newest first. Extract the project's INITIATIVES, FEATURES, " +
+  "ENHANCEMENTS, and notable themes over time. Do NOT extract per-line code detail. Group related " +
+  "commits into a coherent initiative/theme where messages make that clear; preserve exact " +
+  "identifiers and issue/PR references VERBATIM and emit each as an ENTITY.";
+
+export const CONVERSATION_RETAIN_MISSION =
+  "You are ingesting a developer conversation as a JSONL transcript (one {role, content} turn per line): the " +
+  "user's requests, the assistant's narration, and compact tool-action turns (name + target only). " +
+  "It may be a SHORT decision chat or a LONG working session — scale facts to the substance, never " +
+  "to the message count. Extract the FEWEST facts that capture the OUTCOME: settled DECISIONS and " +
+  "their exact rules/values (quote literals VERBATIM); concrete CHANGES to specific code entities; " +
+  "problems and how they were resolved; conventions or invariants established; at most one fact for " +
+  "a notable REJECTED alternative. CRITICAL: a conversation REVISES itself — record ONLY the FINAL " +
+  "state as what is in effect; a superseded proposal appears ONLY inside the rejected fact, NEVER as " +
+  "its own 'decided' fact; if the same setting changes several times keep only the LAST. Do NOT emit " +
+  "one fact per message or per intermediate proposal. Keep issue/PR references VERBATIM and emit each " +
+  "as an ENTITY. Do not invent; capture only what was actually settled.";
+
+export const DOCUMENT_RETAIN_MISSION =
+  "You are ingesting a standalone document (notes, docs, or structural findings). Extract the " +
+  "concrete facts, concepts, and structure it describes. Preserve identifiers and paths verbatim.";
+
+export const PI_RETAIN_STRATEGIES: Record<string, RetainStrategyConfig> = {
+  git: {
+    retain_mission: GIT_RETAIN_MISSION,
+    retain_extraction_mode: "verbose",
+  },
+  gitlog: {
+    retain_mission: GITLOG_RETAIN_MISSION,
+    retain_extraction_mode: "verbose",
+    retain_chunk_size: 12_000,
+  },
+  conversation: {
+    retain_mission: CONVERSATION_RETAIN_MISSION,
+    retain_extraction_mode: "verbose",
+    retain_chunk_size: 12_000,
+  },
+  document: {
+    retain_mission: DOCUMENT_RETAIN_MISSION,
+    retain_extraction_mode: "verbose",
+    retain_chunk_size: 12_000,
+  },
+  survey: {
+    retain_extraction_mode: "custom",
+    retain_custom_instructions:
+      "This document belongs to a Hindsight codebase-survey lifecycle. Apply ONE of two rules: " +
+      "(1) If the content is an internal status marker — it says it is an internal marker, or " +
+      "merely announces that a survey started/completed — extract NOTHING: return an empty list of facts. " +
+      "(2) Otherwise the content is survey FINDINGS: extract concrete structural facts (components, " +
+      "responsibilities, conventions, tech stack), preserving identifiers verbatim.",
+    retain_chunk_size: 12_000,
+  },
+};
+
+/** Fixed knowledge-tier entity labels (tag: true → knowledge:<value> on facts). */
+export const KNOWLEDGE_ENTITY_LABELS = {
+  key: "knowledge",
+  type: "multi-values" as const,
+  optional: true,
+  tag: true,
+  description:
+    "Routing labels for this project's Hindsight KNOWLEDGE PAGES — curated summaries of durable " +
+    "engineering knowledge. Mark a fact only when it is durable, reusable knowledge a developer " +
+    "would still want in future sessions. Leave EMPTY for routine or transient facts. MOST facts " +
+    "should get no label here.",
+  values: [
+    {
+      value: "feature-work",
+      description:
+        "A new feature, initiative, or enhancement being planned or built — not routine bug-fixes.",
+    },
+    {
+      value: "decision",
+      description: "A technical decision that will constrain future work, with its rationale.",
+    },
+    {
+      value: "convention",
+      description:
+        "An established way this project does things — naming, structure, testing, or patterns.",
+    },
+    {
+      value: "component",
+      description:
+        "What a module, file, service, or subsystem is responsible for, or how components relate.",
+    },
+    {
+      value: "concept",
+      description:
+        "A domain concept, key abstraction, or project vocabulary a contributor must understand.",
+    },
+  ],
+} as const;
+
+/** Seed taxonomy for knowledge pages (used by knowledge seed path; not bare mental models). */
+export interface KnowledgePageSeed {
+  name: string;
+  source_query: string;
+  tags: string[];
+}
+
+export const KNOWLEDGE_PAGE_SEEDS: readonly KnowledgePageSeed[] = [
+  {
+    name: "Component map",
+    source_query:
+      "From this project's commit history and past discussions, what are the main " +
+      "components/modules/subsystems, what is each responsible for, and how do they relate?",
+    tags: ["knowledge:component"],
+  },
+  {
+    name: "Core concepts",
+    source_query:
+      "What are the core concepts, domain abstractions, and key entities in this project — " +
+      "the vocabulary a developer must understand?",
+    tags: ["knowledge:concept"],
+  },
+  {
+    name: "Conventions and patterns",
+    source_query:
+      "What conventions, idioms, and recurring patterns does this project follow — testing, " +
+      "error handling, naming, structure, and how changes are typically made?",
+    tags: ["knowledge:convention"],
+  },
+  {
+    name: "Key decisions and rationale",
+    source_query:
+      "What are the significant technical decisions made in this project and the rationale " +
+      "behind them — the durable 'why we do it this way' a developer should know?",
+    tags: ["knowledge:decision"],
+  },
+  {
+    name: "Initiatives and enhancements",
+    source_query:
+      "Based on this repository's history and discussions, what are the major initiatives, " +
+      "features, and enhancements the project has worked on? Summarize themes over time.",
+    tags: ["knowledge:feature-work"],
+  },
+] as const;
+
+export const KNOWLEDGE_PAGE_MAX_TOKENS = 4096;
+export const KNOWLEDGE_PAGE_TRIGGER = {
+  fact_types: ["world", "experience", "observation"] as const,
+  refresh_after_consolidation: true,
+};
+
+/** Default strategy for live Pi session retains. */
+export const LIVE_SESSION_RETAIN_STRATEGY = "conversation" as const;

--- a/extensions/banks/retain-strategies.ts
+++ b/extensions/banks/retain-strategies.ts
@@ -78,9 +78,16 @@ export const PI_RETAIN_STRATEGIES: Record<string, RetainStrategyConfig> = {
 };
 
 /** Fixed knowledge-tier entity labels (tag: true → knowledge:<value> on facts). */
-export const KNOWLEDGE_ENTITY_LABELS = {
+export const KNOWLEDGE_ENTITY_LABELS: {
+  key: string;
+  type: "multi-values";
+  optional: boolean;
+  tag: boolean;
+  description: string;
+  values: Array<{ value: string; description: string }>;
+} = {
   key: "knowledge",
-  type: "multi-values" as const,
+  type: "multi-values",
   optional: true,
   tag: true,
   description:
@@ -114,7 +121,7 @@ export const KNOWLEDGE_ENTITY_LABELS = {
         "A domain concept, key abstraction, or project vocabulary a contributor must understand.",
     },
   ],
-} as const;
+};
 
 /** Seed taxonomy for knowledge pages (used by knowledge seed path; not bare mental models). */
 export interface KnowledgePageSeed {

--- a/extensions/client/client.ts
+++ b/extensions/client/client.ts
@@ -99,6 +99,7 @@ function retainBatchItem(content: string, options: RetainOptions) {
       ? { observation_scopes: options.observationScopes }
       : {}),
     ...(options?.updateMode ? { update_mode: options.updateMode } : {}),
+    ...(options?.strategy ? { strategy: options.strategy } : {}),
   };
 }
 

--- a/extensions/lifecycle/retain-job-builder.ts
+++ b/extensions/lifecycle/retain-job-builder.ts
@@ -21,6 +21,8 @@ export interface RetainJobBuildArgs {
   documentTags?: string[];
   entities?: RetainJob["item"]["entities"];
   async?: boolean;
+  /** Named bank retain strategy (e.g. conversation, gitlog). Overrides bank default for this item. */
+  strategy?: string;
 }
 
 function sanitizedMetadata(
@@ -57,6 +59,7 @@ export function buildRetainJob(args: RetainJobBuildArgs): RetainJob {
       ...(metadata ? { metadata } : {}),
       ...(args.observationScopes?.length ? { observationScopes: args.observationScopes } : {}),
       ...(args.documentTags?.length ? { documentTags: args.documentTags } : {}),
+      ...(args.strategy ? { strategy: args.strategy } : {}),
     },
     retries: 0,
   };

--- a/extensions/lifecycle/retain.ts
+++ b/extensions/lifecycle/retain.ts
@@ -21,6 +21,7 @@ import {
   type FlushRetainQueueResult,
 } from "../queue/queue.js";
 import { createMemoryIdentity } from "../operations/memory-identity.js";
+import { LIVE_SESSION_RETAIN_STRATEGY } from "../banks/retain-strategies.js";
 import { expandObservationScopes } from "./observation-scopes.js";
 import { buildRetainJob as buildRetainJobCore } from "./retain-job-builder.js";
 import { appendRetainReceipts } from "./retain-receipts.js";
@@ -88,6 +89,8 @@ export function buildRetainJob(args: {
       ...(args.sessionFile ? { pi_session_file: args.sessionFile } : {}),
     },
     ...(observationScopes.length ? { observationScopes } : {}),
+    // Coding bank templates define named strategies; live sessions use conversation.
+    strategy: LIVE_SESSION_RETAIN_STRATEGY,
   });
 }
 

--- a/extensions/queue/queue-delivery.ts
+++ b/extensions/queue/queue-delivery.ts
@@ -49,6 +49,7 @@ export function retainOptionsForJob(job: RetainJob) {
     ...(job.item.tags ? { tags: job.item.tags } : {}),
     ...(job.item.observationScopes ? { observationScopes: job.item.observationScopes } : {}),
     ...(job.item.documentTags ? { documentTags: job.item.documentTags } : {}),
+    ...(job.item.strategy ? { strategy: job.item.strategy } : {}),
     documentId: job.documentId,
     updateMode: job.updateMode,
   };

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -274,6 +274,8 @@ export interface RetainJob {
     observationScopes?: HindsightObservationScopes;
     documentTags?: string[];
     entities?: HindsightEntityInput[];
+    /** Named bank retain strategy (conversation, git, gitlog, document, survey). */
+    strategy?: string;
   };
   retries: number;
   lastError?: string;
@@ -305,6 +307,8 @@ export interface HindsightLikeClient {
       tags?: string[];
       updateMode?: UpdateMode;
       observationScopes?: HindsightObservationScopes;
+      /** Named bank retain strategy override for this item. */
+      strategy?: string;
       signal?: AbortSignal;
     },
   ): Promise<unknown>;
@@ -320,6 +324,7 @@ export interface HindsightLikeClient {
       tags?: string[];
       observation_scopes?: HindsightObservationScopes;
       update_mode?: UpdateMode;
+      strategy?: string;
     }>,
     options?: {
       documentId?: string;

--- a/tests/bank-templates.test.ts
+++ b/tests/bank-templates.test.ts
@@ -41,6 +41,27 @@ describe("bank templates", () => {
     });
   });
 
+  it("seats multi-strategy retain and knowledge entity_labels on the coding project template", () => {
+    const template = getBuiltInBankTemplate("pi-coding-project");
+    const bank = template?.manifest.bank;
+    expect(bank?.retain_default_strategy).toBe("conversation");
+    expect(bank?.retain_extraction_mode).toBe("verbose");
+    expect(bank?.entities_allow_free_form).toBe(true);
+    expect(bank?.retain_strategies).toMatchObject({
+      git: expect.objectContaining({ retain_extraction_mode: "verbose" }),
+      gitlog: expect.objectContaining({ retain_chunk_size: 12_000 }),
+      conversation: expect.objectContaining({ retain_chunk_size: 12_000 }),
+      document: expect.objectContaining({ retain_extraction_mode: "verbose" }),
+      survey: expect.objectContaining({ retain_extraction_mode: "custom" }),
+    });
+    const labels = bank?.entity_labels as Array<{ key?: string; tag?: boolean }> | undefined;
+    expect(labels?.[0]).toMatchObject({ key: "knowledge", tag: true });
+    // Non-coding project templates stay strategy-light.
+    const conversation = getBuiltInBankTemplate("pi-conversation-project");
+    expect(conversation?.manifest.bank?.retain_strategies).toBeUndefined();
+    expect(conversation?.manifest.bank?.entity_labels).toBeUndefined();
+  });
+
   it("matches Pi's own default user-bank missions for the coding user template", () => {
     const template = getBuiltInBankTemplate("pi-coding-user");
     const defaults = defaultGlobalBankMissions();

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -115,6 +115,7 @@ describe("retain queue", () => {
           entities: [{ text: "entity", type: "thing" }],
           observationScopes: [["repo:abc"]],
           documentTags: ["doc:test"],
+          strategy: "conversation",
         },
       }),
     ).toMatchObject({
@@ -127,6 +128,7 @@ describe("retain queue", () => {
       tags: ["source:pi"],
       observationScopes: [["repo:abc"]],
       documentTags: ["doc:test"],
+      strategy: "conversation",
       documentId: "doc",
       updateMode: "append",
     });

--- a/tests/retain.test.ts
+++ b/tests/retain.test.ts
@@ -30,6 +30,7 @@ describe("buildRetainJob", () => {
     expect(job?.documentId).toMatch(/^pi-session:/);
     expect(job?.item.context).toContain("Pi coding session");
     expect(job?.item.async).toBe(true);
+    expect(job?.item.strategy).toBe("conversation");
     expect(job?.item.content).not.toContain("API_KEY=secret");
     const retained = JSON.parse(job?.item.content ?? "[]") as Array<Record<string, unknown>>;
     expect(retained[0]?.role).toBe("user");


### PR DESCRIPTION
## Summary

Align coding bank templates with coding-agents bank-config practices: named retain strategies (git/gitlog/conversation/document/survey), knowledge entity_labels for page routing, and conversation strategy on live session retains.

## Linked issue

- Closes #558
- Epic #557
- Stack: depends on #563

## Scope

- `extensions/banks/retain-strategies.ts` strategy map + knowledge labels
- `pi-coding-project` template: multi-strategy + entity_labels
- Live retain jobs set strategy `conversation`
- Final-state-wins language in project retain mission

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Skipped full matrix/live smoke for stacked layer; unit tests cover template shape and job strategy. Live proof: apply coding template against Hindsight 0.8+ when available.

## Release impact

- [x] User-visible change

Coding project template import applies multi-strategy bank config; live retains carry strategy conversation.

## Risk and rollback

- Risk: older servers may ignore unknown strategy fields; default bank mission still applies.
- Rollback/revert path: revert PR; re-import prior template.

## Follow-ups

- #565 knowledge page seed (next stack layer)

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Does not change ADR-005 domain-tagged banks or append+cursor retain.