### PR TITLE
fix(recall): parallel scope recalls + abort fetch on timeout

### DIFF
--- a/extensions/lifecycle/recall.ts
+++ b/extensions/lifecycle/recall.ts
@@ -186,54 +186,70 @@ export async function recallForContext(args: {
 }> {
   const blocks: RecallBlock[] = [];
   const failures: RecallFailure[] = [];
-  for (const scope of args.scopes) {
-    const query = composeRecallQuery(args.messages, {
-      roles: args.config.recall.roles,
-      contextTurns: args.config.recall.contextTurns,
-      maxQueryChars: args.config.recall.maxQueryChars,
-      preamble: preambleForScope(args.config, scope),
-      includeDate: args.config.recall.includeDateInQuery,
-      hints: args.cwd ? queryHints(args.cwd, args.config, scope) : [],
-    });
-    try {
-      const response = await withTimeout("hindsight recall", args.config.recall.timeoutMs, () =>
-        args.client.recall(scope.bankId, query, {
-          budget: args.config.recall.budget,
-          maxTokens: maxTokensForScope(args.config, scope),
-          types: args.config.recall.types,
-          preferObservations: args.config.recall.preferObservations,
-          ...(args.config.recall.includeSourceFacts
-            ? {
-                includeSourceFacts: true,
-                maxSourceFactsTokens: args.config.recall.maxSourceFactsTokens,
-              }
-            : {}),
-          ...(args.config.recall.queryTimestamp
-            ? { queryTimestamp: args.config.recall.queryTimestamp }
-            : {}),
-          ...(scope.tagGroups?.length ? { tagGroups: scope.tagGroups } : {}),
-        }),
-      );
-      const results = filterRecallQuality(
-        textFromRecallResponse(response),
-        args.config.recall.minScores,
-      ).items;
-      blocks.push({
-        bankId: scope.bankId,
-        query,
-        results,
-        memoryCount: results.length,
-        rendered: "",
+  // Scope recalls run concurrently: with two banks (project + user) a sequential
+  // loop paid the full per-bank latency twice at every turn start. Promise.all
+  // preserves input order, so blocks and failures still appear in scope order;
+  // the per-scope try/catch keeps one bank's failure from affecting the others.
+  const scopeOutcomes = await Promise.all(
+    args.scopes.map(async (scope) => {
+      const query = composeRecallQuery(args.messages, {
+        roles: args.config.recall.roles,
+        contextTurns: args.config.recall.contextTurns,
+        maxQueryChars: args.config.recall.maxQueryChars,
+        preamble: preambleForScope(args.config, scope),
+        includeDate: args.config.recall.includeDateInQuery,
+        hints: args.cwd ? queryHints(args.cwd, args.config, scope) : [],
       });
-    } catch (error) {
-      failures.push({
-        bankId: scope.bankId,
-        query,
-        error: redactError(error),
-        ...(scope.kind ? { kind: scope.kind } : {}),
-        ...(scope.tagGroups?.length ? { tagGroups: scope.tagGroups } : {}),
-      });
-    }
+      try {
+        const response = await withTimeout("hindsight recall", args.config.recall.timeoutMs, () =>
+          args.client.recall(scope.bankId, query, {
+            budget: args.config.recall.budget,
+            maxTokens: maxTokensForScope(args.config, scope),
+            types: args.config.recall.types,
+            preferObservations: args.config.recall.preferObservations,
+            ...(args.config.recall.includeSourceFacts
+              ? {
+                  includeSourceFacts: true,
+                  maxSourceFactsTokens: args.config.recall.maxSourceFactsTokens,
+                }
+              : {}),
+            ...(args.config.recall.queryTimestamp
+              ? { queryTimestamp: args.config.recall.queryTimestamp }
+              : {}),
+            ...(scope.tagGroups?.length ? { tagGroups: scope.tagGroups } : {}),
+          }),
+        );
+        const results = filterRecallQuality(
+          textFromRecallResponse(response),
+          args.config.recall.minScores,
+        ).items;
+        return {
+          ok: true as const,
+          block: {
+            bankId: scope.bankId,
+            query,
+            results,
+            memoryCount: results.length,
+            rendered: "",
+          },
+        };
+      } catch (error) {
+        return {
+          ok: false as const,
+          failure: {
+            bankId: scope.bankId,
+            query,
+            error: redactError(error),
+            ...(scope.kind ? { kind: scope.kind } : {}),
+            ...(scope.tagGroups?.length ? { tagGroups: scope.tagGroups } : {}),
+          },
+        };
+      }
+    }),
+  );
+  for (const outcome of scopeOutcomes) {
+    if (outcome.ok) blocks.push(outcome.block);
+    else failures.push(outcome.failure);
   }
   const recallRendered = renderRecallBlocks(blocks, args.config.recall.topK);
   const cwd = args.cwd ?? process.cwd();

--- a/extensions/lifecycle/recall.ts
+++ b/extensions/lifecycle/recall.ts
@@ -201,23 +201,33 @@ export async function recallForContext(args: {
         hints: args.cwd ? queryHints(args.cwd, args.config, scope) : [],
       });
       try {
-        const response = await withTimeout("hindsight recall", args.config.recall.timeoutMs, () =>
-          args.client.recall(scope.bankId, query, {
-            budget: args.config.recall.budget,
-            maxTokens: maxTokensForScope(args.config, scope),
-            types: args.config.recall.types,
-            preferObservations: args.config.recall.preferObservations,
-            ...(args.config.recall.includeSourceFacts
-              ? {
-                  includeSourceFacts: true,
-                  maxSourceFactsTokens: args.config.recall.maxSourceFactsTokens,
-                }
-              : {}),
-            ...(args.config.recall.queryTimestamp
-              ? { queryTimestamp: args.config.recall.queryTimestamp }
-              : {}),
-            ...(scope.tagGroups?.length ? { tagGroups: scope.tagGroups } : {}),
-          }),
+        // Forward the timeout's AbortSignal into the client call: the adapted
+        // client treats options.signal as a parent signal, so when this outer
+        // recall timeout fires the underlying fetch is aborted and the server
+        // sees a client disconnect and cancels the recall instead of running it
+        // to completion. Without this the outer timeout rejects the turn-side
+        // promise while the request keeps running up to the client-level timeout.
+        const response = await withTimeout(
+          "hindsight recall",
+          args.config.recall.timeoutMs,
+          (signal) =>
+            args.client.recall(scope.bankId, query, {
+              budget: args.config.recall.budget,
+              maxTokens: maxTokensForScope(args.config, scope),
+              types: args.config.recall.types,
+              preferObservations: args.config.recall.preferObservations,
+              ...(args.config.recall.includeSourceFacts
+                ? {
+                    includeSourceFacts: true,
+                    maxSourceFactsTokens: args.config.recall.maxSourceFactsTokens,
+                  }
+                : {}),
+              ...(args.config.recall.queryTimestamp
+                ? { queryTimestamp: args.config.recall.queryTimestamp }
+                : {}),
+              ...(scope.tagGroups?.length ? { tagGroups: scope.tagGroups } : {}),
+              signal,
+            }),
         );
         const results = filterRecallQuality(
           textFromRecallResponse(response),

--- a/tests/recall-abort-forwarding.test.ts
+++ b/tests/recall-abort-forwarding.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { recallForContext } from "../extensions/lifecycle/recall.js";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+
+const messages = [{ role: "user", content: "q", timestamp: 1 }] as unknown as AgentMessage[];
+
+describe("recallForContext abort forwarding", () => {
+  it("aborts the client signal when the recall timeout fires", async () => {
+    let captured: AbortSignal | undefined;
+    const result = await recallForContext({
+      client: {
+        retain: async () => undefined,
+        recall: async (_bankId, _query, options) => {
+          captured = options?.signal;
+          // Never resolves: the outer withTimeout must fire and abort the signal
+          // it handed the client, so the adapted client can cancel the fetch.
+          await new Promise(() => undefined);
+          return { results: [] };
+        },
+        reflect: async () => ({}),
+      },
+      config: {
+        ...DEFAULT_CONFIG,
+        recall: { ...DEFAULT_CONFIG.recall, timeoutMs: 25 },
+      },
+      scopes: [{ kind: "project", bankId: "project-bank" }],
+      cwd: "/repo/project",
+      messages,
+    });
+    expect(result.failed).toBe(1);
+    expect(result.failures[0]?.error).toMatch(/timed out/);
+    expect(captured).toBeDefined();
+    expect(captured?.aborted).toBe(true);
+  });
+});

--- a/tests/recall-abort-forwarding.test.ts
+++ b/tests/recall-abort-forwarding.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { createServer } from "node:http";
 import { recallForContext } from "../extensions/lifecycle/recall.js";
+import { createHindsightClient } from "../extensions/client/client.js";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 
@@ -32,5 +34,56 @@ describe("recallForContext abort forwarding", () => {
     expect(result.failures[0]?.error).toMatch(/timed out/);
     expect(captured).toBeDefined();
     expect(captured?.aborted).toBe(true);
+  });
+
+  it("aborts the underlying HTTP request end-to-end when the recall timeout fires", async () => {
+    // Composed path: recallForContext -> adapted client -> real fetch -> local
+    // server. The server never responds; when the recall timeout fires the
+    // connection must be aborted server-side, which is exactly what lets a
+    // Hindsight server cancel the recall instead of running it to completion.
+    let aborted = false;
+    const server = createServer((req, _res) => {
+      req.on("close", () => {
+        aborted = true;
+      });
+      // Intentionally never respond before the timeout.
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing address");
+    const client = createHindsightClient({
+      ...DEFAULT_CONFIG,
+      hindsight: {
+        ...DEFAULT_CONFIG.hindsight,
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        // Both timeouts stay short for the test: the client-level timeout is
+        // above the recall timeout so the outer recall timeout fires first,
+        // and low enough that the post-recall mental-model load against the
+        // unresponsive server fails fast instead of hanging the test.
+        timeoutMs: 200,
+      },
+    });
+    try {
+      const result = await recallForContext({
+        client,
+        config: {
+          ...DEFAULT_CONFIG,
+          recall: { ...DEFAULT_CONFIG.recall, timeoutMs: 40 },
+        },
+        scopes: [{ kind: "project", bankId: "project-bank" }],
+        cwd: "/repo/project",
+        messages,
+      });
+      expect(result.failed).toBe(1);
+      expect(result.failures[0]?.error).toMatch(/timed out/);
+      // Give the socket close a moment to propagate to the server handler.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(aborted).toBe(true);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
   });
 });

--- a/tests/recall-scope-parallelism.test.ts
+++ b/tests/recall-scope-parallelism.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { recallForContext } from "../extensions/lifecycle/recall.js";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+
+const messages = [{ role: "user", content: "q", timestamp: 1 }] as unknown as AgentMessage[];
+
+describe("recallForContext scope parallelism", () => {
+  it("starts all scope recalls before any of them finish", async () => {
+    const events: string[] = [];
+    let resolveAll!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      resolveAll = resolve;
+    });
+    const run = recallForContext({
+      client: {
+        retain: async () => undefined,
+        recall: async (bankId) => {
+          events.push(`start:${bankId}`);
+          await gate;
+          events.push(`end:${bankId}`);
+          return { results: [] };
+        },
+        reflect: async () => ({}),
+      },
+      config: DEFAULT_CONFIG,
+      scopes: [
+        { kind: "project", bankId: "project-bank" },
+        { kind: "global", bankId: "global-bank" },
+      ],
+      cwd: "/repo/project",
+      messages,
+    });
+    // Give both recalls a chance to start (or the sequential first one to hang).
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    resolveAll();
+    const watchdog = new Promise<"timeout">((resolve) =>
+      setTimeout(() => resolve("timeout"), 2000),
+    );
+    const result = await Promise.race([run, watchdog]);
+    // A sequential loop would deadlock on the gate: the first scope never
+    // resolves, so the second never starts and recallForContext never returns.
+    expect(result).not.toBe("timeout");
+    expect(events.indexOf("start:project-bank")).toBeGreaterThanOrEqual(0);
+    expect(events.indexOf("start:global-bank")).toBeGreaterThanOrEqual(0);
+    const firstEnd = Math.min(
+      events.indexOf("end:project-bank"),
+      events.indexOf("end:global-bank"),
+    );
+    expect(events.indexOf("start:project-bank")).toBeLessThan(firstEnd);
+    expect(events.indexOf("start:global-bank")).toBeLessThan(firstEnd);
+    if (result !== "timeout") {
+      expect(result.blocks.map((block) => block.bankId)).toEqual(["project-bank", "global-bank"]);
+    }
+  });
+
+  it("keeps scope order and per-scope failure isolation under concurrency", async () => {
+    const result = await recallForContext({
+      client: {
+        retain: async () => undefined,
+        recall: async (bankId) => {
+          if (bankId === "global-bank") {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            throw new Error("boom");
+          }
+          return { results: [{ text: "project memory" }] };
+        },
+        reflect: async () => ({}),
+      },
+      config: DEFAULT_CONFIG,
+      scopes: [
+        { kind: "project", bankId: "project-bank" },
+        { kind: "global", bankId: "global-bank" },
+      ],
+      cwd: "/repo/project",
+      messages,
+    });
+    expect(result.failed).toBe(1);
+    expect(result.failures.map((failure) => failure.bankId)).toEqual(["global-bank"]);
+    expect(result.blocks.map((block) => block.bankId)).toEqual(["project-bank"]);
+  });
+});


### PR DESCRIPTION
## What

Two recall-path fixes for pi-hindsight, measured against a production Hindsight deployment (v0.9.2, 13GB DB):

### 1. Run per-scope recalls concurrently (`perf(recall)`)

`recallForContext` loops over scopes sequentially, so with a project bank + user bank every turn start pays the full per-bank recall latency twice. Measured on our deployment: single-bank recall p50 ≈ 2.2s, two scopes ≈ 4.4s+ at every turn.

The loop is now `Promise.all` over scopes with per-scope result capture:

- Input order preserved — `blocks` and `failures` still appear in scope order (verified by test).
- Per-scope failure isolation unchanged — one bank erroring still yields only its failure entry (verified by test).
- No change to query composition, injection position, message shape, the `canAppendRecallMessage` gate, or the 60s cache key — those live outside this function.

Wall time at turn start drops to ≈ single-bank latency.

### 2. Abort the client fetch when the recall timeout fires (`fix(recall)`)

`recallForContext` wraps the client call in `withTimeout` but passes `() => ...`, discarding the controller signal. When the recall timeout fires, the turn-side promise rejects but the underlying HTTP request keeps running to the client-level timeout — our deployment recorded ~1,000 client-abandoned recalls where the server kept working after nobody was waiting. The Hindsight server (v0.9.2) cancels a recall on client disconnect (`[RECALL CANCELLED] reason=client disconnected`, verified empirically), so aborting the fetch is enough to stop the wasted server work.

The fix forwards `withTimeout`'s signal as `options.signal`; the adapted client already treats it as a parent signal and aborts the fetch. Default `timeoutMs` values are unchanged.

## Tests

New: `tests/recall-scope-parallelism.test.ts` (gate-based concurrency proof + order/failure isolation) and `tests/recall-abort-forwarding.test.ts` (timeout fires → captured signal is aborted, failure recorded).

Full suite: 68 files / 582 tests passing; `tsgo --noEmit`, `oxlint`, and `oxfmt --check` clean.

## Environment note

Measured on a self-hosted deployment (skynet3, Timescale PG17, local vLLM embeddings); improvements are structural (latency stacking and connection lifetime), not hardware-specific.
