### PR TITLE
feat(import): add multi-root session orchestration

### DIFF
--- a/docs-site/src/content/docs/guides/importing-sessions.md
+++ b/docs-site/src/content/docs/guides/importing-sessions.md
@@ -39,7 +39,7 @@ Open `/hindsight` and press `i` (import always dry-runs before write). Guided se
 
 There are no import tools and no public `/hindsight:import*` slash commands. Project imports target Pi session JSONL. Chat transcript import is available through guided setup / hub import and defaults to the configured User Bank.
 
-For broader backfills, choose the approved-roots import option and enter only roots you want scanned. Discovery groups sessions by each canonical source `cwd`, reports invalid-header/unreadable counts, and marks missing or temporary worktree cwd groups as stale/transient. Every group defaults to **Skip**. Add target bank IDs explicitly with one mapping line per group, for example:
+For broader backfills, choose the approved-roots import option and enter only roots you want scanned. Discovery groups sessions by each canonical source `cwd`, reports invalid-header/unreadable counts, and marks missing or temporary worktree cwd groups as stale/transient. Every group defaults to **Skip**. Add target bank IDs explicitly with one mapping line per discovered group, for example:
 
 ```text
 /repos/app=coding-bank
@@ -47,7 +47,7 @@ For broader backfills, choose the approved-roots import option and enter only ro
 /private/tmp/old-worktree=skip
 ```
 
-Target bank IDs are resolved only from configured/current aliases or explicit IDs. Pi Hindsight does not silently create banks during import planning. When a group maps to multiple banks, the final plan marks that intentional fan-out. The write path preflights every selected `(source cwd, target bank)` pair again and starts real imports only if all preflights succeed.
+Mapping CWDs are canonicalized with the same rules as discovery and must exactly match a discovered source group; typo or unknown groups reject the whole plan before confirmation. Target aliases `project`, `global`, and `user` resolve to configured bank IDs before planning. Every unique selected target bank is verified with Hindsight bank-profile lookup before any session-pair dry run or write. Missing banks, unavailable profile lookup, or validation errors reject the import without creating banks. When a group maps to multiple banks, the final plan marks that intentional fan-out. The write path preflights every selected `(source cwd, target bank)` pair again and starts real imports only if all preflights succeed.
 
 ## Preview output
 
@@ -63,7 +63,7 @@ Project session discovery avoids broad history imports. It scans only the curren
 
 Equivalent path forms are treated as the same project, including trailing separators, `.` segments, `..` traversal that resolves back to the repo, and resolved absolute paths.
 
-Approved-root discovery scans only the roots entered by the user, reads only a bounded JSONL prefix needed to parse the first nonblank session header, groups sessions by canonical `cwd`, classifies missing or known temporary worktree cwd groups as stale/transient, and canonically deduplicates files reached through overlapping approved roots.
+Approved-root discovery scans only the roots entered by the user, reads only a bounded JSONL prefix needed to parse the first nonblank session header, groups sessions by canonical `cwd`, classifies missing or known temporary worktree cwd groups as stale/transient, and canonically deduplicates files reached through overlapping approved roots. Skipped groups remain visible in the reviewed plan; selected groups are explicit and must map to verified existing target banks.
 
 ## Document IDs and rebuilds
 

--- a/docs-site/src/content/docs/guides/importing-sessions.md
+++ b/docs-site/src/content/docs/guides/importing-sessions.md
@@ -14,9 +14,10 @@ Guided import:
 
 1. chooses the source type from the selected profile/template
 2. previews first
-3. shows counts and target bank
-4. asks before writing memory
-5. can refresh mental models after successful import
+3. shows counts and target bank for single-root imports
+4. requires reviewed source-cwd to target-bank mappings for approved-root imports
+5. asks before writing memory
+6. can refresh mental models after successful import
 
 Project/coding setup offers repo-scoped Pi session import. User/assistant setup offers chat transcript import into User memory.
 
@@ -27,6 +28,7 @@ Pi Hindsight supports:
 - current Pi session
 - explicit Pi session JSONL file
 - repo-scoped Pi sessions from the current session directory
+- approved Pi session JSONL roots, grouped by each session header's canonical `cwd`
 - explicit chat transcript JSONL files for User memory
 
 Pi session imports and chat transcript imports are separate paths. They do not silently mix repo history with user conversation history.
@@ -36,6 +38,16 @@ Pi session imports and chat transcript imports are separate paths. They do not s
 Open `/hindsight` and press `i` (import always dry-runs before write). Guided setup can also offer import after profile selection.
 
 There are no import tools and no public `/hindsight:import*` slash commands. Project imports target Pi session JSONL. Chat transcript import is available through guided setup / hub import and defaults to the configured User Bank.
+
+For broader backfills, choose the approved-roots import option and enter only roots you want scanned. Discovery groups sessions by each canonical source `cwd`, reports invalid-header/unreadable counts, and marks missing or temporary worktree cwd groups as stale/transient. Every group defaults to **Skip**. Add target bank IDs explicitly with one mapping line per group, for example:
+
+```text
+/repos/app=coding-bank
+/repos/archive=coding-bank, archive-bank
+/private/tmp/old-worktree=skip
+```
+
+Target bank IDs are resolved only from configured/current aliases or explicit IDs. Pi Hindsight does not silently create banks during import planning. When a group maps to multiple banks, the final plan marks that intentional fan-out. The write path preflights every selected `(source cwd, target bank)` pair again and starts real imports only if all preflights succeed.
 
 ## Preview output
 
@@ -50,6 +62,8 @@ Use these numbers to catch noisy imports before writing memory.
 Project session discovery avoids broad history imports. It scans only the current session file's directory and keeps `.jsonl` files whose parsed `cwd` resolves to the current repo/cwd.
 
 Equivalent path forms are treated as the same project, including trailing separators, `.` segments, `..` traversal that resolves back to the repo, and resolved absolute paths.
+
+Approved-root discovery scans only the roots entered by the user, reads only a bounded JSONL prefix needed to parse the first nonblank session header, groups sessions by canonical `cwd`, classifies missing or known temporary worktree cwd groups as stale/transient, and canonically deduplicates files reached through overlapping approved roots.
 
 ## Document IDs and rebuilds
 

--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -25,6 +25,7 @@ Pi Hindsight supports:
 - current Pi session
 - explicit Pi session JSONL file
 - repo-scoped Pi sessions from the current session directory
+- approved Pi session JSONL roots, grouped by each session header's canonical `cwd`
 - explicit chat transcript JSONL files for User memory
 
 Pi session imports and chat transcript imports are separate paths. They do not silently mix repo history with user conversation history.
@@ -38,6 +39,8 @@ Open `/hindsight` and press `i` (import always dry-runs before write). Guided se
 ```
 
 If the preview looks right, rerun without `--dry-run`. Non-dry-run imports announce the start and require confirmation because they write memory plus local checkpoint/manifest files.
+
+For broader backfills, choose the approved-roots import option and enter only roots you want scanned. The hub previews first; after confirmation the write path preflights every discovered project group again and starts real imports only if all preflights succeed.
 
 Use `--all-leaves` only when you intentionally want every fork leaf from a session file. Default import follows the current branch.
 
@@ -58,6 +61,8 @@ Use these numbers to catch noisy imports before writing memory.
 Project session discovery avoids broad history imports. It scans only the current session file's directory and keeps `.jsonl` files whose parsed `cwd` resolves to the current repo/cwd.
 
 Equivalent path forms are treated as the same project, including trailing separators, `.` segments, `..` traversal that resolves back to the repo, and resolved absolute paths.
+
+Approved-root discovery scans only the roots entered by the user, reads only a bounded JSONL prefix needed to parse the first nonblank session header, groups sessions by canonical `cwd`, and canonically deduplicates files reached through overlapping approved roots.
 
 ## Document IDs and rebuilds
 

--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -41,7 +41,7 @@ Open `/hindsight` and press `i` (import always dry-runs before write). Guided se
 
 If the preview looks right, rerun without `--dry-run`. Non-dry-run imports announce the start and require confirmation because they write memory plus local checkpoint/manifest files.
 
-For broader backfills, choose the approved-roots import option and enter only roots you want scanned. Discovery groups sessions by each canonical source `cwd`, reports invalid-header/unreadable counts, and marks missing or temporary worktree cwd groups as stale/transient. Every group defaults to **Skip**. Add target bank IDs explicitly with one mapping line per group, for example:
+For broader backfills, choose the approved-roots import option and enter only roots you want scanned. Discovery groups sessions by each canonical source `cwd`, reports invalid-header/unreadable counts, and marks missing or temporary worktree cwd groups as stale/transient. Every group defaults to **Skip**. Add target bank IDs explicitly with one mapping line per discovered group, for example:
 
 ```text
 /repos/app=coding-bank
@@ -49,7 +49,7 @@ For broader backfills, choose the approved-roots import option and enter only ro
 /private/tmp/old-worktree=skip
 ```
 
-Target bank IDs are resolved only from configured/current aliases or explicit IDs. Pi Hindsight does not silently create banks during import planning. When a group maps to multiple banks, the final plan marks that intentional fan-out. The write path preflights every selected `(source cwd, target bank)` pair again and starts real imports only if all preflights succeed.
+Mapping CWDs are canonicalized with the same rules as discovery and must exactly match a discovered source group; typo or unknown groups reject the whole plan before confirmation. Target aliases `project`, `global`, and `user` resolve to configured bank IDs before planning. Every unique selected target bank is verified with Hindsight bank-profile lookup before any session-pair dry run or write. Missing banks, unavailable profile lookup, or validation errors reject the import without creating banks. When a group maps to multiple banks, the final plan marks that intentional fan-out. The write path preflights every selected `(source cwd, target bank)` pair again and starts real imports only if all preflights succeed.
 
 Use `--all-leaves` only when you intentionally want every fork leaf from a session file. Default import follows the current branch.
 
@@ -71,7 +71,7 @@ Project session discovery avoids broad history imports. It scans only the curren
 
 Equivalent path forms are treated as the same project, including trailing separators, `.` segments, `..` traversal that resolves back to the repo, and resolved absolute paths.
 
-Approved-root discovery scans only the roots entered by the user, reads only a bounded JSONL prefix needed to parse the first nonblank session header, groups sessions by canonical `cwd`, classifies missing or known temporary worktree cwd groups as stale/transient, and canonically deduplicates files reached through overlapping approved roots.
+Approved-root discovery scans only the roots entered by the user, reads only a bounded JSONL prefix needed to parse the first nonblank session header, groups sessions by canonical `cwd`, classifies missing or known temporary worktree cwd groups as stale/transient, and canonically deduplicates files reached through overlapping approved roots. Skipped groups remain visible in the reviewed plan; selected groups are explicit and must map to verified existing target banks.
 
 ## Document IDs and rebuilds
 

--- a/docs/importing-sessions.md
+++ b/docs/importing-sessions.md
@@ -12,9 +12,10 @@ Guided import:
 
 1. chooses the source type from the selected profile/template
 2. previews first
-3. shows counts and target bank
-4. asks before writing memory
-5. can refresh mental models after successful import
+3. shows counts and target bank for single-root imports
+4. requires reviewed source-cwd to target-bank mappings for approved-root imports
+5. asks before writing memory
+6. can refresh mental models after successful import
 
 Project/coding setup offers repo-scoped Pi session import. User/assistant setup offers chat transcript import into User memory.
 
@@ -40,7 +41,15 @@ Open `/hindsight` and press `i` (import always dry-runs before write). Guided se
 
 If the preview looks right, rerun without `--dry-run`. Non-dry-run imports announce the start and require confirmation because they write memory plus local checkpoint/manifest files.
 
-For broader backfills, choose the approved-roots import option and enter only roots you want scanned. The hub previews first; after confirmation the write path preflights every discovered project group again and starts real imports only if all preflights succeed.
+For broader backfills, choose the approved-roots import option and enter only roots you want scanned. Discovery groups sessions by each canonical source `cwd`, reports invalid-header/unreadable counts, and marks missing or temporary worktree cwd groups as stale/transient. Every group defaults to **Skip**. Add target bank IDs explicitly with one mapping line per group, for example:
+
+```text
+/repos/app=coding-bank
+/repos/archive=coding-bank, archive-bank
+/private/tmp/old-worktree=skip
+```
+
+Target bank IDs are resolved only from configured/current aliases or explicit IDs. Pi Hindsight does not silently create banks during import planning. When a group maps to multiple banks, the final plan marks that intentional fan-out. The write path preflights every selected `(source cwd, target bank)` pair again and starts real imports only if all preflights succeed.
 
 Use `--all-leaves` only when you intentionally want every fork leaf from a session file. Default import follows the current branch.
 
@@ -62,7 +71,7 @@ Project session discovery avoids broad history imports. It scans only the curren
 
 Equivalent path forms are treated as the same project, including trailing separators, `.` segments, `..` traversal that resolves back to the repo, and resolved absolute paths.
 
-Approved-root discovery scans only the roots entered by the user, reads only a bounded JSONL prefix needed to parse the first nonblank session header, groups sessions by canonical `cwd`, and canonically deduplicates files reached through overlapping approved roots.
+Approved-root discovery scans only the roots entered by the user, reads only a bounded JSONL prefix needed to parse the first nonblank session header, groups sessions by canonical `cwd`, classifies missing or known temporary worktree cwd groups as stale/transient, and canonically deduplicates files reached through overlapping approved roots.
 
 ## Document IDs and rebuilds
 

--- a/docs/tools-and-commands.md
+++ b/docs/tools-and-commands.md
@@ -14,19 +14,19 @@ Pi Hindsight is **TUI-first**. Public slash commands:
 
 ### Hub keys
 
-| Key | Action                                                                |
-| --- | --------------------------------------------------------------------- |
-| `g` | Guided setup (profile, agent use, banks, optional templates + import) |
-| `m` | Session mode: `normal` / `read-only` / `ignored`                      |
-| `x` | Next-opt-out: skip automatic retain for the next agent run            |
-| `f` | Flush retain queue                                                    |
-| `o` | Doctor diagnostics report (includes status tones)                     |
-| `n` | Write `.pi/hindsight.json` with the selected project bank             |
-| `d` | Deployment / connection helpers                                       |
-| `i` | Historical import (dry-run first)                                     |
-| `t` | Apply starter bank template / mental-model set (dry-run first)        |
-| `a` | Toggle advanced settings (prefer agent tools for day-to-day edits)    |
-| `q` | Close                                                                 |
+| Key | Action                                                                 |
+| --- | ---------------------------------------------------------------------- |
+| `g` | Guided setup (profile, agent use, banks, optional templates + import)  |
+| `m` | Session mode: `normal` / `read-only` / `ignored`                       |
+| `x` | Next-opt-out: skip automatic retain for the next agent run             |
+| `f` | Flush retain queue                                                     |
+| `o` | Doctor diagnostics report (includes status tones)                      |
+| `n` | Write `.pi/hindsight.json` with the selected project bank              |
+| `d` | Deployment / connection helpers                                        |
+| `i` | Historical import, including approved Pi session roots (dry-run first) |
+| `t` | Apply starter bank template / mental-model set (dry-run first)         |
+| `a` | Toggle advanced settings (prefer agent tools for day-to-day edits)     |
+| `q` | Close                                                                  |
 
 Day-to-day mission, mental-model, knowledge-page, and config edits: prefer agent control-plane tools (`hindsight_status`, `hindsight_config`, `hindsight_bank`, `hindsight_mental_model`, `hindsight_knowledge`); the advanced TUI farm is an escape hatch, not the primary surface.
 

--- a/extensions/imports/import-multi-root.ts
+++ b/extensions/imports/import-multi-root.ts
@@ -1,0 +1,460 @@
+import type { HindsightLikeClient, ResolvedConfig } from "../types.js";
+import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
+import { lstat, open, readdir, realpath } from "node:fs/promises";
+import { redactError, redactSecrets } from "../utils/sanitize.js";
+import { resolveOperationBank } from "../banks/bank-selection.js";
+import {
+  importProjectSessions as defaultImportProjectSessions,
+  type ImportOperationDeps,
+  type ImportProgressReporter,
+  type ImportProjectSessionsResult,
+} from "./import-sessions.js";
+
+export type MultiRootImportGroupStatus =
+  | "dry-run-completed"
+  | "dry-run-failed"
+  | "imported"
+  | "import-failed";
+
+export type MultiRootImportOutcomeCategory =
+  | MultiRootInvalidSession["reason"]
+  | MultiRootImportGroupStatus;
+
+export type MultiRootImportCategoryCounts = Record<MultiRootImportOutcomeCategory, number>;
+
+export interface MultiRootSessionHeader {
+  sessionFile: string;
+  sessionId: string;
+}
+
+export interface MultiRootInvalidSession {
+  sessionFile: string;
+  reason: "invalid-header" | "unreadable";
+  error?: string;
+}
+
+export interface MultiRootSessionGroup {
+  cwd: string;
+  sessions: MultiRootSessionHeader[];
+}
+
+export interface MultiRootSessionDiscoveryResult {
+  approvedRoots: string[];
+  scannedFileCount: number;
+  validSessionCount: number;
+  invalidSessionCount: number;
+  groups: MultiRootSessionGroup[];
+  invalidSessions: MultiRootInvalidSession[];
+}
+
+export interface MultiRootProjectImportGroupResult {
+  cwd: string;
+  searchRoots: string[];
+  status: MultiRootImportGroupStatus;
+  dryRuns: ImportProjectSessionsResult[];
+  importResults: ImportProjectSessionsResult[];
+  error?: string;
+}
+
+export interface MultiRootProjectImportResult {
+  dryRun: boolean;
+  discovery: MultiRootSessionDiscoveryResult;
+  groups: MultiRootProjectImportGroupResult[];
+  summary: {
+    approvedRootCount: number;
+    scannedFileCount: number;
+    validSessionCount: number;
+    invalidSessionCount: number;
+    groupCount: number;
+    dryRunGroupCount: number;
+    importedGroupCount: number;
+    failedGroupCount: number;
+    documentCount: number;
+    messageCount: number;
+    malformedLineCount: number;
+    categoryCounts: MultiRootImportCategoryCounts;
+  };
+}
+
+type ImportProjectSessionsDelegate = typeof defaultImportProjectSessions;
+
+interface SessionHeader {
+  cwd: string;
+  sessionId: string;
+}
+
+interface PendingSessionHeader extends MultiRootSessionHeader {
+  root: string;
+}
+
+const SESSION_HEADER_READ_CHUNK_BYTES = 4096;
+const SESSION_HEADER_MAX_BYTES = 64 * 1024;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function canonicalPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function parseSessionHeaderLine(line: string): SessionHeader | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(parsed)) return undefined;
+  if (parsed.type !== "session") return undefined;
+  if (typeof parsed.cwd !== "string" || !parsed.cwd.trim()) return undefined;
+  if (typeof parsed.id !== "string" || !parsed.id.trim()) return undefined;
+  return { cwd: parsed.cwd, sessionId: parsed.id };
+}
+
+async function readSessionHeader(sessionFile: string): Promise<SessionHeader | undefined> {
+  const handle = await open(sessionFile, "r");
+  try {
+    const buffer = Buffer.alloc(SESSION_HEADER_READ_CHUNK_BYTES);
+    let text = "";
+    let bytesReadTotal = 0;
+    while (bytesReadTotal < SESSION_HEADER_MAX_BYTES) {
+      const remaining = SESSION_HEADER_MAX_BYTES - bytesReadTotal;
+      const read = await handle.read(buffer, 0, Math.min(buffer.length, remaining), bytesReadTotal);
+      if (read.bytesRead === 0) break;
+      bytesReadTotal += read.bytesRead;
+      text += buffer.toString("utf8", 0, read.bytesRead);
+      const lines = text.split("\n");
+      for (const line of lines.slice(0, -1)) {
+        if (line.trim()) return parseSessionHeaderLine(line);
+      }
+      if (text.includes("\n")) text = lines.at(-1) ?? "";
+    }
+    const line = text.split("\n").find((candidate) => candidate.trim());
+    return line ? parseSessionHeaderLine(line) : undefined;
+  } finally {
+    await handle.close();
+  }
+}
+
+function redactImportError(error: unknown): string {
+  return redactSecrets(redactError(error));
+}
+
+async function collectJsonlFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+  async function visit(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const path = join(dir, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        await visit(path);
+        continue;
+      }
+      if (!entry.isFile() || extname(entry.name) !== ".jsonl") continue;
+      const info = await lstat(path);
+      if (info.isFile()) files.push(path);
+    }
+  }
+  await visit(root);
+  return files.sort();
+}
+
+export async function discoverMultiRootPiSessionHeaders(args: {
+  approvedRoots: string[];
+}): Promise<MultiRootSessionDiscoveryResult> {
+  const approvedRoots = (await Promise.all(args.approvedRoots.map((root) => canonicalPath(root))))
+    .filter((root, index, roots) => roots.indexOf(root) === index)
+    .sort();
+  const validSessions: Array<{ cwd: string; session: PendingSessionHeader }> = [];
+  const invalidSessions: MultiRootInvalidSession[] = [];
+  const seenSessionFiles = new Set<string>();
+  let scannedFileCount = 0;
+
+  for (const root of approvedRoots) {
+    let files: string[];
+    try {
+      files = await collectJsonlFiles(root);
+    } catch (error) {
+      invalidSessions.push({
+        sessionFile: root,
+        reason: "unreadable",
+        error: redactImportError(error),
+      });
+      continue;
+    }
+    for (const discoveredSessionFile of files) {
+      const sessionFile = await canonicalPath(discoveredSessionFile);
+      if (seenSessionFiles.has(sessionFile)) continue;
+      seenSessionFiles.add(sessionFile);
+      scannedFileCount += 1;
+      let header: SessionHeader | undefined;
+      try {
+        header = await readSessionHeader(sessionFile);
+      } catch (error) {
+        invalidSessions.push({
+          sessionFile,
+          reason: "unreadable",
+          error: redactImportError(error),
+        });
+        continue;
+      }
+      if (!header) {
+        invalidSessions.push({ sessionFile, reason: "invalid-header" });
+        continue;
+      }
+      validSessions.push({
+        cwd: await canonicalPath(header.cwd),
+        session: { sessionFile, sessionId: header.sessionId, root },
+      });
+    }
+  }
+
+  const grouped = new Map<string, PendingSessionHeader[]>();
+  for (const item of validSessions) {
+    grouped.set(item.cwd, [...(grouped.get(item.cwd) ?? []), item.session]);
+  }
+
+  return {
+    approvedRoots,
+    scannedFileCount,
+    validSessionCount: validSessions.length,
+    invalidSessionCount: invalidSessions.length,
+    groups: [...grouped]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([cwd, sessions]) => ({
+        cwd,
+        sessions: sessions
+          .map(({ sessionFile, sessionId }) => ({ sessionFile, sessionId }))
+          .sort((left, right) => left.sessionFile.localeCompare(right.sessionFile)),
+      })),
+    invalidSessions: invalidSessions.sort((left, right) =>
+      left.sessionFile.localeCompare(right.sessionFile),
+    ),
+  };
+}
+
+function rootsForGroup(discovery: MultiRootSessionDiscoveryResult, cwd: string): string[] {
+  const group = discovery.groups.find((candidate) => candidate.cwd === cwd);
+  if (!group) return [];
+  return [
+    ...new Set(
+      group.sessions.map((session) => {
+        const root = discovery.approvedRoots.find((candidate) => {
+          const path = relative(candidate, session.sessionFile);
+          return path && !path.startsWith("..") && !isAbsolute(path);
+        });
+        return root ?? dirname(session.sessionFile);
+      }),
+    ),
+  ].sort();
+}
+
+function aggregateDocumentCount(groups: MultiRootProjectImportGroupResult[]): number {
+  return groups.reduce((count, group) => {
+    const results = group.importResults.length ? group.importResults : group.dryRuns;
+    return count + results.reduce((innerCount, result) => innerCount + result.documentCount, 0);
+  }, 0);
+}
+
+function aggregateMessageCount(groups: MultiRootProjectImportGroupResult[]): number {
+  return groups.reduce((count, group) => {
+    const results = group.importResults.length ? group.importResults : group.dryRuns;
+    return count + results.reduce((innerCount, result) => innerCount + result.messageCount, 0);
+  }, 0);
+}
+
+function aggregateMalformedLineCount(groups: MultiRootProjectImportGroupResult[]): number {
+  return groups.reduce((count, group) => {
+    const results = group.importResults.length ? group.importResults : group.dryRuns;
+    return (
+      count + results.reduce((innerCount, result) => innerCount + result.malformedLineCount, 0)
+    );
+  }, 0);
+}
+
+function multiRootImportCategoryCounts(
+  discovery: MultiRootSessionDiscoveryResult,
+  groups: MultiRootProjectImportGroupResult[],
+): MultiRootImportCategoryCounts {
+  const counts: MultiRootImportCategoryCounts = {
+    unreadable: 0,
+    "invalid-header": 0,
+    "dry-run-completed": 0,
+    "dry-run-failed": 0,
+    imported: 0,
+    "import-failed": 0,
+  };
+  for (const invalidSession of discovery.invalidSessions) counts[invalidSession.reason] += 1;
+  for (const group of groups) counts[group.status] += 1;
+  return counts;
+}
+
+function multiRootImportSummary(
+  discovery: MultiRootSessionDiscoveryResult,
+  groups: MultiRootProjectImportGroupResult[],
+) {
+  return {
+    approvedRootCount: discovery.approvedRoots.length,
+    scannedFileCount: discovery.scannedFileCount,
+    validSessionCount: discovery.validSessionCount,
+    invalidSessionCount: discovery.invalidSessionCount,
+    groupCount: discovery.groups.length,
+    dryRunGroupCount: groups.filter((group) => group.dryRuns.length > 0).length,
+    importedGroupCount: groups.filter((group) => group.status === "imported").length,
+    failedGroupCount: groups.filter((group) => group.status.endsWith("failed")).length,
+    documentCount: aggregateDocumentCount(groups),
+    messageCount: aggregateMessageCount(groups),
+    malformedLineCount: aggregateMalformedLineCount(groups),
+    categoryCounts: multiRootImportCategoryCounts(discovery, groups),
+  };
+}
+
+export async function importMultiRootProjectSessions(
+  args: {
+    approvedRoots: string[];
+    bankId: string;
+    client: HindsightLikeClient;
+    config: ResolvedConfig;
+    dryRun?: boolean;
+    dryRunFirst?: boolean;
+    includeBranches?: ResolvedConfig["import"]["includeBranches"];
+    onProgress?: ImportProgressReporter;
+  },
+  deps: { importProjectSessions?: ImportProjectSessionsDelegate } = {},
+): Promise<MultiRootProjectImportResult> {
+  const importProjectSessions = deps.importProjectSessions ?? defaultImportProjectSessions;
+  const discovery = await discoverMultiRootPiSessionHeaders({ approvedRoots: args.approvedRoots });
+  const groups: MultiRootProjectImportGroupResult[] = [];
+  const dryRun = args.dryRun ?? false;
+  const dryRunFirst = !dryRun && (args.dryRunFirst ?? false);
+
+  const delegateGroup = async (
+    group: MultiRootSessionGroup,
+    searchRoots: string[],
+    delegateDryRun: boolean,
+  ): Promise<ImportProjectSessionsResult[]> => {
+    const results: ImportProjectSessionsResult[] = [];
+    for (const searchDir of searchRoots) {
+      results.push(
+        await importProjectSessions({
+          cwd: group.cwd,
+          searchDir,
+          bankId: args.bankId,
+          client: args.client,
+          config: args.config,
+          dryRun: delegateDryRun,
+          ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
+          ...(args.onProgress ? { onProgress: args.onProgress } : {}),
+        }),
+      );
+    }
+    return results;
+  };
+
+  if (dryRun || dryRunFirst) {
+    for (const group of discovery.groups) {
+      const searchRoots = rootsForGroup(discovery, group.cwd);
+      try {
+        groups.push({
+          cwd: group.cwd,
+          searchRoots,
+          status: "dry-run-completed",
+          dryRuns: await delegateGroup(group, searchRoots, true),
+          importResults: [],
+        });
+      } catch (error) {
+        groups.push({
+          cwd: group.cwd,
+          searchRoots,
+          status: "dry-run-failed",
+          dryRuns: [],
+          importResults: [],
+          error: redactImportError(error),
+        });
+      }
+    }
+    if (dryRun || groups.some((group) => group.status === "dry-run-failed")) {
+      return {
+        dryRun,
+        discovery,
+        groups,
+        summary: multiRootImportSummary(discovery, groups),
+      };
+    }
+  }
+
+  for (const group of discovery.groups) {
+    const searchRoots = rootsForGroup(discovery, group.cwd);
+    const preflight = groups.find((candidate) => candidate.cwd === group.cwd);
+    const dryRuns: ImportProjectSessionsResult[] = preflight?.dryRuns ?? [];
+    const importResults: ImportProjectSessionsResult[] = [];
+
+    try {
+      importResults.push(...(await delegateGroup(group, searchRoots, false)));
+    } catch (error) {
+      const failedGroup = {
+        cwd: group.cwd,
+        searchRoots,
+        status: "import-failed" as const,
+        dryRuns,
+        importResults,
+        error: redactImportError(error),
+      };
+      if (preflight) groups[groups.indexOf(preflight)] = failedGroup;
+      else groups.push(failedGroup);
+      continue;
+    }
+
+    const importedGroup = {
+      cwd: group.cwd,
+      searchRoots,
+      status: "imported" as const,
+      dryRuns,
+      importResults,
+    };
+    if (preflight) groups[groups.indexOf(preflight)] = importedGroup;
+    else groups.push(importedGroup);
+  }
+
+  return {
+    dryRun,
+    discovery,
+    groups,
+    summary: multiRootImportSummary(discovery, groups),
+  };
+}
+
+export async function importMemoryMultiRootProjectSessions(
+  args: {
+    approvedRoots: string[];
+    bank?: string;
+    dryRun?: boolean;
+    dryRunFirst?: boolean;
+    includeBranches?: ResolvedConfig["import"]["includeBranches"];
+    onProgress?: ImportProgressReporter;
+  },
+  deps: ImportOperationDeps,
+) {
+  const bankId = resolveOperationBank({
+    requestedBank: args.bank,
+    config: deps.getConfig(),
+    projectBankId: deps.getProjectBankId(),
+  });
+  const result = await importMultiRootProjectSessions({
+    approvedRoots: args.approvedRoots,
+    bankId,
+    client: deps.getClient(),
+    config: deps.getConfig(),
+    ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+    ...(args.dryRunFirst !== undefined ? { dryRunFirst: args.dryRunFirst } : {}),
+    ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
+    ...(args.onProgress ? { onProgress: args.onProgress } : {}),
+  });
+  return { bankId, ...result };
+}

--- a/extensions/imports/import-multi-root.ts
+++ b/extensions/imports/import-multi-root.ts
@@ -1,6 +1,9 @@
 import type { HindsightLikeClient, ResolvedConfig } from "../types.js";
 import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
 import { lstat, open, readdir, realpath } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { redactError, redactSecrets } from "../utils/sanitize.js";
 import { resolveOperationBank } from "../banks/bank-selection.js";
 import {
@@ -49,6 +52,7 @@ export interface MultiRootSessionDiscoveryResult {
 
 export interface MultiRootProjectImportGroupResult {
   cwd: string;
+  targetBankId?: string;
   searchRoots: string[];
   status: MultiRootImportGroupStatus;
   dryRuns: ImportProjectSessionsResult[];
@@ -59,6 +63,7 @@ export interface MultiRootProjectImportGroupResult {
 export interface MultiRootProjectImportResult {
   dryRun: boolean;
   discovery: MultiRootSessionDiscoveryResult;
+  plan: MultiRootProjectImportPlan;
   groups: MultiRootProjectImportGroupResult[];
   summary: {
     approvedRootCount: number;
@@ -66,6 +71,12 @@ export interface MultiRootProjectImportResult {
     validSessionCount: number;
     invalidSessionCount: number;
     groupCount: number;
+    skippedGroupCount: number;
+    transientGroupCount: number;
+    mappingPairCount: number;
+    fanOutGroupCount: number;
+    importedPairCount: number;
+    failedPairCount: number;
     dryRunGroupCount: number;
     importedGroupCount: number;
     failedGroupCount: number;
@@ -73,6 +84,34 @@ export interface MultiRootProjectImportResult {
     messageCount: number;
     malformedLineCount: number;
     categoryCounts: MultiRootImportCategoryCounts;
+  };
+}
+
+export interface MultiRootProjectImportPlanMapping {
+  cwd: string;
+  targetBankIds: string[];
+}
+
+export interface MultiRootProjectImportPlanGroup {
+  cwd: string;
+  sessionCount: number;
+  targetBankIds: string[];
+  skipped: boolean;
+  skipReason?: string;
+  fanOut: boolean;
+  classification: "active" | "transient" | "stale";
+  classificationReasons: string[];
+}
+
+export interface MultiRootProjectImportPlan {
+  groups: MultiRootProjectImportPlanGroup[];
+  summary: {
+    groupCount: number;
+    skippedGroupCount: number;
+    transientGroupCount: number;
+    mappingPairCount: number;
+    fanOutGroupCount: number;
+    invalidCategoryCounts: Record<MultiRootInvalidSession["reason"], number>;
   };
 }
 
@@ -150,6 +189,92 @@ function invalidApprovedRoot(root: string): MultiRootInvalidSession {
     sessionFile: redactSecrets(root),
     reason: "unreadable",
     error: "Approved root must be absolute.",
+  };
+}
+
+function uniqueTargetBankIds(targetBankIds: string[]): string[] {
+  return targetBankIds
+    .map((targetBankId) => targetBankId.trim())
+    .filter(Boolean)
+    .filter((targetBankId, index, ids) => ids.indexOf(targetBankId) === index);
+}
+
+function importStatePathForBank(path: string, bankId: string): string {
+  const hash = createHash("sha256").update(bankId).digest("hex").slice(0, 8);
+  const label = bankId
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  const suffix = `${label || "bank"}-${hash}`;
+  const extension = extname(path);
+  if (!extension) return `${path}.${suffix}`;
+  return `${path.slice(0, -extension.length)}.${suffix}${extension}`;
+}
+
+function invalidCategoryCounts(
+  invalidSessions: MultiRootInvalidSession[],
+): Record<MultiRootInvalidSession["reason"], number> {
+  const counts = { "invalid-header": 0, unreadable: 0 };
+  for (const invalidSession of invalidSessions) counts[invalidSession.reason] += 1;
+  return counts;
+}
+
+function classifySourceCwd(
+  cwd: string,
+): Pick<MultiRootProjectImportPlanGroup, "classification" | "classificationReasons"> {
+  const reasons: string[] = [];
+  if (!existsSync(cwd)) reasons.push("cwd-missing");
+  const normalized = cwd.replaceAll("\\", "/");
+  const tmpRoot = resolve(tmpdir()).replaceAll("\\", "/");
+  if (
+    normalized === tmpRoot ||
+    normalized.startsWith(`${tmpRoot}/`) ||
+    normalized.startsWith("/tmp/") ||
+    normalized.startsWith("/private/tmp/") ||
+    normalized.includes("/pi-hindsight-worktrees/")
+  ) {
+    reasons.push("temporary-worktree-path");
+  }
+  if (reasons.includes("cwd-missing"))
+    return { classification: "stale", classificationReasons: reasons };
+  if (reasons.length > 0) return { classification: "transient", classificationReasons: reasons };
+  return { classification: "active", classificationReasons: [] };
+}
+
+export function buildMultiRootProjectImportPlan(args: {
+  discovery: MultiRootSessionDiscoveryResult;
+  mappings?: MultiRootProjectImportPlanMapping[];
+  defaultBankId?: string;
+}): MultiRootProjectImportPlan {
+  const mappingByCwd = new Map<string, string[]>();
+  for (const mapping of args.mappings ?? []) {
+    mappingByCwd.set(mapping.cwd, uniqueTargetBankIds(mapping.targetBankIds));
+  }
+  const groups = args.discovery.groups.map((group): MultiRootProjectImportPlanGroup => {
+    const targetBankIds = uniqueTargetBankIds(
+      mappingByCwd.get(group.cwd) ?? (args.defaultBankId ? [args.defaultBankId] : []),
+    );
+    const classification = classifySourceCwd(group.cwd);
+    return {
+      cwd: group.cwd,
+      sessionCount: group.sessions.length,
+      targetBankIds,
+      skipped: targetBankIds.length === 0,
+      ...(targetBankIds.length === 0 ? { skipReason: "No target bank selected." } : {}),
+      fanOut: targetBankIds.length > 1,
+      ...classification,
+    };
+  });
+  return {
+    groups,
+    summary: {
+      groupCount: groups.length,
+      skippedGroupCount: groups.filter((group) => group.skipped).length,
+      transientGroupCount: groups.filter((group) => group.classification !== "active").length,
+      mappingPairCount: groups.reduce((count, group) => count + group.targetBankIds.length, 0),
+      fanOutGroupCount: groups.filter((group) => group.fanOut).length,
+      invalidCategoryCounts: invalidCategoryCounts(args.discovery.invalidSessions),
+    },
   };
 }
 
@@ -320,6 +445,7 @@ function multiRootImportCategoryCounts(
 
 function multiRootImportSummary(
   discovery: MultiRootSessionDiscoveryResult,
+  plan: MultiRootProjectImportPlan,
   groups: MultiRootProjectImportGroupResult[],
 ) {
   return {
@@ -328,6 +454,12 @@ function multiRootImportSummary(
     validSessionCount: discovery.validSessionCount,
     invalidSessionCount: discovery.invalidSessionCount,
     groupCount: discovery.groups.length,
+    skippedGroupCount: plan.summary.skippedGroupCount,
+    transientGroupCount: plan.summary.transientGroupCount,
+    mappingPairCount: plan.summary.mappingPairCount,
+    fanOutGroupCount: plan.summary.fanOutGroupCount,
+    importedPairCount: groups.filter((group) => group.status === "imported").length,
+    failedPairCount: groups.filter((group) => group.status.endsWith("failed")).length,
     dryRunGroupCount: groups.filter((group) => group.dryRuns.length > 0).length,
     importedGroupCount: groups.filter((group) => group.status === "imported").length,
     failedGroupCount: groups.filter((group) => group.status.endsWith("failed")).length,
@@ -341,7 +473,8 @@ function multiRootImportSummary(
 export async function importMultiRootProjectSessions(
   args: {
     approvedRoots: string[];
-    bankId: string;
+    bankId?: string;
+    importPlan?: { mappings: MultiRootProjectImportPlanMapping[] };
     client: HindsightLikeClient;
     config: ResolvedConfig;
     dryRun?: boolean;
@@ -353,12 +486,18 @@ export async function importMultiRootProjectSessions(
 ): Promise<MultiRootProjectImportResult> {
   const importProjectSessions = deps.importProjectSessions ?? defaultImportProjectSessions;
   const discovery = await discoverMultiRootPiSessionHeaders({ approvedRoots: args.approvedRoots });
+  const plan = buildMultiRootProjectImportPlan({
+    discovery,
+    ...(args.importPlan ? { mappings: args.importPlan.mappings } : {}),
+    ...(args.bankId ? { defaultBankId: args.bankId } : {}),
+  });
   const groups: MultiRootProjectImportGroupResult[] = [];
   const dryRun = args.dryRun ?? false;
   const dryRunFirst = !dryRun && (args.dryRunFirst ?? false);
 
   const delegateGroup = async (
     group: MultiRootSessionGroup,
+    targetBankId: string,
     searchRoots: string[],
     delegateDryRun: boolean,
   ): Promise<ImportProjectSessionsResult[]> => {
@@ -368,9 +507,19 @@ export async function importMultiRootProjectSessions(
         await importProjectSessions({
           cwd: group.cwd,
           searchDir,
-          bankId: args.bankId,
+          bankId: targetBankId,
           client: args.client,
-          config: args.config,
+          config: {
+            ...args.config,
+            import: {
+              ...args.config.import,
+              manifestPath: importStatePathForBank(args.config.import.manifestPath, targetBankId),
+              checkpointPath: importStatePathForBank(
+                args.config.import.checkpointPath,
+                targetBankId,
+              ),
+            },
+          },
           dryRun: delegateDryRun,
           sessionFiles: sessionFilesForSearchRoot(group, searchDir),
           ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
@@ -382,75 +531,91 @@ export async function importMultiRootProjectSessions(
   };
 
   if (dryRun || dryRunFirst) {
-    for (const group of discovery.groups) {
+    for (const planned of plan.groups.filter((group) => !group.skipped)) {
+      const group = discovery.groups.find((candidate) => candidate.cwd === planned.cwd);
+      if (!group) continue;
       const searchRoots = rootsForGroup(discovery, group.cwd);
-      try {
-        groups.push({
-          cwd: group.cwd,
-          searchRoots,
-          status: "dry-run-completed",
-          dryRuns: await delegateGroup(group, searchRoots, true),
-          importResults: [],
-        });
-      } catch (error) {
-        groups.push({
-          cwd: group.cwd,
-          searchRoots,
-          status: "dry-run-failed",
-          dryRuns: [],
-          importResults: [],
-          error: redactImportError(error),
-        });
+      for (const targetBankId of planned.targetBankIds) {
+        try {
+          groups.push({
+            cwd: group.cwd,
+            targetBankId,
+            searchRoots,
+            status: "dry-run-completed",
+            dryRuns: await delegateGroup(group, targetBankId, searchRoots, true),
+            importResults: [],
+          });
+        } catch (error) {
+          groups.push({
+            cwd: group.cwd,
+            targetBankId,
+            searchRoots,
+            status: "dry-run-failed",
+            dryRuns: [],
+            importResults: [],
+            error: redactImportError(error),
+          });
+        }
       }
     }
     if (dryRun || groups.some((group) => group.status === "dry-run-failed")) {
       return {
         dryRun,
         discovery,
+        plan,
         groups,
-        summary: multiRootImportSummary(discovery, groups),
+        summary: multiRootImportSummary(discovery, plan, groups),
       };
     }
   }
 
-  for (const group of discovery.groups) {
+  for (const planned of plan.groups.filter((group) => !group.skipped)) {
+    const group = discovery.groups.find((candidate) => candidate.cwd === planned.cwd);
+    if (!group) continue;
     const searchRoots = rootsForGroup(discovery, group.cwd);
-    const preflight = groups.find((candidate) => candidate.cwd === group.cwd);
-    const dryRuns: ImportProjectSessionsResult[] = preflight?.dryRuns ?? [];
-    const importResults: ImportProjectSessionsResult[] = [];
+    for (const targetBankId of planned.targetBankIds) {
+      const preflight = groups.find(
+        (candidate) => candidate.cwd === group.cwd && candidate.targetBankId === targetBankId,
+      );
+      const dryRuns: ImportProjectSessionsResult[] = preflight?.dryRuns ?? [];
+      const importResults: ImportProjectSessionsResult[] = [];
 
-    try {
-      importResults.push(...(await delegateGroup(group, searchRoots, false)));
-    } catch (error) {
-      const failedGroup = {
+      try {
+        importResults.push(...(await delegateGroup(group, targetBankId, searchRoots, false)));
+      } catch (error) {
+        const failedGroup = {
+          cwd: group.cwd,
+          targetBankId,
+          searchRoots,
+          status: "import-failed" as const,
+          dryRuns,
+          importResults,
+          error: redactImportError(error),
+        };
+        if (preflight) groups[groups.indexOf(preflight)] = failedGroup;
+        else groups.push(failedGroup);
+        continue;
+      }
+
+      const importedGroup = {
         cwd: group.cwd,
+        targetBankId,
         searchRoots,
-        status: "import-failed" as const,
+        status: "imported" as const,
         dryRuns,
         importResults,
-        error: redactImportError(error),
       };
-      if (preflight) groups[groups.indexOf(preflight)] = failedGroup;
-      else groups.push(failedGroup);
-      continue;
+      if (preflight) groups[groups.indexOf(preflight)] = importedGroup;
+      else groups.push(importedGroup);
     }
-
-    const importedGroup = {
-      cwd: group.cwd,
-      searchRoots,
-      status: "imported" as const,
-      dryRuns,
-      importResults,
-    };
-    if (preflight) groups[groups.indexOf(preflight)] = importedGroup;
-    else groups.push(importedGroup);
   }
 
   return {
     dryRun,
     discovery,
+    plan,
     groups,
-    summary: multiRootImportSummary(discovery, groups),
+    summary: multiRootImportSummary(discovery, plan, groups),
   };
 }
 
@@ -458,6 +623,7 @@ export async function importMemoryMultiRootProjectSessions(
   args: {
     approvedRoots: string[];
     bank?: string;
+    importPlan?: { mappings: MultiRootProjectImportPlanMapping[] };
     dryRun?: boolean;
     dryRunFirst?: boolean;
     includeBranches?: ResolvedConfig["import"]["includeBranches"];
@@ -465,20 +631,46 @@ export async function importMemoryMultiRootProjectSessions(
   },
   deps: ImportOperationDeps,
 ) {
-  const bankId = resolveOperationBank({
-    requestedBank: args.bank,
-    config: deps.getConfig(),
-    projectBankId: deps.getProjectBankId(),
-  });
+  const config = deps.getConfig();
+  const needsBankResolution =
+    Boolean(args.bank) ||
+    Boolean(
+      args.importPlan?.mappings.some((mapping) =>
+        mapping.targetBankIds.some((targetBankId) => ["project", "global"].includes(targetBankId)),
+      ),
+    );
+  const projectBankId = needsBankResolution ? deps.getProjectBankId() : "";
+  const bankId = args.bank
+    ? resolveOperationBank({
+        requestedBank: args.bank,
+        config,
+        projectBankId,
+      })
+    : undefined;
+  const importPlan = args.importPlan
+    ? {
+        mappings: args.importPlan.mappings.map((mapping) => ({
+          cwd: mapping.cwd,
+          targetBankIds: mapping.targetBankIds.map((targetBankId) =>
+            resolveOperationBank({
+              requestedBank: targetBankId,
+              config,
+              projectBankId,
+            }),
+          ),
+        })),
+      }
+    : undefined;
   const result = await importMultiRootProjectSessions({
     approvedRoots: args.approvedRoots,
-    bankId,
+    ...(bankId ? { bankId } : {}),
+    ...(importPlan ? { importPlan } : {}),
     client: deps.getClient(),
-    config: deps.getConfig(),
+    config,
     ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
     ...(args.dryRunFirst !== undefined ? { dryRunFirst: args.dryRunFirst } : {}),
     ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
     ...(args.onProgress ? { onProgress: args.onProgress } : {}),
   });
-  return { bankId, ...result };
+  return { ...(bankId ? { bankId } : {}), ...result };
 }

--- a/extensions/imports/import-multi-root.ts
+++ b/extensions/imports/import-multi-root.ts
@@ -303,6 +303,10 @@ export function buildMultiRootProjectImportPlan(args: {
       throw new Error(
         `Submitted import mapping cwd ${redactSecrets(cwd)} does not match a discovered source group.`,
       );
+    if (mappingByCwd.has(cwd))
+      throw new Error(
+        `Duplicate import mapping cwd ${redactSecrets(cwd)} maps to the same source group.`,
+      );
     mappingByCwd.set(cwd, uniqueTargetBankIds(mapping.targetBankIds));
   }
   const groups = args.discovery.groups.map((group): MultiRootProjectImportPlanGroup => {

--- a/extensions/imports/import-multi-root.ts
+++ b/extensions/imports/import-multi-root.ts
@@ -145,6 +145,14 @@ function redactImportError(error: unknown): string {
   return redactSecrets(redactError(error));
 }
 
+function invalidApprovedRoot(root: string): MultiRootInvalidSession {
+  return {
+    sessionFile: redactSecrets(root),
+    reason: "unreadable",
+    error: "Approved root must be absolute.",
+  };
+}
+
 async function collectJsonlFiles(root: string): Promise<string[]> {
   const files: string[] = [];
   async function visit(dir: string): Promise<void> {
@@ -168,11 +176,16 @@ async function collectJsonlFiles(root: string): Promise<string[]> {
 export async function discoverMultiRootPiSessionHeaders(args: {
   approvedRoots: string[];
 }): Promise<MultiRootSessionDiscoveryResult> {
-  const approvedRoots = (await Promise.all(args.approvedRoots.map((root) => canonicalPath(root))))
+  const rootInputs = args.approvedRoots.map((root) => root.trim()).filter(Boolean);
+  const invalidSessions = rootInputs.filter((root) => !isAbsolute(root)).map(invalidApprovedRoot);
+  const approvedRoots = (
+    await Promise.all(
+      rootInputs.filter((root) => isAbsolute(root)).map((root) => canonicalPath(root)),
+    )
+  )
     .filter((root, index, roots) => roots.indexOf(root) === index)
     .sort();
   const validSessions: Array<{ cwd: string; session: PendingSessionHeader }> = [];
-  const invalidSessions: MultiRootInvalidSession[] = [];
   const seenSessionFiles = new Set<string>();
   let scannedFileCount = 0;
 
@@ -253,6 +266,16 @@ function rootsForGroup(discovery: MultiRootSessionDiscoveryResult, cwd: string):
       }),
     ),
   ].sort();
+}
+
+function sessionFilesForSearchRoot(group: MultiRootSessionGroup, searchRoot: string): string[] {
+  return group.sessions
+    .map((session) => session.sessionFile)
+    .filter((sessionFile) => {
+      const path = relative(searchRoot, sessionFile);
+      return path && !path.startsWith("..") && !isAbsolute(path);
+    })
+    .sort();
 }
 
 function aggregateDocumentCount(groups: MultiRootProjectImportGroupResult[]): number {
@@ -349,6 +372,7 @@ export async function importMultiRootProjectSessions(
           client: args.client,
           config: args.config,
           dryRun: delegateDryRun,
+          sessionFiles: sessionFilesForSearchRoot(group, searchDir),
           ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
           ...(args.onProgress ? { onProgress: args.onProgress } : {}),
         }),

--- a/extensions/imports/import-multi-root.ts
+++ b/extensions/imports/import-multi-root.ts
@@ -1,7 +1,7 @@
 import type { HindsightLikeClient, ResolvedConfig } from "../types.js";
 import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { lstat, open, readdir, realpath } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { redactError, redactSecrets } from "../utils/sanitize.js";
@@ -141,6 +141,14 @@ async function canonicalPath(path: string): Promise<string> {
   }
 }
 
+function canonicalPathSync(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
 function parseSessionHeaderLine(line: string): SessionHeader | undefined {
   let parsed: unknown;
   try {
@@ -199,6 +207,47 @@ function uniqueTargetBankIds(targetBankIds: string[]): string[] {
     .filter((targetBankId, index, ids) => ids.indexOf(targetBankId) === index);
 }
 
+function isNotFoundError(error: unknown): boolean {
+  if (typeof error !== "object" || !error) return false;
+  const fields = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    code?: unknown;
+    message?: unknown;
+  };
+  return (
+    fields.status === 404 ||
+    fields.statusCode === 404 ||
+    fields.code === 404 ||
+    fields.code === "404" ||
+    (typeof fields.message === "string" && /\b404\b|not found/i.test(fields.message))
+  );
+}
+
+async function validateTargetBankIds(
+  client: HindsightLikeClient,
+  targetBankIds: string[],
+): Promise<void> {
+  const uniqueBankIds = uniqueTargetBankIds(targetBankIds);
+  if (uniqueBankIds.length === 0) return;
+  if (!client.getBankProfile)
+    throw new Error("Cannot validate target Hindsight banks: getBankProfile unavailable.");
+  for (const bankId of uniqueBankIds) {
+    try {
+      const profile = await client.getBankProfile(bankId);
+      if (profile == null) throw new Error("empty bank profile response");
+    } catch (error) {
+      if (isNotFoundError(error))
+        throw new Error(`Target Hindsight bank is unavailable: ${redactSecrets(bankId)}`);
+      throw new Error(
+        `Failed to validate target Hindsight bank ${redactSecrets(bankId)}: ${redactImportError(
+          error,
+        )}`,
+      );
+    }
+  }
+}
+
 function importStatePathForBank(path: string, bankId: string): string {
   const hash = createHash("sha256").update(bankId).digest("hex").slice(0, 8);
   const label = bankId
@@ -247,8 +296,14 @@ export function buildMultiRootProjectImportPlan(args: {
   defaultBankId?: string;
 }): MultiRootProjectImportPlan {
   const mappingByCwd = new Map<string, string[]>();
+  const discoveredCwds = new Set(args.discovery.groups.map((group) => group.cwd));
   for (const mapping of args.mappings ?? []) {
-    mappingByCwd.set(mapping.cwd, uniqueTargetBankIds(mapping.targetBankIds));
+    const cwd = canonicalPathSync(mapping.cwd);
+    if (!discoveredCwds.has(cwd))
+      throw new Error(
+        `Submitted import mapping cwd ${redactSecrets(cwd)} does not match a discovered source group.`,
+      );
+    mappingByCwd.set(cwd, uniqueTargetBankIds(mapping.targetBankIds));
   }
   const groups = args.discovery.groups.map((group): MultiRootProjectImportPlanGroup => {
     const targetBankIds = uniqueTargetBankIds(
@@ -494,6 +549,10 @@ export async function importMultiRootProjectSessions(
   const groups: MultiRootProjectImportGroupResult[] = [];
   const dryRun = args.dryRun ?? false;
   const dryRunFirst = !dryRun && (args.dryRunFirst ?? false);
+  await validateTargetBankIds(
+    args.client,
+    plan.groups.flatMap((group) => group.targetBankIds),
+  );
 
   const delegateGroup = async (
     group: MultiRootSessionGroup,
@@ -630,47 +689,53 @@ export async function importMemoryMultiRootProjectSessions(
     onProgress?: ImportProgressReporter;
   },
   deps: ImportOperationDeps,
+  delegateDeps: { importProjectSessions?: ImportProjectSessionsDelegate } = {},
 ) {
   const config = deps.getConfig();
   const needsBankResolution =
     Boolean(args.bank) ||
     Boolean(
       args.importPlan?.mappings.some((mapping) =>
-        mapping.targetBankIds.some((targetBankId) => ["project", "global"].includes(targetBankId)),
+        mapping.targetBankIds.some((targetBankId) =>
+          ["project", "global", "user"].includes(targetBankId),
+        ),
       ),
     );
   const projectBankId = needsBankResolution ? deps.getProjectBankId() : "";
-  const bankId = args.bank
-    ? resolveOperationBank({
-        requestedBank: args.bank,
-        config,
-        projectBankId,
-      })
-    : undefined;
+  const resolveMultiRootOperationBank = (requestedBank: string) =>
+    requestedBank === "user"
+      ? resolveOperationBank({
+          requestedBank: "global",
+          config,
+          projectBankId,
+        })
+      : resolveOperationBank({
+          requestedBank,
+          config,
+          projectBankId,
+        });
+  const bankId = args.bank ? resolveMultiRootOperationBank(args.bank) : undefined;
   const importPlan = args.importPlan
     ? {
         mappings: args.importPlan.mappings.map((mapping) => ({
           cwd: mapping.cwd,
-          targetBankIds: mapping.targetBankIds.map((targetBankId) =>
-            resolveOperationBank({
-              requestedBank: targetBankId,
-              config,
-              projectBankId,
-            }),
-          ),
+          targetBankIds: mapping.targetBankIds.map(resolveMultiRootOperationBank),
         })),
       }
     : undefined;
-  const result = await importMultiRootProjectSessions({
-    approvedRoots: args.approvedRoots,
-    ...(bankId ? { bankId } : {}),
-    ...(importPlan ? { importPlan } : {}),
-    client: deps.getClient(),
-    config,
-    ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
-    ...(args.dryRunFirst !== undefined ? { dryRunFirst: args.dryRunFirst } : {}),
-    ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
-    ...(args.onProgress ? { onProgress: args.onProgress } : {}),
-  });
+  const result = await importMultiRootProjectSessions(
+    {
+      approvedRoots: args.approvedRoots,
+      ...(bankId ? { bankId } : {}),
+      ...(importPlan ? { importPlan } : {}),
+      client: deps.getClient(),
+      config,
+      ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+      ...(args.dryRunFirst !== undefined ? { dryRunFirst: args.dryRunFirst } : {}),
+      ...(args.includeBranches ? { includeBranches: args.includeBranches } : {}),
+      ...(args.onProgress ? { onProgress: args.onProgress } : {}),
+    },
+    delegateDeps,
+  );
   return { ...(bankId ? { bankId } : {}), ...result };
 }

--- a/extensions/imports/import-sessions.ts
+++ b/extensions/imports/import-sessions.ts
@@ -754,6 +754,7 @@ export async function importProjectSessions(args: {
   cwd: string;
   currentSessionFile?: string;
   searchDir?: string;
+  sessionFiles?: string[];
   bankId: string;
   client: HindsightLikeClient;
   config: ResolvedConfig;
@@ -762,11 +763,14 @@ export async function importProjectSessions(args: {
   onProgress?: ImportProgressReporter;
 }): Promise<ImportProjectSessionsResult> {
   args.onProgress?.({ phase: "discovering", message: "Scanning project session files" });
-  const discovery = await discoverProjectSessionFiles({
-    cwd: args.cwd,
-    ...(args.currentSessionFile ? { currentSessionFile: args.currentSessionFile } : {}),
-    ...(args.searchDir ? { searchDir: args.searchDir } : {}),
-  });
+  const discovery =
+    args.sessionFiles !== undefined
+      ? { sessionFiles: [...args.sessionFiles].sort(), scanned: args.sessionFiles.length }
+      : await discoverProjectSessionFiles({
+          cwd: args.cwd,
+          ...(args.currentSessionFile ? { currentSessionFile: args.currentSessionFile } : {}),
+          ...(args.searchDir ? { searchDir: args.searchDir } : {}),
+        });
   args.onProgress?.({
     phase: "discovered",
     message: `Found ${discovery.sessionFiles.length} project session${discovery.sessionFiles.length === 1 ? "" : "s"} after scanning ${discovery.scanned} file${discovery.scanned === 1 ? "" : "s"}`,

--- a/extensions/operations/memory-operation-service.ts
+++ b/extensions/operations/memory-operation-service.ts
@@ -4,6 +4,7 @@ import {
   importMemoryProjectSessions,
   importMemorySession,
 } from "../imports/import-sessions.js";
+import { importMemoryMultiRootProjectSessions } from "../imports/import-multi-root.js";
 import { createBankTemplateOperations } from "./memory-bank-template-operations.js";
 import { createConfigOperations } from "./memory-config-operations.js";
 import { createControlOperations } from "./memory-control-operations.js";
@@ -50,6 +51,17 @@ function createImportOperations(deps: MemoryOperationsDeps) {
       onProgress?: ImportProgressReporter;
     }) {
       return importMemoryProjectSessions(args, deps);
+    },
+
+    async importMultiRootProjectSessions(args: {
+      approvedRoots: string[];
+      bank?: string;
+      dryRun?: boolean;
+      dryRunFirst?: boolean;
+      includeBranches?: ResolvedConfig["import"]["includeBranches"];
+      onProgress?: ImportProgressReporter;
+    }) {
+      return importMemoryMultiRootProjectSessions(args, deps);
     },
   };
 }

--- a/extensions/operations/memory-operation-service.ts
+++ b/extensions/operations/memory-operation-service.ts
@@ -15,6 +15,7 @@ import { createRetainOperations } from "./memory-retain-operations.js";
 import { createSessionOperations } from "./memory-session-operations.js";
 import type { ResolvedConfig } from "../types.js";
 import type { ImportProgressReporter } from "../imports/import-sessions.js";
+import type { MultiRootProjectImportPlanMapping } from "../imports/import-multi-root.js";
 
 export type { ConfigureMemoryArgs, MemoryOperationsDeps } from "./memory-operation-types.js";
 
@@ -56,6 +57,7 @@ function createImportOperations(deps: MemoryOperationsDeps) {
     async importMultiRootProjectSessions(args: {
       approvedRoots: string[];
       bank?: string;
+      importPlan?: { mappings: MultiRootProjectImportPlanMapping[] };
       dryRun?: boolean;
       dryRunFirst?: boolean;
       includeBranches?: ResolvedConfig["import"]["includeBranches"];

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -8,6 +8,7 @@ import {
   type MemoryOperationsDeps,
 } from "../operations/memory-operation-service.js";
 import { importDocumentSummary } from "../imports/import-presentation.js";
+import type { MultiRootProjectImportPlanMapping } from "../imports/import-multi-root.js";
 import type { ImportProgressEvent } from "../imports/import-sessions.js";
 import type { MemoryProfile, ProjectConfigPatchInput } from "../config/config-writer.js";
 import type { SetupProfileChoice } from "./setup-tui-types.js";
@@ -309,6 +310,56 @@ function parseApprovedRootsInput(input: string): string[] {
     .split(/[\n,]+/)
     .map((root) => root.trim())
     .filter(Boolean);
+}
+
+function parseApprovedRootMappingsInput(input: string): MultiRootProjectImportPlanMapping[] {
+  return input
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [cwdPart, targetsPart = ""] = line.split("=");
+      const cwd = cwdPart?.trim() ?? "";
+      const targets = targetsPart.trim();
+      const targetBankIds =
+        targets.toLowerCase() === "skip"
+          ? []
+          : targets
+              .split(",")
+              .map((target) => target.trim())
+              .filter(Boolean)
+              .filter((target, index, targets) => targets.indexOf(target) === index);
+      return { cwd, targetBankIds };
+    })
+    .filter((mapping) => mapping.cwd);
+}
+
+function formatApprovedRootDiscoverySummary(
+  result: Awaited<ReturnType<MemoryOperations["importMultiRootProjectSessions"]>>,
+): string {
+  const invalid = result.plan.summary.invalidCategoryCounts;
+  const groups = result.plan.groups
+    .map((group) => {
+      const reasons = group.classificationReasons.length
+        ? ` (${group.classificationReasons.join(", ")})`
+        : "";
+      return `${group.cwd} [${group.classification}${reasons}; sessions=${group.sessionCount}; default=skip]`;
+    })
+    .join(" | ");
+  return `Dry run: roots=${result.summary.approvedRootCount}; groups=${result.summary.groupCount}; sessions=${result.summary.validSessionCount}; documents=${result.summary.documentCount}; messages=${result.summary.messageCount}; invalid=${result.summary.invalidSessionCount} (invalid-header=${invalid["invalid-header"]}, unreadable=${invalid.unreadable}); malformed=${result.summary.malformedLineCount}; ${groups}`;
+}
+
+function formatApprovedRootPlanSummary(
+  result: Awaited<ReturnType<MemoryOperations["importMultiRootProjectSessions"]>>,
+): string {
+  const mapped = result.plan.groups
+    .map((group) =>
+      group.skipped
+        ? `${group.cwd} -> Skip (${group.skipReason ?? "skipped"})`
+        : `${group.cwd} -> ${group.targetBankIds.join(", ")}${group.fanOut ? " [fan-out]" : ""}`,
+    )
+    .join(" | ");
+  return `Plan: pairs=${result.plan.summary.mappingPairCount}; fan-out groups=${result.plan.summary.fanOutGroupCount}; skipped=${result.plan.summary.skippedGroupCount}; transient/stale=${result.plan.summary.transientGroupCount}; ${mapped}`;
 }
 
 function isNotFoundError(error: unknown): boolean {
@@ -675,25 +726,37 @@ export async function maybeOfferHistoricalImportForSetup(args: {
     args.ctx.ui.notify("Preparing approved-root Pi session import preview...", "info");
     const dryRun = await args.operations.importMultiRootProjectSessions({
       approvedRoots,
-      ...(args.projectBankId ? { bank: args.projectBankId } : {}),
+      dryRun: true,
+      onProgress,
+    });
+    const mappingInput = await args.ctx.ui.input(
+      "Map source cwd groups to target banks",
+      `${formatApprovedRootDiscoverySummary(dryRun)}\nEnter one line per group: <source cwd>=<bank id>[, <bank id>] or <source cwd>=skip. No banks are inferred or created.`,
+    );
+    const mappings = mappingInput ? parseApprovedRootMappingsInput(mappingInput) : [];
+    if (mappings.length === 0) return;
+    args.ctx.ui.notify("Preflighting approved-root import plan...", "info");
+    const preflight = await args.operations.importMultiRootProjectSessions({
+      approvedRoots,
+      importPlan: { mappings },
       dryRun: true,
       onProgress,
     });
     const confirmed = await args.ctx.ui.confirm(
-      `Import approved Pi session roots into ${dryRun.bankId}?`,
-      `Dry run: roots=${dryRun.summary.approvedRootCount}; groups=${dryRun.summary.groupCount}; sessions=${dryRun.summary.validSessionCount}; documents=${dryRun.summary.documentCount}; messages=${dryRun.summary.messageCount}; invalid=${dryRun.summary.invalidSessionCount}; malformed=${dryRun.summary.malformedLineCount}`,
+      "Import approved Pi session roots with reviewed bank mapping?",
+      formatApprovedRootPlanSummary(preflight),
     );
     if (!confirmed) return;
     args.ctx.ui.notify("Starting approved-root Pi session import write...", "info");
     const result = await args.operations.importMultiRootProjectSessions({
       approvedRoots,
-      ...(args.projectBankId ? { bank: args.projectBankId } : {}),
+      importPlan: { mappings },
       dryRun: false,
       dryRunFirst: true,
       onProgress,
     });
     args.ctx.ui.notify(
-      `Imported approved Pi session roots into ${result.bankId}: groups=${result.summary.importedGroupCount}/${result.summary.groupCount}; documents=${result.summary.documentCount}; messages=${result.summary.messageCount}; failed=${result.summary.failedGroupCount}`,
+      `Imported approved Pi session roots: pairs=${result.summary.importedPairCount}/${result.summary.mappingPairCount}; documents=${result.summary.documentCount}; messages=${result.summary.messageCount}; failed=${result.summary.failedPairCount}`,
       "info",
     );
     return;

--- a/extensions/tui/guided-setup.ts
+++ b/extensions/tui/guided-setup.ts
@@ -286,6 +286,7 @@ export function importChoicesForSetup(args: {
   const choices = ["Skip import"];
   if (profileUsesProject(args.setupProfile) && args.projectBankId) {
     choices.push("Preview repo Pi sessions");
+    choices.push("Preview approved Pi session roots");
   }
   if (profileUsesUser(args.setupProfile) && args.globalBankId) {
     choices.push("Preview chat transcript");
@@ -301,6 +302,13 @@ function setupDocsHint(topic: string, path: string): string {
 
 function setupImportProgressMessage(event: ImportProgressEvent): string {
   return `Hindsight import progress: ${event.message}`;
+}
+
+function parseApprovedRootsInput(input: string): string[] {
+  return input
+    .split(/[\n,]+/)
+    .map((root) => root.trim())
+    .filter(Boolean);
 }
 
 function isNotFoundError(error: unknown): boolean {
@@ -651,6 +659,41 @@ export async function maybeOfferHistoricalImportForSetup(args: {
     });
     args.ctx.ui.notify(
       `Imported repo Pi sessions into ${result.bankId}: sessions=${result.sessionFiles.length}; documents=${result.documentCount}; messages=${result.messageCount}`,
+      "info",
+    );
+    return;
+  }
+
+  if (choice === "Preview approved Pi session roots") {
+    const input = await args.ctx.ui.input(
+      "Approved Pi session roots",
+      "Enter absolute roots separated by commas or new lines",
+    );
+    const approvedRoots = input ? parseApprovedRootsInput(input) : [];
+    if (approvedRoots.length === 0) return;
+    const onProgress = setupImportProgressReporter(args.ctx);
+    args.ctx.ui.notify("Preparing approved-root Pi session import preview...", "info");
+    const dryRun = await args.operations.importMultiRootProjectSessions({
+      approvedRoots,
+      ...(args.projectBankId ? { bank: args.projectBankId } : {}),
+      dryRun: true,
+      onProgress,
+    });
+    const confirmed = await args.ctx.ui.confirm(
+      `Import approved Pi session roots into ${dryRun.bankId}?`,
+      `Dry run: roots=${dryRun.summary.approvedRootCount}; groups=${dryRun.summary.groupCount}; sessions=${dryRun.summary.validSessionCount}; documents=${dryRun.summary.documentCount}; messages=${dryRun.summary.messageCount}; invalid=${dryRun.summary.invalidSessionCount}; malformed=${dryRun.summary.malformedLineCount}`,
+    );
+    if (!confirmed) return;
+    args.ctx.ui.notify("Starting approved-root Pi session import write...", "info");
+    const result = await args.operations.importMultiRootProjectSessions({
+      approvedRoots,
+      ...(args.projectBankId ? { bank: args.projectBankId } : {}),
+      dryRun: false,
+      dryRunFirst: true,
+      onProgress,
+    });
+    args.ctx.ui.notify(
+      `Imported approved Pi session roots into ${result.bankId}: groups=${result.summary.importedGroupCount}/${result.summary.groupCount}; documents=${result.summary.documentCount}; messages=${result.summary.messageCount}; failed=${result.summary.failedGroupCount}`,
       "info",
     );
     return;

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -129,6 +129,18 @@ describe("session memory ops used by the TUI hub", () => {
   });
 });
 
+describe("import ops used by the TUI hub", () => {
+  it("exposes multi-root project import through shared operations", () => {
+    const operations = createMemoryOperations({
+      getClient: () => client(),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "bank",
+    });
+
+    expect("importMultiRootProjectSessions" in operations).toBe(true);
+  });
+});
+
 describe("mental model template ops used by the TUI hub", () => {
   it("lists agent-use templates and dry-run gates apply", async () => {
     const importBankTemplate = vi.fn(async (_bankId, _manifest, options) => ({

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -323,7 +323,7 @@ describe("guided setup", () => {
     expect(importProjectSessions).toHaveBeenCalledTimes(1);
   });
 
-  it("previews user-approved session roots before writing with dryRunFirst", async () => {
+  it("reviews user-approved session root mappings before writing with dryRunFirst", async () => {
     const ctx = {
       cwd: "/repo",
       ui: {
@@ -331,14 +331,53 @@ describe("guided setup", () => {
         select: vi.fn().mockResolvedValueOnce("Preview approved Pi session roots"),
         input: vi
           .fn()
-          .mockResolvedValueOnce("/sessions/root-a, /sessions/root-b\n/sessions/root-c"),
+          .mockResolvedValueOnce("/sessions/root-a, /sessions/root-b\n/sessions/root-c")
+          .mockResolvedValueOnce("/repo-a=coding-bank, archive-bank\n/repo-b=skip"),
         notify: vi.fn(),
       },
     } as never;
     const importMultiRootProjectSessions = vi
       .fn()
       .mockResolvedValueOnce({
-        bankId: "project-bank",
+        dryRun: true,
+        discovery: {
+          groups: [
+            {
+              cwd: "/repo-a",
+              sessions: [{ sessionFile: "/sessions/root-a/a.jsonl", sessionId: "a" }],
+            },
+            {
+              cwd: "/repo-b",
+              sessions: [{ sessionFile: "/sessions/root-b/b.jsonl", sessionId: "b" }],
+            },
+          ],
+          invalidSessions: [],
+        },
+        plan: {
+          groups: [
+            {
+              cwd: "/repo-a",
+              targetBankIds: [],
+              skipped: true,
+              classification: "active",
+              classificationReasons: [],
+            },
+            {
+              cwd: "/repo-b",
+              targetBankIds: [],
+              skipped: true,
+              classification: "active",
+              classificationReasons: [],
+            },
+          ],
+          summary: {
+            mappingPairCount: 0,
+            fanOutGroupCount: 0,
+            skippedGroupCount: 2,
+            transientGroupCount: 0,
+            invalidCategoryCounts: { "invalid-header": 0, unreadable: 0 },
+          },
+        },
         summary: {
           approvedRootCount: 3,
           groupCount: 2,
@@ -350,11 +389,51 @@ describe("guided setup", () => {
         },
       })
       .mockResolvedValueOnce({
-        bankId: "project-bank",
+        dryRun: true,
+        plan: {
+          groups: [
+            {
+              cwd: "/repo-a",
+              targetBankIds: ["coding-bank", "archive-bank"],
+              skipped: false,
+              fanOut: true,
+            },
+            {
+              cwd: "/repo-b",
+              targetBankIds: [],
+              skipped: true,
+              skipReason: "No target bank selected.",
+            },
+          ],
+          summary: {
+            mappingPairCount: 2,
+            fanOutGroupCount: 1,
+            skippedGroupCount: 1,
+            transientGroupCount: 0,
+          },
+        },
         summary: {
           groupCount: 2,
           importedGroupCount: 2,
           failedGroupCount: 0,
+          documentCount: 5,
+          messageCount: 10,
+        },
+      })
+      .mockResolvedValueOnce({
+        dryRun: false,
+        plan: {
+          summary: {
+            mappingPairCount: 2,
+            fanOutGroupCount: 1,
+            skippedGroupCount: 1,
+            transientGroupCount: 0,
+          },
+        },
+        summary: {
+          importedPairCount: 2,
+          mappingPairCount: 2,
+          failedPairCount: 0,
           documentCount: 5,
           messageCount: 10,
         },
@@ -375,13 +454,28 @@ describe("guided setup", () => {
 
     expect(importMultiRootProjectSessions).toHaveBeenNthCalledWith(1, {
       approvedRoots: ["/sessions/root-a", "/sessions/root-b", "/sessions/root-c"],
-      bank: "project-bank",
       dryRun: true,
       onProgress: expect.any(Function),
     });
     expect(importMultiRootProjectSessions).toHaveBeenNthCalledWith(2, {
       approvedRoots: ["/sessions/root-a", "/sessions/root-b", "/sessions/root-c"],
-      bank: "project-bank",
+      importPlan: {
+        mappings: [
+          { cwd: "/repo-a", targetBankIds: ["coding-bank", "archive-bank"] },
+          { cwd: "/repo-b", targetBankIds: [] },
+        ],
+      },
+      dryRun: true,
+      onProgress: expect.any(Function),
+    });
+    expect(importMultiRootProjectSessions).toHaveBeenNthCalledWith(3, {
+      approvedRoots: ["/sessions/root-a", "/sessions/root-b", "/sessions/root-c"],
+      importPlan: {
+        mappings: [
+          { cwd: "/repo-a", targetBankIds: ["coding-bank", "archive-bank"] },
+          { cwd: "/repo-b", targetBankIds: [] },
+        ],
+      },
       dryRun: false,
       dryRunFirst: true,
       onProgress: expect.any(Function),

--- a/tests/guided-setup.test.ts
+++ b/tests/guided-setup.test.ts
@@ -265,14 +265,19 @@ describe("guided setup", () => {
         setupProfile: "project-only",
         projectBankId: "project-bank",
       }),
-    ).toEqual(["Skip import", "Preview repo Pi sessions"]);
+    ).toEqual(["Skip import", "Preview repo Pi sessions", "Preview approved Pi session roots"]);
     expect(
       importChoicesForSetup({
         setupProfile: "project-user",
         projectBankId: "project-bank",
         globalBankId: "user-bank",
       }),
-    ).toEqual(["Skip import", "Preview repo Pi sessions", "Preview chat transcript"]);
+    ).toEqual([
+      "Skip import",
+      "Preview repo Pi sessions",
+      "Preview approved Pi session roots",
+      "Preview chat transcript",
+    ]);
   });
 
   it("previews repo session import after project setup before writing", async () => {
@@ -296,6 +301,7 @@ describe("guided setup", () => {
     });
     const operations = {
       importProjectSessions,
+      importMultiRootProjectSessions: vi.fn(),
       importChatTranscript: vi.fn(),
     } as never;
 
@@ -317,6 +323,71 @@ describe("guided setup", () => {
     expect(importProjectSessions).toHaveBeenCalledTimes(1);
   });
 
+  it("previews user-approved session roots before writing with dryRunFirst", async () => {
+    const ctx = {
+      cwd: "/repo",
+      ui: {
+        confirm: vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(true),
+        select: vi.fn().mockResolvedValueOnce("Preview approved Pi session roots"),
+        input: vi
+          .fn()
+          .mockResolvedValueOnce("/sessions/root-a, /sessions/root-b\n/sessions/root-c"),
+        notify: vi.fn(),
+      },
+    } as never;
+    const importMultiRootProjectSessions = vi
+      .fn()
+      .mockResolvedValueOnce({
+        bankId: "project-bank",
+        summary: {
+          approvedRootCount: 3,
+          groupCount: 2,
+          validSessionCount: 4,
+          invalidSessionCount: 0,
+          documentCount: 5,
+          messageCount: 10,
+          malformedLineCount: 0,
+        },
+      })
+      .mockResolvedValueOnce({
+        bankId: "project-bank",
+        summary: {
+          groupCount: 2,
+          importedGroupCount: 2,
+          failedGroupCount: 0,
+          documentCount: 5,
+          messageCount: 10,
+        },
+      });
+    const operations = {
+      importProjectSessions: vi.fn(),
+      importMultiRootProjectSessions,
+      importChatTranscript: vi.fn(),
+    } as never;
+
+    await maybeOfferHistoricalImportForSetup({
+      ctx,
+      operations,
+      setupProfile: "project-only",
+      cwd: "/repo",
+      projectBankId: "project-bank",
+    });
+
+    expect(importMultiRootProjectSessions).toHaveBeenNthCalledWith(1, {
+      approvedRoots: ["/sessions/root-a", "/sessions/root-b", "/sessions/root-c"],
+      bank: "project-bank",
+      dryRun: true,
+      onProgress: expect.any(Function),
+    });
+    expect(importMultiRootProjectSessions).toHaveBeenNthCalledWith(2, {
+      approvedRoots: ["/sessions/root-a", "/sessions/root-b", "/sessions/root-c"],
+      bank: "project-bank",
+      dryRun: false,
+      dryRunFirst: true,
+      onProgress: expect.any(Function),
+    });
+  });
+
   it("previews chat transcript import after user setup before writing", async () => {
     const ctx = {
       ui: {
@@ -336,6 +407,7 @@ describe("guided setup", () => {
     });
     const operations = {
       importProjectSessions: vi.fn(),
+      importMultiRootProjectSessions: vi.fn(),
       importChatTranscript,
     } as never;
 

--- a/tests/import-multi-root.test.ts
+++ b/tests/import-multi-root.test.ts
@@ -416,6 +416,57 @@ describe("multi-root Pi session import orchestration", () => {
     expect(delegate).not.toHaveBeenCalled();
   });
 
+  it("rejects duplicate canonical mapping cwd values before target validation or delegate import calls", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-sk-live-secret-"));
+    const nested = join(project, "nested");
+    mkdirSync(nested);
+    writeFileSync(join(root, "session.jsonl"), sessionJsonl({ id: "session", cwd: project }));
+    const getBankProfile = vi.fn(async (bankId: string) => ({ id: bankId }));
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) =>
+      projectResult({ sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"), dryRun: true }),
+    );
+
+    await expect(
+      importMultiRootProjectSessions(
+        {
+          approvedRoots: [root],
+          importPlan: {
+            mappings: [
+              { cwd: project, targetBankIds: ["first-bank"] },
+              { cwd: join(nested, ".."), targetBankIds: ["second-bank"] },
+            ],
+          },
+          config: DEFAULT_CONFIG,
+          client: memoryClient({ getBankProfile }),
+          dryRun: true,
+        },
+        { importProjectSessions: delegate },
+      ),
+    ).rejects.toThrow(/Duplicate import mapping cwd .* maps to the same source group/);
+
+    await expect(
+      importMultiRootProjectSessions(
+        {
+          approvedRoots: [root],
+          importPlan: {
+            mappings: [
+              { cwd: project, targetBankIds: ["first-bank"] },
+              { cwd: join(nested, ".."), targetBankIds: ["second-bank"] },
+            ],
+          },
+          config: DEFAULT_CONFIG,
+          client: memoryClient({ getBankProfile }),
+          dryRun: true,
+        },
+        { importProjectSessions: delegate },
+      ),
+    ).rejects.not.toThrow("sk-live-secret");
+
+    expect(getBankProfile).not.toHaveBeenCalled();
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
   it("executes unique reviewed group-to-bank pairs with dry-run-first all-or-nothing preflight", async () => {
     const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
     const projectA = mkdtempSync(join(tmpdir(), "pi-hindsight-project-a-"));

--- a/tests/import-multi-root.test.ts
+++ b/tests/import-multi-root.test.ts
@@ -27,14 +27,15 @@ function sessionJsonl(args: { id: string; cwd: string; content?: string }): stri
 }
 
 function projectResult(args: {
-  sessionFile: string;
+  sessionFile?: string;
+  sessionFiles?: string[];
   dryRun: boolean;
   documentCount?: number;
   messageCount?: number;
 }): ImportProjectSessionsResult {
   return {
-    sessionFiles: [args.sessionFile],
-    scanned: 1,
+    sessionFiles: args.sessionFiles ?? [args.sessionFile ?? ""],
+    scanned: args.sessionFiles?.length ?? 1,
     imported: [],
     messageCount: args.messageCount ?? 1,
     documentCount: args.documentCount ?? 1,
@@ -84,6 +85,111 @@ describe("multi-root Pi session import orchestration", () => {
     ]);
     expect(JSON.stringify(result)).not.toContain("outside root");
     expect(JSON.stringify(result)).not.toContain(outside);
+  });
+
+  it("delegates the exact recursively discovered nested session files for import", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const nested = join(root, "nested");
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    mkdirSync(nested);
+    const topLevel = join(root, "top.jsonl");
+    const nestedFile = join(nested, "nested.jsonl");
+    writeFileSync(topLevel, sessionJsonl({ id: "top", cwd: project }));
+    writeFileSync(nestedFile, sessionJsonl({ id: "nested", cwd: project }));
+    const canonicalProject = realpathSync(project);
+    const expectedSessionFiles = [realpathSync(nestedFile), realpathSync(topLevel)].sort();
+    const calls: Array<{
+      cwd: string;
+      searchDir: string;
+      sessionFiles?: string[];
+      dryRun?: boolean;
+    }> = [];
+    const delegate = vi.fn(
+      async (args: ImportProjectSessionsArgs & { sessionFiles?: string[] }) => {
+        calls.push({
+          cwd: args.cwd,
+          searchDir: args.searchDir ?? "",
+          ...(args.sessionFiles ? { sessionFiles: args.sessionFiles } : {}),
+          ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+        });
+        const sessionFiles = args.sessionFiles ?? [];
+        return projectResult({
+          sessionFiles,
+          dryRun: Boolean(args.dryRun),
+          documentCount: sessionFiles.length,
+          messageCount: sessionFiles.length,
+        });
+      },
+    );
+
+    const result = await importMultiRootProjectSessions(
+      {
+        approvedRoots: [root],
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+      },
+      { importProjectSessions: delegate },
+    );
+
+    expect(calls).toEqual([
+      {
+        cwd: canonicalProject,
+        searchDir: realpathSync(root),
+        sessionFiles: expectedSessionFiles,
+        dryRun: false,
+      },
+    ]);
+    expect(result.discovery.groups[0]?.sessions.map((session) => session.sessionFile)).toEqual(
+      expectedSessionFiles,
+    );
+    expect(result.groups[0]?.importResults[0]?.sessionFiles).toEqual(expectedSessionFiles);
+    expect(result.summary).toMatchObject({
+      scannedFileCount: 2,
+      validSessionCount: 2,
+      documentCount: 2,
+      messageCount: 2,
+    });
+  });
+
+  it("rejects relative approved roots without resolving them against process cwd", async () => {
+    const cwd = process.cwd();
+    const processRoot = mkdtempSync(join(tmpdir(), "pi-hindsight-process-cwd-"));
+    const relativeRoot = "pi-hindsight-relative-root-sk-live-secret-root";
+    const cwdResolvedRoot = join(processRoot, relativeRoot);
+    mkdirSync(cwdResolvedRoot, { recursive: true });
+    writeFileSync(
+      join(cwdResolvedRoot, "session.jsonl"),
+      sessionJsonl({ id: "relative", cwd: processRoot }),
+    );
+    process.chdir(processRoot);
+    let result;
+    try {
+      result = await discoverMultiRootPiSessionHeaders({ approvedRoots: [relativeRoot] });
+    } finally {
+      process.chdir(cwd);
+    }
+
+    expect(result).toMatchObject({
+      approvedRoots: [],
+      scannedFileCount: 0,
+      validSessionCount: 0,
+      invalidSessionCount: 1,
+      groups: [],
+      invalidSessions: [
+        {
+          sessionFile: "pi-hindsight-relative-root-[REDACTED_API_KEY]",
+          reason: "unreadable",
+          error: "Approved root must be absolute.",
+        },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain(cwdResolvedRoot);
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret-root");
   });
 
   it("delegates grouped roots through dry-run first and aggregates terminal outcomes", async () => {

--- a/tests/import-multi-root.test.ts
+++ b/tests/import-multi-root.test.ts
@@ -6,12 +6,14 @@ import { DEFAULT_CONFIG } from "../extensions/config/config.js";
 import {
   buildMultiRootProjectImportPlan,
   discoverMultiRootPiSessionHeaders,
+  importMemoryMultiRootProjectSessions,
   importMultiRootProjectSessions,
 } from "../extensions/imports/import-multi-root.js";
 import type {
   importProjectSessions,
   ImportProjectSessionsResult,
 } from "../extensions/imports/import-sessions.js";
+import type { HindsightLikeClient, ResolvedConfig } from "../extensions/types.js";
 
 type ImportProjectSessionsArgs = Parameters<typeof importProjectSessions>[0];
 
@@ -46,6 +48,15 @@ function projectResult(args: {
 }
 
 describe("multi-root Pi session import orchestration", () => {
+  function memoryClient(args: Partial<HindsightLikeClient> = {}): HindsightLikeClient {
+    return {
+      retain: async () => undefined,
+      recall: async () => [],
+      reflect: async () => ({}),
+      ...args,
+    };
+  }
+
   it("discovers only valid session headers under approved roots and groups canonical cwd values", async () => {
     const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
     const unapproved = mkdtempSync(join(tmpdir(), "pi-hindsight-unapproved-root-"));
@@ -128,11 +139,7 @@ describe("multi-root Pi session import orchestration", () => {
         approvedRoots: [root],
         bankId: "bank",
         config: DEFAULT_CONFIG,
-        client: {
-          retain: async () => undefined,
-          recall: async () => [],
-          reflect: async () => ({}),
-        },
+        client: memoryClient({ getBankProfile: async (bankId: string) => ({ id: bankId }) }),
       },
       { importProjectSessions: delegate },
     );
@@ -212,6 +219,203 @@ describe("multi-root Pi session import orchestration", () => {
     });
   });
 
+  it("canonicalizes reviewed mapping cwd values and rejects unknown source groups", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    const nested = join(project, "nested");
+    mkdirSync(nested);
+    writeFileSync(join(root, "session.jsonl"), sessionJsonl({ id: "session", cwd: project }));
+    const discovery = await discoverMultiRootPiSessionHeaders({ approvedRoots: [root] });
+    const canonicalProject = realpathSync(project);
+
+    const relativeCwd = process.cwd();
+    process.chdir(nested);
+    let plan;
+    try {
+      plan = buildMultiRootProjectImportPlan({
+        discovery,
+        mappings: [{ cwd: "..", targetBankIds: ["coding-bank"] }],
+      });
+    } finally {
+      process.chdir(relativeCwd);
+    }
+
+    expect(plan.groups).toEqual([
+      expect.objectContaining({
+        cwd: canonicalProject,
+        targetBankIds: ["coding-bank"],
+        skipped: false,
+      }),
+    ]);
+    expect(
+      buildMultiRootProjectImportPlan({
+        discovery,
+        mappings: [{ cwd: `${project}/`, targetBankIds: ["archive-bank"] }],
+      }).groups,
+    ).toEqual([
+      expect.objectContaining({
+        cwd: canonicalProject,
+        targetBankIds: ["archive-bank"],
+        skipped: false,
+      }),
+    ]);
+    expect(() =>
+      buildMultiRootProjectImportPlan({
+        discovery,
+        mappings: [{ cwd: join(project, "typo"), targetBankIds: ["coding-bank"] }],
+      }),
+    ).toThrow(/does not match a discovered source group/);
+  });
+
+  it("rejects explicit target bank ids that are missing before delegating imports", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    writeFileSync(join(root, "session.jsonl"), sessionJsonl({ id: "session", cwd: project }));
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) =>
+      projectResult({ sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"), dryRun: true }),
+    );
+    const getBankProfile = vi.fn(async (bankId: string) => {
+      if (bankId === "missing-bank") throw new Error("404 missing sk-live-secret-bank");
+      return { id: bankId };
+    });
+
+    await expect(
+      importMultiRootProjectSessions(
+        {
+          approvedRoots: [root],
+          importPlan: {
+            mappings: [
+              { cwd: project, targetBankIds: ["existing-bank", "missing-bank", "existing-bank"] },
+            ],
+          },
+          config: DEFAULT_CONFIG,
+          client: memoryClient({ getBankProfile }),
+          dryRun: true,
+        },
+        { importProjectSessions: delegate },
+      ),
+    ).rejects.toThrow("Target Hindsight bank is unavailable: missing-bank");
+
+    expect(getBankProfile).toHaveBeenCalledTimes(2);
+    expect(getBankProfile).toHaveBeenNthCalledWith(1, "existing-bank");
+    expect(getBankProfile).toHaveBeenNthCalledWith(2, "missing-bank");
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for explicit multi-bank plans when bank profile validation is unavailable", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    writeFileSync(join(root, "session.jsonl"), sessionJsonl({ id: "session", cwd: project }));
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) =>
+      projectResult({ sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"), dryRun: true }),
+    );
+
+    await expect(
+      importMultiRootProjectSessions(
+        {
+          approvedRoots: [root],
+          importPlan: {
+            mappings: [{ cwd: project, targetBankIds: ["existing-bank", "archive-bank"] }],
+          },
+          config: DEFAULT_CONFIG,
+          client: memoryClient(),
+          dryRun: true,
+        },
+        { importProjectSessions: delegate },
+      ),
+    ).rejects.toThrow("Cannot validate target Hindsight banks: getBankProfile unavailable.");
+
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it("resolves project/global/user aliases before validating mapped target banks", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    writeFileSync(join(root, "session.jsonl"), sessionJsonl({ id: "session", cwd: project }));
+    const config: ResolvedConfig = {
+      ...DEFAULT_CONFIG,
+      banks: {
+        ...DEFAULT_CONFIG.banks,
+        user: { ...DEFAULT_CONFIG.banks.user, enabled: true, bankId: "user-bank" },
+      },
+    };
+    const getBankProfile = vi.fn(async (bankId: string) => ({ id: bankId }));
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) =>
+      projectResult({
+        sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"),
+        dryRun: Boolean(args.dryRun),
+      }),
+    );
+
+    await importMemoryMultiRootProjectSessions(
+      {
+        approvedRoots: [root],
+        importPlan: {
+          mappings: [{ cwd: project, targetBankIds: ["project", "global", "user"] }],
+        },
+        dryRun: true,
+      },
+      {
+        getConfig: () => config,
+        getClient: () => memoryClient({ getBankProfile }),
+        getProjectBankId: () => "project-bank",
+      },
+      { importProjectSessions: delegate },
+    );
+
+    expect(getBankProfile).toHaveBeenCalledWith("project-bank");
+    expect(getBankProfile).toHaveBeenCalledWith("user-bank");
+    expect(delegate.mock.calls.map(([args]) => args.bankId)).toEqual(["project-bank", "user-bank"]);
+  });
+
+  it("redacts target validation errors before surfacing them", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    writeFileSync(join(root, "session.jsonl"), sessionJsonl({ id: "session", cwd: project }));
+
+    await expect(
+      importMultiRootProjectSessions({
+        approvedRoots: [root],
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        client: memoryClient({
+          getBankProfile: async () => {
+            throw new Error("upstream rejected bearer sk-live-secret-target");
+          },
+        }),
+        dryRun: true,
+      }),
+    ).rejects.toThrow("upstream rejected bearer [REDACTED]");
+  });
+
+  it("rejects unknown mapping cwd before target validation or delegate import calls", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    writeFileSync(join(root, "session.jsonl"), sessionJsonl({ id: "session", cwd: project }));
+    const getBankProfile = vi.fn(async (bankId: string) => ({ id: bankId }));
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) =>
+      projectResult({ sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"), dryRun: true }),
+    );
+
+    await expect(
+      importMultiRootProjectSessions(
+        {
+          approvedRoots: [root],
+          importPlan: {
+            mappings: [{ cwd: join(project, "unknown"), targetBankIds: ["existing-bank"] }],
+          },
+          config: DEFAULT_CONFIG,
+          client: memoryClient({ getBankProfile }),
+          dryRun: true,
+        },
+        { importProjectSessions: delegate },
+      ),
+    ).rejects.toThrow(/does not match a discovered source group/);
+
+    expect(getBankProfile).not.toHaveBeenCalled();
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
   it("executes unique reviewed group-to-bank pairs with dry-run-first all-or-nothing preflight", async () => {
     const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
     const projectA = mkdtempSync(join(tmpdir(), "pi-hindsight-project-a-"));
@@ -251,11 +455,7 @@ describe("multi-root Pi session import orchestration", () => {
           ],
         },
         config: DEFAULT_CONFIG,
-        client: {
-          retain: async () => undefined,
-          recall: async () => [],
-          reflect: async () => ({}),
-        },
+        client: memoryClient({ getBankProfile: async (bankId: string) => ({ id: bankId }) }),
         dryRunFirst: true,
       },
       { importProjectSessions: delegate },
@@ -368,11 +568,7 @@ describe("multi-root Pi session import orchestration", () => {
         approvedRoots: [rootA, rootB],
         bankId: "bank",
         config: DEFAULT_CONFIG,
-        client: {
-          retain: async () => undefined,
-          recall: async () => [],
-          reflect: async () => ({}),
-        },
+        client: memoryClient({ getBankProfile: async (bankId: string) => ({ id: bankId }) }),
         dryRunFirst: true,
       },
       { importProjectSessions: delegate },
@@ -430,11 +626,7 @@ describe("multi-root Pi session import orchestration", () => {
         approvedRoots: [root],
         bankId: "bank",
         config: DEFAULT_CONFIG,
-        client: {
-          retain: async () => undefined,
-          recall: async () => [],
-          reflect: async () => ({}),
-        },
+        client: memoryClient({ getBankProfile: async (bankId: string) => ({ id: bankId }) }),
       },
       { importProjectSessions: delegate },
     );
@@ -477,11 +669,7 @@ describe("multi-root Pi session import orchestration", () => {
         approvedRoots: [rootA, rootB],
         bankId: "bank",
         config: DEFAULT_CONFIG,
-        client: {
-          retain: async () => undefined,
-          recall: async () => [],
-          reflect: async () => ({}),
-        },
+        client: memoryClient({ getBankProfile: async (bankId: string) => ({ id: bankId }) }),
         dryRunFirst: true,
       },
       { importProjectSessions: delegate },
@@ -524,11 +712,7 @@ describe("multi-root Pi session import orchestration", () => {
         approvedRoots: [rootA, rootB, missingRoot],
         bankId: "bank",
         config: DEFAULT_CONFIG,
-        client: {
-          retain: async () => undefined,
-          recall: async () => [],
-          reflect: async () => ({}),
-        },
+        client: memoryClient({ getBankProfile: async (bankId: string) => ({ id: bankId }) }),
         dryRunFirst: true,
       },
       { importProjectSessions: delegate },
@@ -569,11 +753,7 @@ describe("multi-root Pi session import orchestration", () => {
         approvedRoots: [rootA, rootB],
         bankId: "bank",
         config: DEFAULT_CONFIG,
-        client: {
-          retain: async () => undefined,
-          recall: async () => [],
-          reflect: async () => ({}),
-        },
+        client: memoryClient({ getBankProfile: async (bankId: string) => ({ id: bankId }) }),
       },
       { importProjectSessions: delegate },
     );
@@ -654,11 +834,7 @@ describe("multi-root Pi session import orchestration", () => {
         approvedRoots: [root],
         bankId: "bank",
         config: DEFAULT_CONFIG,
-        client: {
-          retain: async () => undefined,
-          recall: async () => [],
-          reflect: async () => ({}),
-        },
+        client: memoryClient({ getBankProfile: async (bankId: string) => ({ id: bankId }) }),
         dryRun: true,
       },
       { importProjectSessions: delegate },

--- a/tests/import-multi-root.test.ts
+++ b/tests/import-multi-root.test.ts
@@ -1,0 +1,432 @@
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import {
+  discoverMultiRootPiSessionHeaders,
+  importMultiRootProjectSessions,
+} from "../extensions/imports/import-multi-root.js";
+import type {
+  importProjectSessions,
+  ImportProjectSessionsResult,
+} from "../extensions/imports/import-sessions.js";
+
+type ImportProjectSessionsArgs = Parameters<typeof importProjectSessions>[0];
+
+function sessionJsonl(args: { id: string; cwd: string; content?: string }): string {
+  return [
+    JSON.stringify({ type: "session", id: args.id, cwd: args.cwd }),
+    JSON.stringify({
+      type: "message",
+      id: "m1",
+      parentId: null,
+      message: { role: "user", content: args.content ?? "import me" },
+    }),
+  ].join("\n");
+}
+
+function projectResult(args: {
+  sessionFile: string;
+  dryRun: boolean;
+  documentCount?: number;
+  messageCount?: number;
+}): ImportProjectSessionsResult {
+  return {
+    sessionFiles: [args.sessionFile],
+    scanned: 1,
+    imported: [],
+    messageCount: args.messageCount ?? 1,
+    documentCount: args.documentCount ?? 1,
+    dryRun: args.dryRun,
+    malformedLineCount: 0,
+  };
+}
+
+describe("multi-root Pi session import orchestration", () => {
+  it("discovers only valid session headers under approved roots and groups canonical cwd values", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const unapproved = mkdtempSync(join(tmpdir(), "pi-hindsight-unapproved-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    const equivalent = join(project, "nested", "..");
+    mkdirSync(join(project, "nested"));
+    mkdirSync(join(root, "nested"));
+    const first = join(root, "first.jsonl");
+    const second = join(root, "nested", "second.jsonl");
+    const invalidHeader = join(root, "invalid-header.jsonl");
+    const malformedHeader = join(root, "malformed-header.jsonl");
+    const outside = join(unapproved, "outside.jsonl");
+    writeFileSync(first, sessionJsonl({ id: "first", cwd: project }));
+    writeFileSync(second, sessionJsonl({ id: "second", cwd: equivalent }));
+    writeFileSync(invalidHeader, JSON.stringify({ type: "session", id: "no-cwd" }));
+    writeFileSync(malformedHeader, "{not json}\n");
+    writeFileSync(outside, sessionJsonl({ id: "outside", cwd: project, content: "outside root" }));
+    const canonicalProject = realpathSync(project);
+    const canonicalRoot = realpathSync(root);
+
+    const result = await discoverMultiRootPiSessionHeaders({ approvedRoots: [root] });
+
+    expect(result.scannedFileCount).toBe(4);
+    expect(result.validSessionCount).toBe(2);
+    expect(result.invalidSessionCount).toBe(2);
+    expect(result.groups).toEqual([
+      {
+        cwd: canonicalProject,
+        sessions: [
+          { sessionFile: join(canonicalRoot, "first.jsonl"), sessionId: "first" },
+          { sessionFile: join(canonicalRoot, "nested", "second.jsonl"), sessionId: "second" },
+        ],
+      },
+    ]);
+    expect(result.invalidSessions.map((item) => item.sessionFile).sort()).toEqual([
+      join(canonicalRoot, "invalid-header.jsonl"),
+      join(canonicalRoot, "malformed-header.jsonl"),
+    ]);
+    expect(JSON.stringify(result)).not.toContain("outside root");
+    expect(JSON.stringify(result)).not.toContain(outside);
+  });
+
+  it("delegates grouped roots through dry-run first and aggregates terminal outcomes", async () => {
+    const rootA = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-a-"));
+    const rootB = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-b-"));
+    const projectA = mkdtempSync(join(tmpdir(), "pi-hindsight-project-a-"));
+    const projectB = mkdtempSync(join(tmpdir(), "pi-hindsight-project-b-"));
+    const fileA = join(rootA, "a.jsonl");
+    const fileB = join(rootB, "b.jsonl");
+    writeFileSync(fileA, sessionJsonl({ id: "a", cwd: projectA }));
+    writeFileSync(fileB, sessionJsonl({ id: "b", cwd: projectB }));
+    const canonicalRootA = realpathSync(rootA);
+    const canonicalRootB = realpathSync(rootB);
+    const canonicalProjectA = realpathSync(projectA);
+    const canonicalProjectB = realpathSync(projectB);
+    const calls: Array<{ cwd: string; searchDir: string; dryRun?: boolean }> = [];
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) => {
+      calls.push({
+        cwd: args.cwd,
+        searchDir: args.searchDir ?? "",
+        ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+      });
+      if (args.cwd === canonicalProjectB && args.dryRun === false) {
+        throw new Error("offline token sk-live-secret-123456");
+      }
+      return projectResult({
+        sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"),
+        dryRun: Boolean(args.dryRun),
+      });
+    });
+
+    const result = await importMultiRootProjectSessions(
+      {
+        approvedRoots: [rootA, rootB],
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+        dryRunFirst: true,
+      },
+      { importProjectSessions: delegate },
+    );
+
+    expect(calls).toEqual([
+      { cwd: canonicalProjectA, searchDir: canonicalRootA, dryRun: true },
+      { cwd: canonicalProjectB, searchDir: canonicalRootB, dryRun: true },
+      { cwd: canonicalProjectA, searchDir: canonicalRootA, dryRun: false },
+      { cwd: canonicalProjectB, searchDir: canonicalRootB, dryRun: false },
+    ]);
+    expect(result.summary).toMatchObject({
+      approvedRootCount: 2,
+      validSessionCount: 2,
+      invalidSessionCount: 0,
+      groupCount: 2,
+      dryRunGroupCount: 2,
+      importedGroupCount: 1,
+      failedGroupCount: 1,
+      documentCount: 2,
+      messageCount: 2,
+    });
+    expect(result.summary.categoryCounts).toEqual({
+      unreadable: 0,
+      "invalid-header": 0,
+      "dry-run-completed": 0,
+      "dry-run-failed": 0,
+      imported: 1,
+      "import-failed": 1,
+    });
+    expect(result.groups.map((group) => group.status)).toEqual(["imported", "import-failed"]);
+    expect(result.groups[1]).toMatchObject({
+      cwd: canonicalProjectB,
+      status: "import-failed",
+      error: "offline token [REDACTED_API_KEY]",
+    });
+    expect(delegate).toHaveBeenCalledTimes(4);
+  });
+
+  it("defaults write imports to no preflight unless dryRunFirst is requested", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    writeFileSync(join(root, "session.jsonl"), sessionJsonl({ id: "session", cwd: project }));
+    const canonicalRoot = realpathSync(root);
+    const canonicalProject = realpathSync(project);
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) =>
+      projectResult({
+        sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"),
+        dryRun: Boolean(args.dryRun),
+      }),
+    );
+
+    await importMultiRootProjectSessions(
+      {
+        approvedRoots: [root],
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+      },
+      { importProjectSessions: delegate },
+    );
+
+    expect(delegate).toHaveBeenCalledTimes(1);
+    expect(delegate).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: canonicalProject, searchDir: canonicalRoot, dryRun: false }),
+    );
+  });
+
+  it("preflights every group before starting writes when dryRunFirst is requested", async () => {
+    const rootA = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-a-"));
+    const rootB = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-b-"));
+    const projectA = mkdtempSync(join(tmpdir(), "pi-hindsight-project-a-"));
+    const projectB = mkdtempSync(join(tmpdir(), "pi-hindsight-project-b-"));
+    writeFileSync(join(rootA, "a.jsonl"), sessionJsonl({ id: "a", cwd: projectA }));
+    writeFileSync(join(rootB, "b.jsonl"), sessionJsonl({ id: "b", cwd: projectB }));
+    const canonicalRootA = realpathSync(rootA);
+    const canonicalRootB = realpathSync(rootB);
+    const canonicalProjectA = realpathSync(projectA);
+    const canonicalProjectB = realpathSync(projectB);
+    const calls: Array<{ cwd: string; searchDir: string; dryRun?: boolean }> = [];
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) => {
+      calls.push({
+        cwd: args.cwd,
+        searchDir: args.searchDir ?? "",
+        ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+      });
+      if (args.cwd === canonicalProjectB && args.dryRun === true) {
+        throw new Error("preflight failed with sk-live-secret-abcdef");
+      }
+      return projectResult({
+        sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"),
+        dryRun: Boolean(args.dryRun),
+      });
+    });
+
+    const result = await importMultiRootProjectSessions(
+      {
+        approvedRoots: [rootA, rootB],
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+        dryRunFirst: true,
+      },
+      { importProjectSessions: delegate },
+    );
+
+    expect(calls).toEqual([
+      { cwd: canonicalProjectA, searchDir: canonicalRootA, dryRun: true },
+      { cwd: canonicalProjectB, searchDir: canonicalRootB, dryRun: true },
+    ]);
+    expect(result.groups.map((group) => group.status)).toEqual([
+      "dry-run-completed",
+      "dry-run-failed",
+    ]);
+    expect(result.groups[1]?.error).toBe("preflight failed with [REDACTED_API_KEY]");
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret-abcdef");
+  });
+
+  it("reports deterministic category counts for mixed dry-run-first outcomes", async () => {
+    const rootA = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-a-"));
+    const rootB = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-b-"));
+    const missingRoot = join(tmpdir(), `pi-hindsight-missing-${Date.now()}`);
+    const projectA = mkdtempSync(join(tmpdir(), "pi-hindsight-project-a-"));
+    const projectB = mkdtempSync(join(tmpdir(), "pi-hindsight-project-b-"));
+    writeFileSync(join(rootA, "a.jsonl"), sessionJsonl({ id: "a", cwd: projectA }));
+    writeFileSync(join(rootA, "invalid.jsonl"), JSON.stringify({ type: "session", id: "no-cwd" }));
+    writeFileSync(join(rootB, "b.jsonl"), sessionJsonl({ id: "b", cwd: projectB }));
+    const canonicalProjectB = realpathSync(projectB);
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) => {
+      if (args.cwd === canonicalProjectB && args.dryRun === false) {
+        throw new Error("import failed with sk-live-secret-category");
+      }
+      return projectResult({
+        sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"),
+        dryRun: Boolean(args.dryRun),
+      });
+    });
+
+    const result = await importMultiRootProjectSessions(
+      {
+        approvedRoots: [rootA, rootB, missingRoot],
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+        dryRunFirst: true,
+      },
+      { importProjectSessions: delegate },
+    );
+
+    expect(result.summary.categoryCounts).toEqual({
+      unreadable: 1,
+      "invalid-header": 1,
+      "dry-run-completed": 0,
+      "dry-run-failed": 0,
+      imported: 1,
+      "import-failed": 1,
+    });
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret-category");
+  });
+
+  it("reports deterministic category counts for mixed normal write outcomes", async () => {
+    const rootA = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-a-"));
+    const rootB = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-b-"));
+    const projectA = mkdtempSync(join(tmpdir(), "pi-hindsight-project-a-"));
+    const projectB = mkdtempSync(join(tmpdir(), "pi-hindsight-project-b-"));
+    writeFileSync(join(rootA, "a.jsonl"), sessionJsonl({ id: "a", cwd: projectA }));
+    writeFileSync(join(rootA, "invalid.jsonl"), "not-json\n");
+    writeFileSync(join(rootB, "b.jsonl"), sessionJsonl({ id: "b", cwd: projectB }));
+    const canonicalProjectB = realpathSync(projectB);
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) => {
+      if (args.cwd === canonicalProjectB && args.dryRun === false) {
+        throw new Error("write failed with sk-live-secret-normal");
+      }
+      return projectResult({
+        sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"),
+        dryRun: Boolean(args.dryRun),
+      });
+    });
+
+    const result = await importMultiRootProjectSessions(
+      {
+        approvedRoots: [rootA, rootB],
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+      },
+      { importProjectSessions: delegate },
+    );
+
+    expect(result.summary.categoryCounts).toEqual({
+      unreadable: 0,
+      "invalid-header": 1,
+      "dry-run-completed": 0,
+      "dry-run-failed": 0,
+      imported: 1,
+      "import-failed": 1,
+    });
+    expect(delegate).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret-normal");
+  });
+
+  it("deduplicates sessions found through overlapping approved roots by canonical file path", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const child = join(root, "child");
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    mkdirSync(child);
+    const file = join(child, "session.jsonl");
+    writeFileSync(file, sessionJsonl({ id: "session", cwd: project }));
+    const canonicalFile = realpathSync(file);
+
+    const result = await discoverMultiRootPiSessionHeaders({ approvedRoots: [root, child] });
+
+    expect(result.scannedFileCount).toBe(1);
+    expect(result.validSessionCount).toBe(1);
+    expect(result.groups).toEqual([
+      {
+        cwd: realpathSync(project),
+        sessions: [{ sessionFile: canonicalFile, sessionId: "session" }],
+      },
+    ]);
+  });
+
+  it("reads only the bounded header prefix and does not surface later session body content", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    writeFileSync(
+      join(root, "session.jsonl"),
+      [
+        JSON.stringify({ type: "session", id: "session", cwd: project }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            content: `do not read this body token sk-live-secret-${"x".repeat(70_000)}`,
+          },
+        }),
+      ].join("\n"),
+    );
+
+    const result = await discoverMultiRootPiSessionHeaders({ approvedRoots: [root] });
+
+    expect(result.validSessionCount).toBe(1);
+    expect(JSON.stringify(result)).not.toContain("do not read this body token");
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret");
+  });
+
+  it("stops after dry-run delegation when requested", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const project = mkdtempSync(join(tmpdir(), "pi-hindsight-project-"));
+    const file = join(root, "session.jsonl");
+    writeFileSync(file, sessionJsonl({ id: "session", cwd: project }));
+    const canonicalRoot = realpathSync(root);
+    const canonicalProject = realpathSync(project);
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) =>
+      projectResult({
+        sessionFile: join(args.searchDir ?? "", "placeholder.jsonl"),
+        dryRun: Boolean(args.dryRun),
+      }),
+    );
+
+    const result = await importMultiRootProjectSessions(
+      {
+        approvedRoots: [root],
+        bankId: "bank",
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+        dryRun: true,
+      },
+      { importProjectSessions: delegate },
+    );
+
+    expect(delegate).toHaveBeenCalledTimes(1);
+    expect(delegate).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: canonicalProject, searchDir: canonicalRoot, dryRun: true }),
+    );
+    expect(result.groups[0]).toMatchObject({ status: "dry-run-completed" });
+    expect(result.summary).toMatchObject({
+      dryRunGroupCount: 1,
+      importedGroupCount: 0,
+      failedGroupCount: 0,
+      documentCount: 1,
+      messageCount: 1,
+    });
+  });
+});

--- a/tests/import-multi-root.test.ts
+++ b/tests/import-multi-root.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
 import {
+  buildMultiRootProjectImportPlan,
   discoverMultiRootPiSessionHeaders,
   importMultiRootProjectSessions,
 } from "../extensions/imports/import-multi-root.js";
@@ -154,6 +155,147 @@ describe("multi-root Pi session import orchestration", () => {
       documentCount: 2,
       messageCount: 2,
     });
+  });
+
+  it("builds reviewed plans with skipped default groups, deduplicated target banks, and fan-out counts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const projectA = mkdtempSync(join(tmpdir(), "pi-hindsight-project-a-"));
+    const projectB = mkdtempSync(join(tmpdir(), "pi-hindsight-project-b-"));
+    writeFileSync(join(root, "a.jsonl"), sessionJsonl({ id: "a", cwd: projectA }));
+    writeFileSync(join(root, "b.jsonl"), sessionJsonl({ id: "b", cwd: projectB }));
+    writeFileSync(join(root, "invalid.jsonl"), "{not json}\n");
+    const discovery = await discoverMultiRootPiSessionHeaders({ approvedRoots: [root] });
+    const cwdA = realpathSync(projectA);
+    const cwdB = realpathSync(projectB);
+
+    const skipped = buildMultiRootProjectImportPlan({ discovery });
+    expect(skipped.summary).toMatchObject({
+      groupCount: 2,
+      skippedGroupCount: 2,
+      mappingPairCount: 0,
+      fanOutGroupCount: 0,
+      invalidCategoryCounts: { "invalid-header": 1, unreadable: 0 },
+    });
+    expect(
+      skipped.groups.map((group) => ({ cwd: group.cwd, targetBankIds: group.targetBankIds })),
+    ).toEqual([
+      { cwd: cwdA, targetBankIds: [] },
+      { cwd: cwdB, targetBankIds: [] },
+    ]);
+
+    const reviewed = buildMultiRootProjectImportPlan({
+      discovery,
+      mappings: [
+        { cwd: cwdA, targetBankIds: ["coding-bank", "archive-bank", "coding-bank"] },
+        { cwd: cwdB, targetBankIds: [] },
+      ],
+    });
+
+    expect(reviewed.groups).toEqual([
+      expect.objectContaining({
+        cwd: cwdA,
+        targetBankIds: ["coding-bank", "archive-bank"],
+        skipped: false,
+        fanOut: true,
+      }),
+      expect.objectContaining({
+        cwd: cwdB,
+        targetBankIds: [],
+        skipped: true,
+        skipReason: "No target bank selected.",
+      }),
+    ]);
+    expect(reviewed.summary).toMatchObject({
+      mappingPairCount: 2,
+      fanOutGroupCount: 1,
+      skippedGroupCount: 1,
+    });
+  });
+
+  it("executes unique reviewed group-to-bank pairs with dry-run-first all-or-nothing preflight", async () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-hindsight-import-root-"));
+    const projectA = mkdtempSync(join(tmpdir(), "pi-hindsight-project-a-"));
+    const projectB = mkdtempSync(join(tmpdir(), "pi-hindsight-project-b-"));
+    writeFileSync(join(root, "a.jsonl"), sessionJsonl({ id: "a", cwd: projectA }));
+    writeFileSync(join(root, "b.jsonl"), sessionJsonl({ id: "b", cwd: projectB }));
+    const cwdA = realpathSync(projectA);
+    const cwdB = realpathSync(projectB);
+    const calls: Array<{
+      cwd: string;
+      bankId: string;
+      dryRun?: boolean;
+      manifestPath: string;
+      checkpointPath: string;
+    }> = [];
+    const delegate = vi.fn(async (args: ImportProjectSessionsArgs) => {
+      calls.push({
+        cwd: args.cwd,
+        bankId: args.bankId,
+        manifestPath: args.config.import.manifestPath,
+        checkpointPath: args.config.import.checkpointPath,
+        ...(args.dryRun !== undefined ? { dryRun: args.dryRun } : {}),
+      });
+      if (args.cwd === cwdB && args.bankId === "bad-bank" && args.dryRun) {
+        throw new Error("preflight failed for sk-live-secret-bank");
+      }
+      return projectResult({ dryRun: Boolean(args.dryRun) });
+    });
+
+    const result = await importMultiRootProjectSessions(
+      {
+        approvedRoots: [root],
+        importPlan: {
+          mappings: [
+            { cwd: cwdA, targetBankIds: ["coding-bank", "archive-bank", "coding-bank"] },
+            { cwd: cwdB, targetBankIds: ["bad-bank"] },
+          ],
+        },
+        config: DEFAULT_CONFIG,
+        client: {
+          retain: async () => undefined,
+          recall: async () => [],
+          reflect: async () => ({}),
+        },
+        dryRunFirst: true,
+      },
+      { importProjectSessions: delegate },
+    );
+
+    expect(calls).toEqual([
+      {
+        cwd: cwdA,
+        bankId: "coding-bank",
+        dryRun: true,
+        manifestPath: ".pi/hindsight/import-manifest.coding-bank-88395709.json",
+        checkpointPath: ".pi/hindsight/import-checkpoint.coding-bank-88395709.json",
+      },
+      {
+        cwd: cwdA,
+        bankId: "archive-bank",
+        dryRun: true,
+        manifestPath: ".pi/hindsight/import-manifest.archive-bank-8bcae765.json",
+        checkpointPath: ".pi/hindsight/import-checkpoint.archive-bank-8bcae765.json",
+      },
+      {
+        cwd: cwdB,
+        bankId: "bad-bank",
+        dryRun: true,
+        manifestPath: ".pi/hindsight/import-manifest.bad-bank-018da784.json",
+        checkpointPath: ".pi/hindsight/import-checkpoint.bad-bank-018da784.json",
+      },
+    ]);
+    expect(result.summary).toMatchObject({
+      mappingPairCount: 3,
+      fanOutGroupCount: 1,
+      importedPairCount: 0,
+      failedPairCount: 1,
+    });
+    expect(result.groups.map((group) => group.status)).toEqual([
+      "dry-run-completed",
+      "dry-run-completed",
+      "dry-run-failed",
+    ]);
+    expect(JSON.stringify(result)).not.toContain("sk-live-secret-bank");
   });
 
   it("rejects relative approved roots without resolving them against process cwd", async () => {


### PR DESCRIPTION
## Summary

- Adds multi-root historical session import orchestration for guided setup/import workflows.
- Adds an explicit reviewed import-plan model so approved-root groups default to Skip and write only to explicitly mapped target banks.
- Validates canonical source mappings and existing target Hindsight banks before any multi-root dry run or write.
- Updates import documentation, command surface coverage, and guided setup tests for multi-root imports.

## Linked issue

- Closes #597

## Scope

- Adds `import-multi-root` orchestration for planning and executing imports across multiple roots.
- Adds reviewed source-cwd group mapping with 0..N target banks, target dedupe, fan-out reporting, skipped-group reporting, and stale/transient cwd classification.
- Canonicalizes submitted mapping CWDs and rejects typo/unknown source groups before confirmation or delegate import calls.
- Resolves `project`, `global`, and `user` aliases to configured bank IDs, then verifies every unique selected target bank with `getBankProfile` before any session-pair dry run or write.
- Wires the Memory Operation Service and guided setup flow to the reviewed multi-root import path without defaulting approved-root groups to the current Project Bank.
- Keeps skipped groups visible in the reviewed plan and selected valid groups explicit.
- Updates tools/commands and importing docs, plus tests for command registration, guided setup, and multi-root orchestration.

## Verification

- [x] `pnpm exec vitest run tests/import-multi-root.test.ts tests/guided-setup.test.ts`
- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [x] GitNexus impact analysis before edits and `node .gitnexus/run.cjs detect-changes --scope all --repo /Users/macos/dev/pi-hindsight-worktrees/pi-hindsight-codex-20260829-052949494-geaik` before commit; detect-changes reported HIGH risk limited to multi-root import execution/docs.
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) - not applicable; no release or platform-sensitive scope.
- [ ] package verification requested/passed (release/package changes or `ci:package`) - not applicable; package/release path unchanged.
- [ ] `npm run pack:verify` (release/package changes) - not applicable; package/release path unchanged.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) - attempted twice against local Hindsight. Retain/recall reached successfully both times; final smoke failed outside this import path: first on server `retainBatch` context-size 500, second on reflect because configured `openai/gemma-4-e2b-it` did not produce the required tool call. Cleanup succeeded both times.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds documented guided setup/import behavior that should be included in changelog/release notes.

## Risk and rollback

- Risk: Multi-root import planning could reject intended imports when submitted CWDs do not canonicalize to discovered groups or when Hindsight profile lookup is unavailable; covered by focused mapping, alias, missing-bank, unavailable-client, and no-delegate tests.
- Risk: Guided import is a shared TUI/hub flow. GitNexus impact reports HIGH/critical aggregate risk for that surface; mitigated by targeted guided setup tests plus full repository checks.
- Rollback/revert path: Revert commits 68dd553414c200f02144388c0e9cd8e41c3c9995, 04426d5f20b1c180cff72a1aeb0cac19fd53392d, 6056872, and cebf504.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable; this PR does not change those guidance areas.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

No ADR conflicts identified. Reviewed approved-root targets now resolve configured/current aliases or explicit bank IDs and must already verify through Hindsight `getBankProfile`; imports fail closed when that profile capability is unavailable.
