### PR TITLE
feat(banks): opt-in basename isolated-bank ids

### DIFF
--- a/docs-site/src/content/docs/concepts/memory-banks.md
+++ b/docs-site/src/content/docs/concepts/memory-banks.md
@@ -44,7 +44,7 @@ One **dedicated** bank for a single repo. Hard wall; no shared coding bank.
 
 Use for client work, secrets, or “this repo must not share memory with anything else.”
 
-Guided setup profile: **Isolated project**. Path-derived bank id is fine if you leave the default.
+Guided setup profile: **Isolated project**. Path-derived hashed bank id is fine if you leave the default. Set `banks.project.derive` to `basename` only when this repo must share a folder-named bank with another Hindsight client.
 
 ## Quick compare
 

--- a/docs-site/src/content/docs/concepts/project-identity.md
+++ b/docs-site/src/content/docs/concepts/project-identity.md
@@ -56,6 +56,16 @@ When dual-tag can end: every active project memory you care about carries `proje
 | **`domain-tagged`** (default) | Shared coding bank (`banks.project.bankId`)    | `project:<id>` isolates repos |
 | **`isolated-bank`**           | Hard wall per repo (path-derived if no bankId) | project tags still written    |
 
+When `banks.project.bankId` is unset, `banks.project.derive` picks the isolated bank name:
+
+| `derive`                 | Bank id                                    |
+| ------------------------ | ------------------------------------------ |
+| `repo` / `cwd` (default) | hashed `pi-project-<slug>-<pathHash>`      |
+| `basename`               | git-root folder name as-is (`my_websites`) |
+| `manual`                 | requires `bankId`                          |
+
+`basename` is opt-in interoperability with clients that already use folder-named banks (for example Claude Code / Grok `dynamicBankId` + project granularity). It is not the recommended Coding profile. Two different repos with the same folder name share that bank.
+
 `banks.coding` aliases `banks.project`. `banks.life` aliases `banks.user`.
 
 ## Config

--- a/docs-site/src/content/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/reference/configuration.md
@@ -55,6 +55,16 @@ Project config SecretRef shape:
 
 When a profile uses user memory, guided setup asks for a user bank ID and writes it to global Pi config. Override it later with `PI_HINDSIGHT_USER_BANK_ID`, `~/.pi/agent/hindsight.json` `banks.user.bankId`, or the setup TUI if you prefer a different shared bank. Legacy `PI_HINDSIGHT_GLOBAL_BANK_ID`, `banks.global`, and `global-only` config names are migrated/supported during transition.
 
+## Isolated bank naming
+
+`banks.project.bankId` always wins. If it is unset, `banks.project.derive` chooses the name:
+
+- `repo` / `cwd` (default): hashed `pi-project-<slug>-<pathHash>`
+- `basename`: git-root folder name as-is (opt-in; share isolated banks with folder-named clients)
+- `manual`: set `bankId` explicitly
+
+Domain-tagged mode still requires an explicit coding bank id. See [Project identity](/pi-hindsight/concepts/project-identity/).
+
 ## Bank settings display
 
 Pi Hindsight distinguishes local Pi behavior from bank-owned Hindsight settings. Setup and status surfaces show both:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,16 @@ Project config SecretRef shape:
 
 When a profile uses user memory, guided setup asks for a user bank ID and writes it to global Pi config. Override it later with `PI_HINDSIGHT_USER_BANK_ID`, `~/.pi/agent/hindsight.json` `banks.user.bankId`, or the setup TUI if you prefer a different shared bank. Legacy `PI_HINDSIGHT_GLOBAL_BANK_ID`, `banks.global`, and `global-only` config names are migrated/supported during transition.
 
+## Isolated bank naming
+
+`banks.project.bankId` always wins. If it is unset, `banks.project.derive` chooses the name:
+
+- `repo` / `cwd` (default): hashed `pi-project-<slug>-<pathHash>`
+- `basename`: git-root folder name as-is (opt-in; share isolated banks with folder-named clients)
+- `manual`: set `bankId` explicitly
+
+Domain-tagged mode still requires an explicit coding bank id. See [Project identity](project-identity.md).
+
 ## Bank settings display
 
 Pi Hindsight distinguishes local Pi behavior from bank-owned Hindsight settings. Setup and status surfaces show both:

--- a/docs/project-identity.md
+++ b/docs/project-identity.md
@@ -54,6 +54,16 @@ When dual-tag can end: every active project memory you care about carries `proje
 | **`domain-tagged`** (default) | Shared coding bank (`banks.project.bankId`)    | `project:<id>` isolates repos |
 | **`isolated-bank`**           | Hard wall per repo (path-derived if no bankId) | project tags still written    |
 
+When `banks.project.bankId` is unset, `banks.project.derive` picks the isolated bank name:
+
+| `derive`                 | Bank id                                    |
+| ------------------------ | ------------------------------------------ |
+| `repo` / `cwd` (default) | hashed `pi-project-<slug>-<pathHash>`      |
+| `basename`               | git-root folder name as-is (`my_websites`) |
+| `manual`                 | requires `bankId`                          |
+
+`basename` is opt-in interoperability with clients that already use folder-named banks (for example Claude Code / Grok `dynamicBankId` + project granularity). It is not the recommended Coding profile. Two different repos with the same folder name share that bank.
+
 `banks.coding` aliases `banks.project`. `banks.life` aliases `banks.user`.
 
 ## Config

--- a/extensions/banks/banking.ts
+++ b/extensions/banks/banking.ts
@@ -166,17 +166,24 @@ export function legacyRepoScopeTag(legacyKey: string): string {
   return `repo:${legacyKey}`;
 }
 
+/** Folder name as Claude/Grok dynamic project banks use it (no slug, keep underscores). */
+export function folderBankId(path: string): string {
+  return basename(path).trim() || "default";
+}
+
 /**
  * Resolve the coding-role bank id.
  * - Explicit banks.project.bankId always wins (domain coding bank or isolated override).
  * - isolated-bank mode (or legacy path when no bankId): path/cwd-derived bank.
  * - domain-tagged without bankId: still path-derived for upgrade safety; setup should set bankId.
+ * - derive "basename": git-root folder name so Pi shares banks with Claude/Grok.
  */
 export function deriveProjectBankId(cwd: string, config: ResolvedConfig): string {
   if (config.banks.project.bankId) return config.banks.project.bankId;
   // Domain-tagged + explicit bankId is the preferred shared coding bank path.
   // Without bankId, keep path-derived identity so upgrades do not silently merge banks.
   const basis = config.banks.project.derive === "cwd" ? resolve(cwd) : findRepoRoot(cwd);
+  if (config.banks.project.derive === "basename") return folderBankId(basis);
   return `pi-project-${slug(basename(basis))}-${hash(basis)}`;
 }
 

--- a/extensions/config/config-normalize.ts
+++ b/extensions/config/config-normalize.ts
@@ -278,7 +278,7 @@ export function normalizeConfig(
         ...(projectBankId ? { bankId: projectBankId } : {}),
         derive: enumValue(
           config.banks?.project?.derive,
-          ["repo", "cwd", "manual"],
+          ["repo", "cwd", "manual", "basename"],
           DEFAULT_CONFIG.banks.project.derive,
         ),
         ...missionFields(config.banks?.project),

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -111,7 +111,13 @@ export interface ResolvedConfig {
     project: BankMissionSettings & {
       enabled: boolean;
       bankId?: string;
-      derive: "repo" | "cwd" | "manual";
+      /**
+       * How to pick a bank id when banks.project.bankId is unset.
+       * - repo/cwd: hashed `pi-project-<slug>-<pathHash>` (upstream default)
+       * - basename: git-root folder name, Claude/Grok compatible (`my_websites`)
+       * - manual: bankId is required; leftover hashed fallback if missing
+       */
+      derive: "repo" | "cwd" | "manual" | "basename";
     };
     user: BankMissionSettings & { enabled: boolean; bankId?: string };
     global: BankMissionSettings & { enabled: boolean; bankId?: string };

--- a/tests/banking.test.ts
+++ b/tests/banking.test.ts
@@ -187,4 +187,37 @@ describe("domain coding bank roles", () => {
     expect(deriveProjectBankId("/any/repo", config)).toBe("kai-coding");
     expect(deriveProjectBankId("/other/repo", config)).toBe("kai-coding");
   });
+
+  it("uses the git-root folder name when derive is basename", () => {
+    const parent = mkdtempSync(join(tmpdir(), "pi-hindsight-basename-"));
+    const root = join(parent, "my_websites");
+    mkdirSync(root);
+    mkdirSync(join(root, ".git"));
+    const child = join(root, "apps", "web");
+    mkdirSync(child, { recursive: true });
+    const config = {
+      ...DEFAULT_CONFIG,
+      scope: { ...DEFAULT_CONFIG.scope, mode: "isolated-bank" as const },
+      banks: {
+        ...DEFAULT_CONFIG.banks,
+        project: { enabled: true, derive: "basename" as const },
+      },
+    };
+    withoutLocalGitEnv(() => {
+      expect(deriveProjectBankId(child, config)).toBe("my_websites");
+      expect(deriveProjectBankId(root, config)).toBe("my_websites");
+    });
+  });
+
+  it("keeps hashed bank ids for the default repo derive", () => {
+    const parent = mkdtempSync(join(tmpdir(), "pi-hindsight-hashed-"));
+    const root = join(parent, "my_websites");
+    mkdirSync(root);
+    mkdirSync(join(root, ".git"));
+    withoutLocalGitEnv(() => {
+      expect(deriveProjectBankId(root, DEFAULT_CONFIG)).toMatch(
+        /^pi-project-my-websites-[0-9a-f]{12}$/,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add an opt-in `banks.project.derive: "basename"` so isolated banks can use the git-root folder name as-is (`my_websites`) instead of hashed `pi-project-<slug>-<pathHash>`.

This lets Pi share existing per-folder banks with Claude Code / Grok `hindsight-memory` (`dynamicBankId` + project granularity). It does **not** change the recommended Coding profile (shared coding bank + `project:` tags). Explicit `bankId` still wins. Domain-tagged setup still requires an explicit coding bank id.

## Linked issue

- Closes #590

## Scope

- Accept `basename` on `banks.project.derive`
- When `bankId` is unset and derive is `basename`, use the worktree-aware git-root folder name without slugifying underscores
- Keep hashed ids for default `repo` / `cwd`
- Document the opt-in in project-identity, memory-banks, and configuration docs

## Verification

- [x] `npm run check`
- [ ] `npm run check:coverage` (not run because this is a small opt-in derive path plus unit tests; no critical-path rewrite)
- [ ] `npm run typecheck:tsc` (not run because `npm run check` already ran `tsgo` typecheck)
- [ ] full matrix requested/passed (not run because this is not a release PR or platform-sensitive change)
- [ ] package verification requested/passed (not run because there is no package/release-path change)
- [ ] `npm run pack:verify` (not run because there is no package/release-path change)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (not run because live Hindsight proof is unavailable in this contributor environment; unit tests cover hashed vs basename derivation)

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Changelog: new opt-in `banks.project.derive: "basename"` for isolated-bank folder names. Default hashed derivation and domain-tagged Coding profile are unchanged.

## Risk and rollback

- Risk: two different repos with the same folder name share one isolated bank if someone enables `basename`. Folder names are weaker than path hashes. Default installs are unaffected.
- Rollback/revert path: revert this PR, or set `derive` back to `repo` / pin `banks.project.bankId`. Existing hashed banks stay reachable.

## Follow-ups

- None

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

ADR-005 / #488 stay the default topology. This only adds an isolated-bank naming option. `scope.projectIdStrategy: basename` remains tag-only.

Issue #590 was filed when proposing this upstream after a local fork experiment; the implementation matches the issue acceptance criteria.
