### PR TITLE
feat: opt-in gitlog seed and sync readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ Required:
 
 Agent control plane (selected banks only; ADR-005):
 
-- `hindsight_status`, `hindsight_scope`, `hindsight_config` (allowlisted get/patch; no raw secrets), `hindsight_bank`, `hindsight_mental_model`, `hindsight_knowledge`
+- `hindsight_status`, `hindsight_seed_git` (opt-in gitlog seed), `hindsight_scope`, `hindsight_config` (allowlisted get/patch; no raw secrets), `hindsight_bank`, `hindsight_mental_model`, `hindsight_knowledge`
 - `hindsight_scope_migrate` (dry-run dual-tag / legacy guidance + local receipt; never silent rewrite)
 
 Human surface (thin TUI):

--- a/docs-site/src/content/docs/reference/surface-reference.md
+++ b/docs-site/src/content/docs/reference/surface-reference.md
@@ -17,6 +17,7 @@ Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi w
 | `hindsight_retain_global` | core 1.0             |
 | `hindsight_reflect`       | core 1.0             |
 | `hindsight_status`        | supported 1.0        |
+| `hindsight_seed_git`      | supported 1.0        |
 | `hindsight_scope`         | supported 1.0        |
 | `hindsight_config`        | supported 1.0        |
 | `hindsight_bank`          | supported 1.0        |
@@ -122,10 +123,20 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 
 ### `hindsight_status`
 
-Inspect Pi Hindsight status: setup gate, coding/life banks, project scope tags (basis), recall/retain flags, queue. Use before changing memory config. Read-only.
+Inspect Pi Hindsight status: setup gate, coding/life banks, project scope tags (basis), recall/retain flags, queue, and sync readiness (queue depth, git seed receipt, knowledge-page capability). Use before changing memory config. Read-only.
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
+
+### `hindsight_seed_git`
+
+Opt-in cold-repo seed: retain recent git commit messages (strategy gitlog) into the project bank. Not automatic — conversation retain remains primary. dryRun defaults true; set dryRun=false to enqueue (and flush by default).
+
+| Parameter | Type    | Required | Description                                                      |
+| --------- | ------- | -------- | ---------------------------------------------------------------- |
+| `limit`   | integer | no       | Max commits to include (default 300).                            |
+| `dryRun`  | boolean | no       | Default true (preview). Set false to enqueue retain.             |
+| `flush`   | boolean | no       | When dryRun=false, flush the queue after enqueue (default true). |
 
 ### `hindsight_scope`
 

--- a/docs/memory-behavior.md
+++ b/docs/memory-behavior.md
@@ -134,6 +134,8 @@ Live session retains set the named bank strategy `conversation` (coding project 
 
 Applying the `pi-coding-project` bank template (or `hindsight_knowledge` action `seed_taxonomy`) idempotently seeds a fixed five-page knowledge taxonomy tagged `knowledge:component|concept|convention|decision|feature-work`. When the client/server lacks knowledge-base APIs, seeding returns `knowledge_pages_unavailable` and does not fail template apply.
 
+Opt-in cold-repo git seed: `hindsight_seed_git` retains recent commit messages (strategy `gitlog`, stable `pi-gitlog:<head>` document ids) without replacing live session retain. It is never automatic on session start. `hindsight_status` and doctor include a `sync` readiness block (queue depth, git seed receipt, knowledge-page capability).
+
 Explicit retain tool tags are merged with base `source:pi`, repo, and session tags so manually retained memories remain visible to default project recall.
 
 ## Queue-first durability

--- a/docs/surface-reference.md
+++ b/docs/surface-reference.md
@@ -13,6 +13,7 @@ Pi Hindsight 1.0 supports a stable Pi-first Hindsight integration. Core and Pi w
 | `hindsight_retain_global` | core 1.0             |
 | `hindsight_reflect`       | core 1.0             |
 | `hindsight_status`        | supported 1.0        |
+| `hindsight_seed_git`      | supported 1.0        |
 | `hindsight_scope`         | supported 1.0        |
 | `hindsight_config`        | supported 1.0        |
 | `hindsight_bank`          | supported 1.0        |
@@ -118,10 +119,20 @@ Ask Hindsight to synthesize an answer from memory. Use explicitly, not for defau
 
 ### `hindsight_status`
 
-Inspect Pi Hindsight status: setup gate, coding/life banks, project scope tags (basis), recall/retain flags, queue. Use before changing memory config. Read-only.
+Inspect Pi Hindsight status: setup gate, coding/life banks, project scope tags (basis), recall/retain flags, queue, and sync readiness (queue depth, git seed receipt, knowledge-page capability). Use before changing memory config. Read-only.
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
+
+### `hindsight_seed_git`
+
+Opt-in cold-repo seed: retain recent git commit messages (strategy gitlog) into the project bank. Not automatic — conversation retain remains primary. dryRun defaults true; set dryRun=false to enqueue (and flush by default).
+
+| Parameter | Type    | Required | Description                                                      |
+| --------- | ------- | -------- | ---------------------------------------------------------------- |
+| `limit`   | integer | no       | Max commits to include (default 300).                            |
+| `dryRun`  | boolean | no       | Default true (preview). Set false to enqueue retain.             |
+| `flush`   | boolean | no       | When dryRun=false, flush the queue after enqueue (default true). |
 
 ### `hindsight_scope`
 

--- a/extensions/lifecycle/git-seed.ts
+++ b/extensions/lifecycle/git-seed.ts
@@ -1,0 +1,319 @@
+/**
+ * Opt-in cold-repo gitlog seed (coding-agents-aligned, Pi-native).
+ *
+ * Seeds an aggregated commit-message history document (strategy gitlog) with a stable
+ * document id for idempotent re-runs. Does not replace live session retain; default off
+ * (explicit tool/command only — no session-start auto-seed).
+ */
+import { execFile } from "node:child_process";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import type { HindsightLikeClient, ResolvedConfig, RetainJob } from "../types.js";
+import { baseTags } from "../banks/banking.js";
+import { createMemoryIdentity } from "../operations/memory-identity.js";
+import { buildRetainJob } from "./retain-job-builder.js";
+import { enqueueRetain, flushRetain, retainQueuePath } from "../queue/queue.js";
+import { recordRetainDeliveries } from "./retain.js";
+
+const execFileAsync = promisify(execFile);
+
+export const DEFAULT_GIT_SEED_LIMIT = 300;
+export const GIT_SEED_RECEIPT_PATH = ".pi/hindsight/git-seed-receipt.json";
+
+export interface GitSeedReceipt {
+  bankId: string;
+  documentId: string;
+  headSha: string;
+  commitCount: number;
+  seededAt: string;
+  dryRun?: boolean;
+}
+
+export interface CollectGitLogArgs {
+  cwd: string;
+  limit?: number;
+  /** Injectable for tests. */
+  execGit?: (args: string[], cwd: string) => Promise<string>;
+}
+
+export interface CollectGitLogResult {
+  headSha: string;
+  commitCount: number;
+  content: string;
+  documentId: string;
+}
+
+async function defaultExecGit(args: string[], cwd: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, {
+    cwd,
+    maxBuffer: 8 * 1024 * 1024,
+    encoding: "utf8",
+  });
+  return stdout;
+}
+
+/** Collect newest-first commit subjects for gitlog strategy retain. */
+export async function collectGitLogForSeed(
+  args: CollectGitLogArgs,
+): Promise<CollectGitLogResult | { error: string }> {
+  const limit = Math.max(1, Math.min(args.limit ?? DEFAULT_GIT_SEED_LIMIT, 2000));
+  const execGit = args.execGit ?? defaultExecGit;
+  try {
+    const headSha = (await execGit(["rev-parse", "HEAD"], args.cwd)).trim();
+    if (!/^[0-9a-f]{7,40}$/i.test(headSha)) {
+      return { error: "Could not resolve git HEAD" };
+    }
+    const log = await execGit(["log", `-n${limit}`, "--format=%H%x09%s", "--no-merges"], args.cwd);
+    const lines = log
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+    if (lines.length === 0) {
+      return { error: "No commits found for git seed" };
+    }
+    const subjects = lines.map((line) => {
+      const tab = line.indexOf("\t");
+      if (tab === -1) return line;
+      const sha = line.slice(0, tab).slice(0, 12);
+      const subject = line.slice(tab + 1);
+      return `${sha} ${subject}`;
+    });
+    const content = [
+      `# Git commit message history (newest first, limit ${limit})`,
+      "",
+      ...subjects,
+    ].join("\n");
+    return {
+      headSha,
+      commitCount: subjects.length,
+      content,
+      // Stable id per project head so re-seed at same HEAD is idempotent; new HEAD creates a new doc.
+      documentId: `pi-gitlog:${headSha.slice(0, 12)}`,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { error: message.includes("not a git") ? "Not a git repository" : message };
+  }
+}
+
+export function resolveGitSeedReceiptPath(cwd: string): string {
+  return join(cwd, GIT_SEED_RECEIPT_PATH);
+}
+
+export async function readGitSeedReceipt(cwd: string): Promise<GitSeedReceipt | null> {
+  try {
+    const raw = await readFile(resolveGitSeedReceiptPath(cwd), "utf8");
+    const parsed = JSON.parse(raw) as GitSeedReceipt;
+    if (!parsed || typeof parsed.headSha !== "string") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeGitSeedReceipt(cwd: string, receipt: GitSeedReceipt): Promise<void> {
+  const path = resolveGitSeedReceiptPath(cwd);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(receipt, null, 2)}\n`, "utf8");
+}
+
+export function buildGitLogRetainJob(args: {
+  config: ResolvedConfig;
+  cwd: string;
+  bankId: string;
+  content: string;
+  documentId: string;
+  headSha: string;
+}): RetainJob {
+  const identity = createMemoryIdentity(args.cwd, args.config);
+  const tags = [...baseTags(args.cwd, "git-seed", args.config), "source:git", "strategy:gitlog"];
+  return buildRetainJob({
+    config: args.config,
+    bankId: args.bankId,
+    content: args.content,
+    context: `Git commit-message seed for ${identity.projectId} (HEAD ${args.headSha.slice(0, 12)})`,
+    documentId: args.documentId,
+    // Full snapshot of the limited log window — replace keeps one doc per HEAD id.
+    updateMode: "replace",
+    tags: [...new Set(tags)],
+    metadata: {
+      cwd: args.cwd,
+      imported: "true",
+      seed: "gitlog",
+      head_sha: args.headSha,
+    },
+    strategy: "gitlog",
+  });
+}
+
+export interface SeedGitLogArgs {
+  cwd: string;
+  bankId: string;
+  config: ResolvedConfig;
+  client: HindsightLikeClient;
+  limit?: number;
+  dryRun?: boolean;
+  flush?: boolean;
+  execGit?: CollectGitLogArgs["execGit"];
+}
+
+export interface SeedGitLogResult {
+  dryRun: boolean;
+  bankId: string;
+  ok: boolean;
+  error?: string;
+  documentId?: string;
+  headSha?: string;
+  commitCount?: number;
+  queued?: boolean;
+  flushed?: number;
+  receipt?: GitSeedReceipt;
+}
+
+/** Opt-in gitlog seed: queue a retain job (and optionally flush). */
+export async function seedGitLog(args: SeedGitLogArgs): Promise<SeedGitLogResult> {
+  const dryRun = args.dryRun ?? true;
+  const collectArgs: CollectGitLogArgs = {
+    cwd: args.cwd,
+    ...(args.limit !== undefined ? { limit: args.limit } : {}),
+    ...(args.execGit ? { execGit: args.execGit } : {}),
+  };
+  const collected = await collectGitLogForSeed(collectArgs);
+  if ("error" in collected) {
+    return { dryRun, bankId: args.bankId, ok: false, error: collected.error };
+  }
+
+  const receipt: GitSeedReceipt = {
+    bankId: args.bankId,
+    documentId: collected.documentId,
+    headSha: collected.headSha,
+    commitCount: collected.commitCount,
+    seededAt: new Date().toISOString(),
+    ...(dryRun ? { dryRun: true } : {}),
+  };
+
+  if (dryRun) {
+    return {
+      dryRun: true,
+      bankId: args.bankId,
+      ok: true,
+      documentId: collected.documentId,
+      headSha: collected.headSha,
+      commitCount: collected.commitCount,
+      receipt,
+    };
+  }
+
+  const job = buildGitLogRetainJob({
+    config: args.config,
+    cwd: args.cwd,
+    bankId: args.bankId,
+    content: collected.content,
+    documentId: collected.documentId,
+    headSha: collected.headSha,
+  });
+  await enqueueRetain(args.cwd, args.config, job);
+  let flushed = 0;
+  if (args.flush !== false) {
+    const result = await flushRetain(args.cwd, args.config, args.client, {
+      maxJobs: 1,
+    });
+    await recordRetainDeliveries(args.cwd, args.config, result);
+    flushed = result.sent;
+  }
+  await writeGitSeedReceipt(args.cwd, receipt);
+  return {
+    dryRun: false,
+    bankId: args.bankId,
+    ok: true,
+    documentId: collected.documentId,
+    headSha: collected.headSha,
+    commitCount: collected.commitCount,
+    queued: true,
+    flushed,
+    receipt,
+  };
+}
+
+export interface SyncStatus {
+  ready: boolean;
+  reasons: string[];
+  queue: {
+    path: string;
+    active: number;
+    deadLetter: number;
+    malformed: number;
+  };
+  gitSeed: {
+    receipt: GitSeedReceipt | null;
+    /** True when receipt HEAD matches current git HEAD (when resolvable). */
+    headMatches?: boolean;
+    currentHead?: string;
+  };
+  knowledgePages: "unknown" | "supported" | "unavailable";
+}
+
+export async function buildSyncStatus(args: {
+  cwd: string;
+  config: ResolvedConfig;
+  client: HindsightLikeClient;
+  bankId: string;
+  execGit?: CollectGitLogArgs["execGit"];
+}): Promise<SyncStatus> {
+  const { summarizeRetainQueue } = await import("../queue/queue.js");
+  const queueSummary = await summarizeRetainQueue(retainQueuePath(args.cwd, args.config));
+  const receipt = await readGitSeedReceipt(args.cwd);
+  const reasons: string[] = [];
+
+  let currentHead: string | undefined;
+  let headMatches: boolean | undefined;
+  try {
+    const execGit = args.execGit ?? defaultExecGit;
+    currentHead = (await execGit(["rev-parse", "HEAD"], args.cwd)).trim();
+    if (receipt) {
+      headMatches = receipt.headSha === currentHead;
+      if (!headMatches) reasons.push("git_seed_stale");
+    } else {
+      reasons.push("git_seed_missing");
+    }
+  } catch {
+    // Not a git repo — seed is N/A, not a readiness failure for chat-only memory.
+    headMatches = undefined;
+  }
+
+  if (queueSummary.active.valid > 0) reasons.push("queue_pending");
+  if (queueSummary.deadLetter.valid > 0) reasons.push("queue_dead_letter");
+
+  let knowledgePages: SyncStatus["knowledgePages"] = "unknown";
+  if (!args.client.getKnowledgeBaseTree && !args.client.createKnowledgePage) {
+    knowledgePages = "unavailable";
+  } else if (args.client.getKnowledgeBaseTree) {
+    try {
+      await args.client.getKnowledgeBaseTree(args.bankId);
+      knowledgePages = "supported";
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      knowledgePages = /\b404\b|\b405\b|\b501\b|not found|unavail/i.test(msg)
+        ? "unavailable"
+        : "unknown";
+    }
+  }
+
+  return {
+    ready: reasons.length === 0,
+    reasons,
+    queue: {
+      path: queueSummary.active.path,
+      active: queueSummary.active.valid,
+      deadLetter: queueSummary.deadLetter.valid,
+      malformed: queueSummary.active.malformed,
+    },
+    gitSeed: {
+      receipt,
+      ...(headMatches !== undefined ? { headMatches } : {}),
+      ...(currentHead ? { currentHead } : {}),
+    },
+    knowledgePages,
+  };
+}

--- a/extensions/operations/memory-control-operations.ts
+++ b/extensions/operations/memory-control-operations.ts
@@ -169,17 +169,25 @@ function clientMethod<K extends keyof HindsightLikeClient>(
 
 export function createControlOperations(deps: MemoryOperationsDeps) {
   return {
-    status(cwd: string) {
+    async status(cwd: string) {
       const config = deps.getConfig();
       const fields = buildStatusFields(config, {
         cwd,
         projectBankId: deps.getProjectBankId(),
+      });
+      const { buildSyncStatus } = await import("../lifecycle/git-seed.js");
+      const sync = await buildSyncStatus({
+        cwd,
+        config,
+        client: deps.getClient(),
+        bankId: deps.getProjectBankId(),
       });
       return {
         setupComplete: isMemorySetupComplete(config, cwd),
         ...(isMemorySetupComplete(config, cwd) ? {} : { setupHint: setupRequiredMessage() }),
         project: resolveProjectIdentity(cwd, config),
         fields,
+        sync,
       };
     },
 

--- a/extensions/operations/memory-diagnostics-operations.ts
+++ b/extensions/operations/memory-diagnostics-operations.ts
@@ -6,6 +6,7 @@ import {
   readImportManifestSafe,
   resolveImportManifestPath,
 } from "../imports/import-plan.js";
+import { buildSyncStatus, DEFAULT_GIT_SEED_LIMIT, seedGitLog } from "../lifecycle/git-seed.js";
 import type { MemoryOperationsDeps } from "./memory-operation-types.js";
 import {
   buildScopeMigratePlan,
@@ -19,10 +20,16 @@ export function createDiagnosticsOperations(deps: MemoryOperationsDeps) {
       const config = deps.getConfig();
       const projectBankId = deps.getProjectBankId();
       const manifestPath = resolveImportManifestPath(cwd, config.import.manifestPath);
-      const [health, queueSummary, manifestResult] = await Promise.all([
+      const [health, queueSummary, manifestResult, sync] = await Promise.all([
         checkHindsight(deps.getClient(), projectBankId),
         summarizeRetainQueue(resolveQueuePath(cwd, config.retain.queuePath)),
         readImportManifestSafe(manifestPath),
+        buildSyncStatus({
+          cwd,
+          config,
+          client: deps.getClient(),
+          bankId: projectBankId,
+        }),
       ]);
       const imports = importManifestSummary(manifestResult.manifest);
       const scopeMigrate = buildScopeMigratePlan({ cwd, config, projectBankId });
@@ -46,6 +53,33 @@ export function createDiagnosticsOperations(deps: MemoryOperationsDeps) {
         ...(imports.latest ? { latestImport: imports.latest } : {}),
         health,
         scopeMigrate,
+        sync,
+      });
+    },
+
+    /** Memory readiness: queue depth, git seed receipt, knowledge-page capability. */
+    async syncStatus(cwd: string) {
+      return buildSyncStatus({
+        cwd,
+        config: deps.getConfig(),
+        client: deps.getClient(),
+        bankId: deps.getProjectBankId(),
+      });
+    },
+
+    /**
+     * Opt-in cold-repo gitlog seed (commit messages only). dryRun defaults true.
+     * Does not auto-run on session start — conversation retain remains the product core.
+     */
+    async seedGitLog(args: { cwd: string; limit?: number; dryRun?: boolean; flush?: boolean }) {
+      return seedGitLog({
+        cwd: args.cwd,
+        bankId: deps.getProjectBankId(),
+        config: deps.getConfig(),
+        client: deps.getClient(),
+        limit: args.limit ?? DEFAULT_GIT_SEED_LIMIT,
+        dryRun: args.dryRun ?? true,
+        ...(args.flush !== undefined ? { flush: args.flush } : {}),
       });
     },
 

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -493,12 +493,52 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       name: "hindsight_status",
       label: "Hindsight Status",
       description:
-        "Inspect Pi Hindsight status: setup gate, coding/life banks, project scope tags (basis), recall/retain flags, queue. Use before changing memory config. Read-only.",
+        "Inspect Pi Hindsight status: setup gate, coding/life banks, project scope tags (basis), recall/retain flags, queue, and sync readiness (queue depth, git seed receipt, knowledge-page capability). Use before changing memory config. Read-only.",
       parameters: Type.Object({}),
       async execute(_id, _params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         if (signal?.aborted) throw new Error("Aborted");
-        const result = operations.status(ctx.cwd);
+        const result = await operations.status(ctx.cwd);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          details: result,
+        };
+      },
+      renderResult: renderMemoryToolTextResult,
+    }),
+    defineCatalogTool({
+      name: "hindsight_seed_git",
+      label: "Hindsight Seed Git",
+      description:
+        "Opt-in cold-repo seed: retain recent git commit messages (strategy gitlog) into the project bank. Not automatic — conversation retain remains primary. dryRun defaults true; set dryRun=false to enqueue (and flush by default).",
+      parameters: Type.Object({
+        limit: Type.Optional(
+          Type.Integer({
+            minimum: 1,
+            maximum: 2000,
+            description: "Max commits to include (default 300).",
+          }),
+        ),
+        dryRun: Type.Optional(
+          Type.Boolean({
+            description: "Default true (preview). Set false to enqueue retain.",
+          }),
+        ),
+        flush: Type.Optional(
+          Type.Boolean({
+            description: "When dryRun=false, flush the queue after enqueue (default true).",
+          }),
+        ),
+      }),
+      async execute(_id, params, signal, _onUpdate, ctx) {
+        useCwd(ctx.cwd);
+        if (signal?.aborted) throw new Error("Aborted");
+        const result = await operations.seedGitLog({
+          cwd: ctx.cwd,
+          ...(params.limit !== undefined ? { limit: params.limit } : {}),
+          dryRun: params.dryRun ?? true,
+          ...(params.flush !== undefined ? { flush: params.flush } : {}),
+        });
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
           details: result,

--- a/extensions/utils/diagnostics.ts
+++ b/extensions/utils/diagnostics.ts
@@ -49,6 +49,8 @@ export interface DebugReportArgs {
   memoryCount?: number;
   queueRemaining?: number;
   scopeMigrate?: ScopeMigratePlan;
+  /** Memory readiness: queue, git seed receipt, knowledge-page capability. */
+  sync?: unknown;
 }
 
 export function bankSelectionMessage(projectBankId: string, config: ResolvedConfig): string {
@@ -146,6 +148,7 @@ export function formatDebugReport(args: DebugReportArgs): string {
         },
       },
       health,
+      ...(args.sync !== undefined ? { sync: args.sync } : {}),
       cwd: args.cwd,
       repoRoot: findRepoRoot(args.cwd),
       sessionFile: args.sessionFile ?? null,

--- a/tests/extension-hooks.test.ts
+++ b/tests/extension-hooks.test.ts
@@ -547,6 +547,7 @@ describe("extension hooks", () => {
       "hindsight_retain_global",
       "hindsight_scope",
       "hindsight_scope_migrate",
+      "hindsight_seed_git",
       "hindsight_status",
     ]);
   });

--- a/tests/git-seed.test.ts
+++ b/tests/git-seed.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import {
+  buildGitLogRetainJob,
+  collectGitLogForSeed,
+  seedGitLog,
+} from "../extensions/lifecycle/git-seed.js";
+import type { HindsightLikeClient } from "../extensions/types.js";
+
+describe("git seed", () => {
+  it("collects newest-first commit subjects with stable document id", async () => {
+    const result = await collectGitLogForSeed({
+      cwd: "/repo",
+      limit: 2,
+      execGit: async (args) => {
+        if (args[0] === "rev-parse") return "abcdef1234567890\n";
+        if (args[0] === "log") {
+          return "aaaaaaaaaaaa\tfirst commit\nbbbbbbbbbbbb\tsecond commit\n";
+        }
+        throw new Error(`unexpected git ${args.join(" ")}`);
+      },
+    });
+    expect(result).not.toHaveProperty("error");
+    if ("error" in result) return;
+    expect(result.headSha).toBe("abcdef1234567890");
+    expect(result.commitCount).toBe(2);
+    expect(result.documentId).toBe("pi-gitlog:abcdef123456");
+    expect(result.content).toContain("first commit");
+    expect(result.content).toContain("second commit");
+  });
+
+  it("builds a gitlog strategy replace job", () => {
+    const job = buildGitLogRetainJob({
+      config: DEFAULT_CONFIG,
+      cwd: "/repo",
+      bankId: "bank",
+      content: "# log",
+      documentId: "pi-gitlog:abc",
+      headSha: "abcdef1234567890",
+    });
+    expect(job.item.strategy).toBe("gitlog");
+    expect(job.updateMode).toBe("replace");
+    expect(job.item.tags).toEqual(expect.arrayContaining(["source:git", "harness:pi"]));
+    expect(job.documentId).toBe("pi-gitlog:abc");
+  });
+
+  it("dry-runs seed without enqueue", async () => {
+    const client: HindsightLikeClient = {
+      retain: vi.fn(),
+      recall: vi.fn(),
+      reflect: vi.fn(),
+    };
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-git-seed-"));
+    const result = await seedGitLog({
+      cwd,
+      bankId: "bank",
+      config: DEFAULT_CONFIG,
+      client,
+      dryRun: true,
+      execGit: async (args) => {
+        if (args[0] === "rev-parse") return "deadbeefcafebabe\n";
+        return "deadbeefcafe\tseed me\n";
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.commitCount).toBe(1);
+    expect(vi.mocked(client.retain)).not.toHaveBeenCalled();
+  });
+});

--- a/tests/memory-control-operations.test.ts
+++ b/tests/memory-control-operations.test.ts
@@ -6,7 +6,7 @@ import { DEFAULT_CONFIG } from "../extensions/config/config.js";
 import { createControlOperations } from "../extensions/operations/memory-control-operations.js";
 
 describe("memory control operations", () => {
-  it("status reports setup required on fresh cwd", () => {
+  it("status reports setup required on fresh cwd", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-ctrl-"));
     const ops = createControlOperations({
       getClient: () => ({
@@ -17,9 +17,13 @@ describe("memory control operations", () => {
       getConfig: () => DEFAULT_CONFIG,
       getProjectBankId: () => "pi-project-x",
     });
-    const status = ops.status(cwd);
+    const status = await ops.status(cwd);
     expect(status.setupComplete).toBe(false);
     expect(status.fields.some((f) => f.key === "setup" && f.tone === "warn")).toBe(true);
+    expect(status.sync).toMatchObject({
+      queue: expect.objectContaining({ active: expect.any(Number) }),
+      knowledgePages: expect.any(String),
+    });
   });
 
   it("mental model create defaults project tags and supports dry-run", async () => {

--- a/tests/operation-catalog.test.ts
+++ b/tests/operation-catalog.test.ts
@@ -501,6 +501,7 @@ describe("operation catalog", () => {
       "hindsight_retain_global",
       "hindsight_reflect",
       "hindsight_status",
+      "hindsight_seed_git",
       "hindsight_scope",
       "hindsight_config",
       "hindsight_bank",


### PR DESCRIPTION
## Summary

Opt-in cold-repo gitlog seed (`hindsight_seed_git`) and sync readiness on `hindsight_status`/doctor. Never automatic on session start; conversation retain stays primary.

## Linked issue

- Closes #560
- Epic #557
- Stack: depends on #565

## Scope

- `hindsight_seed_git` tool (dryRun default true; strategy gitlog; document id `pi-gitlog:<head>`)
- Local git seed receipt; status.sync block (queue, receipt, knowledge capability)
- No background deepen engine

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Unit tests with injectable git. Live proof optional: dryRun then apply seed against a real bank.

## Release impact

- [x] User-visible change

New tool `hindsight_seed_git`; status includes sync readiness.

## Risk and rollback

- Risk: large gitlog retains may be expensive on huge histories (limit capped, default 300).
- Rollback/revert path: revert PR; remove tool registration and receipt file if present.

## Follow-ups

- #567 retain tool-call compaction

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Git is not the sole memory source; seed is explicit only.