### PR TITLE
fix(smoke): raise sync retain timeout for parallel CI

### DIFF
--- a/scripts/smoke-hindsight.ts
+++ b/scripts/smoke-hindsight.ts
@@ -39,7 +39,8 @@ const smokeExtensionConfig = {
   hindsight: {
     ...DEFAULT_CONFIG.hindsight,
     baseUrl: config.baseUrl,
-    timeoutMs: 90_000,
+    // Sync import retain under parallel CI can exceed 90s; leave headroom for load.
+    timeoutMs: 180_000,
     ...(config.apiKey ? { apiKey: config.apiKey } : {}),
   },
   recall: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Raises live-smoke `hindsight.timeoutMs` from 90s to 180s so sync import retain can finish under parallel CI load.

## Linked issue

- Closes #579

## Scope

- `scripts/smoke-hindsight.ts` only: bump client timeout used for sync retain/import flush.

## Verification

- [x] `npm run check` (via precommit)
- [ ] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`) — skipped: smoke script timeout constant only
- [ ] `npm run typecheck:tsc` (source/critical paths or full CI) — skipped: smoke script timeout constant only
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) — skipped: not a release/platform change
- [ ] package verification requested/passed (release/package changes or `ci:package`) — skipped: not a package change
- [ ] `npm run pack:verify` (release/package changes) — skipped: not a package change
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) — smoke script path change; expect CI live-smoke on this PR

## Release impact

Check exactly one:

- [x] No release impact
- [ ] User-visible change
- [ ] Package/release path change

Smoke harness timeout only; no package behavior change.

## Risk and rollback

- Risk: Low — longer smoke wall-clock on slow retains only.
- Rollback/revert path: Revert this commit.

## Follow-ups

- None for this flake. Epic #557 stack already merged (`3629c3b`). Issue close/comment for #557 may need a human (integration token 403).

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. — N/A

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

Root cause of the prior #566 flake: after sync retain (`retain.async: false`), import flush under parallel stacked live-smoke could hit the 90s client timeout and leave `1 retain job pending`. Tip #568 already passed recall/import; this hardens residual CI flake.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff5de-43ad-7046-9183-a413645f2d9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff5de-43ad-7046-9183-a413645f2d9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

