### PR TITLE
feat: compact tool-call write-back for retain noise

### DIFF
--- a/docs/memory-behavior.md
+++ b/docs/memory-behavior.md
@@ -128,7 +128,7 @@ The retain projection is controlled by:
 - `retain.toolFilter`
 - `retain.strip`
 
-Defaults keep user/assistant text, assistant tool calls, tool result errors, and per-message timestamps while excluding recursive Hindsight tool output and noisy read/search results.
+Defaults keep user/assistant text, assistant tool calls, tool result errors, and per-message timestamps while excluding recursive Hindsight tool output and noisy read/search results. Assistant tool calls are compacted by default (`retain.compactToolCalls: true`) to name + primary target only (no full args), matching coding-agents write-back noise discipline. Set `retain.compactToolCalls: false` for full argument objects.
 
 Live session retains set the named bank strategy `conversation` (coding project templates define multi-strategy maps: `git`, `gitlog`, `conversation`, `document`, `survey`, plus knowledge `entity_labels` for page routing). Default bank mission text prefers final-state-wins extraction when a conversation amends itself.
 

--- a/extensions/config/config-defaults.ts
+++ b/extensions/config/config-defaults.ts
@@ -101,6 +101,7 @@ export const DEFAULT_CONFIG: ResolvedConfig = {
         ],
       },
     },
+    compactToolCalls: true,
     strip: { message: ["usage", "cost", "responseId"], topLevel: ["id", "parentId"] },
     redactSecrets: true,
     entities: [],

--- a/extensions/config/config-normalize.ts
+++ b/extensions/config/config-normalize.ts
@@ -441,6 +441,10 @@ export function normalizeConfig(
           DEFAULT_CONFIG.retain.toolFilter.toolResult,
         ),
       },
+      compactToolCalls: bool(
+        config.retain?.compactToolCalls,
+        DEFAULT_CONFIG.retain.compactToolCalls,
+      ),
       strip: {
         message: stringArray(config.retain?.strip?.message, DEFAULT_CONFIG.retain.strip.message),
         topLevel: stringArray(config.retain?.strip?.topLevel, DEFAULT_CONFIG.retain.strip.topLevel),

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -171,6 +171,11 @@ export interface ResolvedConfig {
       toolCall: { include?: string[]; exclude?: string[] };
       toolResult: { include?: string[]; exclude?: string[] };
     };
+    /**
+     * When true (default), assistant tool calls retain name + primary target only
+     * (no full args). Set false for full argument objects (debug / forensic).
+     */
+    compactToolCalls: boolean;
     strip: {
       message: string[];
       topLevel: string[];

--- a/extensions/utils/messages.ts
+++ b/extensions/utils/messages.ts
@@ -18,6 +18,53 @@ function toolAllowed(name: string, filter: { include?: string[]; exclude?: strin
   return !filter.exclude?.includes(name);
 }
 
+/** Keys tried, in order, for a compact tool-action target (coding-agents write-back discipline). */
+const TOOL_TARGET_KEYS = [
+  "file_path",
+  "path",
+  "notebook_path",
+  "command",
+  "pattern",
+  "query",
+  "url",
+  "name",
+  "id",
+] as const;
+
+const ACTION_TARGET_CAP = 100;
+
+/**
+ * Compact tool input to a primary target string (file path, command, pattern, …).
+ * Full args/outputs bury decisions in mechanical noise; retain only WHAT was touched.
+ */
+export function toolActionTarget(input: unknown): string {
+  let target = "";
+  if (input && typeof input === "object") {
+    const rec = input as Record<string, unknown>;
+    for (const key of TOOL_TARGET_KEYS) {
+      const value = rec[key];
+      if (typeof value === "string" && value.trim()) {
+        target = value.trim().split("\n")[0] ?? "";
+        break;
+      }
+    }
+  } else if (typeof input === "string") {
+    target = input.trim().split("\n")[0] ?? "";
+  }
+  if (target.length > ACTION_TARGET_CAP) target = `${target.slice(0, ACTION_TARGET_CAP)}…`;
+  return target;
+}
+
+function compactToolCallPart(name: string, args: unknown): Record<string, unknown> {
+  const target = toolActionTarget(args);
+  return {
+    type: "toolCall",
+    name,
+    // Compact form: name + primary target only (no full argument object / no outputs).
+    arguments: target ? { target } : {},
+  };
+}
+
 function textFromContent(
   content: unknown,
   options: {
@@ -26,6 +73,8 @@ function textFromContent(
     includeToolCall: boolean;
     includeUnknownJson?: boolean;
     toolCallFilter?: { include?: string[]; exclude?: string[] };
+    /** When true (default), tool calls become name+target only. */
+    compactToolCalls?: boolean;
   },
 ): string {
   if (typeof content === "string") return options.includeText ? content : "";
@@ -41,6 +90,10 @@ function textFromContent(
           if (!options.includeToolCall) return "";
           const name = stringValue(p.name, "unknown");
           if (options.toolCallFilter && !toolAllowed(name, options.toolCallFilter)) return "";
+          if (options.compactToolCalls !== false) {
+            const target = toolActionTarget(p.arguments);
+            return target ? `[action ${name} ${target}]` : `[action ${name}]`;
+          }
           return `[toolCall ${name}] ${JSON.stringify(p.arguments ?? {})}`;
         }
         if (p.type === "image") return options.includeText ? "[image omitted]" : "";
@@ -60,6 +113,7 @@ function projectContent(
     includeThinking: boolean;
     includeToolCall: boolean;
     toolCallFilter?: { include?: string[]; exclude?: string[] };
+    compactToolCalls?: boolean;
   },
 ): unknown {
   if (typeof content === "string") return options.includeText ? content : "";
@@ -75,6 +129,9 @@ function projectContent(
           const name = stringValue(p.name, "unknown");
           if (options.toolCallFilter && !toolAllowed(name, options.toolCallFilter))
             return undefined;
+          if (options.compactToolCalls !== false) {
+            return compactToolCallPart(name, p.arguments);
+          }
           return part;
         }
         if (p.type === "image") return options.includeText ? part : undefined;
@@ -108,6 +165,7 @@ export function projectMessage(
   const includeAssistantText = retain?.content.assistant.includes("text") ?? true;
   const includeThinking = retain?.content.assistant.includes("thinking") ?? false;
   const includeToolCall = retain?.content.assistant.includes("toolCall") ?? true;
+  const compactToolCalls = retain?.compactToolCalls !== false;
   const base: Record<string, unknown> = {
     role,
     timestamp: messageTimestamp(m),
@@ -115,6 +173,7 @@ export function projectMessage(
       includeText: !isAssistant || includeAssistantText,
       includeThinking: isAssistant && includeThinking,
       includeToolCall: isAssistant && includeToolCall,
+      compactToolCalls,
       ...(retain ? { toolCallFilter: retain.toolFilter.toolCall } : {}),
     }),
   };
@@ -140,6 +199,7 @@ export function projectMessageText(
   const includeAssistantText = retain?.content.assistant.includes("text") ?? true;
   const includeThinking = retain?.content.assistant.includes("thinking") ?? false;
   const includeToolCall = retain?.content.assistant.includes("toolCall") ?? true;
+  const compactToolCalls = retain?.compactToolCalls !== false;
   const base: Record<string, unknown> = {
     role,
     timestamp: messageTimestamp(m),
@@ -148,6 +208,7 @@ export function projectMessageText(
       includeThinking: isAssistant && includeThinking,
       includeToolCall: isAssistant && includeToolCall,
       includeUnknownJson: false,
+      compactToolCalls,
       ...(retain ? { toolCallFilter: retain.toolFilter.toolCall } : {}),
     }),
   };

--- a/tests/recall-format.test.ts
+++ b/tests/recall-format.test.ts
@@ -120,7 +120,7 @@ describe("recall formatting", () => {
     expect(query).toContain("user: look at this");
     expect(query).toContain("[image omitted]");
     expect(query).toContain("assistant: running command");
-    expect(query).toContain("[toolCall bash]");
+    expect(query).toContain("[action bash echo hi]");
     expect(query).not.toContain("base64-secret");
     expect(query).not.toContain('"type"');
   });

--- a/tests/retain.test.ts
+++ b/tests/retain.test.ts
@@ -132,7 +132,7 @@ describe("buildRetainJob", () => {
       content: Array<Record<string, unknown>>;
     }>;
     expect(toolOnlyRetained[0]?.content).toEqual([
-      { type: "toolCall", name: "bash", arguments: { command: "echo hi" } },
+      { type: "toolCall", name: "bash", arguments: { target: "echo hi" } },
     ]);
     expect(toolOnly?.item.content).not.toContain("assistant text");
 
@@ -176,9 +176,59 @@ describe("buildRetainJob", () => {
     }>;
     expect(retained[0]?.content).toEqual([
       { type: "text", text: "keep this" },
-      { type: "toolCall", name: "bash", arguments: { command: "echo ok" } },
+      { type: "toolCall", name: "bash", arguments: { target: "echo ok" } },
     ]);
     expect(job?.item.content).not.toContain("hindsight_recall");
+  });
+
+  it("compacts tool-call arguments to primary target by default", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "edit",
+            arguments: { file_path: "src/a.ts", old_string: "x", new_string: "y".repeat(50) },
+          },
+        ],
+        timestamp: Date.now(),
+      },
+    ] as unknown as AgentEndEvent["messages"];
+    const job = buildRetainJob({ config: DEFAULT_CONFIG, cwd: "/repo", bankId: "bank", messages });
+    const retained = JSON.parse(job?.item.content ?? "[]") as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(retained[0]?.content).toEqual([
+      { type: "toolCall", name: "edit", arguments: { target: "src/a.ts" } },
+    ]);
+    expect(job?.item.content).not.toContain("old_string");
+    expect(job?.item.content).not.toContain("new_string");
+  });
+
+  it("keeps full tool-call arguments when compactToolCalls is false", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "bash", arguments: { command: "echo hi" } }],
+        timestamp: Date.now(),
+      },
+    ] as unknown as AgentEndEvent["messages"];
+    const job = buildRetainJob({
+      config: {
+        ...DEFAULT_CONFIG,
+        retain: { ...DEFAULT_CONFIG.retain, compactToolCalls: false },
+      },
+      cwd: "/repo",
+      bankId: "bank",
+      messages,
+    });
+    const retained = JSON.parse(job?.item.content ?? "[]") as Array<{
+      content: Array<Record<string, unknown>>;
+    }>;
+    expect(retained[0]?.content).toEqual([
+      { type: "toolCall", name: "bash", arguments: { command: "echo hi" } },
+    ]);
   });
 
   it("preserves rich user content instead of flattening to text", () => {


### PR DESCRIPTION
## Summary

Default `retain.compactToolCalls=true` so assistant tool calls retain name + primary target only (no full args), matching coding-agents write-back noise discipline.

## Linked issue

- Closes #561
- Epic #557
- Stack: depends on #566

## Scope

- Compact toolCall projection in `messages.ts`
- Config `retain.compactToolCalls` (default true; false for full args)
- Docs + retain/recall tests updated

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Unit tests cover compact default and full-args opt-out. Live smoke not required for pure projection change.

## Release impact

- [x] User-visible change

Automatic retain payloads compact tool-call arguments by default.

## Risk and rollback

- Risk: less tool argument detail in memory (intentional); set compactToolCalls false to restore.
- Rollback/revert path: revert PR or set compactToolCalls false in config.

## Follow-ups

- #568 eval tasks (top of stack)

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

User/assistant text is still retained raw; only tool-call argument objects are compacted.