### PR TITLE
test: conversation amended-rule consolidation eval tasks

### DIFF
--- a/docs-site/src/content/docs/concepts/coding-memory-evaluation.md
+++ b/docs-site/src/content/docs/concepts/coding-memory-evaluation.md
@@ -34,6 +34,20 @@ What Vectorize’s own evaluation surface implies for **pi-hindsight** defaults.
 - Mega bank-global “everything about the user” models.
 - Pre-summarizing before retain.
 - Silent background MM create on every boot (setup / hub `t` is explicit).
+- Default session-start `reflect` or per-repo banks (ADR-005 domain-tagged + Pi `context`/`recall` stay).
+
+## Conversation / amended-rule eval tasks (in-repo)
+
+sde-bench treats **non-guessable project decisions from conversation** (including later amendments that must win) as the hard discriminator. We do **not** vendor sde-bench; we encode client-side signals that preserve that evaluation path:
+
+| Task id                 | Scenario                                                        | What must hold in pi-hindsight                                                                                                               | Enforced by                                                                       |
+| ----------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `conv-final-state`      | User proposes rule A, then amends to rule B in the same session | Project + conversation retain missions require FINAL/LAST state only; superseded proposals only as rejected                                  | `tests/coding-memory-eval.test.ts`, bank missions / `CONVERSATION_RETAIN_MISSION` |
+| `conv-not-git-only`     | Decision exists only in chat, not in git history                | Live session retain uses strategy `conversation` and remains the product core; git seed is opt-in only                                       | retain job strategy + seed tool dry-run defaults                                  |
+| `tool-noise`            | Assistant runs many tools with large args                       | Compact tool-call write-back keeps name + target, drops full args by default                                                                 | `retain.compactToolCalls` + retain projection tests                               |
+| `amended-cross-session` | Later session revises an earlier rule                           | Append + stable live document IDs + final-state mission text (server consolidation); client does not re-emit intermediate proposals as facts | missions + append/cursor design (docs)                                            |
+
+Release validation priority: **conversation-amended / cross-session consolidation** over git-only smoke. Prefer live or fixture paths that retain a short decision chat that revises itself, then recall/reflect for the **last** rule.
 
 ## Related issues
 
@@ -41,3 +55,4 @@ What Vectorize’s own evaluation surface implies for **pi-hindsight** defaults.
 - Delta MM triggers on templates: #529
 - MM size discipline: #530
 - Mission wording vs best practices: #531
+- Coding-agents shortlist stack: #557–#562

--- a/docs/coding-memory-evaluation.md
+++ b/docs/coding-memory-evaluation.md
@@ -30,6 +30,20 @@ What Vectorize’s own evaluation surface implies for **pi-hindsight** defaults.
 - Mega bank-global “everything about the user” models.
 - Pre-summarizing before retain.
 - Silent background MM create on every boot (setup / hub `t` is explicit).
+- Default session-start `reflect` or per-repo banks (ADR-005 domain-tagged + Pi `context`/`recall` stay).
+
+## Conversation / amended-rule eval tasks (in-repo)
+
+sde-bench treats **non-guessable project decisions from conversation** (including later amendments that must win) as the hard discriminator. We do **not** vendor sde-bench; we encode client-side signals that preserve that evaluation path:
+
+| Task id                 | Scenario                                                        | What must hold in pi-hindsight                                                                                                               | Enforced by                                                                       |
+| ----------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `conv-final-state`      | User proposes rule A, then amends to rule B in the same session | Project + conversation retain missions require FINAL/LAST state only; superseded proposals only as rejected                                  | `tests/coding-memory-eval.test.ts`, bank missions / `CONVERSATION_RETAIN_MISSION` |
+| `conv-not-git-only`     | Decision exists only in chat, not in git history                | Live session retain uses strategy `conversation` and remains the product core; git seed is opt-in only                                       | retain job strategy + seed tool dry-run defaults                                  |
+| `tool-noise`            | Assistant runs many tools with large args                       | Compact tool-call write-back keeps name + target, drops full args by default                                                                 | `retain.compactToolCalls` + retain projection tests                               |
+| `amended-cross-session` | Later session revises an earlier rule                           | Append + stable live document IDs + final-state mission text (server consolidation); client does not re-emit intermediate proposals as facts | missions + append/cursor design (docs)                                            |
+
+Release validation priority: **conversation-amended / cross-session consolidation** over git-only smoke. Prefer live or fixture paths that retain a short decision chat that revises itself, then recall/reflect for the **last** rule.
 
 ## Related issues
 
@@ -37,3 +51,4 @@ What Vectorize’s own evaluation surface implies for **pi-hindsight** defaults.
 - Delta MM triggers on templates: #529
 - MM size discipline: #530
 - Mission wording vs best practices: #531
+- Coding-agents shortlist stack: #557–#562

--- a/tests/coding-memory-eval.test.ts
+++ b/tests/coding-memory-eval.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Client-side evaluation signals for sde-bench-style coding memory:
+ * conversation final-state-wins, not git-only, tool-noise compaction.
+ * Not a full sde-bench harness — locks mission text and retain projection shape.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  defaultProjectBankMissions,
+  defaultGlobalBankMissions,
+} from "../extensions/banks/bank-operations.js";
+import {
+  CONVERSATION_RETAIN_MISSION,
+  LIVE_SESSION_RETAIN_STRATEGY,
+  PI_RETAIN_STRATEGIES,
+} from "../extensions/banks/retain-strategies.js";
+import { getBuiltInBankTemplate } from "../extensions/banks/bank-templates.js";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import { buildRetainJob } from "../extensions/lifecycle/retain.js";
+import { toolActionTarget } from "../extensions/utils/messages.js";
+import type { AgentEndEvent } from "@earendil-works/pi-coding-agent";
+
+describe("coding memory eval signals", () => {
+  it("conv-final-state: project and conversation missions require final/last state wins", () => {
+    const project = defaultProjectBankMissions().retainMission;
+    expect(project).toMatch(/FINAL/i);
+    expect(project).toMatch(/LAST/i);
+    expect(project).toMatch(/amended|superseded|rejected/i);
+
+    expect(CONVERSATION_RETAIN_MISSION).toMatch(/FINAL/i);
+    expect(CONVERSATION_RETAIN_MISSION).toMatch(/REVISES|LAST/i);
+    expect(CONVERSATION_RETAIN_MISSION).toMatch(/REJECTED|superseded/i);
+    // Must not encourage one-fact-per-message extraction noise.
+    expect(CONVERSATION_RETAIN_MISSION).toMatch(/Do NOT emit one fact per message/i);
+  });
+
+  it("conv-not-git-only: live sessions use conversation strategy; coding template defaults to conversation", () => {
+    expect(LIVE_SESSION_RETAIN_STRATEGY).toBe("conversation");
+    const template = getBuiltInBankTemplate("pi-coding-project");
+    expect(template?.manifest.bank?.retain_default_strategy).toBe("conversation");
+    expect(PI_RETAIN_STRATEGIES.conversation?.retain_mission).toBe(CONVERSATION_RETAIN_MISSION);
+    expect(PI_RETAIN_STRATEGIES.git).toBeDefined();
+    expect(PI_RETAIN_STRATEGIES.gitlog).toBeDefined();
+
+    const messages = [
+      {
+        role: "user",
+        content: "Use port 3000. Wait — actually use 8080.",
+        timestamp: Date.now(),
+      },
+    ] as unknown as AgentEndEvent["messages"];
+    const job = buildRetainJob({
+      config: DEFAULT_CONFIG,
+      cwd: "/repo",
+      bankId: "bank",
+      messages,
+    });
+    expect(job?.item.strategy).toBe("conversation");
+    expect(job?.updateMode).toBe("append");
+    const content = job?.item.content ?? "";
+    expect(content).toContain("8080");
+    expect(content).toContain("3000");
+  });
+
+  it("tool-noise: compactToolCalls is default and strips large tool args", () => {
+    expect(DEFAULT_CONFIG.retain.compactToolCalls).toBe(true);
+    const target = toolActionTarget({
+      file_path: "extensions/utils/messages.ts",
+      old_string: "a".repeat(500),
+      new_string: "b".repeat(500),
+    });
+    expect(target).toBe("extensions/utils/messages.ts");
+
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "edit",
+            arguments: {
+              file_path: "src/rule.ts",
+              old_string: "const PORT = 3000",
+              new_string: "const PORT = 8080",
+            },
+          },
+        ],
+        timestamp: Date.now(),
+      },
+    ] as unknown as AgentEndEvent["messages"];
+    const job = buildRetainJob({
+      config: DEFAULT_CONFIG,
+      cwd: "/repo",
+      bankId: "bank",
+      messages,
+    });
+    expect(job?.item.content).toContain("src/rule.ts");
+    expect(job?.item.content).not.toContain("const PORT");
+    expect(job?.item.content).not.toContain("old_string");
+  });
+
+  it("user bank missions stay prefs-focused (not conversation final-state dump)", () => {
+    const global = defaultGlobalBankMissions().retainMission;
+    expect(global).toMatch(/preferences|workflows|habits/i);
+    // Global/user bank should not be the home of repo decision final-state extraction.
+    expect(global).not.toMatch(/FINAL settled state/);
+  });
+});


### PR DESCRIPTION
## Summary

Encode sde-bench-aligned evaluation signals: final-state-wins missions, conversation strategy for live retain, compact tool write-back, and a documented eval task matrix with unit tests.

## Linked issue

- Closes #562
- Epic #557
- Stack: depends on #567

## Scope

- Expand `docs/coding-memory-evaluation.md` with eval task table
- `tests/coding-memory-eval.test.ts` locks mission text and projection shape
- Docs-site sync for coding-memory-evaluation

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`)
- [ ] package verification requested/passed (release/package changes or `ci:package`)
- [ ] `npm run pack:verify` (release/package changes)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof)

Docs + unit tests only; full matrix/live smoke not required.

## Release impact

- [x] No release impact

Documentation and tests only; no runtime package behavior change beyond documenting existing stack signals.

## Risk and rollback

- Risk: low (docs/tests).
- Rollback/revert path: revert PR.

## Follow-ups

- None for this slice. Epic #557 closes when stack merges.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Does not vendor sde-bench; client-side signals only.