### PR TITLE
perf: lazy-load memory operation services

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -114,6 +114,20 @@ The run prints and saves a JSON report (path is logged; override with `PI_HINDSI
 
 The benchmark is gated like live smoke: it skips unless `HINDSIGHT_INTEGRATION_ENABLED=true`, and runs in the label-gated `Hindsight Integration` lane (labels `ci:live-smoke` or `memory-path`). Compare reports across runs to catch regressions from refactors or Hindsight upgrades.
 
+## Startup benchmark
+
+Measure Pi readiness with and without this extension using fresh temporary config directories and offline RPC mode:
+
+```bash
+npm run bench:startup
+```
+
+Set `PI_STARTUP_BENCH_RUNS` or `PI_STARTUP_BENCH_WARMUPS` to change the sample counts. Pass an extension entrypoint after `--` to compare another build:
+
+```bash
+npm run bench:startup -- ./extensions/index.ts
+```
+
 ## Source-of-truth order
 
 1. Official Hindsight docs and API behavior

--- a/extensions/index.ts
+++ b/extensions/index.ts
@@ -1,13 +1,15 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { registerTools } from "./operations/tools.js";
 import { registerCommands } from "./tui/commands.js";
 import { createMemoryLifecycle } from "./lifecycle/memory-lifecycle.js";
+import { createOperationCatalog } from "./operations/operation-catalog.js";
+import { registerTools } from "./operations/tools.js";
 
 export default function hindsightExtension(pi: ExtensionAPI) {
   const lifecycle = createMemoryLifecycle(process.cwd());
+  const catalog = createOperationCatalog(lifecycle.deps);
 
-  registerTools(pi, lifecycle.deps);
-  registerCommands(pi, lifecycle.deps);
+  registerTools(pi, catalog);
+  registerCommands(pi, catalog);
 
   pi.on("session_start", async (_event, ctx) => {
     await lifecycle.initialize(ctx);

--- a/extensions/operations/operation-catalog.ts
+++ b/extensions/operations/operation-catalog.ts
@@ -4,10 +4,8 @@ import {
   type ExtensionAPI,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
-import type { MemoryOperationsDeps } from "./memory-operation-service.js";
-import { createMemoryOperations } from "./memory-operation-service.js";
+import type { MemoryOperations, MemoryOperationsDeps } from "./memory-operation-service.js";
 import { formatReflectResult } from "./reflect-presenter.js";
-import { runHindsightSetupTui } from "../tui/setup-tui.js";
 import { renderMemoryToolTextResult, retainToolResponse } from "../tui/tool-presenters.js";
 import { getSessionFile } from "../utils/session.js";
 
@@ -146,7 +144,13 @@ export interface OperationCatalog {
 }
 
 export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCatalog {
-  const operations = createMemoryOperations(deps);
+  let operations: Promise<MemoryOperations> | undefined;
+  const loadOperations = () => {
+    operations ??= import("./memory-operation-service.js").then(({ createMemoryOperations }) =>
+      createMemoryOperations(deps),
+    );
+    return operations;
+  };
   const useCwd = (cwd: string) => deps.reloadConfig?.(cwd);
 
   function defineCatalogTool<TParams extends ToolDefinition["parameters"], TDetails = unknown>(
@@ -268,6 +272,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       }),
       async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
+        const operations = await loadOperations();
         const sessionFile = ctx.sessionManager.getSessionFile?.();
         const { bankId, result } = await operations.recall(
           ctx.cwd,
@@ -337,6 +342,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       }),
       async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
+        const operations = await loadOperations();
         const sessionFile = ctx.sessionManager.getSessionFile?.();
         const result = await operations.retainExplicit({
           cwd: ctx.cwd,
@@ -370,6 +376,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       }),
       async execute(_id, params, _signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
+        const operations = await loadOperations();
         const sessionFile = ctx.sessionManager.getSessionFile?.();
         const result = await operations.retainExplicit({
           cwd: ctx.cwd,
@@ -448,6 +455,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       }),
       async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
+        const operations = await loadOperations();
         const { bankId, result } = await operations.reflect(
           ctx.cwd,
           params.query,
@@ -498,6 +506,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       async execute(_id, _params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         if (signal?.aborted) throw new Error("Aborted");
+        const operations = await loadOperations();
         const result = await operations.status(ctx.cwd);
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -533,6 +542,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         if (signal?.aborted) throw new Error("Aborted");
+        const operations = await loadOperations();
         const result = await operations.seedGitLog({
           cwd: ctx.cwd,
           ...(params.limit !== undefined ? { limit: params.limit } : {}),
@@ -555,6 +565,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       async execute(_id, _params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         if (signal?.aborted) throw new Error("Aborted");
+        const operations = await loadOperations();
         const result = operations.scopeInfo(ctx.cwd);
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -627,6 +638,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         if (signal?.aborted) throw new Error("Aborted");
+        const operations = await loadOperations();
         const result = await operations.config({
           action: params.action,
           cwd: ctx.cwd,
@@ -663,6 +675,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       async execute(_id, params, signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
         if (signal?.aborted) throw new Error("Aborted");
+        const operations = await loadOperations();
         if (params.action === "get") {
           const result = await operations.bankGet({
             ...(params.bank ? { bank: params.bank } : {}),
@@ -725,6 +738,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           params.action === "update" ||
           params.action === "refresh" ||
           params.action === "delete";
+        const operations = await loadOperations();
         const result = await operations.mentalModel({
           action: params.action,
           cwd: ctx.cwd,
@@ -802,6 +816,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
           params.action === "update" ||
           params.action === "delete" ||
           params.action === "seed_taxonomy";
+        const operations = await loadOperations();
         const result = await operations.knowledge({
           action: params.action,
           cwd: ctx.cwd,
@@ -848,6 +863,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       }),
       async execute(_id, params, _signal, _onUpdate, ctx) {
         useCwd(ctx.cwd);
+        const operations = await loadOperations();
         const result = await operations.scopeMigrateDryRun(ctx.cwd, {
           ...(params.bankTags ? { bankTags: params.bankTags } : {}),
           ...(params.writeReceipt !== undefined ? { writeReceipt: params.writeReceipt } : {}),
@@ -870,6 +886,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
         description:
           "Open Hindsight memory hub (status, mode, next-opt-out, mental models, import, flush, doctor, setup).",
         handler: async (_args, ctx) => {
+          const { runHindsightSetupTui } = await import("../tui/setup-tui.js");
           await runHindsightSetupTui(ctx, deps);
         },
       },
@@ -879,6 +896,7 @@ export function createOperationCatalog(deps: MemoryOperationsDeps): OperationCat
       spec: {
         description: "Skip automatic retain for the next agent run in this session.",
         handler: async (_args, ctx) => {
+          const operations = await loadOperations();
           const result = await operations.setNextRetainOff(ctx.cwd, getSessionFile(ctx));
           ctx.ui.notify(
             `Hindsight will skip automatic retain for the next agent run in this session. nextRetain=${result.meta.nextRetainMode}`,

--- a/extensions/operations/tools.ts
+++ b/extensions/operations/tools.ts
@@ -1,7 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { MemoryOperationsDeps } from "./memory-operation-service.js";
-import { createOperationCatalog } from "./operation-catalog.js";
+import type { OperationCatalog } from "./operation-catalog.js";
 
-export function registerTools(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
-  for (const tool of createOperationCatalog(deps).tools) pi.registerTool(tool);
+export function registerTools(pi: ExtensionAPI, catalog: OperationCatalog) {
+  for (const tool of catalog.tools) pi.registerTool(tool);
 }

--- a/extensions/tui/commands.ts
+++ b/extensions/tui/commands.ts
@@ -1,9 +1,8 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { MemoryOperationsDeps } from "../operations/memory-operation-service.js";
-import { createOperationCatalog } from "../operations/operation-catalog.js";
+import type { OperationCatalog } from "../operations/operation-catalog.js";
 
-export function registerCommands(pi: ExtensionAPI, deps: MemoryOperationsDeps) {
-  for (const command of createOperationCatalog(deps).commands) {
+export function registerCommands(pi: ExtensionAPI, catalog: OperationCatalog) {
+  for (const command of catalog.commands) {
     pi.registerCommand(command.name, command.spec);
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test": "vitest run",
     "smoke:hindsight": "tsx scripts/smoke-hindsight.ts",
     "bench:memory": "tsx scripts/bench-memory.ts",
+    "bench:startup": "node scripts/bench-startup.mjs",
     "changelog": "node scripts/generate-changelog.mjs",
     "version": "npm run changelog && npm run format:fix && git add CHANGELOG.md",
     "test:coverage": "vitest run --coverage",

--- a/scripts/bench-startup.mjs
+++ b/scripts/bench-startup.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const piCli = join(root, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js");
+const extensionPath = resolve(root, process.argv[2] ?? "extensions/index.ts");
+const runCount = Number.parseInt(process.env.PI_STARTUP_BENCH_RUNS ?? "10", 10);
+const warmupCount = Number.parseInt(process.env.PI_STARTUP_BENCH_WARMUPS ?? "2", 10);
+
+if (!Number.isInteger(runCount) || runCount < 1) {
+  throw new Error("PI_STARTUP_BENCH_RUNS must be a positive integer");
+}
+if (!Number.isInteger(warmupCount) || warmupCount < 0) {
+  throw new Error("PI_STARTUP_BENCH_WARMUPS must be a non-negative integer");
+}
+
+function percentile(values, fraction) {
+  const sorted = values.toSorted((left, right) => left - right);
+  const index = Math.min(sorted.length - 1, Math.floor(sorted.length * fraction));
+  return sorted[index];
+}
+
+function median(values) {
+  const sorted = values.toSorted((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function runPi(extension) {
+  const runRoot = mkdtempSync(join(tmpdir(), "pi-hindsight-startup-"));
+  const homeDir = join(runRoot, "home");
+  const configDir = join(homeDir, ".pi", "agent");
+  const projectDir = join(runRoot, "project");
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(projectDir);
+  const args = [
+    piCli,
+    "--no-extensions",
+    "--no-skills",
+    "--no-prompt-templates",
+    "--no-themes",
+    "--no-context-files",
+    "--no-session",
+    "--mode",
+    "rpc",
+    ...(extension ? ["--extension", extension] : []),
+  ];
+  const started = process.hrtime.bigint();
+  try {
+    const result = spawnSync(process.execPath, args, {
+      cwd: projectDir,
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        PI_CODING_AGENT_DIR: configDir,
+        PI_OFFLINE: "1",
+        USERPROFILE: homeDir,
+      },
+      input: '{"type":"get_state"}\n{"type":"abort"}\n',
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(result.stderr.trim() || `Pi exited with status ${result.status}`);
+    }
+    if (!result.stdout.includes('"command":"get_state"')) {
+      throw new Error("Pi did not answer the startup readiness probe");
+    }
+    return Number(process.hrtime.bigint() - started) / 1e6;
+  } finally {
+    rmSync(runRoot, { recursive: true, force: true });
+  }
+}
+
+function benchmark(name, extension) {
+  for (let index = 0; index < warmupCount; index += 1) runPi(extension);
+  const samplesMs = Array.from({ length: runCount }, () => runPi(extension));
+  return {
+    name,
+    medianMs: median(samplesMs),
+    p95Ms: percentile(samplesMs, 0.95),
+    minMs: Math.min(...samplesMs),
+    maxMs: Math.max(...samplesMs),
+    samplesMs,
+  };
+}
+
+const baseline = benchmark("baseline", undefined);
+const hindsight = benchmark("hindsight", extensionPath);
+const result = {
+  piVersion: spawnSync(
+    process.execPath,
+    [
+      "-p",
+      `require(${JSON.stringify(join(root, "node_modules", "@earendil-works", "pi-coding-agent", "package.json"))}).version`,
+    ],
+    { encoding: "utf8" },
+  ).stdout.trim(),
+  extensionPath,
+  runs: runCount,
+  warmups: warmupCount,
+  baseline,
+  hindsight,
+  addedMedianMs: hindsight.medianMs - baseline.medianMs,
+};
+
+console.log(JSON.stringify(result, null, 2));

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -27,17 +27,18 @@ function client(overrides: Partial<HindsightLikeClient> = {}): HindsightLikeClie
 describe("hindsight public command surface", () => {
   it("registers only the /hindsight TUI hub command", () => {
     const commands = new Map<string, RegisteredTestCommand>();
+    const catalog = createOperationCatalog({
+      getClient: () => client(),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "bank",
+    });
     registerCommands(
       {
         registerCommand: (name: string, command: RegisteredTestCommand) => {
           commands.set(name, command);
         },
       } as any,
-      {
-        getClient: () => client(),
-        getConfig: () => DEFAULT_CONFIG,
-        getProjectBankId: () => "bank",
-      },
+      catalog,
     );
 
     expect([...commands.keys()].sort()).toEqual(["hindsight", "hindsight:next-opt-out"]);
@@ -83,17 +84,18 @@ describe("hindsight public command surface", () => {
     const sessionFile = join(cwd, "session.jsonl");
     writeFileSync(sessionFile, "");
     const commands = new Map<string, RegisteredTestCommand>();
+    const catalog = createOperationCatalog({
+      getClient: () => client(),
+      getConfig: () => DEFAULT_CONFIG,
+      getProjectBankId: () => "bank",
+    });
     registerCommands(
       {
         registerCommand: (name: string, command: RegisteredTestCommand) => {
           commands.set(name, command);
         },
       } as any,
-      {
-        getClient: () => client(),
-        getConfig: () => DEFAULT_CONFIG,
-        getProjectBankId: () => "bank",
-      },
+      catalog,
     );
     const ctx = {
       cwd,

--- a/tests/operation-catalog-lazy.test.ts
+++ b/tests/operation-catalog-lazy.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
+import hindsightExtension from "../extensions/index.js";
+import { createOperationCatalog } from "../extensions/operations/operation-catalog.js";
+
+const mocked = vi.hoisted(() => ({
+  setupModuleLoads: 0,
+  runHindsightSetupTui: vi.fn(async () => undefined),
+  createMemoryOperations: vi.fn(() => ({
+    status: vi.fn(async () => ({ connected: true })),
+    setNextRetainOff: vi.fn(async () => ({ meta: { nextRetainMode: "off" } })),
+  })),
+}));
+
+vi.mock("../extensions/lifecycle/memory-lifecycle.js", () => ({
+  createMemoryLifecycle: () => ({
+    deps: {
+      getClient: () => ({}),
+      getConfig: () => ({ enabled: true }),
+      getProjectBankId: () => "test-bank",
+    },
+    initialize: vi.fn(),
+    recall: vi.fn(),
+    retain: vi.fn(),
+    shutdown: vi.fn(),
+  }),
+}));
+
+vi.mock("../extensions/operations/memory-operation-service.js", () => ({
+  createMemoryOperations: mocked.createMemoryOperations,
+}));
+
+vi.mock("../extensions/tui/setup-tui.js", () => {
+  mocked.setupModuleLoads += 1;
+  return { runHindsightSetupTui: mocked.runHindsightSetupTui };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+it("registers the shared catalog through the extension entrypoint", () => {
+  const pi = {
+    on: vi.fn(),
+    registerTool: vi.fn(),
+    registerCommand: vi.fn(),
+  };
+
+  hindsightExtension(pi as never);
+
+  expect(pi.registerTool.mock.calls.map(([tool]) => tool.name)).toContain("hindsight_recall");
+  expect(pi.registerCommand.mock.calls.map(([name]) => name)).toEqual([
+    "hindsight",
+    "hindsight:next-opt-out",
+  ]);
+  expect(mocked.createMemoryOperations).not.toHaveBeenCalled();
+});
+
+it("shares one lazy memory operation service across commands and tools", async () => {
+  const catalog = createOperationCatalog({
+    getClient: () => ({}) as never,
+    getConfig: () => DEFAULT_CONFIG,
+    getProjectBankId: () => "test-bank",
+  });
+
+  expect(mocked.createMemoryOperations).not.toHaveBeenCalled();
+
+  const nextOptOut = catalog.commands.find((command) => command.name === "hindsight:next-opt-out");
+  const context = {
+    cwd: process.cwd(),
+    ui: { notify: vi.fn() },
+    sessionManager: { getSessionFile: () => "/tmp/session.jsonl" },
+  } as never;
+  await nextOptOut?.spec.handler("", context);
+
+  const statusTool = catalog.tools.find((tool) => tool.name === "hindsight_status");
+  expect(statusTool).toBeDefined();
+  await statusTool?.execute("status", {}, undefined, undefined, context);
+
+  expect(mocked.createMemoryOperations).toHaveBeenCalledTimes(1);
+});
+
+it("loads the setup TUI only when the hub command runs", async () => {
+  const catalog = createOperationCatalog({
+    getClient: () => ({}) as never,
+    getConfig: () => DEFAULT_CONFIG,
+    getProjectBankId: () => "test-bank",
+  });
+
+  expect(mocked.setupModuleLoads).toBe(0);
+  const hub = catalog.commands.find((command) => command.name === "hindsight");
+  await hub?.spec.handler("", { cwd: process.cwd() } as never);
+
+  expect(mocked.setupModuleLoads).toBe(1);
+  expect(mocked.runHindsightSetupTui).toHaveBeenCalledOnce();
+});


### PR DESCRIPTION
## Summary

- Defer the Memory Operation Service and guided setup TUI until the first Hindsight tool or command uses them.
- Build and register one shared Operation Catalog instead of constructing separate tool and command catalogs.
- Add a hermetic fresh-process Pi startup benchmark and regression coverage for entrypoint registration, command-first loading, shared caching, and setup-TUI loading.

Hermetic benchmark on Linux with Pi 0.84.1, 10 measured runs and 2 warmups:

| Revision | Baseline median | Extension median | Added median |
| --- | ---: | ---: | ---: |
| npm 0.12.0 | 831.9 ms | 1965.5 ms | 1133.6 ms |
| this PR | 817.5 ms | 1300.4 ms | 482.9 ms |

The extension-added median fell by 650.7 ms, or 57.4%.

## Linked issue

- Closes #600

## Scope

- Startup import and registration work only. Retain, Recall, Reflect, bank selection, queue behavior, tool schemas, command names, and setup behavior are unchanged.
- A precompiled entrypoint was tested and rejected because it loaded deferred modules more eagerly than Pi's TypeScript/Jiti path.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (601 tests passed; all coverage thresholds passed)
- [x] `npm run typecheck:tsc`
- [ ] full matrix requested/passed (not platform-sensitive; normal PR CI is sufficient)
- [ ] package verification requested/passed (package metadata and published file paths are unchanged)
- [ ] `npm run pack:verify` (package path is unchanged)
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (local server was unavailable; see Notes)
- [x] `PI_STARTUP_BENCH_RUNS=10 PI_STARTUP_BENCH_WARMUPS=2 npm run bench:startup`

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Pi reaches readiness faster. No command, tool, config, or memory-policy interface changes.

## Risk and rollback

- Risk: The first explicit Hindsight tool or command now performs one dynamic import before running. Regression tests cover command-first loading, later tool reuse, setup-TUI loading, and entrypoint registration.
- Rollback/revert path: Revert commit `8df8853` to restore eager imports and separate catalog construction.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] This does not change source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, so no guidance sync is required.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

`npm run smoke:hindsight` attempted `http://localhost:8888` and failed at `createBank` because no Hindsight server was running. This PR does not change Hindsight requests or memory policy. The lower-level proof is the full 601-test suite, coverage gates, both TypeScript checkers, generated surface checks, command/tool registration tests, and first-use lazy-loading tests.

GitNexus classified the full catalog diff as critical because 123 explicit-operation flows pass through the Operation Catalog. The focused follow-up diff after review was low risk. All catalog surfaces and generated references passed.
