### PR TITLE
feat(retain): gate jobs before queue admission

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,11 @@ Bank missions are intentionally absent from this JSON example. Hindsight bank co
     "updateMode": "append",
     "shutdownFlushMaxJobs": 10,
     "shutdownFlushTimeoutMs": 2000,
-    "postRetainReflect": false
+    "postRetainReflect": false,
+    "beforeEnqueue": {
+      "command": ["/usr/local/bin/retain-check"],
+      "timeoutMs": 5000
+    }
   },
   "import": {
     "manifestPath": ".pi/hindsight/import-manifest.json",
@@ -163,3 +167,20 @@ top-k without score thresholds). When set, drop candidates whose returned `score
   tool calls).
 
 Behavior, why defaults stay off, and a suggested starting floor: [Memory behavior → Recall quality](memory-behavior.md#recall-quality).
+
+### `retain.beforeEnqueue` (optional)
+
+Runs a local argv command immediately before Retain Queue admission. The command is spawned without
+a shell and receives canonical, sanitized Retain Job JSON on stdin. Exit `0` allows the job into the
+queue; nonzero exit, timeout, spawn failure, or malformed config blocks before queue/Hindsight calls.
+
+```json
+{
+  "retain": {
+    "beforeEnqueue": {
+      "command": ["/usr/local/bin/retain-check"],
+      "timeoutMs": 5000
+    }
+  }
+}
+```

--- a/extensions/config/config-normalize.ts
+++ b/extensions/config/config-normalize.ts
@@ -137,6 +137,20 @@ function toolNameFilter(
   };
 }
 
+function retainBeforeEnqueue(
+  value: unknown,
+): NonNullable<ResolvedConfig["retain"]["beforeEnqueue"]> {
+  if (!isRecord(value)) return { command: [], timeoutMs: 5_000, malformed: true };
+  const command =
+    Array.isArray(value.command) &&
+    value.command.length > 0 &&
+    value.command.every((item) => typeof item === "string" && item.length > 0)
+      ? value.command
+      : undefined;
+  const timeoutMs = positiveInt(value.timeoutMs, 5_000);
+  return command ? { command, timeoutMs } : { command: [], timeoutMs, malformed: true };
+}
+
 function scoreFloors(value: unknown): RecallMinScores | undefined {
   if (!isRecord(value)) return undefined;
   const floors: RecallMinScores = {};
@@ -479,6 +493,9 @@ export function normalizeConfig(
         config.retain?.postRetainReflect,
         DEFAULT_CONFIG.retain.postRetainReflect,
       ),
+      ...(config.retain?.beforeEnqueue !== undefined
+        ? { beforeEnqueue: retainBeforeEnqueue(config.retain.beforeEnqueue) }
+        : {}),
     },
     import: {
       mode: enumValue(

--- a/extensions/imports/import-execute.ts
+++ b/extensions/imports/import-execute.ts
@@ -14,7 +14,8 @@ import { expandObservationScopes } from "../lifecycle/observation-scopes.js";
 import { hashImportContent, type ImportManifestEntry } from "./import-plan.js";
 import { importDocumentId, stableSessionId } from "../utils/session.js";
 import { isInjectedHindsightMemory, projectMessage, projectMessages } from "../utils/messages.js";
-import { redactSecrets } from "../utils/sanitize.js";
+import { redactError, redactSecrets } from "../utils/sanitize.js";
+import { runRetainBeforeEnqueueCheck } from "../queue/retain-before-enqueue.js";
 
 export interface ImportRetainIdentity {
   bankId: string;
@@ -644,7 +645,8 @@ export interface ImportDocumentPreview {
   updateMode: "append" | "replace";
   bankId: string;
   wouldWrite: boolean;
-  status: "pending" | "queued" | "completed" | "failed" | "skipped";
+  status: "pending" | "queued" | "completed" | "failed" | "skipped" | "quarantined";
+  queueAdmission?: "would-enqueue" | "quarantined";
   skipReason?: "already-imported" | "empty-curated-projection";
   error?: string;
 }
@@ -946,6 +948,84 @@ export function previewImportBranch(args: Omit<ImportRetainArgs, "client">): Imp
     document: { ...built.document, wouldWrite: false },
     manifestEntry: built.manifestEntry,
   }));
+}
+
+export async function previewImportBranchWithQueueAdmission(
+  args: Omit<ImportRetainArgs, "client">,
+): Promise<ImportRetainResult[]> {
+  const parentSessionId = resolvedParentSessionId(args.parsed, args.cwd);
+  const previews: ImportRetainResult[] = [];
+  for (const built of buildImportBranch(args)) {
+    const preview = { ...built.document, wouldWrite: false };
+    if (!built.document.wouldWrite || built.document.status === "skipped") {
+      previews.push({ document: preview, manifestEntry: built.manifestEntry });
+      continue;
+    }
+    const job = buildDurableRetainJob({
+      cwd: args.cwd,
+      config: args.config,
+      bankId: args.bankId,
+      content: built.content,
+      context: built.context,
+      documentId: built.document.documentId,
+      updateMode: built.document.updateMode,
+      tags: built.document.tags,
+      metadata: {
+        pi_session_file: args.sessionFile,
+        imported: "true",
+        cwd: args.cwd,
+        session_id: args.sessionId,
+        ...(parentSessionId ? { parent_session_id: parentSessionId } : {}),
+        ...(args.parsed.parentSessionFile
+          ? { parent_session_file: args.parsed.parentSessionFile }
+          : {}),
+        branch_leaf_id: built.document.leafId,
+        import_mode: args.config.import.mode,
+        ...(shouldSurfaceImportQualityProfile(args.config)
+          ? { import_quality_profile: args.config.import.qualityProfile }
+          : {}),
+        ...(built.document.projectionVersion
+          ? { projection_version: built.document.projectionVersion }
+          : {}),
+        ...(built.document.importProfile ? { import_profile: built.document.importProfile } : {}),
+        ...(built.document.chunkIndex !== undefined
+          ? { chunk_index: String(built.document.chunkIndex) }
+          : {}),
+        ...(built.document.messageRange
+          ? {
+              message_range_start: String(built.document.messageRange.start),
+              message_range_end: String(built.document.messageRange.end),
+            }
+          : {}),
+        content_hash: built.document.contentHash,
+        include_branches: args.config.import.includeBranches,
+        tool_results: args.config.import.toolResults,
+        ...(args.parsed.sessionTimestamp
+          ? { session_timestamp: args.parsed.sessionTimestamp }
+          : {}),
+      },
+      source: "import",
+      ...(built.observationScopes.length ? { observationScopes: built.observationScopes } : {}),
+    });
+    try {
+      await runRetainBeforeEnqueueCheck(args.config, job);
+      previews.push({
+        document: { ...preview, queueAdmission: "would-enqueue" as const },
+        manifestEntry: built.manifestEntry,
+      });
+    } catch (error) {
+      previews.push({
+        document: {
+          ...preview,
+          status: "quarantined" as const,
+          queueAdmission: "quarantined" as const,
+          error: redactError(error),
+        },
+        manifestEntry: built.manifestEntry,
+      });
+    }
+  }
+  return previews;
 }
 
 export async function retainImportBranch(

--- a/extensions/imports/import-presentation.ts
+++ b/extensions/imports/import-presentation.ts
@@ -18,6 +18,7 @@ export type ImportDocumentSummaryResult = {
     estimatedChunkCount?: number;
     importMode?: "curated" | "raw" | "forensic";
     importQualityProfile?: "compatible" | "strict";
+    queueAdmission?: "would-enqueue" | "quarantined";
     skipReason?: "already-imported" | "empty-curated-projection";
   }[];
   malformedLineCount?: number;
@@ -164,12 +165,27 @@ function importDocumentQualitySummary(result: ImportDocumentSummaryResult): stri
   const skipReasons = [
     ...new Set(result.documents.map((document) => document.skipReason).filter(Boolean)),
   ].join(",");
+  const admissionCounts = result.documents.reduce((counts, document) => {
+    if (document.queueAdmission) {
+      counts.set(document.queueAdmission, (counts.get(document.queueAdmission) ?? 0) + 1);
+    }
+    return counts;
+  }, new Map<string, number>());
+  const admissions = Array.from(admissionCounts)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([admission, count]) => `${admission}:${count}`)
+    .join(",");
   const forensicWarning = importModes.includes("forensic")
     ? "; WARNING forensic mode preserves recalled memory blocks for audit-only use"
     : "";
   const qualityDetails = `${keptSignals ? `; keptSignals=${keptSignals}` : ""}${droppedNoise ? `; droppedNoise=${droppedNoise}` : ""}${reasonCounts ? `; reasons=${reasonCounts}` : ""}${topDroppedTools ? `; topDroppedTools=${topDroppedTools}` : ""}`;
-  return rawMessages || droppedToolResults || rawBytes || projectedBytes || skipReasons
-    ? `; mode=${importModes || "unknown"}${importProfiles ? `; profile=${importProfiles}` : ""}; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; keptToolErrors=${keptErrors}; estimatedChunks=${estimatedChunks}; bytes=${projectedBytes}/${rawBytes}${qualityDetails}${skipReasons ? `; skipReasons=${skipReasons}` : ""}${forensicWarning}`
+  return rawMessages ||
+    droppedToolResults ||
+    rawBytes ||
+    projectedBytes ||
+    admissions ||
+    skipReasons
+    ? `; mode=${importModes || "unknown"}${importProfiles ? `; profile=${importProfiles}` : ""}; projected=${projectedMessages}/${rawMessages || projectedMessages} messages; droppedToolResults=${droppedToolResults}; keptToolErrors=${keptErrors}; estimatedChunks=${estimatedChunks}; bytes=${projectedBytes}/${rawBytes}${qualityDetails}${admissions ? `; admission=${admissions}` : ""}${skipReasons ? `; skipReasons=${skipReasons}` : ""}${forensicWarning}`
     : "";
 }
 

--- a/extensions/imports/import-presentation.ts
+++ b/extensions/imports/import-presentation.ts
@@ -42,6 +42,18 @@ export type ImportProjectPresentationResult = {
   imported?: Array<{ documents: ImportDocumentSummaryResult["documents"] }>;
 };
 
+function compareCodePoints(left: string, right: string): number {
+  const leftPoints = Array.from(left);
+  const rightPoints = Array.from(right);
+  const length = Math.min(leftPoints.length, rightPoints.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPoint = leftPoints[index]!.codePointAt(0)!;
+    const rightPoint = rightPoints[index]!.codePointAt(0)!;
+    if (leftPoint !== rightPoint) return leftPoint - rightPoint;
+  }
+  return leftPoints.length - rightPoints.length;
+}
+
 function sumReasonCounts(
   documents: ImportDocumentSummaryResult["documents"],
 ): Record<string, number> {
@@ -172,7 +184,7 @@ function importDocumentQualitySummary(result: ImportDocumentSummaryResult): stri
     return counts;
   }, new Map<string, number>());
   const admissions = Array.from(admissionCounts)
-    .sort(([left], [right]) => left.localeCompare(right))
+    .sort(([left], [right]) => compareCodePoints(left, right))
     .map(([admission, count]) => `${admission}:${count}`)
     .join(",");
   const forensicWarning = importModes.includes("forensic")

--- a/extensions/imports/import-sessions.ts
+++ b/extensions/imports/import-sessions.ts
@@ -22,6 +22,7 @@ import {
   type ImportRetainResult,
   isImportRetainQueuedError,
   previewImportBranch,
+  previewImportBranchWithQueueAdmission,
   retainImportBranch,
 } from "./import-execute.js";
 import { importDocumentId } from "../utils/session.js";
@@ -138,7 +139,9 @@ export async function executeImportPlan(args: {
       message: `Projecting branch ${branch.leafId}`,
       sessionFile,
     });
-    const previews = previewImportBranch(common);
+    const previews = args.dryRun
+      ? await previewImportBranchWithQueueAdmission(common)
+      : previewImportBranch(common);
     for (const [index, preview] of previews.entries()) {
       args.onProgress?.({
         phase: args.dryRun ? "previewing" : "retaining",

--- a/extensions/queue/queue.ts
+++ b/extensions/queue/queue.ts
@@ -9,6 +9,7 @@ import type {
 } from "../types.js";
 import { deliverRetainJob, parseRetainOutcome, redactQueueError } from "./queue-delivery.js";
 import { JsonlQueueStore, type JsonlQueueFileSummary } from "./jsonl-queue-store.js";
+import { runRetainBeforeEnqueueCheck } from "./retain-before-enqueue.js";
 import { withQueueLock } from "./queue-lock.js";
 
 export { RETAIN_QUEUE_LOCK, isQueueLockOwnerStale, type QueueLockOwner } from "./queue-lock.js";
@@ -97,6 +98,7 @@ export function coalesceRetainJob(existing: RetainJob, incoming: RetainJob): Ret
 export async function enqueueRetainJobCoalesced(
   path: string,
   job: RetainJob,
+  beforeAdmit?: (candidate: RetainJob) => Promise<void>,
 ): Promise<{ coalesced: boolean; currentLength: number }> {
   return withQueueLock(path, async () => {
     const store = retainQueueStore(path);
@@ -104,11 +106,14 @@ export async function enqueueRetainJobCoalesced(
     const jobs = parsed.jobs;
     const last = jobs[jobs.length - 1];
     if (last && canCoalesceRetainJobs(last, job)) {
-      jobs[jobs.length - 1] = coalesceRetainJob(last, job);
+      const candidate = coalesceRetainJob(last, job);
+      await beforeAdmit?.(candidate);
+      jobs[jobs.length - 1] = candidate;
       await appendMalformedQueueLines(path, parsed.malformedLines);
       await store.replace(jobs);
       return { coalesced: true, currentLength: jobs.length };
     }
+    await beforeAdmit?.(job);
     await store.append([job]);
     return { coalesced: false, currentLength: jobs.length + 1 };
   });
@@ -352,6 +357,7 @@ export async function enqueueRetain(
   config: ResolvedConfig,
   job: RetainJob,
 ): Promise<EnqueueRetainJobResult> {
+  await runRetainBeforeEnqueueCheck(config, job);
   return enqueueRetainJobWithStats(retainQueuePath(cwd, config), job);
 }
 
@@ -360,7 +366,9 @@ export async function enqueueRetainCoalesced(
   config: ResolvedConfig,
   job: RetainJob,
 ): Promise<{ coalesced: boolean; currentLength: number }> {
-  return enqueueRetainJobCoalesced(retainQueuePath(cwd, config), job);
+  return enqueueRetainJobCoalesced(retainQueuePath(cwd, config), job, (candidate) =>
+    runRetainBeforeEnqueueCheck(config, candidate),
+  );
 }
 
 export async function flushRetain(

--- a/extensions/queue/queue.ts
+++ b/extensions/queue/queue.ts
@@ -100,23 +100,51 @@ export async function enqueueRetainJobCoalesced(
   job: RetainJob,
   beforeAdmit?: (candidate: RetainJob) => Promise<void>,
 ): Promise<{ coalesced: boolean; currentLength: number }> {
-  return withQueueLock(path, async () => {
-    const store = retainQueueStore(path);
-    const parsed = await store.readTolerant();
-    const jobs = parsed.jobs;
-    const last = jobs[jobs.length - 1];
-    if (last && canCoalesceRetainJobs(last, job)) {
-      const candidate = coalesceRetainJob(last, job);
-      await beforeAdmit?.(candidate);
-      jobs[jobs.length - 1] = candidate;
-      await appendMalformedQueueLines(path, parsed.malformedLines);
-      await store.replace(jobs);
-      return { coalesced: true, currentLength: jobs.length };
-    }
-    await beforeAdmit?.(job);
-    await store.append([job]);
-    return { coalesced: false, currentLength: jobs.length + 1 };
-  });
+  if (!beforeAdmit) {
+    return withQueueLock(path, async () => {
+      const store = retainQueueStore(path);
+      const parsed = await store.readTolerant();
+      const jobs = parsed.jobs;
+      const last = jobs[jobs.length - 1];
+      if (last && canCoalesceRetainJobs(last, job)) {
+        const candidate = coalesceRetainJob(last, job);
+        jobs[jobs.length - 1] = candidate;
+        await appendMalformedQueueLines(path, parsed.malformedLines);
+        await store.replace(jobs);
+        return { coalesced: true, currentLength: jobs.length };
+      }
+      await store.append([job]);
+      return { coalesced: false, currentLength: jobs.length + 1 };
+    });
+  }
+
+  let checkedCandidateJson: string | undefined;
+  while (true) {
+    const decision = await withQueueLock(path, async () => {
+      const store = retainQueueStore(path);
+      const parsed = await store.readTolerant();
+      const jobs = parsed.jobs;
+      const last = jobs[jobs.length - 1];
+      const coalesced = Boolean(last && canCoalesceRetainJobs(last, job));
+      const candidate = coalesced ? coalesceRetainJob(last!, job) : job;
+      const candidateJson = JSON.stringify(candidate);
+      if (candidateJson !== checkedCandidateJson) {
+        return { candidate, candidateJson };
+      }
+      if (coalesced) {
+        jobs[jobs.length - 1] = candidate;
+        await appendMalformedQueueLines(path, parsed.malformedLines);
+        await store.replace(jobs);
+        return { result: { coalesced: true, currentLength: jobs.length } };
+      }
+      await store.append([candidate]);
+      return { result: { coalesced: false, currentLength: jobs.length + 1 } };
+    });
+
+    if ("result" in decision) return decision.result;
+    await beforeAdmit(decision.candidate);
+    checkedCandidateJson = decision.candidateJson;
+  }
 }
 
 export async function readRetainQueue(path: string): Promise<RetainJob[]> {

--- a/extensions/queue/retain-before-enqueue.ts
+++ b/extensions/queue/retain-before-enqueue.ts
@@ -1,0 +1,74 @@
+import { spawn } from "node:child_process";
+import type { ResolvedConfig, RetainJob } from "../types.js";
+
+export class RetainBeforeEnqueueError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RetainBeforeEnqueueError";
+  }
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, canonicalize(item)]),
+  );
+}
+
+export function canonicalRetainJobJson(job: RetainJob): string {
+  return `${JSON.stringify(canonicalize(job), null, 2)}\n`;
+}
+
+export async function runRetainBeforeEnqueueCheck(
+  config: ResolvedConfig,
+  job: RetainJob,
+): Promise<void> {
+  const check = config.retain.beforeEnqueue;
+  if (!check) return;
+  if (check.malformed || check.command.length === 0) {
+    throw new RetainBeforeEnqueueError(
+      "retain.beforeEnqueue is malformed; blocked retain job before queue admission",
+    );
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(check.command[0]!, check.command.slice(1), {
+      shell: false,
+      stdio: ["pipe", "ignore", "ignore"],
+      windowsHide: true,
+    });
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve();
+    };
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(new RetainBeforeEnqueueError("retain.beforeEnqueue timed out"));
+    }, check.timeoutMs);
+
+    child.on("error", () => {
+      finish(new RetainBeforeEnqueueError("retain.beforeEnqueue could not start"));
+    });
+    child.on("exit", (code, signal) => {
+      if (code === 0) {
+        finish();
+        return;
+      }
+      finish(
+        new RetainBeforeEnqueueError(
+          signal
+            ? "retain.beforeEnqueue blocked retain job before queue admission"
+            : "retain.beforeEnqueue blocked retain job before queue admission",
+        ),
+      );
+    });
+    child.stdin.end(canonicalRetainJobJson(job), "utf8");
+  });
+}

--- a/extensions/queue/retain-before-enqueue.ts
+++ b/extensions/queue/retain-before-enqueue.ts
@@ -8,12 +8,24 @@ export class RetainBeforeEnqueueError extends Error {
   }
 }
 
+function compareCodePoints(left: string, right: string): number {
+  const leftPoints = Array.from(left);
+  const rightPoints = Array.from(right);
+  const length = Math.min(leftPoints.length, rightPoints.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftPoint = leftPoints[index]!.codePointAt(0)!;
+    const rightPoint = rightPoints[index]!.codePointAt(0)!;
+    if (leftPoint !== rightPoint) return leftPoint - rightPoint;
+  }
+  return leftPoints.length - rightPoints.length;
+}
+
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalize);
   if (!value || typeof value !== "object") return value;
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>)
-      .sort(([left], [right]) => left.localeCompare(right))
+      .sort(([left], [right]) => compareCodePoints(left, right))
       .map(([key, item]) => [key, canonicalize(item)]),
   );
 }

--- a/extensions/types.ts
+++ b/extensions/types.ts
@@ -17,6 +17,11 @@ export type UpdateMode = "append" | "replace";
 //   This collapses many small per-run retain operations into few larger ones, cutting
 //   Hindsight extraction/consolidation and Postgres WAL/write amplification.
 export type RetainDelivery = "immediate" | "coalesced";
+export interface RetainBeforeEnqueueConfig {
+  command: string[];
+  timeoutMs: number;
+  malformed?: boolean;
+}
 export type RetainUserContent = "text";
 export type RetainAssistantContent = "text" | "toolCall" | "thinking";
 export type RetainToolResultContent = "error" | "summary" | "content";
@@ -189,6 +194,7 @@ export interface ResolvedConfig {
     shutdownFlushMaxJobs: number;
     shutdownFlushTimeoutMs: number;
     postRetainReflect: boolean;
+    beforeEnqueue?: RetainBeforeEnqueueConfig;
   };
   import: {
     mode: ImportMode;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -444,6 +444,7 @@ describe("resolveConfig", () => {
         globalRetain: { mode: "nonsense" },
         retain: {
           queuePath: "",
+          beforeEnqueue: { command: [], timeoutMs: 0 },
           flushIntervalMs: -1,
           entities: [{ text: "ok" }, { text: 42 }],
           periodicFlushMaxJobs: -1,
@@ -497,6 +498,11 @@ describe("resolveConfig", () => {
     expect(config.retain.toolFilter.toolResult.exclude).toContain("read");
     expect(config.retain.strip.message).toContain("usage");
     expect(config.retain.queuePath).toBe(".pi/hindsight/retain-queue.jsonl");
+    expect(config.retain.beforeEnqueue).toEqual({
+      command: [],
+      timeoutMs: 5_000,
+      malformed: true,
+    });
     expect(config.retain.flushIntervalMs).toBe(0);
     expect(config.retain.entities).toEqual([]);
     expect(config.retain.periodicFlushMaxJobs).toBe(1);
@@ -515,6 +521,24 @@ describe("resolveConfig", () => {
     expect(config.notifications.startup).toBe(true);
     expect(config.notifications.recall).toBe(true);
     expect(config.notifications.retain).toBe(true);
+  });
+
+  it("normalizes retain.beforeEnqueue argv command and timeout", () => {
+    const cwd = tmp();
+    mkdirSync(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(
+      join(cwd, ".pi", "hindsight.json"),
+      JSON.stringify({
+        retain: {
+          beforeEnqueue: { command: ["/usr/bin/env", "node", "checker.mjs"], timeoutMs: 1234 },
+        },
+      }),
+    );
+
+    expect(resolveConfig(cwd).retain.beforeEnqueue).toEqual({
+      command: ["/usr/bin/env", "node", "checker.mjs"],
+      timeoutMs: 1234,
+    });
   });
 
   it("accepts banks.coding and banks.life aliases", () => {

--- a/tests/import-presentation.test.ts
+++ b/tests/import-presentation.test.ts
@@ -152,6 +152,7 @@ describe("import presentation", () => {
             estimatedChunkCount: 1,
             importMode: "curated" as const,
             importQualityProfile: "strict" as const,
+            queueAdmission: "would-enqueue" as const,
             droppedTools: [
               { name: "read", count: 1, bytes: 500 },
               { name: "bash", count: 1, bytes: 200 },
@@ -177,6 +178,7 @@ describe("import presentation", () => {
             estimatedChunkCount: 2,
             importMode: "curated" as const,
             importQualityProfile: "strict" as const,
+            queueAdmission: "quarantined" as const,
             droppedTools: [
               { name: "read", count: 2, bytes: 100 },
               { name: "grep", count: 1, bytes: 50 },
@@ -198,7 +200,7 @@ describe("import presentation", () => {
       imported,
     };
     const quality =
-      "mode=curated; profile=strict; projected=4/7 messages; droppedToolResults=3; keptToolErrors=2; estimatedChunks=3; bytes=500/1500; keptSignals=assistant:1,tool-errors:1; droppedNoise=successful-tools:3; reasons=tool-filter-excluded:3,assistant-text:1,tool-error-kept:1; topDroppedTools=read:3,bash:1,grep:1";
+      "mode=curated; profile=strict; projected=4/7 messages; droppedToolResults=3; keptToolErrors=2; estimatedChunks=3; bytes=500/1500; keptSignals=assistant:1,tool-errors:1; droppedNoise=successful-tools:3; reasons=tool-filter-excluded:3,assistant-text:1,tool-error-kept:1; topDroppedTools=read:3,bash:1,grep:1; admission=quarantined:1,would-enqueue:1";
 
     expect(renderProjectImportMessage({ ...base, dryRun: true })).toBe(
       `Project import preview: sessions=2/3; documents=2; messages=7; malformedLines=1; ${quality}; write=no`,

--- a/tests/import-presentation.test.ts
+++ b/tests/import-presentation.test.ts
@@ -102,6 +102,36 @@ describe("import presentation", () => {
     ).toContain("skipReasons=empty-curated-projection");
   });
 
+  it("renders queue admission counts with deterministic code-point ordering", () => {
+    expect(
+      importDocumentSummary({
+        documents: [
+          {
+            updateMode: "replace",
+            status: "pending",
+            rawMessageCount: 1,
+            projectedMessageCount: 1,
+            queueAdmission: "\u{1f600}" as "would-enqueue",
+          },
+          {
+            updateMode: "replace",
+            status: "pending",
+            rawMessageCount: 1,
+            projectedMessageCount: 1,
+            queueAdmission: "\ue000" as "would-enqueue",
+          },
+          {
+            updateMode: "replace",
+            status: "pending",
+            rawMessageCount: 1,
+            projectedMessageCount: 1,
+            queueAdmission: "a" as "would-enqueue",
+          },
+        ],
+      }),
+    ).toContain("admission=a:1,\ue000:1,\u{1f600}:1");
+  });
+
   it("aggregates complete dropped-tool totals before slicing preview output", () => {
     const documents = [0, 1].map((chunk) => ({
       updateMode: "replace",

--- a/tests/import-sessions.test.ts
+++ b/tests/import-sessions.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from
 import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
-import type { RetainJob, UpdateMode } from "../extensions/types.js";
+import type { ResolvedConfig, RetainJob, UpdateMode } from "../extensions/types.js";
 import {
   discoverProjectSessionFiles,
   importPiSession,
@@ -1340,6 +1340,86 @@ describe("Pi session import", () => {
       version: 1,
       imports: {},
     });
+  });
+
+  it("runs retain.beforeEnqueue during dry-run import and reports would-enqueue or quarantine", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-hindsight-import-before-enqueue-"));
+    mkdirSync(join(dir, ".git"));
+    const sessionFile = join(dir, "session.jsonl");
+    writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", id: "session-preview-check", cwd: dir }),
+        JSON.stringify({
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "root API_KEY=sk-secret" },
+        }),
+      ].join("\n"),
+    );
+    const checker = join(dir, "checker.mjs");
+    writeFileSync(
+      checker,
+      `
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => input += chunk);
+process.stdin.on("end", () => {
+  const job = JSON.parse(input);
+  if (job.item.content.includes("sk-secret")) process.exit(3);
+  process.exit(job.documentId.includes("session-preview-check") ? 0 : 4);
+});
+`,
+    );
+    const config: ResolvedConfig = {
+      ...DEFAULT_CONFIG,
+      retain: {
+        ...DEFAULT_CONFIG.retain,
+        beforeEnqueue: { command: [process.execPath, checker], timeoutMs: 2_000 },
+      },
+    };
+    const retain = vi.fn(async () => undefined);
+
+    const passed = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config,
+      dryRun: true,
+      client: { retain, recall: async () => [], reflect: async () => ({}) },
+    });
+
+    expect(passed.documents[0]).toMatchObject({
+      queueAdmission: "would-enqueue",
+      status: "pending",
+      wouldWrite: false,
+    });
+    expect(retain).not.toHaveBeenCalled();
+    await expect(readRetainQueue(resolveQueuePath(dir, config.retain.queuePath))).resolves.toEqual(
+      [],
+    );
+    await expect(readImportCheckpoint(passed.checkpointPath)).resolves.toBeUndefined();
+
+    writeFileSync(checker, "process.exit(1);\n");
+    const blocked = await importPiSession({
+      sessionFile,
+      bankId: "bank",
+      config,
+      dryRun: true,
+      client: { retain, recall: async () => [], reflect: async () => ({}) },
+    });
+
+    expect(blocked.documents[0]).toMatchObject({
+      queueAdmission: "quarantined",
+      status: "quarantined",
+      wouldWrite: false,
+      error: "retain.beforeEnqueue blocked retain job before queue admission",
+    });
+    expect(retain).not.toHaveBeenCalled();
+    await expect(readImportCheckpoint(blocked.checkpointPath)).resolves.toBeUndefined();
+    await expect(readRetainQueue(resolveQueuePath(dir, config.retain.queuePath))).resolves.toEqual(
+      [],
+    );
   });
 
   it("historical import ignores pending next opt-out session state", async () => {

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -10,10 +10,13 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
+import { DEFAULT_CONFIG } from "../extensions/config/config.js";
 import { isQueueLockRaceError } from "../extensions/queue/queue-lock.js";
 import {
   canCoalesceRetainJobs,
   coalesceRetainJob,
+  enqueueRetain,
+  enqueueRetainCoalesced,
   enqueueRetainJob,
   enqueueRetainJobCoalesced,
   flushRetainQueue,
@@ -71,6 +74,12 @@ const stressCases = [0, 1, 2, 3, 4];
 async function createQueueWithJob(id = "1"): Promise<string> {
   const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
   await enqueueRetainJob(path, { ...job, id });
+  return path;
+}
+
+function writeChecker(dir: string, body: string): string {
+  const path = join(dir, "checker.mjs");
+  writeFileSync(path, body);
   return path;
 }
 
@@ -232,6 +241,160 @@ describe("retain queue", () => {
     });
     expect(replaceJob.coalesced).toBe(false);
     expect(await readRetainQueue(path)).toHaveLength(3);
+  });
+
+  it("runs retain.beforeEnqueue with sanitized canonical job JSON before queue admission", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-before-enqueue-"));
+    const inputPath = join(cwd, "stdin.json");
+    const checker = writeChecker(
+      cwd,
+      `
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => input += chunk);
+process.stdin.on("end", async () => {
+  const job = JSON.parse(input);
+  if (input !== JSON.stringify(job, null, 2) + "\\n") process.exit(2);
+  if (job.item.content.includes("sk-secret")) process.exit(3);
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(${JSON.stringify(inputPath)}, input);
+});
+`,
+    );
+    const config = {
+      ...DEFAULT_CONFIG,
+      retain: {
+        ...DEFAULT_CONFIG.retain,
+        beforeEnqueue: { command: [process.execPath, checker], timeoutMs: 2_000 },
+      },
+    };
+
+    const result = await enqueueRetain(cwd, config, {
+      ...job,
+      item: { ...job.item, content: "token [REDACTED]", metadata: { api_key: "[REDACTED]" } },
+    });
+
+    expect(result.currentLength).toBe(1);
+    expect(readFileSync(inputPath, "utf8")).toContain('"documentId": "doc"');
+    expect(await readRetainQueue(join(cwd, DEFAULT_CONFIG.retain.queuePath))).toHaveLength(1);
+  });
+
+  it("blocks queue admission on retain.beforeEnqueue nonzero exit without queue writes", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-before-enqueue-"));
+    const checker = writeChecker(cwd, "process.exit(42);\n");
+    const config = {
+      ...DEFAULT_CONFIG,
+      retain: {
+        ...DEFAULT_CONFIG.retain,
+        beforeEnqueue: { command: [process.execPath, checker], timeoutMs: 2_000 },
+      },
+    };
+
+    await expect(enqueueRetain(cwd, config, job)).rejects.toThrow(
+      "retain.beforeEnqueue blocked retain job before queue admission",
+    );
+    expect(existsSync(join(cwd, DEFAULT_CONFIG.retain.queuePath))).toBe(false);
+  });
+
+  it("checks the merged coalesced retain candidate and preserves existing queue content on rejection", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-before-enqueue-"));
+    const inputPath = join(cwd, "stdin.json");
+    const checker = writeChecker(
+      cwd,
+      `
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => input += chunk);
+process.stdin.on("end", async () => {
+  const job = JSON.parse(input);
+  const content = JSON.parse(job.item.content);
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(${JSON.stringify(inputPath)}, input);
+  process.exit(JSON.stringify(content) === JSON.stringify([{ m: 1 }, { m: 2 }]) ? 42 : 0);
+});
+`,
+    );
+    const config = {
+      ...DEFAULT_CONFIG,
+      retain: {
+        ...DEFAULT_CONFIG.retain,
+        beforeEnqueue: { command: [process.execPath, checker], timeoutMs: 2_000 },
+      },
+    };
+    const queuePath = join(cwd, DEFAULT_CONFIG.retain.queuePath);
+    const existing: RetainJob = {
+      ...job,
+      item: { ...job.item, content: JSON.stringify([{ m: 1 }]) },
+    };
+    const incoming: RetainJob = {
+      ...job,
+      id: "2",
+      item: { ...job.item, content: JSON.stringify([{ m: 2 }]) },
+    };
+    await enqueueRetainJob(queuePath, existing);
+
+    await expect(enqueueRetainCoalesced(cwd, config, incoming)).rejects.toThrow(
+      "retain.beforeEnqueue blocked retain job before queue admission",
+    );
+
+    expect(JSON.parse(JSON.parse(readFileSync(inputPath, "utf8")).item.content)).toEqual([
+      { m: 1 },
+      { m: 2 },
+    ]);
+    expect(await readRetainQueue(queuePath)).toEqual([existing]);
+  });
+
+  it("blocks queue admission on retain.beforeEnqueue timeout and spawn failure", async () => {
+    const timeoutCwd = mkdtempSync(join(tmpdir(), "pi-hindsight-before-enqueue-"));
+    const slowChecker = writeChecker(timeoutCwd, "setTimeout(() => {}, 1000);\n");
+    await expect(
+      enqueueRetain(
+        timeoutCwd,
+        {
+          ...DEFAULT_CONFIG,
+          retain: {
+            ...DEFAULT_CONFIG.retain,
+            beforeEnqueue: { command: [process.execPath, slowChecker], timeoutMs: 20 },
+          },
+        },
+        job,
+      ),
+    ).rejects.toThrow("retain.beforeEnqueue timed out");
+    expect(existsSync(join(timeoutCwd, DEFAULT_CONFIG.retain.queuePath))).toBe(false);
+
+    const spawnCwd = mkdtempSync(join(tmpdir(), "pi-hindsight-before-enqueue-"));
+    await expect(
+      enqueueRetain(
+        spawnCwd,
+        {
+          ...DEFAULT_CONFIG,
+          retain: {
+            ...DEFAULT_CONFIG.retain,
+            beforeEnqueue: { command: [join(spawnCwd, "missing-checker")], timeoutMs: 2_000 },
+          },
+        },
+        job,
+      ),
+    ).rejects.toThrow("retain.beforeEnqueue could not start");
+    expect(existsSync(join(spawnCwd, DEFAULT_CONFIG.retain.queuePath))).toBe(false);
+  });
+
+  it("blocks queue admission when retain.beforeEnqueue config is malformed", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-before-enqueue-"));
+    await expect(
+      enqueueRetain(
+        cwd,
+        {
+          ...DEFAULT_CONFIG,
+          retain: {
+            ...DEFAULT_CONFIG.retain,
+            beforeEnqueue: { command: [], timeoutMs: 5_000, malformed: true },
+          },
+        },
+        job,
+      ),
+    ).rejects.toThrow("retain.beforeEnqueue is malformed");
+    expect(existsSync(join(cwd, DEFAULT_CONFIG.retain.queuePath))).toBe(false);
   });
 
   it("refuses to coalesce into a job that has already failed delivery", async () => {

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { spawn } from "node:child_process";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
 import { isQueueLockRaceError } from "../extensions/queue/queue-lock.js";
+import { canonicalRetainJobJson } from "../extensions/queue/retain-before-enqueue.js";
 import {
   canCoalesceRetainJobs,
   coalesceRetainJob,
@@ -243,6 +244,27 @@ describe("retain queue", () => {
     expect(await readRetainQueue(path)).toHaveLength(3);
   });
 
+  it("canonicalizes retain job keys with deterministic code-point ordering", () => {
+    const canonical = canonicalRetainJobJson({
+      ...job,
+      item: {
+        ...job.item,
+        metadata: {
+          "\u{1f600}": "emoji",
+          "\ue000": "private-use",
+          a: "ascii",
+        },
+      },
+    });
+
+    expect(canonical.indexOf('"a": "ascii"')).toBeLessThan(
+      canonical.indexOf('"\ue000": "private-use"'),
+    );
+    expect(canonical.indexOf('"\ue000": "private-use"')).toBeLessThan(
+      canonical.indexOf('"\u{1f600}": "emoji"'),
+    );
+  });
+
   it("runs retain.beforeEnqueue with sanitized canonical job JSON before queue admission", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-before-enqueue-"));
     const inputPath = join(cwd, "stdin.json");
@@ -342,6 +364,89 @@ process.stdin.on("end", async () => {
       { m: 2 },
     ]);
     expect(await readRetainQueue(queuePath)).toEqual([existing]);
+  });
+
+  it("retries retain.beforeEnqueue outside the queue lock when the tail changes before admission", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    const existing: RetainJob = {
+      ...job,
+      item: { ...job.item, content: JSON.stringify([{ m: 1 }]) },
+    };
+    const incoming: RetainJob = {
+      ...job,
+      id: "2",
+      item: { ...job.item, content: JSON.stringify([{ m: 2 }]) },
+    };
+    const intervening: RetainJob = { ...job, id: "3", documentId: "doc-2" };
+    await enqueueRetainJob(path, existing);
+
+    let releaseFirstCheck!: () => void;
+    let firstCheckStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      firstCheckStarted = resolve;
+    });
+    const checkedContents: unknown[] = [];
+    const pending = enqueueRetainJobCoalesced(path, incoming, async (candidate) => {
+      checkedContents.push(JSON.parse(candidate.item.content));
+      if (checkedContents.length === 1) {
+        firstCheckStarted();
+        await new Promise<void>((resolve) => {
+          releaseFirstCheck = resolve;
+        });
+      }
+    });
+
+    await started;
+    await enqueueRetainJobCoalesced(path, intervening);
+    releaseFirstCheck();
+
+    await expect(pending).resolves.toEqual({ coalesced: false, currentLength: 3 });
+    expect(checkedContents).toEqual([[{ m: 1 }, { m: 2 }], [{ m: 2 }]]);
+    expect(await readRetainQueue(path)).toEqual([existing, intervening, incoming]);
+  });
+
+  it("rejects the final revalidated retain candidate without writing a stale checked candidate", async () => {
+    const path = join(mkdtempSync(join(tmpdir(), "pi-hindsight-q-")), "q.jsonl");
+    const existing: RetainJob = {
+      ...job,
+      item: { ...job.item, content: JSON.stringify([{ m: 1 }]) },
+    };
+    const incoming: RetainJob = {
+      ...job,
+      id: "2",
+      item: { ...job.item, content: JSON.stringify([{ m: 2 }]) },
+    };
+    const intervening: RetainJob = { ...job, id: "3", documentId: "doc-2" };
+    await enqueueRetainJob(path, existing);
+
+    let releaseFirstCheck!: () => void;
+    let firstCheckStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      firstCheckStarted = resolve;
+    });
+    const checkedContents: unknown[] = [];
+    const pending = enqueueRetainJobCoalesced(path, incoming, async (candidate) => {
+      const content = JSON.parse(candidate.item.content);
+      checkedContents.push(content);
+      if (checkedContents.length === 1) {
+        firstCheckStarted();
+        await new Promise<void>((resolve) => {
+          releaseFirstCheck = resolve;
+        });
+        return;
+      }
+      if (JSON.stringify(content) === JSON.stringify([{ m: 2 }])) {
+        throw new Error("blocked final candidate");
+      }
+    });
+
+    await started;
+    await enqueueRetainJobCoalesced(path, intervening);
+    releaseFirstCheck();
+
+    await expect(pending).rejects.toThrow("blocked final candidate");
+    expect(checkedContents).toEqual([[{ m: 1 }, { m: 2 }], [{ m: 2 }]]);
+    expect(await readRetainQueue(path)).toEqual([existing, intervening]);
   });
 
   it("blocks queue admission on retain.beforeEnqueue timeout and spawn failure", async () => {

--- a/tests/retain-durable.test.ts
+++ b/tests/retain-durable.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
@@ -117,6 +117,34 @@ describe("durable explicit retain", () => {
     });
     expect(JSON.stringify(queued[0]?.item.metadata)).not.toContain("super-secret");
     expect(JSON.stringify(queued[0]?.item.metadata)).not.toContain("abcdefghijklmnopqrstuvwxyz");
+  });
+
+  it("blocks explicit retain before queue admission when retain.beforeEnqueue fails", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-retain-"));
+    const checker = join(cwd, "checker.mjs");
+    writeFileSync(checker, "process.exit(1);\n");
+    const config: ResolvedConfig = {
+      ...testConfig(),
+      retain: {
+        ...testConfig().retain,
+        beforeEnqueue: { command: [process.execPath, checker], timeoutMs: 2_000 },
+      },
+    };
+    const retain = client(async () => undefined);
+    const operations = createMemoryOperations({
+      getClient: () => retain,
+      getConfig: () => config,
+      getProjectBankId: () => "project-bank",
+    });
+
+    await expect(
+      operations.retainExplicit({
+        cwd,
+        content: "Durable fact",
+        context: "unit test explicit retain",
+      }),
+    ).rejects.toThrow("retain.beforeEnqueue blocked retain job before queue admission");
+    expect(existsSync(resolveQueuePath(cwd, config.retain.queuePath))).toBe(false);
   });
 
   it("passes configured observation scopes for explicit retain", async () => {

--- a/tests/retain.test.ts
+++ b/tests/retain.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_CONFIG } from "../extensions/config/config.js";
@@ -354,6 +354,32 @@ describe("enqueueRetainFromAgentEnd delivery modes", () => {
     expect(result.sent).toBe(1);
     expect(tracked.retainCalls).toBe(1);
     expect(await readQueuedRetains(cwd, config)).toHaveLength(0);
+  });
+
+  it("blocks automatic retain before queue admission when retain.beforeEnqueue fails", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-hindsight-delivery-"));
+    const checker = join(cwd, "checker.mjs");
+    writeFileSync(checker, "process.exit(1);\n");
+    const tracked = trackingClient();
+    const config: ResolvedConfig = {
+      ...DEFAULT_CONFIG,
+      retain: {
+        ...DEFAULT_CONFIG.retain,
+        beforeEnqueue: { command: [process.execPath, checker], timeoutMs: 2_000 },
+      },
+    };
+
+    await expect(
+      enqueueRetainFromAgentEnd({
+        event: { messages } as AgentEndEvent,
+        cwd,
+        config,
+        client: tracked.client,
+        bankId: "bank",
+      }),
+    ).rejects.toThrow("retain.beforeEnqueue blocked retain job before queue admission");
+    expect(tracked.retainCalls).toBe(0);
+    expect(existsSync(join(cwd, DEFAULT_CONFIG.retain.queuePath))).toBe(false);
   });
 
   it("coalesced delivery enqueues without contacting the client and merges runs", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional `retain.beforeEnqueue` so a local argv command can approve or block a sanitized Retain Job immediately before Retain Queue admission. Failed checks never write the queue or call Hindsight. This continues and supersedes #598, whose fork workflows stayed `action_required`.

## Linked issue

- Closes #596
- Refs #598

## Scope

- Optional `retain.beforeEnqueue` config (absent by default; not writable through `hindsight_config`).
- Spawn without a shell; canonical sanitized Retain Job JSON on stdin; stdout/stderr discarded.
- Gate automatic, explicit, and historical-import retain before queue admission.
- Dry-run import reports would-enqueue vs quarantined without queue or Hindsight calls.
- Import delivery runs the check before removing stale queued jobs.
- Coalesced enqueue checks the merged candidate outside the queue lock, then revalidates.

## Verification

- [x] `npm run check`
- [x] `npm run check:coverage` (source, tests, critical paths, or `ci:coverage`)
- [x] `npm run typecheck:tsc` (source/critical paths or full CI)
- [ ] full matrix requested/passed (release PRs/release verification, manual dispatch, platform-sensitive changes, or `ci:full`) - not applicable; no release or platform-sensitive scope.
- [ ] package verification requested/passed (release/package changes or `ci:package`) - not applicable; package/release path unchanged.
- [ ] `npm run pack:verify` (release/package changes) - not applicable; package/release path unchanged.
- [ ] `npm run smoke:hindsight` or configured `Hindsight Integration` pass (memory-path behavior changes or `ci:live-smoke`; document unavailable live proof) - live proof is unavailable here because `HINDSIGHT_INTEGRATION_ENABLED` and Hindsight credentials are not set. Lower-level tests cover admission policy, queue-first rejection, secret-free errors, import dry-run, and stale queued-job preservation.

## Release impact

Check exactly one:

- [ ] No release impact
- [x] User-visible change
- [ ] Package/release path change

Adds documented opt-in retain/import-retain gating that should appear in changelog/release notes.

## Risk and rollback

- Risk: A misconfigured or overly strict `retain.beforeEnqueue` command can block automatic, explicit, and import retain before queue admission. Malformed config fails closed. Covered by queue, retain, import, and config tests.
- Rollback/revert path: Remove `retain.beforeEnqueue` from config to restore default admission immediately. Full code rollback is reverting this PR.

## Follow-ups

- None.

## Memory invariants

- [x] Retain still stores raw rich content, not summaries.
- [x] Recall Blocks remain ephemeral and are not retained back into Hindsight.
- [x] Project Bank and User Bank isolation is preserved.
- [x] Retain Queue behavior remains queue-first and retry-safe.
- [x] Debug output and sidecars remain opt-in and redacted.
- [x] Import behavior remains deterministic and idempotent when touched.

## Guidance sync

- [x] If this changes source-of-truth order, contributor workflow, verification expectations, memory policy, or definition of done, `AGENTS.md` and `CONTRIBUTING.md` were updated together. Not applicable; this PR does not change those guidance areas.

## Agent checklist

- [x] I read and followed `AGENTS.md` and `CONTRIBUTING.md`.
- [x] I linked the issue before implementation.
- [x] I kept the diff focused on one vertical slice.
- [x] Final branch contains only focused, reviewable commits.
- [x] I did not bypass hooks or checks.
- [x] I documented skipped checks with reasons.

## Notes

No ADR conflicts identified. GitNexus MCP/CLI was not available in this environment, so impact analysis used direct file reads of queue, import, retain, and config paths. Live Hindsight smoke was not run because credentials are unavailable; unit tests cover the admission gate, including no secret leak from checker stdio and no queue mutation on failed checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-345a36af-dc17-5ea7-98a5-981f66372c6d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-345a36af-dc17-5ea7-98a5-981f66372c6d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

